### PR TITLE
Adopt a singleton pattern for the media player instance

### DIFF
--- a/lib/media_player.py
+++ b/lib/media_player.py
@@ -27,6 +27,8 @@ class MediaPlayer(object):
 
 
 class VLCMediaPlayer(MediaPlayer):
+    INSTANCE = None
+
     def __init__(self):
         MediaPlayer.__init__(self)
 
@@ -35,6 +37,12 @@ class VLCMediaPlayer(MediaPlayer):
         self.player = self.instance.media_player_new()
 
         self.player.audio_output_set('alsa')
+
+    @classmethod
+    def get_instance(cls):
+        if cls.INSTANCE is None:
+            cls.INSTANCE = VLCMediaPlayer()
+        return cls.INSTANCE
 
     def get_alsa_audio_device(self):
         if settings['audio_output'] == 'local':

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -1,4 +1,3 @@
-import mock
 import os
 import unittest
 
@@ -6,13 +5,6 @@ from datetime import datetime, timedelta
 from lib import db, assets_helper
 
 import settings
-
-mock.patch(
-    'lib.raspberry_pi_helper.lookup_raspberry_pi_version',
-    return_value='pi4'
-).__enter__()
-mock.patch('vlc.Instance', mock.MagicMock()).__enter__()
-
 import viewer  # noqa: E402
 
 asset_x = {

--- a/tests/viewer_test.py
+++ b/tests/viewer_test.py
@@ -5,19 +5,12 @@ from __future__ import unicode_literals
 import mock
 import unittest
 import os
+import viewer
 from time import sleep
 
 
 class ViewerTestCase(unittest.TestCase):
     def setUp(self):
-        mock.patch(
-            'lib.raspberry_pi_helper.lookup_raspberry_pi_version',
-            return_value='pi4'
-        ).__enter__()
-        mock.patch('vlc.Instance', mock.MagicMock()).__enter__()
-
-        import viewer
-
         self.original_splash_delay = viewer.SPLASH_DELAY
         viewer.SPLASH_DELAY = 0
 
@@ -96,7 +89,12 @@ class TestLoadBrowser(ViewerTestCase):
 
 
 class TestSignalHandlers(ViewerTestCase):
-    def test_usr1(self):
+    @mock.patch('vlc.Instance', mock.MagicMock())
+    @mock.patch(
+        'lib.media_player.lookup_raspberry_pi_version',
+        return_value='pi4'
+    )
+    def test_usr1(self, lookup_mock):
         self.p_killall.start()
         self.assertEqual(None, self.u.sigusr1(None, None))
         self.p_killall.stop()

--- a/viewer.py
+++ b/viewer.py
@@ -66,8 +66,6 @@ loop_is_stopped = False
 browser_bus = None
 r = connect_to_redis()
 
-media_player = VLCMediaPlayer()
-
 HOME = None
 db_conn = None
 
@@ -87,7 +85,7 @@ def sigusr1(signum, frame):
     playing web or image asset is skipped.
     """
     logging.info('USR1 received, skipping.')
-    media_player.stop()
+    VLCMediaPlayer.get_instance().stop()
 
 
 def skip_asset(back=False):
@@ -382,6 +380,7 @@ def view_image(uri):
 
 def view_video(uri, duration):
     logging.debug('Displaying video %s for %s ', uri, duration)
+    media_player = VLCMediaPlayer.get_instance()
 
     media_player.set_asset(uri, duration)
     media_player.play()


### PR DESCRIPTION
#### Overview

* Using the singleton pattern for the media player instance will help us avoid doing mocking (in tests) at module level.
* It's unpleasant to see a mock statement in the same level as the file-level imports in tests.