### PR TITLE
Upgrade containers to use Bookworm

### DIFF
--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -64,7 +64,7 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           docker compose -f docker-compose.test.yml exec anthias-test bash ./bin/prepare_test_environment.sh -s
-          docker compose -f docker-compose.test.yml exec anthias-test nosetests -v -a '!fixme'
+          docker compose -f docker-compose.test.yml exec anthias-test nose2 -v -A '!fixme'
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -54,7 +54,7 @@
 - name: Add pi4 section in config.txt if it doesn't exist
   ansible.builtin.lineinfile:
     path: "{{ config_path }}"
-    line: "[pi4]"
+    line: "\n[pi4]"
   when: config_txt.stdout.find('[pi4]') == -1
 
 - name: Comment out the original dtoverlay config.
@@ -63,21 +63,11 @@
     regexp: ^(dtoverlay=vc4-kms-v3d)$
     replace: '#\1'
 
-- name: Add FKMS config for Pi 4. (<= Debian 11)
+- name: Add FKMS config for Pi 4.
   ansible.builtin.lineinfile:
     path: "{{ config_path }}"
-    insertafter: '^\[pi4\]$'
+    insertafter: '^\[all\]$'
     line: dtoverlay=vc4-fkms-v3d
-  when:
-    - ansible_distribution_major_version|int <= 11
-
-- name: Add FKMS config for Pi 4. (>= Debian 12)
-  ansible.builtin.lineinfile:
-    path: "{{ config_path }}"
-    insertafter: '^\[pi4\]$'
-    line: dtoverlay=vc4-fkms-v3d
-  when:
-    - ansible_distribution_major_version|int >= 12
 
 - name: Backup kernel boot args
   ansible.builtin.copy:

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -57,17 +57,24 @@
     line: "\n[pi4]"
   when: config_txt.stdout.find('[pi4]') == -1
 
+- name: Remove the Pi 4 FKMS config.
+  ansible.builtin.replace:
+    path: "{{ config_path }}"
+    regexp: "\\[pi4\\]\ndtoverlay=vc4-fkms-v3d"
+    replace: "[pi4]"
+
 - name: Comment out the original dtoverlay config.
   ansible.builtin.replace:
     dest: "{{ config_path }}"
     regexp: ^(dtoverlay=vc4-kms-v3d)$
     replace: '#\1'
 
-- name: Add FKMS config for Pi 4.
+- name: Add FKMS config for all devices.
   ansible.builtin.lineinfile:
     path: "{{ config_path }}"
     insertafter: '^\[all\]$'
     line: dtoverlay=vc4-fkms-v3d
+  when: config_txt.stdout.find('dtoverlay=vc4-fkms-v3d') == -1
 
 - name: Backup kernel boot args
   ansible.builtin.copy:

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -69,6 +69,13 @@
     regexp: ^(dtoverlay=vc4-kms-v3d)$
     replace: '#\1'
 
+- name: Refresh contents of config.txt.
+  ansible.builtin.command: cat {{ config_path }}
+  register: config_txt
+  changed_when: false
+  tags:
+    - touches_boot_partition
+
 - name: Add FKMS config for all devices.
   ansible.builtin.lineinfile:
     path: "{{ config_path }}"

--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -74,7 +74,7 @@ for container in ${SERVICES[@]}; do
 
     if [ "$container" == 'viewer' ]; then
         export QT_VERSION=5.15.14
-        export WEBVIEW_GIT_HASH=5c84d1e1
+        export WEBVIEW_GIT_HASH=ec710ed9b355fc10a758f03058e10d01176f3bd6
         export WEBVIEW_BASE_URL="https://github.com/Screenly/Anthias/releases/download/WebView-v0.3.0"
     elif [ "$container" == 'test' ]; then
         export CHROME_DL_URL="https://storage.googleapis.com/chrome-for-testing-public/123.0.6312.86/linux64/chrome-linux64.zip"

