### PR TITLE
Fixes broken API docs page

### DIFF
--- a/server.py
+++ b/server.py
@@ -1318,14 +1318,7 @@ except Exception:
     pass
 else:
     SWAGGER_URL = '/api/docs'
-    swagger_address = getenv("SWAGGER_HOST", my_ip)
-
-    if settings['use_ssl'] or is_demo_node:
-        API_URL = 'http://{}/api/swagger.json'.format(swagger_address)
-    elif LISTEN == '127.0.0.1' or swagger_address != my_ip:
-        API_URL = "http://{}/api/swagger.json".format(swagger_address)
-    else:
-        API_URL = "http://{}:{}/api/swagger.json".format(swagger_address, PORT)
+    API_URL = "/api/swagger.json"
 
     swaggerui_blueprint = get_swaggerui_blueprint(
         SWAGGER_URL,


### PR DESCRIPTION
#### Description

* When #1950 was merged, the `/api/docs` URL broke.
*The URL specified in the code (for the API docs) is dependent `get_node_ip`, which returns multiple IPv4 and IPv6 addresses (as a string, separated by spaces).
* This pull request removes that dependency, making the `API_URL` just `/api/docs` for flexibility.

#### Screenshots

##### Before fixes

![image](https://github.com/user-attachments/assets/1d32fbe9-5e1a-42d8-ab57-92c44bbd9dae)

##### After fixes

![image](https://github.com/user-attachments/assets/6057f579-b2b8-43f4-88ab-f49342bda3c4)

![image](https://github.com/user-attachments/assets/4a02caa1-182b-4336-a853-b1d059697e55)
