### PR TITLE
Allow aborting currently shown asset via SIGUSR1

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -10,7 +10,7 @@ __email__ = "vpetersson@wireload.net"
 from datetime import datetime, timedelta
 from glob import glob
 from os import path, getenv, remove, makedirs
-from os import stat as os_stat, utime
+from os import stat as os_stat, utime, system
 from platform import machine
 from random import shuffle
 from requests import get as req_get
@@ -18,6 +18,7 @@ from stat import S_ISFIFO
 from subprocess import Popen, call
 from time import sleep, time
 import logging
+import signal
 
 from settings import settings
 import html_templates
@@ -30,6 +31,14 @@ import assets_helper
 # the settings.
 last_settings_refresh = None
 
+
+#This is the signal handler for SIGUSR1
+#After this returns all sleep() calls are aborted
+#Since we also kill omxplayer it means we abort 
+#displaying the current asset
+def sigusr1(signum, frame):
+	logging.info("Skip current asset")
+        system("killall omxplayer.bin")
 
 class Scheduler(object):
     def __init__(self, *args, **kwargs):
@@ -248,6 +257,10 @@ def reload_settings():
 
 
 if __name__ == "__main__":
+
+    #Install signal handler
+    signal.signal(signal.SIGUSR1, sigusr1)
+
 
     # Before we start, reload the settings.
     reload_settings()


### PR DESCRIPTION
This code allows skipping the currently displayed asset.

Why:
If you have a long running asset which you removed from the asset list (or shortened its time), but it is displayed at the moment you need to wait until the asset is finished Not good if you want to display some "Breaking news" as soon as possible.

How:
Unix signals. Normally python will terminate when receiving a signal. Added a signal handler for USR1 Signal. After processing of the signal handler, all calls to sleep() are interrupted, effectively finishing the current asset (the signal handler will also kill omxplayer, in case the current asset was a video).

This includes only the "plumbing". Eventually I plan to add a "Skip current asset" button to the WebIF, but oh my good! I understand nothing about the haml, coffe, js whatever stuff, so for the time being I failed horribly at that :)

To test, the signal could be sent like this (possibly it can be done more elegantly)

<pre>
kill -s USR1 `ps a | grep [v]iewer.py | awk '{ print $1 }'`
</pre>


which effectively does a "kill -s USR1 <viewer_PID>"
