### PR TITLE
Removes Monitor Info from the System Info page

### DIFF
--- a/lib/diagnostics.py
+++ b/lib/diagnostics.py
@@ -4,20 +4,12 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from builtins import str
 import os
-import sh
 import sqlite3
 from . import utils
 import cec
 from lib import raspberry_pi_helper
 from pprint import pprint
 from datetime import datetime
-
-
-def get_monitor_status():
-    try:
-        return sh.tvservice('-s').stdout.strip().decode('utf-8')
-    except Exception:
-        return 'Unable to run tvservice.'
 
 
 def get_display_power():
@@ -132,7 +124,6 @@ def compile_report():
     report['cpu_info'] = get_raspberry_code()
     report['pi_model'] = get_raspberry_model()
     report['uptime'] = get_uptime()
-    report['monitor'] = get_monitor_status()
     report['display_power'] = get_display_power()
     report['playlist'] = get_playlist()
     report['git_hash'] = get_git_hash()

--- a/server.py
+++ b/server.py
@@ -1227,7 +1227,6 @@ class Info(Resource):
             'viewlog': viewlog,
             'loadavg': diagnostics.get_load_avg()['15 min'],
             'free_space': free_space,
-            'display_info': diagnostics.get_monitor_status(),
             'display_power': display_power,
             'up_to_date': is_up_to_date()
         }
@@ -1535,7 +1534,6 @@ def system_info():
     viewlog = ["Yet to be implemented"]
 
     loadavg = diagnostics.get_load_avg()['15 min']
-    display_info = diagnostics.get_monitor_status()
     display_power = r.get('display_power')
 
     # Calculate disk space
@@ -1575,7 +1573,6 @@ def system_info():
         free_space=free_space,
         uptime=system_uptime,
         memory=memory,
-        display_info=display_info,
         display_power=display_power,
         raspberry_pi_model=raspberry_pi_model,
         version=version,

--- a/templates/system-info.html
+++ b/templates/system-info.html
@@ -43,10 +43,7 @@
                         <th scope="row">Uptime</th>
                         <td>{{ context.uptime.days }} days and {{ (context.uptime.seconds / 3600)|round(2) }} hours</td>
                     </tr>
-                    <tr>
-                        <th scope="row">Monitor Info</th>
-                        <td>{{ context.display_info }}</td>
-                    </tr>
+
                     <tr>
                         <th scope="row">Display Power (CEC)</th>
                         <td>{{ context.display_power }}</td>


### PR DESCRIPTION
#### Description

* Fixes #1999
* The value for **_Monitor Info_** depends on the output of the `tvservice` command, which was dropped in **_Bookworm_**.

#### Screenshot

![image](https://github.com/user-attachments/assets/2639ee61-19e1-407a-aacd-48f4aaf7d277)
