### PR TITLE
chore(ci): bump Docker buildx and qemu actions to `v3`

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -17,11 +17,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: success() && github.event_name != 'pull_request'
@@ -59,11 +59,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache build layers
         uses: actions/cache@v4

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -53,11 +53,11 @@ jobs:
           poetry install --only=docker-image-builder
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
         uses: actions/cache@v4

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Containers
         run: |


### PR DESCRIPTION
### References

* https://github.com/docker/setup-buildx-action/releases/tag/v3.7.1
* https://github.com/docker/setup-qemu-action/releases/tag/v3.2.0