### PR TITLE
Hides "Update Available" navbar  menu for Balena instances

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -12,7 +12,7 @@
             <img src="static/img/logo-full.svg"/>
         </a>
         <ul class="nav float-right">
-            {% if not context.up_to_date %}
+            {% if not context.up_to_date and not context.is_balena %}
                 <li class="update-available">
                     <a href="/settings#upgrade-section">
                         <i class="fas fa-arrow-circle-down pr-1"></i>


### PR DESCRIPTION
#### Description

  * Balena instances don't need to show the **_Update Available_** navbar menu because updates are automatically applied when available.
  * I forgot to hide the menu when I hide the update info in the settings page. This is the follow-up PR for this one.