### PR TITLE
Add support for asoundrc

### DIFF
--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -12,13 +12,13 @@
     - screenly_assets
 
 - name: Create empy .asoundrc
-  file:
+  ansible.builtin.file:
     path: "/home/{{ lookup('env', 'USER') }}/.asoundrc"
     state: touch
     force: false
     group: "{{ lookup('env', 'USER') }}"
     owner: "{{ lookup('env', 'USER') }}"
-    mode: 0644
+    mode: "0644"
 
 - name: Copy Screenly default assets file
   ansible.builtin.copy:

--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -12,8 +12,9 @@
     - screenly_assets
 
 - name: Create empy .asoundrc
-    content: ""
-    dest: "/home/{{ lookup('env', 'USER') }}/.asoundrc"
+  file:
+    path: "/home/{{ lookup('env', 'USER') }}/.asoundrc"
+    state: touch
     force: false
     group: "{{ lookup('env', 'USER') }}"
     owner: "{{ lookup('env', 'USER') }}"

--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -11,6 +11,14 @@
     - .config
     - screenly_assets
 
+- name: Create empy .asoundrc
+    content: ""
+    dest: "/home/{{ lookup('env', 'USER') }}/.asoundrc"
+    force: false
+    group: "{{ lookup('env', 'USER') }}"
+    owner: "{{ lookup('env', 'USER') }}"
+    mode: 0644
+
 - name: Copy Screenly default assets file
   ansible.builtin.copy:
     owner: "{{ lookup('env', 'USER') }}"

--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -11,7 +11,7 @@
     - .config
     - screenly_assets
 
-- name: Create empy .asoundrc
+- name: Create empty .asoundrc
   ansible.builtin.file:
     path: "/home/{{ lookup('env', 'USER') }}/.asoundrc"
     state: touch

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -37,7 +37,6 @@ services:
     restart: always
     volumes:
       - resin-data:/data
-      - /home/${USER}/.asoundrc:/data/.asoundrc
       - /home/${USER}/.screenly:/data/.screenly
       - /home/${USER}/screenly_assets:/data/screenly_assets
       - /home/${USER}/screenly/staticfiles:/data/screenly/staticfiles
@@ -66,6 +65,7 @@ services:
     shm_size: ${SHM_SIZE_KB}kb
     volumes:
       - resin-data:/data
+      - /home/${USER}/.asoundrc:/data/.asoundrc
       - /home/${USER}/.screenly:/data/.screenly
       - /home/${USER}/screenly_assets:/data/screenly_assets
       - /etc/timezone:/etc/timezone:ro

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -37,6 +37,7 @@ services:
     restart: always
     volumes:
       - resin-data:/data
+      - /home/${USER}/.asoundrc:/data/.asoundrc
       - /home/${USER}/.screenly:/data/.screenly
       - /home/${USER}/screenly_assets:/data/screenly_assets
       - /home/${USER}/screenly/staticfiles:/data/screenly/staticfiles


### PR DESCRIPTION
Some x86_64 mini pc's need an `~/.asoundrc` file within the `viewer` container for sound output to work. This PR enables support for setups that need an `~/.asoundrd`.

This has been tested with a [MeLE PCG02 Mini PC 'Stick'](https://mele.cn/product/127-en.html). The `~/.asoundrc` this device needs is:

```
pcm.!default {
    type hw
    card 0
    device 1
}

ctl.!default {
    type hw
    card 0
    device 1
}
```