### PR TITLE
Install `python3-dev` during installation to prevent errors

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -132,7 +132,10 @@ function install_packages() {
     )
 
     if [ "$RASPBERRY_PI_OS_VERSION" -ge 12 ]; then
-        APT_INSTALL_ARGS+=("python3-full")
+        APT_INSTALL_ARGS+=(
+            "python3-dev"
+            "python3-full"
+        )
     else
         APT_INSTALL_ARGS+=(
             "python3"


### PR DESCRIPTION
#### Description

* Installing `python3-dev` prevents the following error when trying to install Python dependencies on a Raspberry Pi 2 running Bookworm.