### PR TITLE
Edit docs for running unit tests locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,14 @@ $ DOCKERFILES_ONLY=1 ./bin_build_containers.sh
 
 ## Running the Unit Tests
 
-Start the containers.
+Build and start the containers.
 
 ```bash
+$ export SKIP_SERVER=1 && \
+  export SKIP_WEBSOCKET=1 && \
+  export SKIP_NGINX=1 && \
+  export SKIP_VIEWER=1 && \
+  export SKIP_WIFI_CONNECT=1
 $ ./bin/build_containers.sh
 $ docker compose \
     -f docker-compose.test.yml up -d

--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ $ DOCKERFILES_ONLY=1 ./bin_build_containers.sh
 Build and start the containers.
 
 ```bash
-$ export SKIP_SERVER=1 && \
-  export SKIP_WEBSOCKET=1 && \
-  export SKIP_NGINX=1 && \
-  export SKIP_VIEWER=1 && \
-  export SKIP_WIFI_CONNECT=1
-$ ./bin/build_containers.sh
+$ SKIP_SERVER=1 \
+  SKIP_WEBSOCKET=1 \
+  SKIP_NGINX=1 \
+  SKIP_VIEWER=1 \
+  SKIP_WIFI_CONNECT=1 \
+  ./bin/build_containers.sh
 $ docker compose \
     -f docker-compose.test.yml up -d
 ```
@@ -108,7 +108,6 @@ $ docker compose \
 Run the unit tests.
 
 ```bash
-$ ./bin/build_containers.sh
 $ docker compose \
     -f docker-compose.test.yml \
     exec -T anthias-test bash ./bin/prepare_test_environment.sh -s


### PR DESCRIPTION
#### Overview

Inside `README.md`, edit the commands used to run unit tests locally. Environment variables starting with `SKIP_` must be set to skip images that are not needed during image builds.