--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -9,7 +9,7 @@ set -euox pipefail
 export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 export GIT_SHORT_HASH=$(git rev-parse --short HEAD)
 export GIT_HASH=$(git rev-parse HEAD)
-export BASE_IMAGE_TAG=buster
+export BASE_IMAGE_TAG=bookworm
 export DEBIAN_VERSION=buster
 
 declare -a SERVICES=(

--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -10,7 +10,7 @@ export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 export GIT_SHORT_HASH=$(git rev-parse --short HEAD)
 export GIT_HASH=$(git rev-parse HEAD)
 export BASE_IMAGE_TAG=bookworm
-export DEBIAN_VERSION=buster
+export DEBIAN_VERSION=bookworm
 
 declare -a SERVICES=(
     server
@@ -73,9 +73,9 @@ for container in ${SERVICES[@]}; do
     fi
 
     if [ "$container" == 'viewer' ]; then
-        export QT_VERSION=5.15.2
-        export WEBVIEW_GIT_HASH=f5ef562982dcb6274c9716b9e375cc5ac0faba84
-        export WEBVIEW_BASE_URL="https://github.com/Screenly/Anthias/releases/download/WebView-v0.2.2"
+        export QT_VERSION=5.15.14
+        export WEBVIEW_GIT_HASH=5c84d1e1
+        export WEBVIEW_BASE_URL="https://github.com/Screenly/Anthias/releases/download/WebView-v0.3.0"
     elif [ "$container" == 'test' ]; then
         export CHROME_DL_URL="https://storage.googleapis.com/chrome-for-testing-public/123.0.6312.86/linux64/chrome-linux64.zip"
         export CHROMEDRIVER_DL_URL="https://storage.googleapis.com/chrome-for-testing-public/123.0.6312.86/linux64/chromedriver-linux64.zip"

--- a/docker/Dockerfile.base.tmpl
+++ b/docker/Dockerfile.base.tmpl
@@ -24,7 +24,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
         lsb-release \
         mplayer \
         net-tools \
-        omxplayer \
         procps \
         psmisc \
         python3-dev \
@@ -42,6 +41,7 @@ RUN c_rehash
 # We need this to ensure that the wheels can be built.
 # Otherwise we get "invalid command 'bdist_wheel'"
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install wheel
+    pip3 install --upgrade pip --break-system-packages && \
+    pip3 install wheel --break-system-packages
 
 # Keep a newline below here to not break the concatination of files.

--- a/docker/Dockerfile.celery.tmpl
+++ b/docker/Dockerfile.celery.tmpl
@@ -2,7 +2,7 @@
 
 COPY requirements/requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-  pip3 install -r /tmp/requirements.txt
+  pip3 install -r /tmp/requirements.txt --break-system-packages
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/docker/Dockerfile.server.tmpl
+++ b/docker/Dockerfile.server.tmpl
@@ -2,7 +2,7 @@
 
 COPY requirements/requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install -r /tmp/requirements.txt
+    pip3 install -r /tmp/requirements.txt --break-system-packages
 
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app/

--- a/docker/Dockerfile.test.tmpl
+++ b/docker/Dockerfile.test.tmpl
@@ -44,7 +44,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip3 install \
         -r /tmp/requirements.txt \
         -r /tmp/requirements.dev.txt \
-        -r /tmp/requirements.viewer.txt
+        -r /tmp/requirements.viewer.txt \
+        --break-system-packages
 
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app

--- a/docker/Dockerfile.test.tmpl
+++ b/docker/Dockerfile.test.tmpl
@@ -25,7 +25,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     libatk1.0-0 \
     libatk-bridge2.0.0 \
     libcups2 \
-    libxcomposite1
+    libxcomposite1 \
+    libxdamage1
 
 # @TODO: Uncomment the lines below when test_add_asset_streaming is fixed.
 # WORKDIR /opt/ffmpeg

--- a/docker/Dockerfile.viewer.tmpl
+++ b/docker/Dockerfile.viewer.tmpl
@@ -9,6 +9,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get -y install --no-install-recommends \
         build-essential \
         ca-certificates \
+        dbus-daemon \
         fonts-arphic-uming \
         git-core \
         libasound2-dev \
@@ -95,7 +96,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
         libzmq5-dev \
         libzmq5 \
         net-tools \
-        omxplayer \
         psmisc \
         python3-dev \
         python3-gi \
@@ -109,13 +109,14 @@ RUN --mount=type=cache,target=/var/cache/apt \
 # We need this to ensure that the wheels can be built.
 # Otherwise we get "invalid command 'bdist_wheel'"
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install wheel
+    pip3 install --upgrade pip --break-system-packages && \
+    pip3 install wheel --break-system-packages
 
 # Install Python requirements
 COPY requirements/requirements.viewer.txt /tmp/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install -r /tmp/requirements.txt
+    pip3 install -r /tmp/requirements.txt --break-system-packages
 
 # Works around issue with `curl`
 # https://github.com/balena-io-library/base-images/issues/562

--- a/docker/Dockerfile.websocket.tmpl
+++ b/docker/Dockerfile.websocket.tmpl
@@ -2,7 +2,7 @@
 
 COPY requirements/requirements-websocket.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install -r /tmp/requirements.txt
+    pip3 install -r /tmp/requirements.txt --break-system-packages
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/docker/Dockerfile.wifi-connect.tmpl
+++ b/docker/Dockerfile.wifi-connect.tmpl
@@ -21,7 +21,7 @@ RUN if [[ ! -z "$ARCHIVE_URL" ]]; then \
 
 COPY requirements/requirements.wifi-connect.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install -r /tmp/requirements.txt
+    pip3 install -r /tmp/requirements.txt --break-system-packages
 
 COPY send_zmq_message.py ./
 

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -81,7 +81,7 @@ $ docker compose \
     exec -T anthias-test bash ./bin/prepare_test_environment.sh -s
 $ docker compose \
     -f docker-compose.test.yml \
-    exec -T anthias-test nosetests -v -a '!fixme'
+    exec -T anthias-test nose2 -v -A '!fixme'
 ```
 
 ### The QA checklist

--- a/lib/media_player.py
+++ b/lib/media_player.py
@@ -5,7 +5,6 @@ from platform import machine
 import sh
 import vlc
 
-from lib.raspberry_pi_helper import lookup_raspberry_pi_version
 from settings import settings
 
 VIDEO_TIMEOUT = 20  # secs
@@ -41,15 +40,9 @@ class VLCMediaPlayer(MediaPlayer):
     def __get_options(self):
         options = []
 
-        if lookup_raspberry_pi_version() == 'pi4':
-            if settings['audio_output'] == 'local':
-                options += [
-                    '--alsa-audio-device=plughw:CARD=Headphones',
-                ]
-
+        if settings['audio_output'] == 'local':
             options += [
-                '--mmal-display=HDMI-2',
-                '--vout=mmal_vout',
+                '--alsa-audio-device=plughw:CARD=Headphones',
             ]
 
         return options

--- a/nose2.cfg
+++ b/nose2.cfg
@@ -1,0 +1,3 @@
+[unittest]
+test-file-pattern = *_test.py
+plugins = nose2.plugins.attrib

--- a/requirements/requirements-websocket.txt
+++ b/requirements/requirements-websocket.txt
@@ -2,10 +2,9 @@ Cython==0.29.33
 Flask==2.2.5
 future==0.18.3
 gevent-websocket==0.10.1
-gevent==21.12.0
+gevent==24.2.1
 itsdangerous==2.0.1
 Jinja2==3.1.4
-MarkupSafe==1.1.1
 pytz==2022.2.1
-pyzmq==19.0.2
+pyzmq==23.2.1
 Werkzeug==2.2.3

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -1,6 +1,6 @@
 future==0.18.3
 mock==3.0.5
-nose==1.3.7
+nose2==0.15.1
 pep8==1.7.1
 selenium==3.141.0
 splinter==0.14.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-cec==0.2.7
+cec==0.2.8
 celery==5.2.2
 certifi==2024.7.4
 cffi==1.14.4
@@ -12,8 +12,7 @@ flask-swagger-ui==3.36.0
 Flask==2.2.5
 future==0.18.3
 gevent-websocket==0.10.1
-gevent==21.12.0
-greenlet==1.1.0
+gevent==24.2.1
 gunicorn==22.0.0
 hurry.filesize==0.9
 importlib-metadata==4.13.0
@@ -21,7 +20,6 @@ itsdangerous==2.0.1
 Jinja2==3.1.4
 kombu==5.2.4
 Mako==1.2.2
-MarkupSafe==1.1.1
 netifaces==0.10.9
 psutil==5.7.3
 pyasn1==0.4.8
@@ -30,9 +28,9 @@ pyOpenSSL==19.1.0
 python-dateutil==2.8.1
 pytz==2022.2.1
 PyYAML==6.0.1
-pyzmq==19.0.2
+pyzmq==23.2.1
 redis==3.5.3
-requests[security]==2.27.1
+requests[security]==2.31.0
 retry==0.9.2
 sh==1.8
 six==1.15.0

--- a/requirements/requirements.viewer.txt
+++ b/requirements/requirements.viewer.txt
@@ -1,4 +1,4 @@
-cec==0.2.7
+cec==0.2.8
 certifi==2024.7.4
 configparser==4.0.2
 cryptography==3.3.2
@@ -8,15 +8,14 @@ future==0.18.3
 idna==3.7
 itsdangerous==2.0.1
 Jinja2==3.1.4
-MarkupSafe==1.1.1
 netifaces==0.10.9
 pydbus==0.6.0
 python-dateutil==2.8.1
-python-vlc==3.0.11115
+python-vlc==3.0.20123
 pytz==2022.2.1
-pyzmq==19.0.2
+pyzmq==23.2.1
 redis==3.5.3
-requests[security]==2.27.1
+requests[security]==2.31.0
 retry==0.9.2
 sh==1.8
 uptime==3.0.1

--- a/requirements/requirements.wifi-connect.txt
+++ b/requirements/requirements.wifi-connect.txt
@@ -1,5 +1,5 @@
 Cython==0.29.33
 future==0.18.3
 netifaces==0.10.9
-pyzmq==19.0.2
+pyzmq==23.2.1
 redis==3.5.3

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -1,4 +1,6 @@
-from __future__ import unicode_literals
+from unittest import mock
+mock.patch('vlc.Instance', mock.MagicMock()).__enter__()
+
 from builtins import object
 from datetime import datetime
 from datetime import timedelta

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -1,15 +1,14 @@
-from unittest import mock
-mock.patch('vlc.Instance', mock.MagicMock()).__enter__()
-
-from builtins import object
-from datetime import datetime
-from datetime import timedelta
-import unittest
-import viewer
-from lib import db
-from lib import assets_helper
-import settings
+import mock
 import os
+import unittest
+
+from datetime import datetime, timedelta
+from lib import db, assets_helper
+
+import settings
+
+mock.patch('vlc.Instance', mock.MagicMock()).__enter__()
+import viewer  # noqa: E402
 
 asset_x = {
     'mimetype': u'web',

--- a/tests/splinter_test.py
+++ b/tests/splinter_test.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from builtins import object
-from nose.plugins.attrib import attr
 from splinter import Browser
 from time import sleep
 from selenium.common.exceptions import ElementNotVisibleException
@@ -226,7 +225,6 @@ class WebTest(unittest.TestCase):
                 self.assertEqual(assets[1]['mimetype'], u'video')
                 self.assertEqual(assets[1]['duration'], u'5')
 
-    @attr('fixme')
     def test_add_asset_streaming(self):
         with get_browser() as browser:
             browser.visit(main_page_url)
@@ -253,6 +251,8 @@ class WebTest(unittest.TestCase):
             self.assertEqual(asset['uri'], u'rtsp://localhost:8091/asset.mov')
             self.assertEqual(asset['mimetype'], u'streaming')
             self.assertEqual(asset['duration'], settings['default_streaming_duration'])
+
+    test_add_asset_streaming.fixme = True
 
     def test_rm_asset(self):
         with db.conn(settings['database']) as conn:

--- a/tests/updates_test.py
+++ b/tests/updates_test.py
@@ -6,7 +6,6 @@ import server
 import os
 
 from settings import settings
-from nose.plugins.attrib import attr
 
 fancy_sha = 'deadbeaf'
 
@@ -27,12 +26,10 @@ class UpdateTest(unittest.TestCase):
 
         self.get_configdir_m.stop()
 
-    @attr('fixme')
     @mock.patch('viewer.settings.get_configdir', mock.MagicMock(return_value='/tmp/.screenly/'))
     def test_if_sha_file_not_exists__is_up_to_date__should_return_false(self):
         self.assertEqual(server.is_up_to_date(), True)
 
-    @attr('fixme')
     @mock.patch('viewer.settings.get_configdir', mock.MagicMock(return_value='/tmp/.screenly/'))
     def test_if_sha_file_not_equals_to_branch_hash__is_up_to_date__should_return_false(self):
         os.environ['GIT_BRANCH'] = 'master'
@@ -40,3 +37,6 @@ class UpdateTest(unittest.TestCase):
             f.write(fancy_sha)
         self.assertEqual(server.is_up_to_date(), False)
         del os.environ['GIT_BRANCH']
+
+    test_if_sha_file_not_exists__is_up_to_date__should_return_false.fixme = True
+    test_if_sha_file_not_equals_to_branch_hash__is_up_to_date__should_return_false.fixme = True

--- a/tests/viewer_test.py
+++ b/tests/viewer_test.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from nose.tools import eq_
 import mock
 import unittest
 import os
@@ -11,6 +10,7 @@ from time import sleep
 
 class ViewerTestCase(unittest.TestCase):
     def setUp(self):
+        mock.patch('vlc.Instance', mock.MagicMock()).__enter__()
         import viewer
 
         self.original_splash_delay = viewer.SPLASH_DELAY
@@ -88,8 +88,7 @@ class TestLoadBrowser(ViewerTestCase):
 class TestSignalHandlers(ViewerTestCase):
     def test_usr1(self):
         self.p_killall.start()
-        eq_(None, self.u.sigusr1(None, None))
-        self.m_killall.assert_called_once_with('omxplayer.bin', _ok_code=[1])
+        self.assertEqual(None, self.u.sigusr1(None, None))
         self.p_killall.stop()
 
 

--- a/viewer.py
+++ b/viewer.py
@@ -26,7 +26,7 @@ import zmq
 from lib import assets_helper
 from lib import db
 from lib.errors import SigalrmException
-from lib.media_player import OMXMediaPlayer
+from lib.media_player import VLCMediaPlayer
 from lib.utils import (
     url_fails,
     is_balena_app,
@@ -63,12 +63,7 @@ loop_is_stopped = False
 browser_bus = None
 r = connect_to_redis()
 
-try:
-    media_player = OMXMediaPlayer()
-    # @TODO: Remove the line above and uncomment the line below once VLC playback issue is fixed.
-    # media_player = VLCMediaPlayer() if 'Raspberry Pi 4' in get_raspberry_model() else OMXMediaPlayer()
-except sh.ErrorReturnCode_1:
-    media_player = OMXMediaPlayer()
+media_player = VLCMediaPlayer()
 
 HOME = None
 db_conn = None


### PR DESCRIPTION
#### Description

* Resolves #1753
* Depends on #1982

#### Checklist

- [x] Re-build the webview but use Bookworm instead of Buster.
  - The webview can't start properly because it's searching for `*.so` files that are missing.
- [x] Update viewer Dockerfile
- Consider using Poetry &mdash; will be addressed in #1985 

#### Notes

* Moving away from OMXPlayer to VLC requires an upgrade from Buster.
* VLC playback in Buster is not possible, as per testing things quickly.
* One of the benefits of upgrading Python from