### PR TITLE
chore(ci): replace `--with` with `--only` when installing specific deps

### DIFF
--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        poetry install --with=dev-host
+        poetry install --only=dev-host
 
     - name: Analyzing the code with flake8
       run: |

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -148,7 +148,7 @@ After installing Poetry, run the following commands:
 
 ```bash
 # Install the dependencies
-$ poetry install --with=dev-host
+$ poetry install --only=dev-host
 $ poetry run flake8 $(git ls-files '**/*.py')
 ```
 


### PR DESCRIPTION
#### Description

* Running `poetry install --with=[groups]` will also install dependencies outside of the specified group(s).
* If we want to install dependencies from specific groups, we have to run `poetry install --with=[groups]`. 