### PR TITLE
Exclude link-local IP addresses in the splash page

### DIFF
--- a/host_agent.py
+++ b/host_agent.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 __author__ = "Nash Kaminski"
 __license__ = "Dual License: GPLv2 and Commercial License"
 
+import ipaddress
 import json
 import logging
 import netifaces
@@ -25,20 +26,16 @@ SUPPORTED_INTERFACES = (
 
 
 def get_ip_addresses():
-    addresses = []
-
-    for interface in netifaces.interfaces():
-        if not interface.startswith(SUPPORTED_INTERFACES):
-            continue
-
-        addrs = netifaces.ifaddresses(interface)
-        if netifaces.AF_INET in addrs or netifaces.AF_INET6 in addrs:
-            for ip in addrs.get(netifaces.AF_INET, []):
-                addresses.append(ip['addr'])
-            for ip in addrs.get(netifaces.AF_INET6, []):
-                addresses.append(ip['addr'])
-
-    return addresses
+    return [
+        ip['addr']
+        for interface in netifaces.interfaces()
+        if interface.startswith(SUPPORTED_INTERFACES)
+        for ip in (
+            netifaces.ifaddresses(interface).get(netifaces.AF_INET, []) +
+            netifaces.ifaddresses(interface).get(netifaces.AF_INET6, [])
+        )
+        if not ipaddress.ip_address(ip['addr']).is_link_local
+    ]
 
 
 def set_ip_addresses():


### PR DESCRIPTION
### Screenshots

#### Before

![image](https://github.com/user-attachments/assets/b05afbfd-05f5-4b78-b76d-c12a3abc4273)

The `fe80::` IP address is link-local and shouldn't be included in the splash page. (The address is not accessible from the browser.)

#### After

![image](https://github.com/user-attachments/assets/85e0173f-02ba-485b-8f05-53e3deaf2002)

Stay tuned for the after photo.