### PR TITLE
GH-229 - Partially fix asset order issue on client-side

### DIFF
--- a/static/coffee/specs/screenly-spec.coffee
+++ b/static/coffee/specs/screenly-spec.coffee
@@ -1,6 +1,6 @@
 
 describe "Screenly Open Source", ->
-  
+
   it "should have a Screenly object at its root", ->
     expect(Screenly).toBeDefined()
 
@@ -9,14 +9,14 @@ describe "Screenly Open Source", ->
 
     test_date = new Date(2014, 5, 6, 14, 20, 0, 0);
     a_date = Screenly.date_to(test_date);
-    
-    it "should format date and time as 'MM/DD/YYYY hh:mm:ss A'", ->  
+
+    it "should format date and time as 'MM/DD/YYYY hh:mm:ss A'", ->
       expect(a_date.string()).toBe '06/06/2014 02:20:00 PM'
-    
-    it "should format date as 'MM/a_date/YYYY'", ->      
+
+    it "should format date as 'MM/a_date/YYYY'", ->
       expect(a_date.date()).toBe '06/06/2014'
-    
-    it "should format date as 'hh:mm:ss A'", ->            
+
+    it "should format date as 'hh:mm:ss A'", ->
       expect(a_date.time()).toBe '02:20 PM'
 
 
@@ -28,7 +28,7 @@ describe "Screenly Open Source", ->
 
       start_date = new Date(2014, 4, 6, 14, 20, 0, 0);
       end_date = new Date();
-      end_date.setMonth(end_date.getMonth() + 2) 
+      end_date.setMonth(end_date.getMonth() + 2)
       asset = new Screenly.Asset({
         asset_id: 2
         duration: "8"
@@ -63,14 +63,14 @@ describe "Screenly Open Source", ->
           name: "Test 2"
           start_date: new Date(2011, 4, 6, 14, 20, 0, 0)
           end_date: new Date(2011, 4, 6, 14, 20, 0, 0)
-          uri: "http://www.wireload.net"               
+          uri: "http://www.wireload.net"
         })
 
         asset.rollback()
 
-        expect(asset.get 'is_enabled').toBe true        
-        expect(asset.get 'name').toBe 'Test'        
-        expect(asset.get 'start_date').toBe start_date        
+        expect(asset.get 'is_enabled').toBe true
+        expect(asset.get 'name').toBe 'Test'
+        expect(asset.get 'start_date').toBe start_date
         expect(asset.get 'uri').toBe "http://www.screenlyapp.com"
 
       it "should erase backup date after rollback", ->
@@ -79,15 +79,15 @@ describe "Screenly Open Source", ->
           name: "Test 2"
           start_date: new Date(2011, 4, 6, 14, 20, 0, 0)
           end_date: new Date(2011, 4, 6, 14, 20, 0, 0)
-          uri: "http://www.wireload.net"               
+          uri: "http://www.wireload.net"
         })
 
         asset.rollback()
 
-        expect(asset.get 'is_enabled').toBe false        
-        expect(asset.get 'name').toBe 'Test 2'        
+        expect(asset.get 'is_enabled').toBe false
+        expect(asset.get 'name').toBe 'Test 2'
         expect(asset.get('start_date').toISOString()).toBe (new Date(2011, 4, 6, 14, 20, 0, 0)).toISOString()
-        expect(asset.get 'uri').toBe "http://www.wireload.net"        
+        expect(asset.get 'uri').toBe "http://www.wireload.net"
 
 
   describe "Collections", ->
@@ -100,6 +100,43 @@ describe "Screenly Open Source", ->
         assets = new Screenly.Assets()
         expect(assets.model).toBe Screenly.Asset
 
+      it "should keep play order of assets", ->
+        assets = new Screenly.Assets()
+        asset1 = new Screenly.Asset({
+          asset_id: 1
+          is_enabled: true
+          name: 'AAA'
+          uri: 'http://www.screenlyapp.com',
+          play_order: 2
+        })
+        asset2 = new Screenly.Asset({
+          asset_id: 2
+          is_enabled: true
+          name: 'BBB'
+          uri: 'http://www.screenlyapp.com',
+          play_order: 1
+        })
+        asset3 = new Screenly.Asset({
+          asset_id: 3
+          is_enabled: true
+          name: 'CCC'
+          uri: 'http://www.screenlyapp.com',
+          play_order: 0
+        })
+
+        assets.add [asset1, asset2, asset3]
+        expect(assets.at 0).toBe asset3
+        expect(assets.at 1).toBe asset2
+        expect(assets.at 2).toBe asset1
+
+        asset1.set 'play_order', 0
+        asset3.set 'play_order', 2
+
+        assets.sort()
+
+        expect(assets.at 0).toBe asset1
+        expect(assets.at 1).toBe asset2
+        expect(assets.at 2).toBe asset3
 
   describe "Views", ->
 

--- a/static/js/screenly-ose.coffee
+++ b/static/js/screenly-ose.coffee
@@ -46,6 +46,7 @@ API.Asset = class Asset extends Backbone.Model
     duration: default_duration
     is_enabled: 0
     nocache: 0
