### PR TITLE
Create a `Scheduler` instance only after server initialization completes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,6 @@ python = ">=3.8,<3.12"
 [tool.poetry.group.dev-host.dependencies]
 flake8 = "^5.0.4"
 
-[tool.poetry.scripts]
-wee = "ls -l"
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/viewer.py
+++ b/viewer.py
@@ -59,6 +59,7 @@ ZMQ_HOST_PUB_URL = 'tcp://host.docker.internal:10001'
 
 MAX_BALENA_IP_RETRIES = 90
 BALENA_IP_RETRY_DELAY = 1
+SERVER_WAIT_TIMEOUT = 60
 
 current_browser_url = None
 browser = None
@@ -520,9 +521,9 @@ def main():
     subscriber_2.daemon = True
     subscriber_2.start()
 
-    scheduler = Scheduler()
+    wait_for_server(SERVER_WAIT_TIMEOUT)
 
-    wait_for_server(60)
+    scheduler = Scheduler()
 
     if settings['show_splash']:
         if is_balena_app():


### PR DESCRIPTION
#### Description

* Moved the creation of a `Scheduler` object right after the server wait.
* Removed a unnecessary Poetry `script` from `pyproject.toml`.