### PR TITLE
Removes non-existing APT package `libssl1.1` for Pi 1 builds

### DIFF
--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -122,6 +122,11 @@ for container in ${SERVICES[@]}; do
             echo "Skipping viewer container for x86 builds..."
             continue
         fi
+    elif [ "$BOARD" == "pi1" ]; then
+        # Remove the libssl1.1 from Dockerfile.viewer
+        if [ "$container" == 'viewer' ]; then
+            sed -i '/libssl1.1/d' "docker/Dockerfile.$container"
+        fi
     else
         if [ "$container" == 'test' ]; then
             echo "Skipping test container for Pi builds..."


### PR DESCRIPTION
#### Description

* The upgrade of the viewer container from Buster to Bullseye caused the Pi 1 builds to fail.
* This pull request removed `libssl1.1` from the list of APT packages to be installed.