### PR TITLE
Fixed unable to find uploaded asset error

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,7 @@ DEFAULTS = {
     'main': {
         'database': CONFIG_DIR + 'screenly.db',
         'listen': '0.0.0.0:8080',
-        'assetdir': 'screenly_assets',
+        'assetdir': '/home/pi/screenly/screenly_assets',
     },
     'viewer': {
         'show_splash': True,


### PR DESCRIPTION
Uploaded videos and images weren't being found, as the existing assets all had absolute paths I tweaked the file to correct the issue - I've only been using screenly for an hour or so however and there might be a more sensible place to make the change
