### PR TITLE
Replaces OMXPlayer with Qt (Python)

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -372,14 +372,11 @@ def view_video(uri, duration):
 
     view_image('null')
 
-    try:
-        while media_player.is_playing():
-            watchdog()
-            sleep(1)
-    except sh.ErrorReturnCode_1:
-        logging.info('Resource URI is not correct, remote host is not responding or request was rejected.')
+    if browser is None or not browser.process.alive:
+        load_browser()
 
-    media_player.stop()
+    browser_bus.loadVideo(uri)
+    logging.info('Current url is {0}'.format(uri))
 
 
 def load_settings():
@@ -416,7 +413,7 @@ def asset_loop(scheduler):
         else:
             logging.error('Unknown MimeType %s', mime)
 
-        if 'image' in mime or 'web' in mime:
+        if 'image' in mime or 'web' in mime or 'video' in mime:
             duration = int(asset['duration'])
             logging.info('Sleeping for %s', duration)
             sleep(duration)


### PR DESCRIPTION
#### Description

* Fixes #1851
* Qt (via [QMediaPlayer](https://doc.qt.io/qt-5/qmediaplayer.html)) will replace OMXPlayer for playing videos.
* This might fix the black gap between active video assets.