### PR TITLE
Initialize the `Scheduler` after the server starts.

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -538,13 +538,13 @@ def main():
     subscriber_2.daemon = True
     subscriber_2.start()
 
-    scheduler = Scheduler()
-
     # This will prevent white screen from happening before showing the
     # splash screen with IP addresses.
     view_image(STANDBY_SCREEN)
 
     wait_for_server(SERVER_WAIT_TIMEOUT)
+
+    scheduler = Scheduler()
 
     if settings['show_splash']:
         if is_balena_app():


### PR DESCRIPTION
#### Overview

The issue (see logs for details) happens during a fresh install on both Raspberry Pi OS and Balena OS instances.

#### Logs

```
nico@raspberrypi4:~/screenly $ sudo docker compose logs -ft anthias-viewer
anthias-viewer-1  | 2024-08-29T01:12:50.234199929Z ./bin/start_viewer.sh: line 39: /sys/fs/cgroup/memory/memory.swappiness: No such file or directory
anthias-viewer-1  | 2024-08-29T01:12:53.257390741Z Loading browser...
anthias-viewer-1  | 2024-08-29T01:12:54.544799658Z Generating asset-list...
anthias-viewer-1  | 2024-08-29T01:12:54.608938054Z Viewer crashed.
anthias-viewer-1  | 2024-08-29T01:12:54.609054534Z Traceback (most recent call last):
anthias-viewer-1  | 2024-08-29T01:12:54.609077756Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 84, in _execute
anthias-viewer-1  | 2024-08-29T01:12:54.609255755Z     return self.cursor.execute(sql, params)
anthias-viewer-1  | 2024-08-29T01:12:54.609282422Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.609297477Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/sqlite3/base.py", line 423, in execute
anthias-viewer-1  | 2024-08-29T01:12:54.609311959Z     return Database.Cursor.execute(self, query, params)
anthias-viewer-1  | 2024-08-29T01:12:54.609325625Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.609338181Z sqlite3.OperationalError: no such table: assets
anthias-viewer-1  | 2024-08-29T01:12:54.609350681Z
anthias-viewer-1  | 2024-08-29T01:12:54.609363532Z The above exception was the direct cause of the following exception:
anthias-viewer-1  | 2024-08-29T01:12:54.609376884Z
anthias-viewer-1  | 2024-08-29T01:12:54.609389569Z Traceback (most recent call last):
anthias-viewer-1  | 2024-08-29T01:12:54.609402217Z   File "/usr/src/app/viewer.py", line 578, in <module>
anthias-viewer-1  | 2024-08-29T01:12:54.609416810Z     main()
anthias-viewer-1  | 2024-08-29T01:12:54.609429847Z   File "/usr/src/app/viewer.py", line 541, in main
anthias-viewer-1  | 2024-08-29T01:12:54.609442958Z     scheduler = Scheduler()
anthias-viewer-1  | 2024-08-29T01:12:54.609456087Z                 ^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.609468735Z   File "/usr/src/app/viewer.py", line 229, in __init__
anthias-viewer-1  | 2024-08-29T01:12:54.609481939Z     self.update_playlist()
anthias-viewer-1  | 2024-08-29T01:12:54.609495587Z   File "/usr/src/app/viewer.py", line 288, in update_playlist
anthias-viewer-1  | 2024-08-29T01:12:54.609509124Z     (new_assets, new_deadline) = generate_asset_list()
anthias-viewer-1  | 2024-08-29T01:12:54.609522494Z                                  ^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.609535902Z   File "/usr/src/app/viewer.py", line 329, in generate_asset_list
anthias-viewer-1  | 2024-08-29T01:12:54.609549142Z     deadlines = [
anthias-viewer-1  | 2024-08-29T01:12:54.609562346Z                 ^
anthias-viewer-1  | 2024-08-29T01:12:54.609576864Z   File "/usr/local/lib/python3.11/dist-packages/django/db/models/query.py", line 280, in __iter__
anthias-viewer-1  | 2024-08-29T01:12:54.609590420Z     self._fetch_all()
anthias-viewer-1  | 2024-08-29T01:12:54.609603808Z   File "/usr/local/lib/python3.11/dist-packages/django/db/models/query.py", line 1324, in _fetch_all
anthias-viewer-1  | 2024-08-29T01:12:54.609642753Z     self._result_cache = list(self._iterable_class(self))
anthias-viewer-1  | 2024-08-29T01:12:54.609662715Z                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.609675845Z   File "/usr/local/lib/python3.11/dist-packages/django/db/models/query.py", line 51, in __iter__
anthias-viewer-1  | 2024-08-29T01:12:54.609762770Z     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
anthias-viewer-1  | 2024-08-29T01:12:54.609790085Z               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.609804270Z   File "/usr/local/lib/python3.11/dist-packages/django/db/models/sql/compiler.py", line 1175, in execute_sql
anthias-viewer-1  | 2024-08-29T01:12:54.609819252Z     cursor.execute(sql, params)
anthias-viewer-1  | 2024-08-29T01:12:54.609832807Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 66, in execute
anthias-viewer-1  | 2024-08-29T01:12:54.609858362Z     return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
anthias-viewer-1  | 2024-08-29T01:12:54.609872659Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.609886436Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
anthias-viewer-1  | 2024-08-29T01:12:54.609900307Z     return executor(sql, params, many, context)
anthias-viewer-1  | 2024-08-29T01:12:54.609913066Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.609926603Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 79, in _execute
anthias-viewer-1  | 2024-08-29T01:12:54.609940232Z     with self.db.wrap_database_errors:
anthias-viewer-1  | 2024-08-29T01:12:54.609953288Z   File "/usr/local/lib/python3.11/dist-packages/django/db/utils.py", line 90, in __exit__
anthias-viewer-1  | 2024-08-29T01:12:54.609966306Z     raise dj_exc_value.with_traceback(traceback) from exc_value
anthias-viewer-1  | 2024-08-29T01:12:54.609979954Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 84, in _execute
anthias-viewer-1  | 2024-08-29T01:12:54.609993528Z     return self.cursor.execute(sql, params)
anthias-viewer-1  | 2024-08-29T01:12:54.610006769Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.610019935Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/sqlite3/base.py", line 423, in execute
anthias-viewer-1  | 2024-08-29T01:12:54.610033454Z     return Database.Cursor.execute(self, query, params)
anthias-viewer-1  | 2024-08-29T01:12:54.610046454Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.610059305Z django.db.utils.OperationalError: no such table: assets
anthias-viewer-1  | 2024-08-29T01:12:54.614905663Z Traceback (most recent call last):
anthias-viewer-1  | 2024-08-29T01:12:54.614997329Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 84, in _execute
anthias-viewer-1  | 2024-08-29T01:12:54.615014903Z     return self.cursor.execute(sql, params)
anthias-viewer-1  | 2024-08-29T01:12:54.617911569Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.619038895Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/sqlite3/base.py", line 423, in execute
anthias-viewer-1  | 2024-08-29T01:12:54.622168282Z     return Database.Cursor.execute(self, query, params)
anthias-viewer-1  | 2024-08-29T01:12:54.625767647Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.626684289Z sqlite3.OperationalError: no such table: assets
anthias-viewer-1  | 2024-08-29T01:12:54.629413512Z
anthias-viewer-1  | 2024-08-29T01:12:54.629500975Z The above exception was the direct cause of the following exception:
anthias-viewer-1  | 2024-08-29T01:12:54.629517586Z
anthias-viewer-1  | 2024-08-29T01:12:54.629530900Z Traceback (most recent call last):
anthias-viewer-1  | 2024-08-29T01:12:54.629544085Z   File "/usr/src/app/viewer.py", line 578, in <module>
anthias-viewer-1  | 2024-08-29T01:12:54.629558659Z     main()
anthias-viewer-1  | 2024-08-29T01:12:54.629571196Z   File "/usr/src/app/viewer.py", line 541, in main
anthias-viewer-1  | 2024-08-29T01:12:54.629585011Z     scheduler = Scheduler()
anthias-viewer-1  | 2024-08-29T01:12:54.629597604Z                 ^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.629610122Z   File "/usr/src/app/viewer.py", line 229, in __init__
anthias-viewer-1  | 2024-08-29T01:12:54.629622918Z     self.update_playlist()
anthias-viewer-1  | 2024-08-29T01:12:54.629635418Z   File "/usr/src/app/viewer.py", line 288, in update_playlist
anthias-viewer-1  | 2024-08-29T01:12:54.634648441Z     (new_assets, new_deadline) = generate_asset_list()
anthias-viewer-1  | 2024-08-29T01:12:54.635244844Z                                  ^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.635686471Z   File "/usr/src/app/viewer.py", line 329, in generate_asset_list
anthias-viewer-1  | 2024-08-29T01:12:54.639471854Z     deadlines = [
anthias-viewer-1  | 2024-08-29T01:12:54.639880999Z                 ^
anthias-viewer-1  | 2024-08-29T01:12:54.640080331Z   File "/usr/local/lib/python3.11/dist-packages/django/db/models/query.py", line 280, in __iter__
anthias-viewer-1  | 2024-08-29T01:12:54.640782790Z     self._fetch_all()
anthias-viewer-1  | 2024-08-29T01:12:54.642045911Z   File "/usr/local/lib/python3.11/dist-packages/django/db/models/query.py", line 1324, in _fetch_all
anthias-viewer-1  | 2024-08-29T01:12:54.643638178Z     self._result_cache = list(self._iterable_class(self))
anthias-viewer-1  | 2024-08-29T01:12:54.644273896Z                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.645899941Z   File "/usr/local/lib/python3.11/dist-packages/django/db/models/query.py", line 51, in __iter__
anthias-viewer-1  | 2024-08-29T01:12:54.646014626Z     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
anthias-viewer-1  | 2024-08-29T01:12:54.646383642Z               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.646568141Z   File "/usr/local/lib/python3.11/dist-packages/django/db/models/sql/compiler.py", line 1175, in execute_sql
anthias-viewer-1  | 2024-08-29T01:12:54.651676237Z     cursor.execute(sql, params)
anthias-viewer-1  | 2024-08-29T01:12:54.652590175Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 66, in execute
anthias-viewer-1  | 2024-08-29T01:12:54.654024036Z     return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
anthias-viewer-1  | 2024-08-29T01:12:54.658100102Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.658224398Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
anthias-viewer-1  | 2024-08-29T01:12:54.659058189Z     return executor(sql, params, many, context)
anthias-viewer-1  | 2024-08-29T01:12:54.659803165Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.660185052Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 79, in _execute
anthias-viewer-1  | 2024-08-29T01:12:54.661374544Z     with self.db.wrap_database_errors:
anthias-viewer-1  | 2024-08-29T01:12:54.661687060Z   File "/usr/local/lib/python3.11/dist-packages/django/db/utils.py", line 90, in __exit__
anthias-viewer-1  | 2024-08-29T01:12:54.663049755Z     raise dj_exc_value.with_traceback(traceback) from exc_value
anthias-viewer-1  | 2024-08-29T01:12:54.663483678Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 84, in _execute
anthias-viewer-1  | 2024-08-29T01:12:54.664214285Z     return self.cursor.execute(sql, params)
anthias-viewer-1  | 2024-08-29T01:12:54.665824404Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.666291382Z   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/sqlite3/base.py", line 423, in execute
anthias-viewer-1  | 2024-08-29T01:12:54.667539429Z     return Database.Cursor.execute(self, query, params)
anthias-viewer-1  | 2024-08-29T01:12:54.669907729Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
anthias-viewer-1  | 2024-08-29T01:12:54.670092691Z django.db.utils.OperationalError: no such table: assets
anthias-viewer-1  | 2024-08-29T01:12:55.835253506Z ./bin/start_viewer.sh: line 57: kill: (37) - No such process
anthias-viewer-1  | 2024-08-29T01:12:58.417597697Z ./bin/start_viewer.sh: line 39: /sys/fs/cgroup/memory/memory.swappiness: No such file or directory
anthias-viewer-1  | 2024-08-29T01:13:01.065887857Z Loading browser...
anthias-viewer-1  | 2024-08-29T01:13:02.115703953Z Generating asset-list...
anthias-viewer-1  | 2024-08-29T01:13:02.153984374Z Current url is http://anthias-nginx:80/static/img/standby.png
anthias-viewer-1  | 2024-08-29T01:13:06.567826016Z Current url is http://anthias-nginx:80/splash-page
```