### PR TITLE
Fix shutdown and reboot via the Web UI.

### DIFF
--- a/ansible/roles/screenly/files/screenly-host-agent.service
+++ b/ansible/roles/screenly/files/screenly-host-agent.service
@@ -5,10 +5,10 @@ StartLimitIntervalSec=10
 StartLimitBurst=3
 
 [Service]
-WorkingDirectory=/home/${USER}/screenly
-User=${USER}
+WorkingDirectory=/home/{{ lookup('env', 'USER') }}/screenly
+User={{ lookup('env', 'USER') }}
 
-ExecStart=/usr/bin/python3 /home/${USER}/screenly/host_agent.py
+ExecStart=/usr/bin/python3 /home/{{ lookup('env', 'USER') }}/screenly/host_agent.py
 Restart=on-failure
 RestartSec=10s
 

--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -90,7 +90,7 @@
     line: 'MountFlags=shared'
 
 - name: Copy screenly systemd units
-  ansible.builtin.copy:
+  ansible.builtin.template:
     src: "{{ item }}"
     dest: "/etc/systemd/system/{{ item }}"
     mode: 0644


### PR DESCRIPTION
#### Overview

- Might fix #1649 

#### Tasks

- [ ] Modify `screenly-host-agent.service` so that the `USER` environment variable can be substituted when running the `ansible-playbook` command (i.e., during installation).
  - [x] Apply changes.
  - [ ] I still need to test the changes on a Raspberry Pi.
- [ ] Investigate why `host_agent.py` cannot retrieve the `shutdown` message published when **_Shutdown Screenly_** was clicked.
  - However, I tried running `PUBLISH hostcmd shutdown` via `redis-cli` (`redis` service ), and the shutdown was successful.