### PR TITLE
Removes Docker repo/tag names that causes error when pushing to Docker Hub

### DIFF
--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -152,9 +152,6 @@ for container in ${SERVICES[@]}; do
         )
     else
         PUSH_ARGS+=(
-            "screenly/srly-ose-$container:latest"
-            "screenly/anthias-$container:latest"
-            "anthias-$container:latest"
             "screenly/anthias-$container:$DOCKER_TAG"
             "screenly/anthias-$container:$GIT_SHORT_HASH-$BOARD"
             "screenly/srly-ose-$container:$DOCKER_TAG"


### PR DESCRIPTION
#### Failed CI runs

* https://github.com/Screenly/Anthias/actions/runs/10218632753/job/28275365903