### PR TITLE
Renames the host virtual environment directory from `installer_venv` to `anthias_venv`

### DIFF
--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Install pip dependencies
   ansible.builtin.pip:
-    executable: "/home/{{ lookup('env', 'USER') }}/installer_venv/bin/pip"
+    executable: "/home/{{ lookup('env', 'USER') }}/anthias_venv/bin/pip"
     requirements: "/home/{{ lookup('env', 'USER') }}/screenly/requirements/requirements.host.txt"
     extra_args: "--no-cache-dir --upgrade"
   when: ansible_distribution_major_version|int >= 12

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -295,7 +295,7 @@
 - name: Remove deprecated pip dependencies (>= Debian 12)
   ansible.builtin.pip:
     name: supervisor
-    executable: /home/{{ lookup('env', 'USER') }}/installer_venv/bin/pip
+    executable: /home/{{ lookup('env', 'USER') }}/anthias_venv/bin/pip
     state: absent
   when:
     - ansible_distribution_major_version|int >= 12

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -187,8 +187,9 @@ fi
 SUDO_ARGS=()
 
 if [ "$RASPBIAN_VERSION" = "12" ]; then
-    python3 -m venv /home/${USER}/installer_venv
-    source /home/${USER}/installer_venv/bin/activate
+    rm -rf /home/${USER}/installer_venv
+    python3 -m venv /home/${USER}/anthias_venv
+    source /home/${USER}/anthias_venv/bin/activate
 
     SUDO_ARGS+=("--preserve-env" "env" "PATH=$PATH")
 fi


### PR DESCRIPTION
#### Description

* The rename signifies that the virtual environment will primarily contain the dependencies needed by the host, especially the helper scripts.