### PR TITLE
Replace `nose` attributes with `unittest`'s `skip`

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -17,6 +17,7 @@ on:
       - '!docs/**'
       - '!bin/install.sh'
       - '!bin/upgrade_containers.sh'
+      - '!tests/**'
 
 jobs:
   run-tests:

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -64,7 +64,7 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           docker compose -f docker-compose.test.yml exec anthias-test bash ./bin/prepare_test_environment.sh -s
-          docker compose -f docker-compose.test.yml exec anthias-test nose2 -v -A '!fixme'
+          docker compose -f docker-compose.test.yml exec anthias-test nose2 -v
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -81,7 +81,7 @@ $ docker compose \
     exec -T anthias-test bash ./bin/prepare_test_environment.sh -s
 $ docker compose \
     -f docker-compose.test.yml \
-    exec -T anthias-test nose2 -v -A '!fixme'
+    exec -T anthias-test nose2 -v
 ```
 
 ### The QA checklist

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
-import unittest
 import os
 import sh
 import shutil
 import sys
 from contextlib import contextmanager
+from unittest import skip, TestCase
 
 user_home_dir = os.getenv('HOME')
 
@@ -65,7 +65,7 @@ def getenv(k, default=None):
         return default
 
 
-class SettingsTest(unittest.TestCase):
+class SettingsTest(TestCase):
     def setUp(self):
         if not os.path.exists(CONFIG_DIR):
             os.mkdir(CONFIG_DIR)
@@ -77,6 +77,8 @@ class SettingsTest(unittest.TestCase):
         shutil.rmtree(CONFIG_DIR)
         os.getenv = self.orig_getenv
 
+    # This test passes locally but fails on CI.
+    @skip('fixme')
     def test_anthias_should_exit_if_no_settings_file_found(self):
         new_env = os.environ.copy()
         new_env["HOME"] = "/tmp"
@@ -134,6 +136,3 @@ class SettingsTest(unittest.TestCase):
                 self.assertEqual(settings['verify_ssl'], True)
                 # no out of thin air changes?
                 self.assertEqual(settings['audio_output'], 'hdmi')
-
-    # The test passes locally but fails on CI.
-    test_anthias_should_exit_if_no_settings_file_found.fixme = True

--- a/tests/splinter_test.py
+++ b/tests/splinter_test.py
@@ -10,7 +10,7 @@ from lib import assets_helper
 import os
 import shutil
 import tempfile
-import unittest
+from unittest import skip, TestCase
 from datetime import datetime, timedelta
 
 asset_x = {
@@ -84,7 +84,7 @@ def wait_for_and_do(browser, query, callback):
             n += 1
 
 
-class WebTest(unittest.TestCase):
+class WebTest(TestCase):
     def setUp(self):
         with db.conn(settings['database']) as conn:
             assets = assets_helper.read(conn)
@@ -250,6 +250,7 @@ class WebTest(unittest.TestCase):
                 self.assertEqual(assets[1]['mimetype'], u'video')
                 self.assertEqual(assets[1]['duration'], u'5')
 
+    @skip('fixme')
     def test_add_asset_streaming(self):
         with get_browser() as browser:
             browser.visit(main_page_url)
@@ -280,8 +281,6 @@ class WebTest(unittest.TestCase):
             self.assertEqual(asset['mimetype'], u'streaming')
             self.assertEqual(
                 asset['duration'], settings['default_streaming_duration'])
-
-    test_add_asset_streaming.fixme = True
 
     def test_rm_asset(self):
         with db.conn(settings['database']) as conn:

--- a/tests/updates_test.py
+++ b/tests/updates_test.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import unittest
+from unittest import skip, TestCase
 
 import mock
 import server
@@ -10,7 +10,8 @@ from settings import settings
 fancy_sha = 'deadbeaf'
 
 
-class UpdateTest(unittest.TestCase):
+@skip('fixme')
+class UpdateTest(TestCase):
     def setUp(self):
         self.get_configdir_m = mock.patch(
             'settings.AnthiasSettings.get_configdir',
@@ -46,6 +47,3 @@ class UpdateTest(unittest.TestCase):
             f.write(fancy_sha)
         self.assertEqual(server.is_up_to_date(), False)
         del os.environ['GIT_BRANCH']
-
-    test_if_sha_file_not_exists__is_up_to_date__should_return_false.fixme = True  # noqa: E501
-    test_if_sha_file_not_equals_to_branch_hash__is_up_to_date__should_return_false.fixme = True  # noqa: E501


### PR DESCRIPTION
#### Description

* Using the `@skip` decorator will make running tests more simpler.
* With this, we can just run `nose2 -v` instead of `nose2 -v -A '!fixme'`

#### Other Changes

* The `docker-build.yaml` workflow was modified so that the CI won't build the Docker images if tests were added or modified.