### PR TITLE
Adds a step for setting fleet-wide configuration options in GitHub Actions

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -112,8 +112,9 @@ jobs:
           fleet: screenly_ose/anthias-${{ matrix.board }}
           source: balena-deploy
 
-      - uses: balena-io-experimental/community-cli-action@0.0.3
+      - uses: balena-io-examples/community-cli-action@1.0.0
         with:
           balena_token: ${{ secrets.BALENA_TOKEN }}
+          balena_cli_version: 18.2.2
           balena_cli_commands: >
             env add BALENA_HOST_CONFIG_disable_overscan 1 --fleet screenly_ose/anthias-${{ matrix.board }};

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -111,3 +111,9 @@ jobs:
           balena_token: ${{ secrets.BALENA_TOKEN }}
           fleet: screenly_ose/anthias-${{ matrix.board }}
           source: balena-deploy
+
+      - uses: balena-io-experimental/community-cli-action@0.0.3
+        with:
+          balena_token: ${{ secrets.BALENA_TOKEN }}
+          balena_cli_commands: >
+            env add BALENA_HOST_CONFIG_disable_overscan 1 --fleet screenly_ose/anthias-${{ matrix.board }};


### PR DESCRIPTION
#### Desciption

* Fixes #1661
* I just included one config for now: `BALENA_HOST_CONFIG_disable_overscan` (set to `1`).
* Configuration with no value changes won't trigger a reboot in the devices.