### PR TITLE
Fix issues with the image build CI action.

### DIFF
--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -46,7 +46,7 @@ elif grep -qF "Raspberry Pi 3" /proc/device-tree/model || [ "${BUILD_TARGET}" ==
 elif grep -qF "Raspberry Pi 2" /proc/device-tree/model || [ "${BUILD_TARGET}" == 'pi2' ]; then
     export BOARD="pi2"
     export BASE_IMAGE=balenalib/raspberry-pi2
-    export TARGET_PLATFORM=linux/arm/v7
+    export TARGET_PLATFORM=linux/arm/v6
 elif grep -qF "Raspberry Pi 1" /proc/device-tree/model || [ "${BUILD_TARGET}" == 'pi1' ]; then
     export BOARD="pi1"
     export BASE_IMAGE=balenalib/raspberry-pi

--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -46,7 +46,7 @@ elif grep -qF "Raspberry Pi 3" /proc/device-tree/model || [ "${BUILD_TARGET}" ==
 elif grep -qF "Raspberry Pi 2" /proc/device-tree/model || [ "${BUILD_TARGET}" == 'pi2' ]; then
     export BOARD="pi2"
     export BASE_IMAGE=balenalib/raspberry-pi2
-    export TARGET_PLATFORM=linux/arm/v6
+    export TARGET_PLATFORM=linux/arm/v7
 elif grep -qF "Raspberry Pi 1" /proc/device-tree/model || [ "${BUILD_TARGET}" == 'pi1' ]; then
     export BOARD="pi1"
     export BASE_IMAGE=balenalib/raspberry-pi

--- a/bin/start_wifi_connect.sh
+++ b/bin/start_wifi_connect.sh
@@ -2,7 +2,12 @@
 
 IS_CONNECTED=''
 
-if [[ $DEVICE_TYPE =~ ^(pi1|pi2)$ ]]; then
+if [[ $DEVICE_TYPE = "pi1" ]]; then
+    echo "The latest version of WiFi Connect does not support Raspberry Pi 1. Exiting..."
+    exit 0
+fi
+
+if [[ $DEVICE_TYPE == "pi2" ]]; then
     if [[ -z $(iw dev | grep Interface) ]]; then
         echo "No Wi-Fi adapters were detected. Exiting..."
         exit 0

--- a/bin/start_wifi_connect.sh
+++ b/bin/start_wifi_connect.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# -*- sh-basic-offset: 4 -*-
+
+set -euox pipefail
+
 IS_CONNECTED=''
 
-if [[ $DEVICE_TYPE = "pi1" ]]; then
-    echo "The latest version of WiFi Connect does not support Raspberry Pi 1. Exiting..."
+if [[ -z $(nmcli device wifi list) ]]; then
+    echo "No Wi-Fi adapters were detected. Exiting..."
     exit 0
-fi
-
-if [[ $DEVICE_TYPE == "pi2" ]]; then
-    if [[ -z $(iw dev | grep Interface) ]]; then
-        echo "No Wi-Fi adapters were detected. Exiting..."
-        exit 0
-    fi
 fi
 
 if [[ ! -z $CHECK_CONN_FREQ ]]

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -26,7 +26,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.server
-    volumes:
     environment:
       - MY_IP=${MY_IP}
       - HOME=/data

--- a/docker/Dockerfile.wifi-connect.tmpl
+++ b/docker/Dockerfile.wifi-connect.tmpl
@@ -11,6 +11,9 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 WORKDIR /usr/src/app
 
+# @TODO: WiFi Connect 4.11.1 doesn't have a release for Raspberry Pi
+#        devices that has ARMv6 support. We should remove this once a
+#        new compatible release is available.
 RUN if [[ ! -z "$ARCHIVE_URL" ]]; then \
     curl -sL -o /tmp/wifi_connect.zip "$ARCHIVE_URL" && \
     unzip -o /tmp/wifi_connect.zip -d /usr/src/app && \

--- a/docker/Dockerfile.wifi-connect.tmpl
+++ b/docker/Dockerfile.wifi-connect.tmpl
@@ -10,9 +10,10 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 WORKDIR /usr/src/app
 
-RUN curl -sL -o /tmp/wifi_connect.zip "$ARCHIVE_URL" && \
+RUN if [[ ! -z "$ARCHIVE_URL" ]]; then \
+    curl -sL -o /tmp/wifi_connect.zip "$ARCHIVE_URL" && \
     unzip -o /tmp/wifi_connect.zip -d /usr/src/app && \
-    rm /tmp/wifi_connect.zip
+    rm /tmp/wifi_connect.zip; fi
 
 COPY requirements/requirements.wifi-connect.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docker/Dockerfile.wifi-connect.tmpl
+++ b/docker/Dockerfile.wifi-connect.tmpl
@@ -4,6 +4,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get -y install --no-install-recommends \
         dnsmasq \
         iw \
+        network-manager \
         unzip \
         wget \
         wireless-tools


### PR DESCRIPTION
#### Overview

- Follow-up fixes to #1778

#### Testing

##### Installation

```bash
cd && \
echo "export CUSTOM_BRANCH='hf-wifi'" > .env && \
bash <(curl -sL https://raw.githubusercontent.com/nicomiguelino/Anthias/custom-install/bin/install.sh)
```

#### Logs

##### Errors

```
#16 [stage-0  7/12] RUN curl -sL -o /tmp/wifi_connect.zip "" &&     unzip -o /tmp/wifi_connect.zip -d /usr/src/app &&     rm /tmp/wifi_connect.zip
#16 ERROR: process "/bin/sh -c curl -sL -o /tmp/wifi_connect.zip \"\" &&     unzip -o /tmp/wifi_connect.zip -d /usr/src/app &&     rm /tmp/wifi_connect.zip" did not complete successfully: exit code: 3
------
 > [stage-0  7/12] RUN curl -sL -o /tmp/wifi_connect.zip "" &&     unzip -o /tmp/wifi_connect.zip -d /usr/src/app &&     rm /tmp/wifi_connect.zip:
------
Dockerfile.wifi-connect:60
--------------------
  59 |     
  60 | >>> RUN curl -sL -o /tmp/wifi_connect.zip "" && \
  61 | >>>     unzip -o /tmp/wifi_connect.zip -d /usr/src/app && \
  62 | >>>     rm /tmp/wifi_connect.zip
  63 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c curl -sL -o /tmp/wifi_connect.zip \"\" &&     unzip -o /tmp/wifi_connect.zip -d /usr/src/app &&     rm /tmp/wifi_connect.zip" did not complete successfully: exit code: 3
Error: Process completed with exit code 1.
```

##### When changes were applied

When running `docker compose logs -f anthias-wifi-connect` on a Raspberry Pi 2 running 32-bit RPi OS Lite (Bullseye)...

```
screenly-anthias-wifi-connect-1  | No Wi-Fi adapters were detected. Exiting...
```

#### Failed jobs (for reference)

- https://github.com/Screenly/Anthias/actions/runs/4539699386/jobs/8016045429
- https://github.com/Screenly/Anthias/actions/runs/4539699386/jobs/8015497704

#### Relevant Forums

- https://forums.balena.io/t/no-archive-file-for-rpi-devices-for-wifi-connect-4-11-1/367302