### PR TITLE
Fixes erroneous data in the Integrations page

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -76,9 +76,11 @@ def validate_url(string):
     return bool(checker.scheme in ('http', 'https', 'rtsp', 'rtmp') and checker.netloc)
 
 
-def get_balena_supervisor_api_response(method, action):
-    return getattr(requests, method)('{}/v1/{}?apikey={}'.format(
+def get_balena_supervisor_api_response(method, action, **kwargs):
+    version = kwargs.get('version', 'v1')
+    return getattr(requests, method)('{}/{}/{}?apikey={}'.format(
         os.getenv('BALENA_SUPERVISOR_ADDRESS'),
+        version,
         action,
         os.getenv('BALENA_SUPERVISOR_API_KEY'),
     ), headers={'Content-Type': 'application/json'})
@@ -94,6 +96,14 @@ def shutdown_via_balena_supervisor():
 
 def reboot_via_balena_supervisor():
     return get_balena_supervisor_api_response(method='post', action='reboot')
+
+
+def get_balena_supervisor_version():
+    response = get_balena_supervisor_api_response(method='get', action='version', version='v2')
+    if response.ok:
+        return response.json()['version']
+    else:
+        return 'Error getting the Supervisor version'
 
 
 def get_node_ip():

--- a/server.py
+++ b/server.py
@@ -56,6 +56,7 @@ from lib.utils import (
     download_video_from_youtube, json_dump,
     generate_perfect_paper_password, is_docker,
     get_active_connections, remove_connection,
+    get_balena_supervisor_version,
     get_node_ip, get_node_mac_address,
     get_video_duration,
     is_balena_app, is_demo_node,
@@ -1807,7 +1808,7 @@ def integrations():
         context['balena_device_id'] = getenv('BALENA_DEVICE_UUID')
         context['balena_app_id'] = getenv('BALENA_APP_ID')
         context['balena_app_name'] = getenv('BALENA_APP_NAME')
-        context['balena_supervisor_version'] = getenv('BALENA_SUPERVISOR_VERSION')
+        context['balena_supervisor_version'] = get_balena_supervisor_version()
         context['balena_host_os_version'] = getenv('BALENA_HOST_OS_VERSION')
         context['balena_device_name_at_init'] = getenv('BALENA_DEVICE_NAME_AT_INIT')
 


### PR DESCRIPTION
#### Overview

* In the Integrations page (for devices running BalenaOS), **_Supervisor Version_** has a value of **_None_**.
* With the changes, the server code retrieves the version from the Supervisor API instead of the `BALENA_SUPERVISOR_VERSION`, which doesn't really exist as an environment variable inside the server container.

#### Screenshots

##### Before

![before](https://github.com/Screenly/Anthias/assets/10234135/3f203aed-1d6c-47b0-85c5-3be8584f4cc8)

##### After

![after](https://github.com/Screenly/Anthias/assets/10234135/40a6f40d-4aa4-424d-bcb1-070f2ff1e083)
