### PR TITLE
Fix permission errors when starting the containers via `install.sh`.

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -45,7 +45,7 @@ if [ "$WEB_UPGRADE" = false ]; then
   tput bold
 
   cat << EOF
-  
+
        d8888            888     888
       d88888            888     888       888
      d88P888            888     888
@@ -192,7 +192,7 @@ cd /home/${USER}/screenly/ansible
 sudo -E -u ${USER} ansible-playbook site.yml "${EXTRA_ARGS[@]}"
 
 # Pull down and install containers
-/home/${USER}/screenly/bin/upgrade_containers.sh
+sudo -u ${USER} /home/${USER}/screenly/bin/upgrade_containers.sh
 
 sudo apt-get autoclean
 sudo apt-get clean


### PR DESCRIPTION
#### Overview

- Resolves the `permission denied while trying to connect to Docker daemon socket [...]` issue

#### Screenshots (Issue)

![image](https://user-images.githubusercontent.com/10234135/234778181-f0e041af-95cf-48e6-bedc-848ec2bcdf74.png)