### PR TITLE
Fixes the `wait_for_server` function to handle non-success HTTP codes as well.

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -489,9 +489,10 @@ def wait_for_node_ip(seconds):
 def wait_for_server(retries, wt=1):
     for _ in range(retries):
         try:
-            requests.get('http://{0}:{1}'.format(LISTEN, PORT))
+            response = requests.get('http://{0}:{1}'.format(LISTEN, PORT))
+            response.raise_for_status()
             break
-        except requests.exceptions.ConnectionError:
+        except requests.exceptions.RequestException:
             sleep(wt)
 
 


### PR DESCRIPTION
#### Description

- This fixes the HTTP 502 issue that happens in the viewer when it tries to query the server, which might not be ready yet.
- The Bad Gateway issue is evident in BalenaOS devices. It can happen on cases during updates, where the server isn't fully ready yet.
- The current implementation might raise a connection error, but it doesn't raise exceptions if the HTTP status code of the response is non-successful.