### PR TITLE
Replaces OMXPlayer with Qt (C++)

### DIFF
--- a/webview/ScreenlyWebview.pro
+++ b/webview/ScreenlyWebview.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 
-QT += webengine webenginewidgets dbus
+QT += webengine webenginewidgets dbus multimediawidgets
 CONFIG += c++11
 
 SOURCES += src/main.cpp \

--- a/webview/src/mainwindow.cpp
+++ b/webview/src/mainwindow.cpp
@@ -1,9 +1,10 @@
 #include <QStandardPaths>
 #include <QWebEngineSettings>
+#include <QVideoWidget>
+#include <QMediaPlayer>
 
 #include "mainwindow.h"
 #include "view.h"
-
 
 MainWindow::MainWindow() : QMainWindow()
 {
@@ -24,4 +25,15 @@ void MainWindow::loadPage(const QString &uri)
 void MainWindow:: loadImage(const QString &uri)
 {
     view -> loadImage(uri);
+}
+
+void MainWindow::loadVideo(const QString &uri)
+{
+    qDebug() << "Type: Image, URI: " << uri;
+
+    QMediaPlayer *player = new QMediaPlayer;
+    QVideoWidget *videoWidget = new QVideoWidget;
+    player -> setVideoOutput(videoWidget);
+    player -> setMedia(QUrl(uri));
+    player -> play();
 }

--- a/webview/src/mainwindow.h
+++ b/webview/src/mainwindow.h
@@ -15,6 +15,7 @@ class MainWindow : public QMainWindow
     public slots:
         void loadPage(const QString &uri);
         void loadImage(const QString &uri);
+        void loadVideo(const QString &uri);
 
     private:
         View *view;


### PR DESCRIPTION
#### Description

* Qt (via [QMediaPlayer](https://doc.qt.io/qt-5/qmediaplayer.html)) will replace OMXPlayer for playing videos.
* This might fix the black gap between active video assets.