### PR TITLE
Fixes formatting of IPv6 addresses in the splash screen

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ __author__ = "Screenly, Inc"
 __copyright__ = "Copyright 2012-2023, Screenly, Inc"
 __license__ = "Dual License: GPLv2 and Commercial License"
 
+import ipaddress
 import json
 import psutil
 
@@ -1525,8 +1526,17 @@ def integrations():
 
 @app.route('/splash-page')
 def splash_page():
-    my_ip = get_node_ip().split()
-    return template('splash-page.html', my_ip=my_ip)
+    ip_addresses = []
+
+    for ip_address in get_node_ip().split():
+        ip_address_object = ipaddress.ip_address(ip_address)
+
+        if isinstance(ip_address_object, ipaddress.IPv6Address):
+            ip_addresses.append(f'http://[{ip_address}]')
+        else:
+            ip_addresses.append(f'http://{ip_address}')
+
+    return template('splash-page.html', ip_addresses=ip_addresses)
 
 
 @app.errorhandler(403)

--- a/templates/splash-page.html
+++ b/templates/splash-page.html
@@ -28,15 +28,15 @@
     <div class="splash-body p-5">
         <div class="row">
             <div class="col-12 text-center">
-                {% if context.my_ip %}
+                {% if context.ip_addresses %}
                     <p>
                         To manage the content on this screen, just point your
                         browser to
-                        {% if context.my_ip | length > 1 %}
+                        {% if context.ip_addresses | length > 1 %}
                             any of
                         {% endif %}
                         the IP
-                        {% if context.my_ip | length > 1 %}
+                        {% if context.ip_addresses | length > 1 %}
                             addresses
                         {% else %}
                             address
@@ -44,8 +44,8 @@
                         provided below.
                     </p>
                     <div class="form-actions">
-                        {% for ip in context.my_ip %}
-                            <a href="http://{{ ip }}">http://{{ ip }}</a>
+                        {% for ip_address in context.ip_addresses %}
+                            <a href="{{ ip_address }}">{{ ip_address }}</a>
                             {% if not loop.last %}
                                 <br/>
                             {% endif %}


### PR DESCRIPTION
#### Description

* [**Square brackets** must surround an IPv6 address](https://www.uptrends.com/support/kb/synthetic-monitoring/monitor-settings/using-an-ipv6-address-instead-of-a-domain-name) if it were to be used in a browser.

#### Screenshots

##### Before fixes

![image](https://github.com/user-attachments/assets/737ece77-2650-46e8-9194-b4abad068eda)

##### After fixes

![image](https://github.com/user-attachments/assets/dc126705-c58d-4166-a439-3f7dfe53eeed)