### PR TITLE
Modifies audio output based on app settings and Pi version

### DIFF
--- a/lib/media_player.py
+++ b/lib/media_player.py
@@ -3,6 +3,7 @@ from builtins import object
 
 import vlc
 
+from lib.raspberry_pi_helper import lookup_raspberry_pi_version
 from settings import settings
 
 VIDEO_TIMEOUT = 20  # secs
@@ -42,6 +43,15 @@ class VLCMediaPlayer(MediaPlayer):
             options += [
                 '--alsa-audio-device=plughw:CARD=Headphones',
             ]
+        else:
+            if lookup_raspberry_pi_version() == 'pi4':
+                options += [
+                    '--alsa-audio-device=default:CARD=vc4hdmi0',
+                ]
+            else:
+                options += [
+                    '--alsa-audio-device=default:CARD=vc4hdmi',
+                ]
 
         return options
 
@@ -53,7 +63,10 @@ class VLCMediaPlayer(MediaPlayer):
         if settings['audio_output'] == 'local':
             self.player.audio_output_device_set('alsa', 'plughw:CARD=Headphones')
         elif settings['audio_output'] == 'hdmi':
-            self.player.audio_output_device_set('alsa', 'default')
+            if lookup_raspberry_pi_version() == 'pi4':
+                self.player.audio_output_device_set('alsa', 'default:CARD=vc4hdmi0')
+            else:
+                self.player.audio_output_device_set('alsa', 'default:CARD=vc4hdmi')
 
     def play(self):
         self.player.play()

--- a/lib/media_player.py
+++ b/lib/media_player.py
@@ -36,37 +36,24 @@ class VLCMediaPlayer(MediaPlayer):
 
         self.player.audio_output_set('alsa')
 
-    def __get_options(self):
-        options = []
-
+    def get_alsa_audio_device(self):
         if settings['audio_output'] == 'local':
-            options += [
-                '--alsa-audio-device=plughw:CARD=Headphones',
-            ]
+            return 'plughw:CARD=Headphones'
         else:
             if lookup_raspberry_pi_version() == 'pi4':
-                options += [
-                    '--alsa-audio-device=default:CARD=vc4hdmi0',
-                ]
+                return 'default:CARD=vc4hdmi0'
             else:
-                options += [
-                    '--alsa-audio-device=default:CARD=vc4hdmi',
-                ]
+                return 'default:CARD=vc4hdmi'
 
-        return options
+    def __get_options(self):
+        return [
+            f'--alsa-audio-device={self.get_alsa_audio_device()}',
+        ]
 
     def set_asset(self, uri, duration):
         self.player.set_mrl(uri)
         settings.load()
-
-        # @TODO: Refactor this conditional statement.
-        if settings['audio_output'] == 'local':
-            self.player.audio_output_device_set('alsa', 'plughw:CARD=Headphones')
-        elif settings['audio_output'] == 'hdmi':
-            if lookup_raspberry_pi_version() == 'pi4':
-                self.player.audio_output_device_set('alsa', 'default:CARD=vc4hdmi0')
-            else:
-                self.player.audio_output_device_set('alsa', 'default:CARD=vc4hdmi')
+        self.player.audio_output_set('alsa', self.get_alsa_audio_device())
 
     def play(self):
         self.player.play()

--- a/lib/media_player.py
+++ b/lib/media_player.py
@@ -53,7 +53,7 @@ class VLCMediaPlayer(MediaPlayer):
     def set_asset(self, uri, duration):
         self.player.set_mrl(uri)
         settings.load()
-        self.player.audio_output_set('alsa', self.get_alsa_audio_device())
+        self.player.audio_output_device_set('alsa', self.get_alsa_audio_device())
 
     def play(self):
         self.player.play()

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -7,7 +7,12 @@ from lib import db, assets_helper
 
 import settings
 
+mock.patch(
+    'lib.raspberry_pi_helper.lookup_raspberry_pi_version',
+    return_value='pi4'
+).__enter__()
 mock.patch('vlc.Instance', mock.MagicMock()).__enter__()
+
 import viewer  # noqa: E402
 
 asset_x = {

--- a/tests/viewer_test.py
+++ b/tests/viewer_test.py
@@ -10,7 +10,12 @@ from time import sleep
 
 class ViewerTestCase(unittest.TestCase):
     def setUp(self):
+        mock.patch(
+            'lib.raspberry_pi_helper.lookup_raspberry_pi_version',
+            return_value='pi4'
+        ).__enter__()
         mock.patch('vlc.Instance', mock.MagicMock()).__enter__()
+
         import viewer
 
         self.original_splash_delay = viewer.SPLASH_DELAY


### PR DESCRIPTION
#### Description

* The default audio device (if not specified) is headphones (for BalenaOS devices) and HDMI (for Raspberry Pi OS devices), thus explicitly stating the ALSA output device based on app settings.