### PR TITLE
Allows support for 4k display  by increasing shared memory in viewer

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -75,6 +75,7 @@ jobs:
         run: |
           echo "GIT_SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "BOARD=${{ matrix.board }}" >> $GITHUB_ENV
+          echo "SHM_SIZE=256mb" >> $GITHUB_ENV
 
       - name: Prepare Balena file
         run: |

--- a/bin/deploy_to_balena.sh
+++ b/bin/deploy_to_balena.sh
@@ -10,6 +10,7 @@ print_help() {
     echo "  -f, --fleet FLEET     specify the fleet name to deploy to"
     echo "  -s, --short-hash HASH specify the short hash to use for the image tag"
     echo "  -d, --dev             run in dev mode"
+    echo "  --shm-size SIZE       specify the size of the /dev/shm partition, e.g. 256mb, 65536kb, 1gb"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -47,6 +48,11 @@ while [[ $# -gt 0 ]]; do
             export DEV_MODE=1
             shift
             ;;
+        --shm-size)
+            export SHM_SIZE="$2"
+            shift
+            shift
+            ;;
         *)
             echo "Unknown option $key"
             print_help
@@ -68,6 +74,12 @@ if [[ -z "${FLEET+x}" ]]; then
 fi
 
 export GIT_SHORT_HASH=${GIT_SHORT_HASH:-latest}
+export DEFAULT_SHM_SIZE='256mb'
+
+if [[ -z "${SHM_SIZE+x}" ]]; then
+    echo "Using default /dev/shm size of $DEFAULT_SHM_SIZE for the viewer service"
+    export SHM_SIZE=$DEFAULT_SHM_SIZE
+fi
 
 function prepare_balena_file() {
     mkdir -p balena-deploy

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -7,6 +7,7 @@
 export MY_IP=$(ip -4 route get 8.8.8.8 | awk {'print $7'} | tr -d '\n')
 TOTAL_MEMORY_KB=$(grep MemTotal /proc/meminfo | awk {'print $2'})
 export VIEWER_MEMORY_LIMIT_KB=$(echo "$TOTAL_MEMORY_KB" \* 0.8 | bc)
+export SHM_SIZE_KB="$(echo "$TOTAL_MEMORY_KB" \* 0.3 | bc | cut -d'.' -f1)"
 
 # Hard code this to latest for now.
 export DOCKER_TAG="latest"

--- a/docker-compose.balena.dev.yml.tmpl
+++ b/docker-compose.balena.dev.yml.tmpl
@@ -54,6 +54,7 @@ services:
       - "host.docker.internal:host-gateway"
     privileged: true
     restart: always
+    shm_size: ${SHM_SIZE}
     volumes:
       - resin-data:/data
     labels:

--- a/docker-compose.balena.yml.tmpl
+++ b/docker-compose.balena.yml.tmpl
@@ -45,6 +45,7 @@ services:
       - "host.docker.internal:host-gateway"
     privileged: true
     restart: always
+    shm_size: ${SHM_SIZE}
     volumes:
       - resin-data:/data
     labels:

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -62,6 +62,7 @@ services:
       - "host.docker.internal:host-gateway"
     privileged: true
     restart: always
+    shm_size: ${SHM_SIZE_KB}kb
     volumes:
       - resin-data:/data
       - /home/${USER}/.screenly:/data/.screenly

--- a/docs/balena-fleet-deployment.md
+++ b/docs/balena-fleet-deployment.md
@@ -111,6 +111,16 @@ $ ./bin/deploy_to_balena.sh \
     --dev
 ```
 
+You can also includa a `--shm-size` flag to specify the shared memory size, which defaults
+to `256mb`. For example:
+
+```bash
+$ ./bin/deploy_to_balena.sh \
+    --board $BOARD_TYPE \
+    --fleet $FLEET_NAME \
+    --shm-size 512mb
+```
+
 It would take a while for the deployment to finish. Once it's done, you should
 see the new release in the fleet's summary page. You can now add your devices to
 the fleet and they should be able to download the new release.


### PR DESCRIPTION
#### Overview

* Fixes #1829

#### Installing and testing the changes

```bash
cd && \
echo "export CUSTOM_BRANCH='fix-1829'" > .env && \
bash <(curl -sL https://raw.githubusercontent.com/nicomiguelino/Anthias/custom-install-1/bin/install.sh)
```


#### Checklist

- [x] Fix web asset display in 4k for Raspberry Pi OS.
- [x] Test changes on Bookworm for Pi 3, and Pi 4 devices.
- [x] Fix web asset display in 4k displays for Balena OS.
- [x] Test changes on Bookworm for Pi 2, Pi 3, and Pi 4 devices.