### PR TITLE
Modifies the installer script to prevent freezing when network should be managed for Bullseye and older.

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -221,10 +221,6 @@ fi
 sudo ${SUDO_ARGS[@]} pip install cryptography==38.0.2
 sudo ${SUDO_ARGS[@]} pip install "$ANSIBLE_VERSION"
 
-# @TODO: Remove the two lines below once the PR's ready to be merged.
-export REPOSITORY='https://github.com/nicomiguelino/Anthias.git'
-export BRANCH=${CUSTOM_BRANCH}
-
 sudo -u ${USER} ${SUDO_ARGS[@]} ansible localhost \
     -m git \
     -a "repo=$REPOSITORY dest=/home/${USER}/screenly version=$BRANCH force=no"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -219,6 +219,10 @@ fi
 sudo ${SUDO_ARGS[@]} pip install cryptography==38.0.2
 sudo ${SUDO_ARGS[@]} pip install "$ANSIBLE_VERSION"
 
+# @TODO: Remove the two lines below once the PR's ready to be merged.
+export REPOSITORY='https://github.com/nicomiguelino/Anthias.git'
+export BRANCH=${CUSTOM_BRANCH}
+
 sudo -u ${USER} ${SUDO_ARGS[@]} ansible localhost \
     -m git \
     -a "repo=$REPOSITORY dest=/home/${USER}/screenly version=$BRANCH force=no"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -105,7 +105,7 @@ export BRANCH="master"
       tput setaf 9
 
       echo ""
-      echo "Anthias requires a wired Ethernet connection if you want to manage your network on this version of Raspbian."
+      echo "Anthias requires a wired Ethernet connection if you want to manage your network on this version of Raspberry Pi OS."
       echo "Please connect your Raspberry Pi to the Internet and make sure that Wi-Fi is disabled."
       echo "If you want to continue without network management, run the installer again and answer 'n' when prompted."
       echo ""

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -106,7 +106,7 @@ export BRANCH="master"
 
       echo ""
       echo "Anthias requires a wired Ethernet connection if you want to manage your network on this version of Raspbian."
-      echo "Please connect your Raspberry Pi to the Internet using an Ethernet connection and try again."
+      echo "Please connect your Raspberry Pi to the Internet and make sure that Wi-Fi is disabled."
       echo "If you want to continue without network management, run the installer again and answer 'n' when prompted."
       echo ""
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -14,14 +14,10 @@ fi
 
 RASPBIAN_VERSION=$(lsb_release -rs)
 WLAN_ON=false
-ETH_ON=true
 
-if [ -d /sys/class/net/wlan0/operstate ] && [ "$(cat /sys/class/net/wlan0/operstate)" = "up" ]; then
+# @TODO: Consider devices that uses Wi-Fi dongle.
+if [ -f /sys/class/net/wlan0/operstate ] && [ "$(cat /sys/class/net/wlan0/operstate)" = "up" ]; then
   WLAN_ON=true
-fi
-
-if [ -d /sys/class/net/eth0/operstate ] && [ "$(cat /sys/class/net/eth0/operstate)" = "up" ]; then
-  ETH_ON=true
 fi
 
 while getopts ":w:b:n:s:" arg; do
@@ -105,10 +101,16 @@ export BRANCH="master"
   echo && read -p "Do you want Anthias to manage your network? This is recommended for most users because this adds features to manage your network. (Y/n)" -n 1 -r -s NETWORK && echo
 
   if [ "$NETWORK" = 'y' ]; then
-    if [ "$RASPBIAN_VERSION" -lt 12 ] && [ "$WLAN_ON" = true ] && [ "$ETH_ON" = false ]; then
+    if [ "$RASPBIAN_VERSION" -lt 12 ] && [ "$WLAN_ON" = true ]; then
+      tput setaf 9
+
+      echo ""
       echo "Anthias requires a wired Ethernet connection if you want to manage your network on this version of Raspbian."
       echo "Please connect your Raspberry Pi to the Internet using an Ethernet connection and try again."
       echo "If you want to continue without network management, run the installer again and answer 'n' when prompted."
+      echo ""
+
+      tput sgr 0
       exit 1
     fi
   fi


### PR DESCRIPTION
#### Overview

* Fixes #1845
* As mentioned in this [Raspberry Pi article](https://www.raspberrypi.com/news/bookworm-the-new-version-of-raspberry-pi-os/) (in the Networking section), `NetworkManager` is now the default network controller on Bookworm, replacing `dhcpcd`.

#### Checklist

- [ ] Support Wi-Fi if it's configured using Network Manager.

#### Screenshot

The following error message will only show on Bullseye and older:

![image](https://github.com/Screenly/Anthias/assets/10234135/1f790813-8adf-4327-b096-61631a49675e)