### PR TITLE
Downgrades installer cryptography to `38.0.1`

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -199,7 +199,7 @@ fi
 # @TODO
 # Remove me later. Cryptography 38.0.3 won't build at the moment.
 # See https://github.com/screenly/anthias/issues/1654
-sudo ${SUDO_ARGS[@]} pip install cryptography==38.0.2
+sudo ${SUDO_ARGS[@]} pip install cryptography==38.0.1
 sudo ${SUDO_ARGS[@]} pip install "$ANSIBLE_VERSION"
 
 sudo -u ${USER} ${SUDO_ARGS[@]} ansible localhost \


### PR DESCRIPTION
#### Description

* `cryptography` version newer than `38.0.2` might break the installer.
* `cryptography` version `38.0.2` was yanked, so we have to use an older version.
* Given that `38.0.2` was yanked, `pip` defaults to installing the latest version, thus having the need to explicitly set an older one.
* If #2028 can be approved and merged, I'll be closing this pull request, as #2028 already includes the `cryptography` version downgrade.