### PR TITLE
Fixes splash screen issue on Pi 2 devices running BalenaOS

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -488,7 +488,7 @@ def main():
 
     if settings['show_splash']:
         if is_balena_app():
-            retry_call(get_balena_device_info, tries=30, delay=1)
+            retry_call(get_balena_device_info, tries=90, delay=1)
 
         view_webpage(SPLASH_PAGE_URL)
         sleep(SPLASH_DELAY)


### PR DESCRIPTION
#### Description

* Increases timeout of the Balena API call (for device info) from 30 to 90.


#### Relevant logs

![image](https://github.com/user-attachments/assets/455a913d-6102-4979-bdb4-af3331423b92)
