### PR TITLE
Add support for generating only Dockerfiles when running `bin/build_containers.sh`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ docker-compose \
 ## Building Containers Locally
 
 Make sure that you have `buildx` installed and that you have run
-`docker buildx create --use` befure you run the following:
+`docker buildx create --use` before you do the following:
 
 ```bash
 ./bin/build_containers.sh

--- a/README.md
+++ b/README.md
@@ -63,6 +63,33 @@ $ docker-compose \
     -f docker-compose.dev.yml up
 ```
 
+## Building Containers Locally
+
+Make sure that you have `buildx` installed and that you have run
+`docker buildx create --use` befure you run the following:
+
+```bash
+./bin/build_containers.sh
+```
+
+### Skipping Specific Services
+
+Say that you would like to skip building the `anthias-viewer` and `anthias-nginx`
+services. Just run the following:
+
+```bash
+SKIP_VIEWER=1 SKIP_NGINX=1 ./bin/build_containers.sh
+```
+
+### Generating Only Dockerfiles
+
+If you'd like to just generate the Dockerfiles from the templates provided
+inside the `docker/` directory, run the following:
+
+```bash
+DOCKERFILES_ONLY=1 ./bin_build_containers.sh
+```
+
 ## Running the Unit Tests
 
 Start the containers.

--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -101,6 +101,11 @@ for container in ${SERVICES[@]}; do
         cat "docker/Dockerfile.$container.tmpl" | envsubst > "docker/Dockerfile.$container"
     fi
 
+    if [[ -n "${DOCKERFILES_ONLY:-}" ]] && [[ "${DOCKERFILES_ONLY}" -ne 0 ]]; then
+        echo "Variable DOCKERFILES_ONLY is set. Skipping build for $container..."
+        continue
+    fi
+
     # If we're running on x86, remove all Pi specific packages
     if [ "$BOARD" == 'x86' ]; then
         if [[ $OSTYPE == 'darwin'* ]]; then


### PR DESCRIPTION
#### Overview

Here's the sample usage of the script:

```bash
DOCKERFILES_ONLY=1 ./bin/build_containers.sh
```

The variable `DOCKERFILES_ONLY` should be set to a non-zero number. Otherwise, the script will still build the containers.