### PR TITLE
Fixes failure to start the host agent service in Bullseye.

### DIFF
--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -28,16 +28,9 @@
 
 - name: Install pip dependencies
   ansible.builtin.pip:
-    requirements: "/home/{{ lookup('env', 'USER') }}/screenly/requirements/requirements.host.txt"
-    extra_args: "--no-cache-dir --upgrade"
-  when: ansible_distribution_major_version|int <= 11
-
-- name: Install pip dependencies
-  ansible.builtin.pip:
     executable: "/home/{{ lookup('env', 'USER') }}/installer_venv/bin/pip"
     requirements: "/home/{{ lookup('env', 'USER') }}/screenly/requirements/requirements.host.txt"
     extra_args: "--no-cache-dir --upgrade"
-  when: ansible_distribution_major_version|int >= 12
 
 - name: Remove screenly_utils.sh
   ansible.builtin.file:

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -163,7 +163,7 @@ APT_INSTALL_ARGS=(
 if [ "$RASPBIAN_VERSION" = "12" ]; then
   APT_INSTALL_ARGS+=("python3-full")
 else
-  APT_INSTALL_ARGS+=("python3" "python3-dev" "python3-pip")
+  APT_INSTALL_ARGS+=("python3" "python3-dev" "python3-pip" "python3-venv")
 fi
 
 sudo sed -i 's/apt.screenlyapp.com/archive.raspbian.org/g' /etc/apt/sources.list


### PR DESCRIPTION
#### Description

- [ ] A follow-up to #1971

#### References

* https://forums.screenly.io/t/settings-page-produces-a-504/1478/4

#### Logs (Before Fixes)

```
nico@raspberrypi3:~ $ sudo journalctl -fu anthias-host-agent
-- Journal begins at Wed 2024-07-03 17:14:43 PDT. --
Jul 17 09:22:01 raspberrypi3 systemd[1]: anthias-host-agent.service: Failed with result 'exit-code'.
Jul 17 09:22:11 raspberrypi3 systemd[1]: anthias-host-agent.service: Scheduled restart job, restart counter is at 58.
Jul 17 09:22:11 raspberrypi3 systemd[1]: Stopped Anthias Host Agent.
Jul 17 09:22:11 raspberrypi3 systemd[1]: Started Anthias Host Agent.
Jul 17 09:22:12 raspberrypi3 python[16784]: Traceback (most recent call last):
Jul 17 09:22:12 raspberrypi3 python[16784]:   File "/home/nico/screenly/host_agent.py", line 10, in <module>
Jul 17 09:22:12 raspberrypi3 python[16784]:     import netifaces
Jul 17 09:22:12 raspberrypi3 python[16784]: ModuleNotFoundError: No module named 'netifaces'
Jul 17 09:22:12 raspberrypi3 systemd[1]: anthias-host-agent.service: Main process exited, code=exited, status=1/FAILURE
Jul 17 09:22:12 raspberrypi3 systemd[1]: anthias-host-agent.service: Failed with result 'exit-code'.
```

#### Logs (After Fixes)

```
nico@raspberrypi3:~ $ sudo journalctl -fu anthias-host-agent
-- Journal begins at Wed 2024-07-03 17:14:43 PDT. --
Jul 17 10:50:27 raspberrypi3 systemd[1]: anthias-host-agent.service: Failed with result 'exit-code'.
Jul 17 10:50:27 raspberrypi3 systemd[1]: anthias-host-agent.service: Consumed 1.033s CPU time.
Jul 17 10:50:37 raspberrypi3 systemd[1]: anthias-host-agent.service: Scheduled restart job, restart counter is at 46.
Jul 17 10:50:37 raspberrypi3 systemd[1]: Stopped Anthias Host Agent.
Jul 17 10:50:37 raspberrypi3 systemd[1]: anthias-host-agent.service: Consumed 1.033s CPU time.
Jul 17 10:50:37 raspberrypi3 systemd[1]: Started Anthias Host Agent.
Jul 17 10:50:39 raspberrypi3 python[16240]: INFO:root:Connecting to redis...
Jul 17 10:50:39 raspberrypi3 python[16240]: INFO:root:Subscribed to channel b'hostcmd', ready to process messages
Jul 17 10:50:40 raspberrypi3 python[16240]: INFO:root:Calling function <function set_ip_addresses at 0x7f83d97d30>
Jul 17 10:51:04 raspberrypi3 python[16240]: INFO:root:Calling function <function set_ip_addresses at 0x7f83d97d30>
```