### PR TITLE
Fix asset not being displayed for single-asset playlists

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -547,6 +547,8 @@ def main():
         show_hotspot_page(mq_data)
         mq_data = None
 
+    sleep(0.5)
+
     start_loop()
 
 


### PR DESCRIPTION
#### Description

* See this [forum discussion comment](https://forums.screenly.io/t/after-booting-the-pi-if-the-asset-set-is-a-single-image-it-doesnt-display-the-screen-remains-dark-with-only-the-small-purple-screenly-logo-in-the-center/1166/28?u=nicomiguelino) for the solution.
* Fixes #1882
* Added a delay before the asset loop starts