### PR TITLE
Fixes viewer to support RTSP playback

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -250,11 +250,8 @@ def url_fails(url):
     If it is streaming
     """
     if urlparse(url).scheme in ('rtsp', 'rtmp'):
-        run_mplayer = mplayer('-identify', '-frames', '0', '-nosound', url)
-        for line in run_mplayer.split('\n'):
-            if 'Clip info:' in line:
-                return False
-        return True
+        # @TODO: Do further validation on the asset before returning.
+        return False
 
     """
     Try HEAD and GET for URL availability check.

--- a/viewer.py
+++ b/viewer.py
@@ -372,10 +372,15 @@ def view_video(uri, duration):
 
     view_image('null')
 
+    timeout = 0
+
     try:
         while media_player.is_playing():
             watchdog()
             sleep(1)
+            timeout += 1
+            if timeout > int(duration):
+                break
     except sh.ErrorReturnCode_1:
         logging.info('Resource URI is not correct, remote host is not responding or request was rejected.')
 


### PR DESCRIPTION
#### Related issues

* Screenly/Anthias#1638

#### Limitations and issues

* When an RTSP asset is added and `Skip asset check` is unchecked, it will be added successfully, but the playback stops after 5 minutes (the default duration for RTSP video assets).
* It will take a while for the device to display the stream again (~10s).