### PR TITLE
Bumps Python version used by the linter to 3.11

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -12,8 +12,10 @@ on:
       - '!.github/workflows/deploy-website.yaml'
       - '!.github/workflows/build-webview.yaml'
       - '!.github/workflows/build-balena-disk-image.yaml'
+      - '!.github/workflows/python-lint.yaml'
       - '!README.md'
       - '!docs/**'
+      - '!bin/build_containers.sh'
       - '!bin/upgrade_containers.sh'
 
 jobs:

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.11"]
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
#### Description

* Bumps linter's Python version from 3.7 to 3.11
* Included `python-lint.yaml` in the files to be ignored for the `docker-build.yaml` workflow.