### PR TITLE
Fix Django DB migration

### DIFF
--- a/bin/start_server.sh
+++ b/bin/start_server.sh
@@ -16,10 +16,10 @@ echo "Running migration..."
 # database is not left in an inconsistent state if the migration fails.
 
 if [ -f /data/.screenly/screenly.db ]; then
-    cp /data/.screenly/screenly.db /data/.screenly/backup.db
-    cp /data/.screenly/screenly.db /data/.screenly/screenly.db.bak
-    ./manage.py migrate --fake-initial --database=backup
-    mv /data/.screenly/backup.db /data/.screenly/screenly.db
+    cp /data/.screenly/screenly.db /data/.screenly/backup.db && \
+        cp /data/.screenly/screenly.db /data/.screenly/screenly.db.bak && \
+        ./manage.py migrate --fake-initial --database=backup && \
+        mv /data/.screenly/backup.db /data/.screenly/screenly.db
 else
     ./manage.py migrate
 fi


### PR DESCRIPTION
#### Description

* Only overwrite the main DB with the backup DB only if the latter is not malformed, which could be caused by an interrupted migration.

#### Logs

```
[Logs]    [2024-10-14T10:49:47.657Z] [anthias-server]   File "/usr/local/lib/python3.11/dist-packages/django/db/utils.py", line 90, in __exit__
[Logs]    [2024-10-14T10:49:47.657Z] [anthias-server]     raise dj_exc_value.with_traceback(traceback) from exc_value
[Logs]    [2024-10-14T10:49:47.659Z] [anthias-server]   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/utils.py", line 82, in _execute
[Logs]    [2024-10-14T10:49:47.659Z] [anthias-server]     return self.cursor.execute(sql)
[Logs]    [2024-10-14T10:49:47.660Z] [anthias-server]            ^^^^^^^^^^^^^^^^^^^^^^^^
[Logs]    [2024-10-14T10:49:47.660Z] [anthias-server]   File "/usr/local/lib/python3.11/dist-packages/django/db/backends/sqlite3/base.py", line 421, in execute
[Logs]    [2024-10-14T10:49:47.660Z] [anthias-server]     return Database.Cursor.execute(self, query)
[Logs]    [2024-10-14T10:49:47.661Z] [anthias-server]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Logs]    [2024-10-14T10:49:47.661Z] [anthias-server] django.db.utils.DatabaseError: database disk image is malformed
[Logs]    [2024-10-14T10:49:49.030Z] [anthias-server] Generating Django static files...
[Logs]    [2024-10-14T10:49:54.263Z] [anthias-server]
[Logs]    [2024-10-14T10:49:54.265Z] [anthias-server] 250 static files copied to '/data/screenly/staticfiles'.
[Logs]    [2024-10-14T10:49:55.225Z] [anthias-server] Starting Gunicorn...
[Logs]    [2024-10-14T10:50:01.236Z] [anthias-server] [2024-10-14 10:50:01 +0000] [24] [INFO] Starting gunicorn 22.0.0
[Logs]    [2024-10-14T10:50:01.239Z] [anthias-server] [2024-10-14 10:50:01 +0000] [24] [INFO] Listening at: http://0.0.0.0:8080 (24)
[Logs]    [2024-10-14T10:50:01.240Z] [anthias-server] [2024-10-14 10:50:01 +0000] [24] [INFO] Using worker: gthread
[Logs]    [2024-10-14T10:50:01.269Z] [anthias-server] [2024-10-14 10:50:01 +0000] [25] [INFO] Booting worker with pid: 25
```