### PR TITLE
Removes unused JS code in `settings.html`

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -9,8 +9,6 @@
     <script src="{{ url_for('static', filename='js/bootstrap-datepicker.js') }}"></script>
 
     <script src="{{ url_for('static', filename='js/settings.js') }}"></script>
-
-    <script>hljs.highlightAll();</script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
#### Description

* I forgot to remove that [`highlight.js`](https://highlightjs.org/) code before merging #1970.