### PR TITLE
Update server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -1606,7 +1606,7 @@ else:
     swagger_address = getenv("SWAGGER_HOST", my_ip)
 
     if settings['use_ssl'] or is_demo_node:
-        API_URL = 'https://{}/api/swagger.json'.format(swagger_address)
+        API_URL = 'http://{}/api/swagger.json'.format(swagger_address)
     elif LISTEN == '127.0.0.1' or swagger_address != my_ip:
         API_URL = "http://{}/api/swagger.json".format(swagger_address)
     else:


### PR DESCRIPTION
Until enabling SSL is functional, the API should default to `HTTP` so users dont see the error when clicking API.

For reference: https://github.com/Screenly/Anthias/issues/1410