### PR TITLE
Enable X11 when building Qt 5

### DIFF
--- a/webview/build_qt5.sh
+++ b/webview/build_qt5.sh
@@ -183,8 +183,6 @@ function build_qt () {
             -no-gtk \
             -no-pch \
             -no-use-gold-linker \
-            -no-xcb \
-            -no-xcb-xlib \
             -nomake examples \
             -nomake tests \
             -opensource \


### PR DESCRIPTION
#### Description

* Setting `QT_QPA_PLATFORM` in the client (Python) code won't work if X11 is enabled during compilation.