### PR TITLE
fix: resolve issue when building the viewer Docker image for x86

### DIFF
--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -123,7 +123,7 @@ def build_image(
         'sqlite3',
     ]
 
-    if board != 'x86':
+    if board in ['pi1', 'pi2', 'pi3', 'pi4']:
         base_apt_dependencies.extend(['libraspberrypi0'])
 
     if service == 'viewer':

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -175,7 +175,6 @@ def build_image(
             'libpng16-16',
             'libpq-dev',
             'libpulse-dev',
-            'libraspberrypi0',
             'librsvg2-common',
             'libsdl2-dev',
             'libsnappy-dev',
@@ -246,6 +245,7 @@ def build_image(
 
         if board != 'x86':
             apt_dependencies.extend([
+                'libraspberrypi0',
                 'libgst-dev',
                 'libsqlite0-dev',
                 'libsrtp0-dev',


### PR DESCRIPTION
#### Description

* Removes `libraspberrypi0` from `Dockerfile.viewer` for x86
* A follow-up pull request to #2060

#### Failed CI Runs

* https://github.com/Screenly/Anthias/actions/runs/11724576804/job/32659200061#step:10:1605