### PR TITLE
api: create v2 endpoints in favor of the v1 endpoints currently used by Anthias from the Settings and home page

### DIFF
--- a/anthias_django/settings.py
+++ b/anthias_django/settings.py
@@ -174,7 +174,10 @@ REST_FRAMEWORK = {
 
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Anthias API',
-    'VERSION': '1.2.0',
+    'VERSION': '2.0.0',
+    'PREPROCESSING_HOOKS': [
+        'api.api_docs_filter_spec.preprocessing_filter_spec'
+    ],
 }
 
 # `django-dbbackup` settings

--- a/api/api_docs_filter_spec.py
+++ b/api/api_docs_filter_spec.py
@@ -1,0 +1,6 @@
+def preprocessing_filter_spec(endpoints):
+    filtered = []
+    for (path, path_regex, method, callback) in endpoints:
+        if path.startswith("/api/v2"):
+            filtered.append((path, path_regex, method, callback))
+    return filtered

--- a/api/tests.py
+++ b/api/tests.py
@@ -292,7 +292,7 @@ class V1EndpointsTest(TestCase, ParametrizedTestCase):
         self.assertEqual(data['viewlog'], 'Not yet implemented')
 
     @mock.patch(
-        'api.views.v1.reboot_anthias.apply_async',
+        'api.views.mixins.reboot_anthias.apply_async',
         side_effect=(lambda: None)
     )
     def test_reboot(self, reboot_anthias_mock):
@@ -303,7 +303,7 @@ class V1EndpointsTest(TestCase, ParametrizedTestCase):
         self.assertEqual(reboot_anthias_mock.call_count, 1)
 
     @mock.patch(
-        'api.views.v1.shutdown_anthias.apply_async',
+        'api.views.mixins.shutdown_anthias.apply_async',
         side_effect=(lambda: None)
     )
     def test_shutdown(self, shutdown_anthias_mock):

