### PR TITLE
Fixes video playback issue in Raspberry Pi 4.

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -70,7 +70,9 @@ browser_bus = None
 r = connect_to_redis()
 
 try:
-    media_player = VLCMediaPlayer() if 'Raspberry Pi 4' in get_raspberry_model() else OMXMediaPlayer()
+    media_player = OMXMediaPlayer()
+    # @TODO: Remove the line below once VLC playback issue is fixed.
+    # media_player = VLCMediaPlayer() if 'Raspberry Pi 4' in get_raspberry_model() else OMXMediaPlayer()
 except sh.ErrorReturnCode_1:
     media_player = OMXMediaPlayer()
 

--- a/viewer.py
+++ b/viewer.py
@@ -71,7 +71,7 @@ r = connect_to_redis()
 
 try:
     media_player = OMXMediaPlayer()
-    # @TODO: Remove the line below once VLC playback issue is fixed.
+    # @TODO: Remove the line above and uncomment the line below once VLC playback issue is fixed.
     # media_player = VLCMediaPlayer() if 'Raspberry Pi 4' in get_raspberry_model() else OMXMediaPlayer()
 except sh.ErrorReturnCode_1:
     media_player = OMXMediaPlayer()


### PR DESCRIPTION
#### General

- (Temporarily) fixes Screenly/Anthias#1679.

#### Installation

```bash
cd && \
echo "export CUSTOM_BRANCH='hotfix-video-playback'" > .env && \
bash <(curl -sL https://raw.githubusercontent.com/nicomiguelino/Anthias/custom-install-1/bin/install.sh)
```

Reboot the system, SSH into the device again, then run the following:

```bash
cd ~/screenly && \
sed -i 's/pull/build/g' bin/upgrade_containers.sh && \
sudo apt-get install -y --no-install-recommends jq && \
docker compose down && \
DOCKERFILES_ONLY=1 DEV_MODE=1 ./bin/build_containers.sh && \
./bin/upgrade_containers.sh
```