### PR TITLE
Update nginx.conf

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -77,7 +77,7 @@ server {
     }
     
     location /static_with_mime {                                    
-        allow 10.0.0.0/16;                                          
+        allow 10.0.0.0/8;                                          
         allow 172.16.0.0/12;                                        
         allow 192.168.0.0/16;                                       
         deny all;                                                   


### PR DESCRIPTION
Subnet for class A network 10.0.0.0 should be /8 (255.0.0.0) and not (255.255.0.0) /16 in order to support all internal private IP addresses for that class.

This was brought to my attention after a user on the forums reported [403 forbidden error](https://forums.screenly.io/t/403-forbidden-nginx-error-when-generating-backup/942/16).

![image](https://user-images.githubusercontent.com/24350198/211679227-7751952a-5a4a-4779-b220-25236e74fd05.png)
