### PR TITLE
Configure preloaded Balena images to pin to a release

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -54,6 +54,7 @@ jobs:
             preload \
               "$BALENA_IMAGE.img" \
               --fleet screenly_ose/anthias-${{ matrix.board }} \
+              --pin-device-to-release \
               --splash-image ansible/roles/splashscreen/files/splashscreen.png \
               --commit latest
           balena_cli_version: 18.1.2


### PR DESCRIPTION
#### Description

* This will set the version of the devices using the image to a fixed one, even if new updates are released.