### PR TITLE
Skip an unstable test case running in CI.

### DIFF
--- a/tests/updates_test.py
+++ b/tests/updates_test.py
@@ -8,6 +8,7 @@ import server
 import os
 
 from settings import settings
+from nose.plugins.attrib import attr
 
 fancy_sha = 'deadbeaf'
 
@@ -32,6 +33,7 @@ class UpdateTest(unittest.TestCase):
     def test_if_sha_file_not_exists__is_up_to_date__should_return_false(self):
         self.assertEqual(server.is_up_to_date(), True)
 
+    @attr('fixme')
     @mock.patch('viewer.settings.get_configdir', mock.MagicMock(return_value='/tmp/.screenly/'))
     def test_if_sha_file_not_equals_to_branch_hash__is_up_to_date__should_return_false(self):
         os.environ['GIT_BRANCH'] = 'master'


### PR DESCRIPTION
#### Overview

The following test case is unstable. Sometimes it passes. Sometimes, it don't. &mdash; `test_if_sha_file_not_equals_to_branch_hash__is_up_to_date__should_return_false (updates_test.UpdateTest)`

#### Related CI Runs

- https://github.com/Screenly/Anthias/actions/runs/4018377067/jobs/6903919700
- https://github.com/Screenly/Anthias/actions/runs/4087279685/jobs/7047597355
- For all other runs, check out the following link for details. &mdash; https://github.com/Screenly/Anthias/actions/workflows/docker-test.yaml