### PR TITLE
Initialize `VERBOSE` to `true` by default to resolve `unbound variable` issue.

### DIFF
--- a/bin/start_wifi_connect.sh
+++ b/bin/start_wifi_connect.sh
@@ -3,9 +3,10 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 # -*- sh-basic-offset: 4 -*-
 
-set -euox pipefail
+set -euo pipefail
 
 IS_CONNECTED=''
+VERBOSE='true'
 
 if [[ -z $(nmcli device wifi list) ]]; then
     echo "No Wi-Fi adapters were detected. Exiting..."

--- a/bin/start_wifi_connect.sh
+++ b/bin/start_wifi_connect.sh
@@ -6,7 +6,6 @@
 set -euo pipefail
 
 IS_CONNECTED=''
-VERBOSE=${VERBOSE:-true}
 
 if [[ -z $(nmcli device wifi list) ]]; then
     echo "No Wi-Fi adapters were detected. Exiting..."
@@ -24,14 +23,12 @@ fi
 sleep 5
 
 while [[ true ]]; do
-    if [[ "$VERBOSE" != 'false' ]]; then echo "Checking internet connectivity ..."; fi
+    echo "Checking internet connectivity ..."
     wget --spider --no-check-certificate 1.1.1.1 > /dev/null 2>&1
 
     if [ $? -eq 0 ]; then
-        if [[ "$VERBOSE" != 'false' ]]; then
-            echo "Your device is already connected to the internet."
-            echo "Skipping setting up Wifi-Connect Access Point."
-        fi
+        echo "Your device is already connected to the internet."
+        echo "Skipping setting up Wifi-Connect Access Point."
 
         if [[ "$IS_CONNECTED" = 'false' ]]; then
             python3 send_zmq_message.py --action='show_splash'
@@ -39,11 +36,9 @@ while [[ true ]]; do
 
         exit 0
     else
-        if [[ "$VERBOSE" != 'false' ]]; then
-            echo "Your device is not connected to the internet."
-            echo "Starting up Wifi-Connect."
-            echo "Connect to the Access Point and configure the SSID and Passphrase for the network to connect to."
-        fi
+        echo "Your device is not connected to the internet."
+        echo "Starting up Wifi-Connect."
+        echo "Connect to the Access Point and configure the SSID and Passphrase for the network to connect to."
 
         if [[ "$IS_CONNECTED" = '' ]]; then
             python3 send_zmq_message.py --action='setup_wifi'

--- a/bin/start_wifi_connect.sh
+++ b/bin/start_wifi_connect.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 IS_CONNECTED=''
-VERBOSE='true'
+VERBOSE=${VERBOSE:-true}
 
 if [[ -z $(nmcli device wifi list) ]]; then
     echo "No Wi-Fi adapters were detected. Exiting..."


### PR DESCRIPTION
#### Overview

![image](https://user-images.githubusercontent.com/10234135/229573127-d981ce8c-68b8-4eb2-a3cb-c288481ae3a5.png)
