### PR TITLE
fix: add nullity check before calling `FFMPEGMediaPlayer.run.kill()`

### DIFF
--- a/lib/media_player.py
+++ b/lib/media_player.py
@@ -47,7 +47,8 @@ class FFMPEGMediaPlayer(MediaPlayer):
 
     def stop(self):
         try:
-            self.run.kill()
+            if self.run:
+                self.run.kill()
         except OSError:
             pass
 


### PR DESCRIPTION
### Issue Overview

* The issue only happens for **_x86 devices_**, which currently uses `ffmpeg` for video playback.
* The issue occurs when the **_Previous Asset_** or **_Next Asset_** button is clicked.

```
anthias-viewer-1  | 2024-11-25T23:27:50.417619808Z ./bin/start_viewer.sh: line 39: /sys/fs/cgroup/memory/memory.swappiness: No such file or directory
anthias-viewer-1  | 2024-11-25T23:27:50.890818091Z Loading browser...
anthias-viewer-1  | 2024-11-25T23:27:51.906726835Z Current url is http://anthias-nginx:80/static/img/standby.png
anthias-viewer-1  | 2024-11-25T23:27:51.919543035Z Generating asset-list...
anthias-viewer-1  | 2024-11-25T23:27:51.926753338Z Current url is http://anthias-nginx:80/splash-page
anthias-viewer-1  | 2024-11-25T23:27:56.220001577Z pkill: killing pid 24 failed: Operation not permitted
anthias-viewer-1  | 2024-11-25T23:27:56.220130731Z USR1 received, skipping.
anthias-viewer-1  | 2024-11-25T23:27:56.222285624Z Viewer crashed.
anthias-viewer-1  | 2024-11-25T23:27:56.222316873Z Traceback (most recent call last):
anthias-viewer-1  | 2024-11-25T23:27:56.222325239Z   File "/usr/src/app/viewer.py", line 578, in <module>
anthias-viewer-1  | 2024-11-25T23:27:56.222333123Z     main()
anthias-viewer-1  | 2024-11-25T23:27:56.222339311Z   File "/usr/src/app/viewer.py", line 559, in main
anthias-viewer-1  | 2024-11-25T23:27:56.222346491Z     sleep(SPLASH_DELAY)
anthias-viewer-1  | 2024-11-25T23:27:56.222350444Z   File "/usr/src/app/viewer.py", line 94, in sigusr1
anthias-viewer-1  | 2024-11-25T23:27:56.222354302Z     MediaPlayerProxy.get_instance().stop()
anthias-viewer-1  | 2024-11-25T23:27:56.222357933Z   File "/usr/src/app/lib/media_player.py", line 50, in stop
anthias-viewer-1  | 2024-11-25T23:27:56.222361802Z     self.run.kill()
anthias-viewer-1  | 2024-11-25T23:27:56.222365370Z     ^^^^^^^^^^^^^
anthias-viewer-1  | 2024-11-25T23:27:56.222368977Z AttributeError: 'NoneType' object has no attribute 'kill'
anthias-viewer-1  | 2024-11-25T23:27:56.222523968Z Traceback (most recent call last):
anthias-viewer-1  | 2024-11-25T23:27:56.222541472Z   File "/usr/src/app/viewer.py", line 578, in <module>
anthias-viewer-1  | 2024-11-25T23:27:56.222869929Z     main()
anthias-viewer-1  | 2024-11-25T23:27:56.222948019Z   File "/usr/src/app/viewer.py", line 559, in main
anthias-viewer-1  | 2024-11-25T23:27:56.223191306Z     sleep(SPLASH_DELAY)
anthias-viewer-1  | 2024-11-25T23:27:56.223240184Z   File "/usr/src/app/viewer.py", line 94, in sigusr1
anthias-viewer-1  | 2024-11-25T23:27:56.223515030Z     MediaPlayerProxy.get_instance().stop()
anthias-viewer-1  | 2024-11-25T23:27:56.223576200Z   File "/usr/src/app/lib/media_player.py", line 50, in stop
anthias-viewer-1  | 2024-11-25T23:27:56.223591128Z     self.run.kill()
anthias-viewer-1  | 2024-11-25T23:27:56.223626601Z     ^^^^^^^^^^^^^
anthias-viewer-1  | 2024-11-25T23:27:56.223698304Z AttributeError: 'NoneType' object has no attribute 'kill'
```