### PR TITLE
Installation script cleanup

### DIFF
--- a/misc/install.sh
+++ b/misc/install.sh
@@ -6,9 +6,9 @@ echo "Installing Screenly OSE (beta)"
 ROOT_AVAIL=$(df -k / | tail -n 1 | awk {'print $4'})
 MIN_REQ="512000"
 
-if [[ $ROOT_AVAIL -lt $MIN_REQ ]]; then
+if [ $ROOT_AVAIL -lt $MIN_REQ ]; then
 	echo "Insufficient disk space. Make sure you have at least 500MB available on the root partition."
-	exit 1 
+	exit 1
 fi
 
 echo "Installing dependencies..."
@@ -26,7 +26,7 @@ sudo mv ~/dphys-swapfile /etc/dphys-swapfile
 
 echo "Adding Screenly's config-file"
 mkdir -p ~/.screenly
-cp ~/screenly/misc/screenly.conf ~/.screenly/ 
+cp ~/screenly/misc/screenly.conf ~/.screenly/
 
 echo "Enabling Watchdog..."
 sudo modprobe bcm2708_wdog
@@ -43,15 +43,16 @@ sudo /etc/init.d/supervisor stop
 sudo /etc/init.d/supervisor start
 
 echo "Making modifications to X..."
-rm -f ~/.gtkrc-2.0
+[ -f ~/.gtkrc-2.0 ] && rm -f ~/.gtkrc-2.0
 ln -s ~/screenly/misc/gtkrc-2.0 ~/.gtkrc-2.0
-mv ~/.config/openbox/lxde-rc.xml ~/.config/openbox/lxde-rc.xml.bak
+[ -f ~/.config/openbox/lxde-rc.xml ] && mv ~/.config/openbox/lxde-rc.xml ~/.config/openbox/lxde-rc.xml.bak
+[ -d ~/.config/openbox ] || mkdir -p ~/.config/openbox
 ln -s ~/screenly/misc/lxde-rc.xml ~/.config/openbox/lxde-rc.xml
-mv ~/.config/lxpanel/LXDE/panels/panel ~/.config/lxpanel/LXDE/panels/panel.bak
-sudo mv /etc/xdg/lxsession/LXDE/autostart /etc/xdg/lxsession/LXDE/autostart.bak
+[ -f ~/.config/lxpanel/LXDE/panels/panel ] && mv ~/.config/lxpanel/LXDE/panels/panel ~/.config/lxpanel/LXDE/panels/panel.bak
+[ -f /etc/xdg/lxsession/LXDE/autostart ] && sudo mv /etc/xdg/lxsession/LXDE/autostart /etc/xdg/lxsession/LXDE/autostart.bak
 
 echo "Quiet the boot process..."
 sudo cp /boot/cmdline.txt /boot/cmdline.txt.bak
-sudo sed 's/$/ quiet/' -i /boot/cmdline.txt  
+sudo sed 's/$/ quiet/' -i /boot/cmdline.txt
 
 echo "Assuming no errors were encountered, go ahead and restart your computer."


### PR DESCRIPTION
Fix misc/install.sh: 9: misc/install.sh: [[: not found
  Non existing [[ in raspbian?

Fix handle non existing openbox configuration path in fresh raspbian image
  Caused windows decorations to show up on some installations.

Check file exists before trying to make backup. (avoid error messages)