+    play_order: 0
   active: =>
     if @get('is_enabled') and @get('start_date') and @get('end_date')
       at = now()
@@ -53,7 +54,7 @@ API.Asset = class Asset extends Backbone.Model
       end_date = new Date(@get('end_date'));
       return start_date <= at <= end_date
     else
-      return false  
+      return false
 
   backup: =>
     @backup_attributes = @toJSON()
@@ -67,6 +68,7 @@ API.Asset = class Asset extends Backbone.Model
 API.Assets = class Assets extends Backbone.Collection
   url: "/api/assets"
   model: Asset
+  comparator: 'play_order'
 
 
 # Views
@@ -185,7 +187,7 @@ API.View.EditAssetView = class EditAssetView extends Backbone.View
     if (@$fv 'mimetype') != "video"
       (@$ '.zerohint').hide()
       @$fv 'duration', default_duration
-    else 
+    else
       (@$ '.zerohint').show()
       @$fv 'duration', 0
 
@@ -345,6 +347,9 @@ API.View.AssetsView = class AssetsView extends Backbone.View
       update: @update_order
 
   update_order: =>
+    @collection.get(id).set('play_order', i) for id, i in (@$ '#active-assets').sortable 'toArray'
+    @collection.sort()
+
     $.post '/api/assets/order', ids: ((@$ '#active-assets').sortable 'toArray').join ','
 
   render: =>

--- a/static/js/screenly-ose.js
+++ b/static/js/screenly-ose.js
@@ -103,7 +103,8 @@
         end_date: (moment().add('days', 7)).toDate(),
         duration: default_duration,
         is_enabled: 0,
-        nocache: 0
+        nocache: 0,
+        play_order: 0
       };
     };
 
@@ -144,6 +145,8 @@
     Assets.prototype.url = "/api/assets";
 
     Assets.prototype.model = Asset;
+
+    Assets.prototype.comparator = 'play_order';
 
     return Assets;
 
@@ -666,6 +669,13 @@
     };
 
     AssetsView.prototype.update_order = function() {
+      var i, id, _i, _len, _ref;
+      _ref = (this.$('#active-assets')).sortable('toArray');
+      for (i = _i = 0, _len = _ref.length; _i < _len; i = ++_i) {
+        id = _ref[i];
+        this.collection.get(id).set('play_order', i);
+      }
+      this.collection.sort();
       return $.post('/api/assets/order', {
         ids: ((this.$('#active-assets')).sortable('toArray')).join(',')
       });

--- a/static/spec/screenly-spec.js
+++ b/static/spec/screenly-spec.js
@@ -87,10 +87,45 @@
         it("should exist", function() {
           return expect(Screenly.Assets).toBeDefined();
         });
-        return it("should use the Asset model", function() {
+        it("should use the Asset model", function() {
           var assets;
           assets = new Screenly.Assets();
           return expect(assets.model).toBe(Screenly.Asset);
+        });
+        return it("should use keep play order of assets", function() {
+          var asset1, asset2, asset3, assets;
+          assets = new Screenly.Assets();
+          asset1 = new Screenly.Asset({
+            asset_id: 1,
+            is_enabled: true,
+            name: 'AAA',
+            uri: 'http://www.screenlyapp.com',
+            play_order: 2
+          });
+          asset2 = new Screenly.Asset({
+            asset_id: 2,
+            is_enabled: true,
+            name: 'BBB',
+            uri: 'http://www.screenlyapp.com',
+            play_order: 1
+          });
+          asset3 = new Screenly.Asset({
+            asset_id: 3,
+            is_enabled: true,
+            name: 'CCC',
+            uri: 'http://www.screenlyapp.com',
+            play_order: 0
+          });
+          assets.add([asset1, asset2, asset3]);
+          expect(assets.at(0)).toBe(asset3);
+          expect(assets.at(1)).toBe(asset2);
+          expect(assets.at(2)).toBe(asset1);
+          asset1.set('play_order', 0);
+          asset3.set('play_order', 2);
+          assets.sort();
+          expect(assets.at(0)).toBe(asset1);
+          expect(assets.at(1)).toBe(asset2);
+          return expect(assets.at(2)).toBe(asset3);
         });
       });
     });


### PR DESCRIPTION
This resolves part of the issue with GH-229. The behavior should now be the same as the current server-side behavior. I also added a basic unit test to test this behavior on the Assets collection.

**Current Server-side behavior**

When active assets are re-ordered, the new order of active assets is saved using the API endpoint `/api/assets/order`

**New Client-side behavior**

When active assets are re-ordered, the new order of active assets is updated on the server side by sorting the collection of assets using the `play_order` attribute, which I added to the Asset model.

---

Note that the some behavior is still left unchanged.

If an asset is set from `enabled` to `disabled`, it's old `play_order` is retained. It's unclear what the actual behavior should be.

This also occurs when the asset becomes `inactive`. In this case, the `play_order` is still retained and not reset.

For example:
1. You have the following assets order like `A, B, C, D`
2. Disable `C`
3. Enable `C`
4. Result is `A, B, C, D`
