### PR TITLE
chore: cleanup unnecessary code from the settings HTML template

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="container"    mode: "0644"
+    <div class="container"
     >
         <div class="row py-2">
             <div class="col-12">


### PR DESCRIPTION
I accidentally pasted Ansible code in the `settings.html`.