### PR TITLE
chore(cleanup): remove workflow related to the `experimental` branch

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - experimental
     paths:
       - '**'
       - '!webview/**'

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - experimental
     paths:
       - '**/**'
       - '!README.md'
@@ -16,7 +15,6 @@ on:
   pull_request:
     branches:
       - master
-      - experimental
     paths:
       - '**/**'
       - '!README.md'

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -10,7 +10,6 @@ on:
   pull_request:
     branches:
       - master
-      - experimental
     paths:
       - '**/*.py'
       - '.github/workflows/python-lint.yaml'

--- a/README.md
+++ b/README.md
@@ -112,25 +112,11 @@ Opting for network management will enable and configure the [NetworkManager](htt
 
 #### Prompt: Version Selection
 
-You can choose between the following choices &mdash; `latest`, `experimental`, and `tag`.
+You can choose between the following choices &mdash; `latest` and `tag`.
 
 * Selecting `latest` will install the version from the `master` branch.
-* Selecting `experimental` will install the version from the `experimental` branch.
 * Selecting `tag` will prompt you to enter a specific tag to install.
-* Do take note the `latest` and `experimental` versions are rolling releases, so you'll always get the latest changes.
-
-##### Experimental Features
-
-We have decided to roll out an `experimental` branch for new features that can break Anthias, especially
-if you already have Anthias installed and wish to upgrade.
-
-Before you proceed, make sure to download a
-backup by going to the **_Settings_** page and clicking **_Get Backup_**. You can load the backup file later by going to **_Settings_** and clicking **_Upload and Recover_**.
-
-Here's a current list of experimental features:
-
-* Migration from Flask to Django &ndash; The database still uses `sqlite3`. We will transition to using ORM in the future.
-* Revamped API docs &ndash; we changed the structure and overall look and feel of the documentation for easier reference.
+* Do take note that `latest` is a rolling release, so you'll always get the latest changes.
 
 ##### Installing from a Specific Tag
 

--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -156,19 +156,12 @@ for container in ${SERVICES[@]}; do
     PUSH_ARGS=()
     BUILDX_ARGS=()
 
-    if [ "$GIT_BRANCH" = "experimental" ]; then
-        PUSH_ARGS+=(
-            "screenly/anthias-$container:experimental-$BOARD"
-            "screenly/anthias-$container:experimental-$GIT_SHORT_HASH-$BOARD"
-        )
-    else
-        PUSH_ARGS+=(
-            "screenly/anthias-$container:$DOCKER_TAG"
-            "screenly/anthias-$container:$GIT_SHORT_HASH-$BOARD"
-            "screenly/srly-ose-$container:$DOCKER_TAG"
-            "screenly/srly-ose-$container:$GIT_SHORT_HASH-$BOARD"
-        )
-    fi
+    PUSH_ARGS+=(
+        "screenly/anthias-$container:$DOCKER_TAG"
+        "screenly/anthias-$container:$GIT_SHORT_HASH-$BOARD"
+        "screenly/srly-ose-$container:$DOCKER_TAG"
+        "screenly/srly-ose-$container:$GIT_SHORT_HASH-$BOARD"
+    )
 
     for tag in "${PUSH_ARGS[@]}"; do
         BUILDX_ARGS+=("-t" "$tag")

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -22,23 +22,18 @@ INTRO_MESSAGE=(
     ""
     "When prompted for the version, you can choose between the following:"
     "  - **latest:** Installs the latest version from the \`master\` branch."
-    "  - **experimental:** Installs the latest version from the \`experimental\` branch."
     "  - **tag:** Installs a pinned version based on the tag name."
     ""
-    "Take note that \`latest\` and \`experimental\` versions are rolling releases."
+    "Take note that \`latest\` is a rolling release."
 )
 MANAGE_NETWORK_PROMPT=(
     "Would you like Anthias to manage the network for you?"
-)
-EXPERIMENTAL_PROMPT=(
-    "Would you like to install the experimental version instead?"
 )
 VERSION_PROMPT=(
     "Which version of Anthias would you like to install?"
 )
 VERSION_PROMPT_CHOICES=(
     "latest"
-    "experimental"
     "tag"
 )
 SYSTEM_UPGRADE_PROMPT=(
@@ -355,9 +350,6 @@ function main() {
 
     if [ "$VERSION" == "latest" ]; then
         BRANCH="master"
-    elif [ "$VERSION" == "experimental" ]; then
-        BRANCH="experimental"
-        DOCKER_TAG="experimental"
     else
         set_custom_version
     fi

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -12,11 +12,7 @@ export SHM_SIZE_KB="$(echo "$TOTAL_MEMORY_KB" \* 0.3 | bc | cut -d'.' -f1)"
 export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if [ -z "$DOCKER_TAG" ]; then
-    if [ "$GIT_BRANCH" = "experimental" ]; then
-        export DOCKER_TAG="experimental"
-    else
-        export DOCKER_TAG="latest"
-    fi
+    export DOCKER_TAG="latest"
 fi
 
 # Detect Raspberry Pi version


### PR DESCRIPTION
### Description

* Now that [Anthias has migrated to Django](https://github.com/Screenly/Anthias/pull/2040), it is time that we remove all workflows that have anything to do with the `experimental` branch.