--- a/api/urls.py
+++ b/api/urls.py
@@ -6,7 +6,7 @@ from .views.v1 import (
     FileAssetView,
     PlaylistOrderView,
     BackupViewV1,
-    RecoverView,
+    RecoverViewV1,
     AssetsControlView,
     InfoView,
     RebootView,
@@ -24,7 +24,8 @@ from .views.v1_2 import (
 from .views.v2 import (
     AssetListViewV2,
     AssetViewV2,
-    BackupViewV2
+    BackupViewV2,
+    RecoverViewV2
 )
 
 app_name = 'api'
@@ -54,7 +55,7 @@ urlpatterns = [
     ),
     path('v1/file_asset', FileAssetView.as_view(), name='file_asset_v1'),
     path('v1/backup', BackupViewV1.as_view(), name='backup_v1'),
-    path('v1/recover', RecoverView.as_view(), name='recover_v1'),
+    path('v1/recover', RecoverViewV1.as_view(), name='recover_v1'),
     path('v1/info', InfoView.as_view(), name='info_v1'),
     path('v1/reboot', RebootView.as_view(), name='reboot_v1'),
     path('v1/shutdown', ShutdownView.as_view(), name='shutdown_v1'),
@@ -88,4 +89,5 @@ urlpatterns = [
         name='asset_detail_v2'
     ),
     path('v2/backup', BackupViewV2.as_view(), name='backup_v2'),
+    path('v2/recover', RecoverViewV2.as_view(), name='recover_v2'),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,8 +9,8 @@ from .views.v1 import (
     RecoverViewV1,
     AssetsControlView,
     InfoView,
-    RebootView,
-    ShutdownView,
+    RebootViewV1,
+    ShutdownViewV1,
     ViewerCurrentAssetView
 )
 from .views.v1_1 import (
@@ -25,7 +25,9 @@ from .views.v2 import (
     AssetListViewV2,
     AssetViewV2,
     BackupViewV2,
-    RecoverViewV2
+    RecoverViewV2,
+    RebootViewV2,
+    ShutdownViewV2
 )
 
 app_name = 'api'
@@ -57,8 +59,8 @@ urlpatterns = [
     path('v1/backup', BackupViewV1.as_view(), name='backup_v1'),
     path('v1/recover', RecoverViewV1.as_view(), name='recover_v1'),
     path('v1/info', InfoView.as_view(), name='info_v1'),
-    path('v1/reboot', RebootView.as_view(), name='reboot_v1'),
-    path('v1/shutdown', ShutdownView.as_view(), name='shutdown_v1'),
+    path('v1/reboot', RebootViewV1.as_view(), name='reboot_v1'),
+    path('v1/shutdown', ShutdownViewV1.as_view(), name='shutdown_v1'),
     path(
         'v1/viewer_current_asset',
         ViewerCurrentAssetView.as_view(),
@@ -90,4 +92,6 @@ urlpatterns = [
     ),
     path('v2/backup', BackupViewV2.as_view(), name='backup_v2'),
     path('v2/recover', RecoverViewV2.as_view(), name='recover_v2'),
+    path('v2/reboot', RebootViewV2.as_view(), name='reboot_v2'),
+    path('v2/shutdown', ShutdownViewV2.as_view(), name='shutdown_v2'),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -5,7 +5,7 @@ from .views.v1 import (
     AssetContentView,
     FileAssetView,
     PlaylistOrderView,
-    BackupView,
+    BackupViewV1,
     RecoverView,
     AssetsControlView,
     InfoView,
@@ -24,6 +24,7 @@ from .views.v1_2 import (
 from .views.v2 import (
     AssetListViewV2,
     AssetViewV2,
+    BackupViewV2
 )
 
 app_name = 'api'
@@ -52,7 +53,7 @@ urlpatterns = [
         name='asset_content_v1',
     ),
     path('v1/file_asset', FileAssetView.as_view(), name='file_asset_v1'),
-    path('v1/backup', BackupView.as_view(), name='backup_v1'),
+    path('v1/backup', BackupViewV1.as_view(), name='backup_v1'),
     path('v1/recover', RecoverView.as_view(), name='recover_v1'),
     path('v1/info', InfoView.as_view(), name='info_v1'),
     path('v1/reboot', RebootView.as_view(), name='reboot_v1'),
@@ -86,4 +87,5 @@ urlpatterns = [
         AssetViewV2.as_view(),
         name='asset_detail_v2'
     ),
+    path('v2/backup', BackupViewV2.as_view(), name='backup_v2'),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -2,16 +2,16 @@ from django.urls import path
 from .views.v1 import (
     AssetViewV1,
     AssetListViewV1,
-    AssetContentView,
-    FileAssetView,
-    PlaylistOrderView,
+    AssetContentViewV1,
+    FileAssetViewV1,
+    PlaylistOrderViewV1,
     BackupViewV1,
     RecoverViewV1,
-    AssetsControlView,
+    AssetsControlViewV1,
     InfoView,
     RebootViewV1,
     ShutdownViewV1,
-    ViewerCurrentAssetView
+    ViewerCurrentAssetViewV1
 )
 from .views.v1_1 import (
     AssetListViewV1_1,
@@ -22,12 +22,16 @@ from .views.v1_2 import (
     AssetViewV1_2
 )
 from .views.v2 import (
+    AssetContentViewV2,
+    AssetsControlViewV2,
     AssetListViewV2,
     AssetViewV2,
     BackupViewV2,
+    PlaylistOrderViewV2,
     RecoverViewV2,
     RebootViewV2,
-    ShutdownViewV2
+    ShutdownViewV2,
+    FileAssetViewV2
 )
 
 app_name = 'api'
@@ -37,12 +41,12 @@ urlpatterns = [
     path('v1/assets', AssetListViewV1.as_view(), name='asset_list_v1'),
     path(
         'v1/assets/order',
-        PlaylistOrderView.as_view(),
+        PlaylistOrderViewV1.as_view(),
         name='playlist_order_v1',
     ),
     path(
         'v1/assets/control/<str:command>',
-        AssetsControlView.as_view(),
+        AssetsControlViewV1.as_view(),
         name='assets_control_v1',
     ),
     path(
@@ -52,10 +56,10 @@ urlpatterns = [
     ),
     path(
         'v1/assets/<str:asset_id>/content',
-        AssetContentView.as_view(),
+        AssetContentViewV1.as_view(),
         name='asset_content_v1',
     ),
-    path('v1/file_asset', FileAssetView.as_view(), name='file_asset_v1'),
+    path('v1/file_asset', FileAssetViewV1.as_view(), name='file_asset_v1'),
     path('v1/backup', BackupViewV1.as_view(), name='backup_v1'),
     path('v1/recover', RecoverViewV1.as_view(), name='recover_v1'),
     path('v1/info', InfoView.as_view(), name='info_v1'),
@@ -63,7 +67,7 @@ urlpatterns = [
     path('v1/shutdown', ShutdownViewV1.as_view(), name='shutdown_v1'),
     path(
         'v1/viewer_current_asset',
-        ViewerCurrentAssetView.as_view(),
+        ViewerCurrentAssetViewV1.as_view(),
         name='viewer_current_asset_v1',
     ),
 
@@ -86,6 +90,16 @@ urlpatterns = [
     # v2 endpoints
     path('v2/assets', AssetListViewV2.as_view(), name='asset_list_v2'),
     path(
+        'v2/assets/order',
+        PlaylistOrderViewV2.as_view(),
+        name='playlist_order_v2',
+    ),
+    path(
+        'v2/assets/control/<str:command>',
+        AssetsControlViewV2.as_view(),
+        name='assets_control_v2',
+    ),
+    path(
         'v2/assets/<str:asset_id>',
         AssetViewV2.as_view(),
         name='asset_detail_v2'
@@ -94,4 +108,10 @@ urlpatterns = [
     path('v2/recover', RecoverViewV2.as_view(), name='recover_v2'),
     path('v2/reboot', RebootViewV2.as_view(), name='reboot_v2'),
     path('v2/shutdown', ShutdownViewV2.as_view(), name='shutdown_v2'),
+    path('v2/file_asset', FileAssetViewV2.as_view(), name='file_asset_v2'),
+    path(
+        'v2/assets/<str:asset_id>/content',
+        AssetContentViewV2.as_view(),
+        name='asset_content_v2',
+    ),
 ]

--- a/api/views/mixins.py
+++ b/api/views/mixins.py
@@ -1,6 +1,9 @@
+from inspect import cleandoc
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.views import APIView
+from lib import backup_helper
 from lib.auth import authorized
 
 from anthias_app.models import Asset
@@ -23,3 +26,28 @@ class DeleteAssetViewMixin:
         asset.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class BackupViewMixin(APIView):
+    @extend_schema(
+        summary='Create backup',
+        description=cleandoc("""
+        Create a backup of the current Anthias instance, which
+        includes the following:
+        * current settings
+        * image and video assets
+        * asset metadata (e.g. name, duration, play order, status),
+          which is stored in a SQLite database
+        """),
+        responses={
+            201: {
+                'type': 'string',
+                'example': 'anthias-backup-2021-09-16T15-00-00.tar.gz',
+                'description': 'Backup file name'
+            }
+        }
+    )
+    @authorized
+    def post(self, request):
+        filename = backup_helper.create_backup(name=settings['player_name'])
+        return Response(filename, status=status.HTTP_201_CREATED)

--- a/api/views/mixins.py
+++ b/api/views/mixins.py
@@ -8,6 +8,7 @@ from lib import backup_helper
 from lib.auth import authorized
 
 from anthias_app.models import Asset
+from celery_tasks import reboot_anthias, shutdown_anthias
 from os import path, remove
 from settings import settings, ZmqPublisher
 
@@ -99,3 +100,19 @@ class RecoverViewMixin(APIView):
             return Response("Recovery successful.")
         finally:
             publisher.send_to_viewer('play')
+
+
+class RebootViewMixin(APIView):
+    @extend_schema(summary='Reboot system')
+    @authorized
+    def post(self, request):
+        reboot_anthias.apply_async()
+        return Response(status=status.HTTP_200_OK)
+
+
+class ShutdownViewMixin(APIView):
+    @extend_schema(summary='Shut down system')
+    @authorized
+    def post(self, request):
+        shutdown_anthias.apply_async()
+        return Response(status=status.HTTP_200_OK)

--- a/api/views/mixins.py
+++ b/api/views/mixins.py
@@ -1,6 +1,9 @@
+import uuid
+
+from base64 import b64encode
 from inspect import cleandoc
-from drf_spectacular.utils import extend_schema
-from mimetypes import guess_type
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
+from mimetypes import guess_type, guess_extension
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -8,6 +11,7 @@ from lib import backup_helper
 from lib.auth import authorized
 
 from anthias_app.models import Asset
+from api.helpers import save_active_assets_ordering
 from celery_tasks import reboot_anthias, shutdown_anthias
 from os import path, remove
 from settings import settings, ZmqPublisher
@@ -116,3 +120,170 @@ class ShutdownViewMixin(APIView):
     def post(self, request):
         shutdown_anthias.apply_async()
         return Response(status=status.HTTP_200_OK)
+
+
+class FileAssetViewMixin(APIView):
+    @extend_schema(
+        summary='Upload file asset',
+        request={
+            'multipart/form-data': {
+                'type': 'object',
+                'properties': {
+                    'file_upload': {
+                        'type': 'string',
+                        'format': 'binary'
+                    }
+                }
+            }
+        },
+        responses={
+            200: {
+                'type': 'object',
+                'properties': {
+                    'uri': {'type': 'string'},
+                    'ext': {'type': 'string'}
+                }
+            }
+        }
+    )
+    @authorized
+    def post(self, request):
+        file_upload = request.data.get('file_upload')
+        filename = file_upload.name
+        file_type = guess_type(filename)[0]
+
+        if not file_type:
+            raise Exception("Invalid file type.")
+
+        if file_type.split('/')[0] not in ['image', 'video']:
+            raise Exception("Invalid file type.")
+
+        file_path = path.join(
+            settings['assetdir'],
+            uuid.uuid5(uuid.NAMESPACE_URL, filename).hex,
+        ) + ".tmp"
+
+        if 'Content-Range' in request.headers:
+            range_str = request.headers['Content-Range']
+            start_bytes = int(range_str.split(' ')[1].split('-')[0])
+            with open(file_path, 'ab') as f:
+                f.seek(start_bytes)
+                f.write(file_upload.read())
+        else:
+            with open(file_path, 'wb') as f:
+                f.write(file_upload.read())
+
+        return Response({'uri': file_path, 'ext': guess_extension(file_type)})
+
+
+class AssetContentViewMixin(APIView):
+    @extend_schema(
+        summary='Get asset content',
+        description=cleandoc("""
+        The content of the asset.
+        `type` can either be `file` or `url`.
+
+        In case of a file, the fields `mimetype`, `filename`, and `content`
+        will be present. In case of a URL, the field `url` will be present.
+        """),
+        responses={
+            200: {
+                'type': 'object',
+                'properties': {
+                    'type': {'type': 'string'},
+                    'url': {'type': 'string'},
+                    'filename': {'type': 'string'},
+                    'mimetype': {'type': 'string'},
+                    'content': {'type': 'string'},
+                }
+            }
+        }
+    )
+    @authorized
+    def get(self, request, asset_id, format=None):
+        asset = Asset.objects.get(asset_id=asset_id)
+
+        if path.isfile(asset.uri):
+            filename = asset.name
+
+            with open(asset.uri, 'rb') as f:
+                content = f.read()
+
+            mimetype = guess_type(filename)[0]
+            if not mimetype:
+                mimetype = 'application/octet-stream'
+
+            result = {
+                'type': 'file',
+                'filename': filename,
+                'content': b64encode(content).decode(),
+                'mimetype': mimetype
+            }
+        else:
+            result = {
+                'type': 'url',
+                'url': asset.uri
+            }
+
+        return Response(result)
+
+
+class PlaylistOrderViewMixin(APIView):
+    @extend_schema(
+        summary='Update playlist order',
+        request={
+            'application/x-www-form-urlencoded': {
+                'type': 'object',
+                'properties': {
+                    'ids': {
+                        'type': 'string',
+                        'description': cleandoc(
+                            """
+                            Comma-separated list of asset IDs in the order
+                            they should be played. For example:
+
+                            `793406aa1fd34b85aa82614004c0e63a,1c5cfa719d1f4a9abae16c983a18903b,9c41068f3b7e452baf4dc3f9b7906595`
+                            """
+                        )
+                    }
+                },
+            }
+        }
+    )
+    @authorized
+    def post(self, request):
+        asset_ids = request.data.get('ids', '').split(',')
+        save_active_assets_ordering(asset_ids)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class AssetsControlViewMixin(APIView):
+    @extend_schema(
+        summary='Control asset playback',
+        description=cleandoc("""
+        Use any of the following commands to control asset playback:
+        * `next` - Show the next asset
+        * `previous` - Show the previous asset
+        * `asset&{asset_id}` - Show the asset with the specified `asset_id`
+        """),
+        responses={
+            200: {
+                'type': 'string',
+                'example': 'Asset switched',
+            }
+        },
+        parameters=[
+            OpenApiParameter(
+                name='command',
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
+                enum=['next', 'previous', 'asset&{asset_id}'],
+            )
+        ]
+    )
+    @authorized
+    def get(self, request, command):
+        publisher = ZmqPublisher.get_instance()
+        publisher.send_to_viewer(command)
+        return Response("Asset switched")

--- a/api/views/v1.py
+++ b/api/views/v1.py
@@ -34,9 +34,10 @@ from anthias_app.models import Asset
 from api.views.mixins import (
     BackupViewMixin,
     DeleteAssetViewMixin,
+    RebootViewMixin,
     RecoverViewMixin,
+    ShutdownViewMixin,
 )
-from celery_tasks import reboot_anthias, shutdown_anthias
 from settings import settings, ZmqCollector, ZmqPublisher
 
 
@@ -371,20 +372,12 @@ class InfoView(APIView):
         })
 
 
-class RebootView(APIView):
-    @extend_schema(summary='Reboot system')
-    @authorized
-    def post(self, request):
-        reboot_anthias.apply_async()
-        return Response(status=status.HTTP_200_OK)
+class RebootViewV1(RebootViewMixin):
+    pass
 
 
-class ShutdownView(APIView):
-    @extend_schema(summary='Shut down system')
-    @authorized
-    def post(self, request):
-        shutdown_anthias.apply_async()
-        return Response(status=status.HTTP_200_OK)
+class ShutdownViewV1(ShutdownViewMixin):
+    pass
 
 
 class ViewerCurrentAssetView(APIView):

--- a/api/views/v1.py
+++ b/api/views/v1.py
@@ -34,7 +34,10 @@ from lib.utils import connect_to_redis
 from mimetypes import guess_type, guess_extension
 from os import path, statvfs
 from anthias_app.models import Asset
-from api.views.mixins import DeleteAssetViewMixin
+from api.views.mixins import (
+    BackupViewMixin,
+    DeleteAssetViewMixin,
+)
 from celery_tasks import reboot_anthias, shutdown_anthias
 from settings import settings, ZmqCollector, ZmqPublisher
 
@@ -290,29 +293,8 @@ class PlaylistOrderView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class BackupView(APIView):
-    @extend_schema(
-        summary='Create backup',
-        description=cleandoc("""
-        Create a backup of the current Anthias instance, which
-        includes the following:
-        * current settings
-        * image and video assets
-        * asset metadata (e.g. name, duration, play order, status),
-          which is stored in a SQLite database
-        """),
-        responses={
-            201: {
-                'type': 'string',
-                'example': 'anthias-backup-2021-09-16T15-00-00.tar.gz',
-                'description': 'Backup file name'
-            }
-        }
-    )
-    @authorized
-    def post(self, request):
-        filename = backup_helper.create_backup(name=settings['player_name'])
-        return Response(filename, status=status.HTTP_201_CREATED)
+class BackupViewV1(BackupViewMixin):
+    pass
 
 
 class RecoverView(APIView):

--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -14,7 +14,10 @@ from api.serializers.v2 import (
     CreateAssetSerializerV2,
     UpdateAssetSerializerV2
 )
-from api.views.mixins import DeleteAssetViewMixin
+from api.views.mixins import (
+    BackupViewMixin,
+    DeleteAssetViewMixin
+)
 from lib.auth import authorized
 
 
@@ -125,3 +128,7 @@ class AssetViewV2(APIView, DeleteAssetViewMixin):
     @authorized
     def put(self, request, asset_id):
         return self.update(request, asset_id, partial=False)
+
+
+class BackupViewV2(BackupViewMixin):
+    pass

--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -15,11 +15,15 @@ from api.serializers.v2 import (
     UpdateAssetSerializerV2
 )
 from api.views.mixins import (
+    AssetContentViewMixin,
+    AssetsControlViewMixin,
     BackupViewMixin,
     DeleteAssetViewMixin,
+    PlaylistOrderViewMixin,
     RebootViewMixin,
     RecoverViewMixin,
-    ShutdownViewMixin
+    ShutdownViewMixin,
+    FileAssetViewMixin
 )
 from lib.auth import authorized
 
@@ -146,4 +150,20 @@ class RebootViewV2(RebootViewMixin):
 
 
 class ShutdownViewV2(ShutdownViewMixin):
+    pass
+
+
+class FileAssetViewV2(FileAssetViewMixin):
+    pass
+
+
+class AssetContentViewV2(AssetContentViewMixin):
+    pass
+
+
+class PlaylistOrderViewV2(PlaylistOrderViewMixin):
+    pass
+
+
+class AssetsControlViewV2(AssetsControlViewMixin):
     pass

--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -17,7 +17,9 @@ from api.serializers.v2 import (
 from api.views.mixins import (
     BackupViewMixin,
     DeleteAssetViewMixin,
-    RecoverViewMixin
+    RebootViewMixin,
+    RecoverViewMixin,
+    ShutdownViewMixin
 )
 from lib.auth import authorized
 
@@ -136,4 +138,12 @@ class BackupViewV2(BackupViewMixin):
 
 
 class RecoverViewV2(RecoverViewMixin):
+    pass
+
+
+class RebootViewV2(RebootViewMixin):
+    pass
+
+
+class ShutdownViewV2(ShutdownViewMixin):
     pass

--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -16,7 +16,8 @@ from api.serializers.v2 import (
 )
 from api.views.mixins import (
     BackupViewMixin,
-    DeleteAssetViewMixin
+    DeleteAssetViewMixin,
+    RecoverViewMixin
 )
 from lib.auth import authorized
 
@@ -131,4 +132,8 @@ class AssetViewV2(APIView, DeleteAssetViewMixin):
 
 
 class BackupViewV2(BackupViewMixin):
+    pass
+
+
+class RecoverViewV2(RecoverViewMixin):
     pass

--- a/static/js/anthias.coffee
+++ b/static/js/anthias.coffee
@@ -207,7 +207,7 @@ API.View.AddAssetView = class AddAssetView extends Backbone.View
         autoUpload: false
         sequentialUploads: true
         maxChunkSize: 5000000 #5 MB
-        url: 'api/v1/file_asset'
+        url: 'api/v2/file_asset'
         progressall: (e, data) => if data.loaded and data.total
           (@$ '.progress .bar').css 'width', "#{data.loaded / data.total * 100}%"
         add: (e, data) ->
@@ -533,7 +533,7 @@ API.View.AssetRowView = class AssetRowView extends Backbone.View
     (@$ 'input, button').prop 'disabled', on
 
   download: (e) =>
-    $.get '/api/v1/assets/' + @model.id + '/content', (result) ->
+    $.get '/api/v2/assets/' + @model.id + '/content', (result) ->
       switch result['type']
         when 'url'
           window.open(result['url'])
@@ -595,7 +595,7 @@ API.View.AssetsView = class AssetsView extends Backbone.View
     @collection.get(id).set('play_order', i) for id, i in active
     @collection.get(el.id).set('play_order', active.length) for el in (@$ '#inactive-assets tr').toArray()
 
-    $.post '/api/v1/assets/order', ids: ((@$ '#active-assets').sortable 'toArray').join ','
+    $.post '/api/v2/assets/order', ids: ((@$ '#active-assets').sortable 'toArray').join ','
 
   render: =>
     @collection.sort()
@@ -665,7 +665,7 @@ API.App = class App extends Backbone.View
     no
 
   previous: (e) ->
-    $.get '/api/v1/assets/control/previous'
+    $.get '/api/v2/assets/control/previous'
 
   next: (e) ->
-    $.get '/api/v1/assets/control/next'
+    $.get '/api/v2/assets/control/next'

--- a/static/js/settings.coffee
+++ b/static/js/settings.coffee
@@ -14,7 +14,7 @@ $().ready ->
 
     $.ajax({
       method: "POST"
-      url: "/api/v1/backup"
+      url: "/api/v2/backup"
       timeout: 1800 * 1000
     })
 
@@ -42,7 +42,7 @@ $().ready ->
     $("[name='backup_upload']").click()
 
   $("[name='backup_upload']").fileupload
-    url: "/api/v1/recover"
+    url: "/api/v2/recover"
     progressall: (e, data) -> if data.loaded and data.total
       valuenow = data.loaded/data.total*100
       $(".progress .bar").css "width", valuenow + "%"
@@ -74,7 +74,7 @@ $().ready ->
 
   $("#btn-reboot-system").click (e) ->
     if confirm "Are you sure you want to reboot your device?"
-      $.post "/api/v1/reboot"
+      $.post "/api/v2/reboot"
       .done  (e) ->
         ($ "#request-error .alert").show()
         ($ "#request-error .alert").addClass "alert-success"
@@ -91,7 +91,7 @@ $().ready ->
 
   $("#btn-shutdown-system").click (e) ->
     if confirm "Are you sure you want to shutdown your device?"
-      $.post "/api/v1/shutdown"
+      $.post "/api/v2/shutdown"
       .done  (e) ->
         ($ "#request-error .alert").show()
         ($ "#request-error .alert").addClass "alert-success"


### PR DESCRIPTION
### Changes

* Created the following endpoints:
  - `/api/v2/backup`
  - `/api/v2/recover`
  - `/api/v2/reboot`
  - `/api/v2/shutdown`
  - /api/v1/file_asset
  - `/api/v1/assets/content`
  - `/api/v1/assets/order`
  - `/api/v1/assets/control`
* Updated `settings.coffee` so that the settings page will use `v2` endpoints instead

### Screenshots

![image](https://github.com/user-attachments/assets/24860401-5427-4d0a-92d1-82baa26d99e4)
![image](https://github.com/user-attachments/assets/e3a5008a-86de-47ec-8aa1-9bd1a2b105b5)
