### PR TITLE
Clean up unused/untraversed steps during server startup

### DIFF
--- a/bin/start_server.sh
+++ b/bin/start_server.sh
@@ -11,17 +11,6 @@ cp -n /usr/src/app/ansible/roles/screenly/files/screenly.conf /data/.screenly/sc
 cp -n /usr/src/app/ansible/roles/screenly/files/default_assets.yml /data/.screenly/default_assets.yml
 cp -n /usr/src/app/ansible/roles/screenly/files/screenly.db /data/.screenly/screenly.db
 
-if [ -n "${OVERWRITE_CONFIG}" ]; then
-    echo "Requested to overwrite Anthias config file."
-    cp /usr/src/app/ansible/roles/screenly/files/screenly.conf "/data/.screenly/screenly.conf"
-fi
-
-# Set management page's user and password from environment variables,
-# but only if both of them are provided. Can have empty values provided.
-if [ -n "${MANAGEMENT_USER+x}" ] && [ -n "${MANAGEMENT_PASSWORD+x}" ]; then
-    sed -i -e "s/^user=.*/user=${MANAGEMENT_USER}/" -e "s/^password=.*/password=${MANAGEMENT_PASSWORD}/" /data/.screenly/screenly.conf
-fi
-
 echo "Running migration..."
 python ./bin/migrate.py
 

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ __author__ = "Screenly, Inc"
 __copyright__ = "Copyright 2012-2023, Screenly, Inc"
 __license__ = "Dual License: GPLv2 and Commercial License"
 
-from os import getenv, makedirs, mkdir, path, stat
+from os import getenv, path, stat
 
 from flask import (
     Flask,
@@ -165,13 +165,6 @@ def static_with_mime(path):
 
 @app.before_first_request
 def main():
-    # Make sure the asset folder exist. If not, create it
-    if not path.isdir(settings['assetdir']):
-        mkdir(settings['assetdir'])
-    # Create config dir if it doesn't exist
-    if not path.isdir(settings.get_configdir()):
-        makedirs(settings.get_configdir())
-
     with db.conn(settings['database']) as conn:
         with db.cursor(conn) as cursor:
             cursor.execute(queries.exists_table)


### PR DESCRIPTION
#### Description

* This pull request is sort of a follow-up to #2078.
* Currently, there's no way the user can specify `OVERWRITE_CONFIG`, `MANAGEMENT_USER`, and `MANAGEMENT_PASSWORD`, as `start_server.sh` is started when the server container starts, as specified in the server Dockerfile.
  * Authentication credentials and most config changes can be done via the web interface for both RPi OS and BalenaOS.
 * In `server.py`, the logic for creating config and asset directories were removed, as those directories were already created when `start_server.sh` runs.`

#### References

* https://github.com/Screenly/Anthias/pull/1409/files