### PR TITLE
Use HTTPS instead of HTTP urls in unit tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,7 +17,7 @@ asset_x = {
     'mimetype': u'web',
     'asset_id': u'4c8dbce552edb5812d3a866cfe5f159d',
     'name': u'WireLoad',
-    'uri': u'http://www.wireload.net',
+    'uri': u'https://www.wireload.net',
     'start_date': datetime.now() - timedelta(days=1),
     'end_date': datetime.now() + timedelta(days=1),
     'duration': u'5',
@@ -104,7 +104,7 @@ class WebTest(TestCase):
 
             wait_for_and_do(
                 browser, 'input[name="uri"]',
-                lambda field: field.fill('http://example.com'))
+                lambda field: field.fill('https://example.com'))
             sleep(1)
 
             wait_for_and_do(browser, '#add-form', lambda form: form.click())
@@ -119,8 +119,8 @@ class WebTest(TestCase):
             self.assertEqual(len(assets), 1)
             asset = assets[0]
 
-            self.assertEqual(asset['name'], u'http://example.com')
-            self.assertEqual(asset['uri'], u'http://example.com')
+            self.assertEqual(asset['name'], u'https://example.com')
+            self.assertEqual(asset['uri'], u'https://example.com')
             self.assertEqual(asset['mimetype'], u'webpage')
             self.assertEqual(asset['duration'], settings['default_duration'])
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -12,7 +12,7 @@ asset_x = {
     'mimetype': u'web',
     'asset_id': u'4c8dbce552edb5812d3a866cfe5f159d',
     'name': u'WireLoad',
-    'uri': u'http://www.wireload.net',
+    'uri': u'https://www.wireload.net',
     'start_date': datetime.now() - timedelta(days=3),
     'end_date': datetime.now() + timedelta(days=3),
     'duration': u'5',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,7 +36,7 @@ asset_w = {
     'mimetype': u'web',
     'asset_id': u'4c8dbce552edb5812d3a866cfe5f159e',
     'name': u'いろはにほへど',
-    'uri': u'http://www.wireload.net',
+    'uri': u'https://www.wireload.net',
     'start_date': date_a,
     'end_date': date_b,
     'duration': u'5',
@@ -55,7 +55,7 @@ asset_x = {
     'mimetype': u'web',
     'asset_id': u'4c8dbce552edb5812d3a866cfe5f159d',
     'name': u'WireLoad',
-    'uri': u'http://www.wireload.net',
+    'uri': u'https://www.wireload.net',
     'start_date': date_a,
     'end_date': date_b,
     'duration': u'5',
@@ -99,10 +99,9 @@ asset_z = {
     'is_processing': 0,
     'skip_asset_check': 0
 }
-url_fail = 'http://doesnotwork.example.com'
-url_redir = 'http://example.com'
+url_fail = 'https://doesnotwork.example.com'
+url_redir = 'https://example.com'
 uri_ = '/home/user/file'
-# url_timeout = 'http://...'
 
 
 class Req(object):
@@ -255,7 +254,7 @@ class DBHelperTest(unittest.TestCase):
                            'mimetype': u'web',
                            'name': 'New name',
                            'nocache': 0,
-                           'uri': u'http://www.wireload.net',
+                           'uri': u'https://www.wireload.net',
                            'skip_asset_check': 0,
                            'play_order': 1,
                            'start_date': datetime.datetime(2013, 1, 16, 0, 0)


### PR DESCRIPTION
#### Description

* The changes help minimize security-related issues found during code quality checks.