### PR TITLE
Fixes CI badge references so that statuses can be displayed properly

### DIFF
--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -6,6 +6,7 @@ on:
       - master
       - production
     paths:
+      - '**/**'
       - '!README.md'
       - '!webview/**'
       - '!website/**'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Anthias - Digital Signage for the Raspberry Pi
-[![Run Unit Tests](https://github.com/Screenly/Anthias/actions/workflows/docker-test.yaml/badge.svg)](https://github.com/Screenly/Anthias/actions/workflows/docker-test.yaml)
-[![CodeQL](https://github.com/Screenly/Anthias/actions/workflows/codeql-analysis.yaml/badge.svg)](https://github.com/Screenly/Anthias/actions/workflows/codeql-analysis.yaml)
-[![Lint Code Base](https://github.com/Screenly/Anthias/actions/workflows/linter.yml/badge.svg)](https://github.com/Screenly/Anthias/actions/workflows/linter.yml)
+[![Run Unit Tests](https://github.com/Screenly/Anthias/actions/workflows/docker-test.yaml/badge.svg?branch=master)](https://github.com/Screenly/Anthias/actions/workflows/docker-test.yaml)
+[![CodeQL](https://github.com/Screenly/Anthias/actions/workflows/codeql-analysis.yaml/badge.svg?branch=master)](https://github.com/Screenly/Anthias/actions/workflows/codeql-analysis.yaml)
+[![Lint Python Code Base](https://github.com/Screenly/Anthias/actions/workflows/python-lint.yaml/badge.svg?branch=master)](https://github.com/Screenly/Anthias/actions/workflows/python-lint.yaml)
 
 ![Anthias Logo](https://github.com/Screenly/Anthias/blob/master/static/img/dark.svg?raw=true  "Anthias Logo")
 


### PR DESCRIPTION
#### Screenshots

![image](https://github.com/Screenly/Anthias/assets/10234135/11286140-410a-4390-bf64-c6daca162bef)

#### Notes

* The CodeQL job still needs investigating. Resolution will be done on a separate pull request.
* When changes are pushed to `master` (for example, when a PR is merged), the [unit test job](https://github.com/Screenly/Anthias/actions/workflows/docker-test.yaml) is not being triggered (looking at face value).
  * Take note, however, that the [image build job](https://github.com/Screenly/Anthias/actions/workflows/docker-build.yaml) does a workflow call to the UT job, therefore running the tests.
* The link to the linter job is broken, thus replacing it with the link to the [Python linter job](https://github.com/Screenly/Anthias/actions/workflows/python-lint.yaml).