### PR TITLE
Fix for installation error on latest raspbian (2014-01-07)

### DIFF
--- a/misc/install.sh
+++ b/misc/install.sh
@@ -24,9 +24,10 @@ echo "Installing dependencies..."
 # "There is a loop between service watchdog and mathkernel if stopped ..."
 # The fix is described in the 7th post in http://www.raspberrypi.org/forum/viewtopic.php?f=28&t=66059
 #
-# If we dont find the LSB signature, insert the stuff after the first line which we expect to be #!/bin/sh
-grep -q "BEGIN INIT INFO" /etc/init.d/mathkernel || \
-sudo sed -e '2i### BEGIN INIT INFO\
+# Check, and if we dont find the LSB signature, insert the stuff after the first line which we expect to be #!/bin/sh
+if grep -q "BEGIN INIT INFO" /etc/init.d/mathkernel ; then
+  sudo cp /etc/init.d/mathkernel /etc/init.d/mathkernel.modified_by_screenly
+  sudo sed -e '2i### BEGIN INIT INFO\
 # Provides:          mathkernel\
 # Required-Start:    $syslog\
 # Required-Stop:     $syslog\
@@ -38,6 +39,7 @@ sudo sed -e '2i### BEGIN INIT INFO\
 ### END INIT INFO\
 #\
 # rest of file here' -i /etc/init.d/mathkernel
+fi
 
 sudo apt-get -y -qq install git-core python-pip python-netifaces python-simplejson python-imaging python-dev uzbl sqlite3 supervisor omxplayer x11-xserver-utils libx11-dev watchdog chkconfig feh > /dev/null
 


### PR DESCRIPTION
Hi,

this commit fixes an error produced when installing. Specifically, against the raspbian-2014-01-07 image, the execution of 

```
apt-get install .. watchdog
```

produces the following error :

```
insserv: warning: script 'mathkernel' missing LSB tags and overrides
insserv: There is a loop between service watchdog and mathkernel if stopped
insserv:  loop involving service mathkernel at depth 2
insserv:  loop involving service watchdog at depth 1
insserv: Stopping mathkernel depends on watchdog and therefore on system facility `$all' which can not be true!
insserv: exiting now without changing boot order!
update-rc.d: error: insserv rejected the script header
dpkg: error processing watchdog (--configure):
 subprocess installed post-installation script returned error exit status 1
Processing triggers for python-support ...
Processing triggers for menu ...
Errors were encountered while processing:
 watchdog
```
