### PR TITLE
docs: make use of alerts in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 ![Anthias Logo](https://github.com/Screenly/Anthias/blob/master/static/img/dark.svg?raw=true  "Anthias Logo")
 
-## About Anthias
+## :sparkles: About Anthias
 
 Anthias is a digital signage platform for Raspberry Pi and x86 devices. Formerly known as Screenly OSE, it was rebranded to clear up the confusion between Screenly (the paid version) and Anthias. More details can be found in [this blog post](https://www.screenly.io/blog/2022/12/06/screenly-ose-now-called-anthias/).
 
 Want to help Anthias thrive? Support us using [GitHub Sponsor](https://github.com/sponsors/Screenly).
 
-## Compatibility
+## :white_check_mark: Compatibility
 
 We've tested Anthias and is known to work on the following Raspberry Pi models:
 
@@ -28,11 +28,11 @@ We've tested Anthias and is known to work on the following Raspberry Pi models:
 > Should you encounter any issues, please file an issue either in this repository or in the
 [forums](https://forums.screenly.io).
 
-## Star History
+## :star: Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Screenly/Anthias&type=Date)](https://star-history.com/#Screenly/Anthias&Date)
 
-## Installation options
+## :package: Installation options
 
 ### Using the image from the Raspberry Pi Imager
 
@@ -159,7 +159,7 @@ Otherwise, if you've selected **No** for the system upgrade, then you don't need
 Go through the steps in [this documentation](/docs/balena-fleet-deployment.md)
 to deploy Anthias on your own Balena fleet.
 
-## Migrating assets from Anthias to Screenly
+## :up: Migrating assets from Anthias to Screenly
 
 This feature is only available in devices running Raspberry Pi OS at the moment.
 
@@ -200,12 +200,12 @@ Run the assets migration script. Follow through the instructions & prompts caref
 $ python tools/migrate-assets-to-screenly.py
 ```
 
-## Issues and bugs
+## :lady_beetle: Issues and bugs
 
 > [!NOTE]
 > We are still in the process of knocking out some bugs. You can track the known issues [here](https://github.com/Screenly/Anthias/issues). You can also check the discussions in the [Anthias forums](https://forums.screenly.io).
 
-## Quick links
+## :pushpin: Quick links
 
  * [Forum](https://forums.screenly.io/)
  * [Website](https://anthias.screenly.io) (hosted on GitHub and the source is available [here](https://github.com/Screenly/Anthias/tree/master/website))

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ We've tested Anthias and is known to work on the following Raspberry Pi models:
 * x86 Devices - 64-bit Bookworm
     * These devices can be something similar to a NUC.
 
-
-We're still fixing the installer so that it'll work with Raspberry Pi Zero and Raspberry Pi 1.
-Should you encounter any issues, please file an issue either in this repository or in the
+> [!NOTE]
+> We're still fixing the installer so that it'll work with Raspberry Pi Zero and Raspberry Pi 1.
+> Should you encounter any issues, please file an issue either in this repository or in the
 [forums](https://forums.screenly.io).
 
 ## Star History

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ The quickest way to get started is to use [Raspberry Pi Imager](https://www.scre
 
 ### Using the images from balenaHub
 
-This option is recommended for those who want to install Anthias without touching the
-command lines. When a new rolling release is available, updates will automatically be
-installed on your device.
+> [!IMPORTANT]
+> This option is recommended for those who want to install Anthias without touching the
+> command line interface. When a new rolling release is available, updates will automatically
+> be installed on your device.
 
 Balena made a [big update to their IoT marketplace](https://blog.balena.io/creating-an-iot-marketplace/). Included in that change is the launch of
 [Fleets for Good](https://hub.balena.io/fleets-for-good). With that, you may find it hard to find the Anthias images on the marketplace. In the meantime,
@@ -80,12 +81,13 @@ is available.
 
 If you'd like more control over your digital signage instance, try installing it on Raspberry Pi OS Lite.
 
-Before you start, make sure that you have `curl` installed. If not, you can install it by running:
-
-```bash
-$ sudo apt update
-$ sudo apt install -y curl
-```
+> [!IMPORTANT]
+> Before you start, make sure that you have `curl` installed. If not, you can install it by running:
+> 
+> ```bash
+> $ sudo apt update
+> $ sudo apt install -y curl
+> ```
 
 The tl;dr for on [Raspberry Pi OS](https://www.raspberrypi.com/software/) is:
 
@@ -112,7 +114,8 @@ installation.
  * The SD card
  * The internet connection
 
-During ideal conditions (Raspberry Pi 3 Model B+, class 10 SD card and fast internet connection), the installation normally takes 15-30 minutes. On a Raspberry Pi Zero or Raspberry Pi Model B with a class 4 SD card, the installation will take hours.
+> [!NOTE]
+> During ideal conditions (Raspberry Pi 3 Model B+, class 10 SD card and fast internet connection), the installation normally takes 15-30 minutes. On a Raspberry Pi Zero or Raspberry Pi Model B with a class 4 SD card, the installation will take hours.
 
 #### Prompt: Network Management
 
@@ -199,7 +202,8 @@ $ python tools/migrate-assets-to-screenly.py
 
 ## Issues and bugs
 
-Do however note that we are still in the process of knocking out some bugs. You can track the known issues [here](https://github.com/Screenly/Anthias/issues). You can also check the discussions in the [Anthias forums](https://forums.screenly.io).
+> [!NOTE]
+> We are still in the process of knocking out some bugs. You can track the known issues [here](https://github.com/Screenly/Anthias/issues). You can also check the discussions in the [Anthias forums](https://forums.screenly.io).
 
 ## Quick links
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,12 +37,13 @@ of the container in the command above. Here's a table of the available container
 
 ### Using `docker-compose logs`
 
-Before running the succeeding commands, make sure that you're in the
-`/home/${USER}/screenly` directory:
-
-```bash
-$ cd /home/${USER}/screenly # e.g., /home/pi/screenly if the user is `pi`
-```
+> [!IMPORTANT]
+> Before running the succeeding commands, make sure that you're in the
+> `/home/${USER}/screenly` directory:
+> 
+> ```bash
+> $ cd /home/${USER}/screenly # e.g., /home/pi/screenly if the user is `pi`
+> ```
 
 If you'd like to see the logs of a specific container or service via Docker Compose,
 you can run the following:
@@ -79,13 +80,14 @@ if you're in development mode). You should see the API docs for the endpoints.
 
 ## Installing (trusted) self-signed certificates
 
-This section only works for devices running Raspberry Pi OS Lite.
-With running the following script, you can install self-signed certificates:
-
-```bash
-$ cd $HOME/screenly
-$ ./bin/add_certificate.sh /path/to/certificate.crt
-```
+> [!WARNING]
+> This section only works for devices running Raspberry Pi OS Lite.
+> With running the following script, you can install self-signed certificates:
+> 
+> ```bash
+> $ cd $HOME/screenly
+> $ ./bin/add_certificate.sh /path/to/certificate.crt
+> ```
 
 More details about generating self-signed certificates can be found [here](https://devopscube.com/create-self-signed-certificates-openssl/).
 

--- a/docs/balena-fleet-deployment.md
+++ b/docs/balena-fleet-deployment.md
@@ -72,8 +72,9 @@ ID      NAME                           VALUE        FLEET
 1979571 BALENA_HOST_CONFIG_gpu_mem      1024         gh_nicomiguelino/anthias-pi4
 ```
 
-Alternatively, you can check the releases page of that fleet and look for the
-`BALENA_HOST_CONFIG_gpu_mem` and `BALENA_HOST_CONFIG_dtoverlay` variables.
+> [!TIP]
+> Alternatively, you can check the releases page of that fleet and look for the
+> `BALENA_HOST_CONFIG_gpu_mem` and `BALENA_HOST_CONFIG_dtoverlay` variables.
 
 ![balena-ss-04](/docs/images/balena-deployment-04-fleet-config-page.png)
 

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -20,7 +20,8 @@ These components and their dependencies are mostly installed and handled with An
 
 To simplify development of the server module of Anthias, we've created a Docker container. This is intended to run on your local machine with the Anthias repository mounted as a volume.
 
-Do note that Anthias is using Docker's [buildx](https://docs.docker.com/engine/reference/commandline/buildx/) for the image builds. This is used both for cross compilation as well as for local caching. You might need to run `docker buildx create --use` first.
+> [!IMPORTANT]
+> Anthias is using Docker's [buildx](https://docs.docker.com/engine/reference/commandline/buildx/) for the image builds. This is used both for cross compilation as well as for local caching. You might need to run `docker buildx create --use` first.
 
 Assuming you're in the source code repository, simply run:
 
@@ -50,12 +51,13 @@ docker compose -f docker-compose.dev.yml down
 
 ## Building containers locally
 
-Make sure that you have `buildx` installed and that you have run
-`docker buildx create --use` before you do the following:
-
-```bash
-$ ./bin/build_containers.sh
-```
+> [!IMPORTANT]
+> Make sure that you have `buildx` installed and that you have run
+> `docker buildx create --use` before you do the following:
+> 
+> ```bash
+> $ ./bin/build_containers.sh
+> ```
 
 ### Skipping specific services
 

--- a/docs/qa-checklist.md
+++ b/docs/qa-checklist.md
@@ -2,7 +2,8 @@
 
 Running unit tests is a good way to make sure that the code is working as expected. However, it's also important to do manual testing as some bugs may not be caught by unit tests. This document contains a list of things that you can do to test the application manually.
 
-The list is not exhaustive, but you can use it as your guide when testing Anthias.
+> [!NOTE]
+> The list is not exhaustive, but you can use it as your guide when testing Anthias.
 
 ## General
 

--- a/docs/wifi-setup.md
+++ b/docs/wifi-setup.md
@@ -4,9 +4,10 @@ There are several ways to connect your Anthias instance to Wi-Fi. You can either
 configure the Wi-Fi settings via the captive portal or you can use
 `NetworkManager`'s `nmcli` or `nmtui` commands.
 
-The `nmcli` and `nmtui` commands will only work on devices running a
-Raspberry Pi OS Lite as those running balenaOS gives users less control over
-some configs.
+> [!WARNING]
+> The `nmcli` and `nmtui` commands will only work on devices running a
+> Raspberry Pi OS Lite as those running balenaOS gives users less control over
+> some configs.
 
 ## Using `nmcli`
 
@@ -53,8 +54,9 @@ IN-USE  BSSID              SSID              MODE   CHAN  RATE        SIGNAL  BA
 # The output is truncated to save space.
 ```
 
-Take good note of the `SSID` (in this example, it's `Network27861`), as you'll
-use it in the next step.
+> [!NOTE]
+> Take good note of the `SSID` (in this example, it's `Network27861`), as you'll
+> use it in the next step.
 
 ### Connect to Wi-Fi with `nmcli`
 
@@ -68,10 +70,11 @@ $ sudo nmcli dev wifi connect $WIFI_SSID password $WIFI_PASSWORD
 $ sudo nmcli --ask dev wifi connect $WIFI_SSID
 ```
 
-We recommend that you use the second one. You don't want someone to know your
-password just by looking at the command `history`. The output should look like
-the following &mdash; `Device 'wlan0' successfully activated with
-<hex>`.
+> [!WARNING]
+> We recommend that you use the second one. You don't want someone to know your
+> password just by looking at the command `history`. The output should look like
+> the following &mdash; `Device 'wlan0' successfully activated with
+> <hex>`.
 
 To see if the Wi-Fi connection is successful, try running a `ping` commad:
 

--- a/webview/README.md
+++ b/webview/README.md
@@ -1,6 +1,7 @@
 ## Building Qt and WebView
 
-**Warning:** To build this, you need **very** beefy hardware. We are building this on a VM with 32 vCPUs and 128GB RAM. If you're trying to build it locally, you likely need to tweak [MAKE_CORES](https://github.com/Screenly/screenly-ose/blob/master/webview/build_qt5.sh#L12) to something lower, but you would still need a powerful workstation (32GB RAM minimum) to make this build.
+> [!WARNING]
+> To build this, you need **very** beefy hardware. We are building this on a VM with 32 vCPUs and 128GB RAM. If you're trying to build it locally, you likely need to tweak [MAKE_CORES](https://github.com/Screenly/screenly-ose/blob/master/webview/build_qt5.sh#L12) to something lower, but you would still need a powerful workstation (32GB RAM minimum) to make this build.
 
 ### Building for Raspberry Pi
 
@@ -90,7 +91,8 @@ Supported protocols: `http://`, `https://`
 
 ## Debugging
 
-You can enable QT debugging by using the following:
-```bash
-export QT_LOGGING_RULES=qt.qpa.*=true
-```
+> [!TIP]
+> You can enable QT debugging by using the following:
+> ```bash
+> export QT_LOGGING_RULES=qt.qpa.*=true
+> ```


### PR DESCRIPTION
#### Description

* Making use of alerts makes the repo docs less dull and more visible.
* See [this doc](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) about Markdown alerts for reference.