### PR TITLE
Fixes container build script for development mode in x86

### DIFF
--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -106,15 +106,6 @@ for container in ${SERVICES[@]}; do
         cat "docker/Dockerfile.$container.tmpl" | envsubst > "docker/Dockerfile.$container"
     fi
 
-    if [[ -n "${DEV_MODE:-}" ]] && [[ "${DEV_MODE}" -ne 0 ]]; then
-        sed -i 's/RUN --mount.\+ /RUN /g' "docker/Dockerfile.$container"
-    fi
-
-    if [[ -n "${DOCKERFILES_ONLY:-}" ]] && [[ "${DOCKERFILES_ONLY}" -ne 0 ]]; then
-        echo "Variable DOCKERFILES_ONLY is set. Skipping build for $container..."
-        continue
-    fi
-
     # If we're running on x86, remove all Pi specific packages
     if [ "$BOARD" == 'x86' ]; then
         if [[ $OSTYPE == 'darwin'* ]]; then
@@ -136,6 +127,15 @@ for container in ${SERVICES[@]}; do
             echo "Skipping test container for Pi builds..."
             continue
         fi
+    fi
+
+    if [[ -n "${DEV_MODE:-}" ]] && [[ "${DEV_MODE}" -ne 0 ]]; then
+        sed -i 's/RUN --mount.\+ /RUN /g' "docker/Dockerfile.$container"
+    fi
+
+    if [[ -n "${DOCKERFILES_ONLY:-}" ]] && [[ "${DOCKERFILES_ONLY}" -ne 0 ]]; then
+        echo "Variable DOCKERFILES_ONLY is set. Skipping build for $container..."
+        continue
     fi
 
     docker "${DOCKER_BUILD_ARGS[@]}" \


### PR DESCRIPTION
#### Description

* The build script fails when installing non-existing packages like `omxplayer` for x86.
* Those packages are not removed from the base Dockerfile.
* This shouldn't affect the Docker image CI builds.