### PR TITLE
fix: enforce HTTPS when using `curl` to install Poetry

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -16,7 +16,9 @@ on:
       - '!docs/**'
       - '!bin/install.sh'
       - '!bin/upgrade_containers.sh'
+      - '!bin/start_development_server.sh'
       - '!tests/**'
+      - '!docker/Dockerfile.dev'
 
 jobs:
   run-tests:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM python:3.11-bookworm
 
 RUN apt-get update -y && \
-    curl -sSL https://install.python-poetry.org | python3 - && \
+    curl --proto "=https" -sSL https://install.python-poetry.org | python3 - && \
     ln -s /root/.local/bin/poetry /usr/local/bin/poetry
 
 WORKDIR /app


### PR DESCRIPTION
### Overview

> Not enforcing HTTPS here might allow for redirections to insecure websites. Make sure it is safe here.

* https://sonarcloud.io/project/security_hotspots?id=Screenly_screenly-ose&branch=master&issueStatuses=OPEN%2CCONFIRMED&sinceLeakPeriod=true&tab=how_to_fix