### PR TITLE
Don't build test container for non-x86 builds.

### DIFF
--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -55,23 +55,28 @@ fi
 
 for container in server celery redis websocket nginx viewer wifi-connect 'test'; do
     echo "Building $container"
-    
+
     # For all but redis and nginx, and viewer append the base layer
     if [ ! "$container" == 'redis' ] || [ ! "$container" == 'nginx' ] || [ ! "$container" == 'viewer' ]; then
         cat "docker/Dockerfile.base.tmpl" | envsubst > "docker/Dockerfile.$container"
-        cat "docker/Dockerfile.$container.tmpl" | envsubst >> "docker/Dockerfile.$container" 
+        cat "docker/Dockerfile.$container.tmpl" | envsubst >> "docker/Dockerfile.$container"
     else
-        cat "docker/Dockerfile.$container.tmpl" | envsubst > "docker/Dockerfile.$container" 
+        cat "docker/Dockerfile.$container.tmpl" | envsubst > "docker/Dockerfile.$container"
     fi
 
     # If we're running on x86, remove all Pi specific packages
     if [ "$BOARD" == 'x86' ]; then
         sed -i '/libraspberrypi0/d' $(find docker/ -maxdepth 1 -not -name "*.tmpl" -type f)
         sed -i '/omxplayer/d' $(find docker/ -maxdepth 1 -not -name "*.tmpl" -type f)
-        
+
         # Don't build the viewer container if we're on x86
         if [ "$container" == 'viewer' ]; then
             echo "Skipping viewer container for x86 builds..."
+            continue
+        fi
+    else
+        if [ "$container" == 'test' ]; then
+            echo "Skipping test container for Pi builds..."
             continue
         fi
     fi


### PR DESCRIPTION
#### Overview

Here's a snippet of the issue:

```
Dockerfile.test:76
--------------------
  75 |     
  76 | >>> RUN --mount=type=cache,target=/var/cache/apt \
  77 | >>>     wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_107.0.5304.121-1_amd64.deb -O /tmp/chrome.deb && \
  78 | >>>     apt-get install -y /tmp/chrome.deb
  79 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_107.0.5304.121-1_amd64.deb -O /tmp/chrome.deb &&     apt-get install -y /tmp/chrome.deb" did not complete successfully: exit code: 100
Error: Process completed with exit code 1.
```

This might fix recent build-related issues. See links below for relevant CI runs:

- https://github.com/Screenly/Anthias/actions/runs/4196556376/jobs/7277884311
- https://github.com/Screenly/Anthias/actions/runs/4196556376/jobs/7277884655