### PR TITLE
Specifies permissions when doing CodeQL analysis via CI

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -25,6 +25,11 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
#### References

* https://github.com/github/codeql/issues/8843
* https://dev.to/pwd9000/fgjgghjgh-19ka

#### Screenshots

Current badge statuses

![image](https://github.com/Screenly/Anthias/assets/10234135/841334bb-5200-405f-acf3-69fa4becade4)
