### PR TITLE
Bumps Werkzeug from 2.2.2 to 2.2.3

### DIFF
--- a/requirements/requirements-websocket.txt
+++ b/requirements/requirements-websocket.txt
@@ -8,4 +8,4 @@ Jinja2==3.1.4
 MarkupSafe==1.1.1
 pytz==2022.2.1
 pyzmq==19.0.2
-Werkzeug==2.2.2
+Werkzeug==2.2.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -37,6 +37,6 @@ retry==0.9.2
 sh==1.8
 six==1.15.0
 urllib3==1.26.19
-Werkzeug==2.2.2
+Werkzeug==2.2.3
 wheel==0.38.1
 yt-dlp==2023.11.16

--- a/requirements/requirements.viewer.txt
+++ b/requirements/requirements.viewer.txt
@@ -21,4 +21,4 @@ retry==0.9.2
 sh==1.8
 uptime==3.0.1
 urllib3==1.26.19
-Werkzeug==2.2.2
+Werkzeug==2.2.3


### PR DESCRIPTION
#### Description

* `2.2.3` is the last release that supports Python 3.7.
* Werkzeug dropped support for Python 3.7 starting at `2.3.0`.