### PR TITLE
Fix the CI pipeline that builds Balena images.

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -45,7 +45,7 @@ jobs:
               --fleet screenly_ose/anthias-${{ matrix.board }} \
               --splash-image ansible/roles/splashscreen/files/splashscreen.png \
               --commit latest
-          balena_cli_version: 13.7.1
+          balena_cli_version: 18.1.2
 
       - name: balena CLI Action - configure
         uses: balena-labs-research/community-cli-action@1.0.0


### PR DESCRIPTION
#### Description

- These changes are needed so that the Anthias images can be re-included in the Raspberry Pi Imager as options