### PR TITLE
Use the complete commit hash in WebView filenames for consistency

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -38,7 +38,7 @@ jobs:
             --output "type=image,push=true" \
             --build-arg "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
             --build-arg "GIT_HASH=$GITHUB_SHA" \
-            --build-arg "GIT_SHORT_HASH=$(git rev-parse --short HEAD)" \
+            --build-arg "GIT_SHORT_HASH=$(git rev-parse HEAD)" \
             --build-arg "GIT_BRANCH=$GITHUB_REF_NAME"
 
       - name: Building container

--- a/webview/README.md
+++ b/webview/README.md
@@ -10,7 +10,7 @@ Since our entire build environment resides inside a Docker container, you don't 
 $ cd webview
 $ docker buildx build \
     --load \
-    --build-arg GIT_HASH=$(git rev-parse --short HEAD) \
+    --build-arg GIT_HASH=$(git rev-parse HEAD) \
     -t qt-builder .
 ```
 


### PR DESCRIPTION
* The existing WebView releases have long hashes in their file names, so I updated the docs and the CI workflow file for consistency.