### PR TITLE
Fixed inverting grep typo that caused tile to not be updated in workaround.

### DIFF
--- a/misc/install.sh
+++ b/misc/install.sh
@@ -26,7 +26,7 @@ echo "Installing dependencies..."
 #
 # Check, and if we dont find the LSB signature, insert the stuff after the first line which we expect to be #!/bin/sh
 if grep -v -q "BEGIN INIT INFO" /etc/init.d/mathkernel ; then
-  sudo cp /etc/init.d/mathkernel /etc/init.d/mathkernel.modified_by_screenly
+  sudo cp /etc/init.d/mathkernel /etc/init.d-mathkernel.modified_by_screenly
   sudo sed -e '2i### BEGIN INIT INFO\
 # Provides:          mathkernel\
 # Required-Start:    $syslog\


### PR DESCRIPTION
I found this when re-testing my kiosk, I somehow managed to muck up my prior merge.

grep needs `-v` so that the patch is applied if the necessary words are missing.  Somehow that fell out of what I pushed to github previously.
