### PR TITLE
Modifies help text for duration settings

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -36,12 +36,12 @@
                         </div>
                         <div class="row">
                             <div class="form-group col-6">
-                                <label class="small text-secondary">Default duration</label>
+                                <label class="small text-secondary">Default duration (seconds)</label>
                                 <input class="form-control" name="default_duration" type="number"
                                        value="{{ context.default_duration }}"/>
                             </div>
                             <div class="form-group col-6">
-                                <label class="small text-secondary">Default streaming duration</label>
+                                <label class="small text-secondary">Default streaming duration (seconds)</label>
                                 <input class="form-control" name="default_streaming_duration" type="number"
                                        value="{{ context.default_streaming_duration }}"/>
                             </div>


### PR DESCRIPTION
#### Overview

* Change input label for default asset duration to "Default duration (seconds)"
* Change input label for default streaming duration to "Default streaming duration (seconds)"

#### Screenshot

![Screenshot from 2024-06-10 10-44-55](https://github.com/Screenly/Anthias/assets/10234135/58c76616-f8a8-45a2-a5e3-31212b7c4d1a)
