### PR TITLE
Fix basic authentication failure

### DIFF
--- a/server.py
+++ b/server.py
@@ -1429,8 +1429,9 @@ def settings_page():
             current_pass = request.form.get('current-password', '')
             auth_backend = request.form.get('auth_backend', '')
 
-            if auth_backend != (
-                settings['auth_backend'] and settings['auth_backend']
+            if (
+                auth_backend != settings['auth_backend']
+                and settings['auth_backend']
             ):
                 if not current_pass:
                     raise ValueError(


### PR DESCRIPTION
#### Description

* See the following Anthias forum topic for details: https://forums.screenly.io/t/set-username-and-password-ask-for-curent-password/1553
* Issue was caused by https://github.com/Screenly/Anthias/pull/2019.