### PR TITLE
docs: add missing step in docs for building WebView for Pi 5

### DIFF
--- a/webview/docs/build_webview_for_pi5.md
+++ b/webview/docs/build_webview_for_pi5.md
@@ -25,7 +25,7 @@ $ cd /path/to/Anthias/webview
 Start the builder container with the following command:
 
 ```bash
-$ export GIT_HASH=$(git rev-parse --short HEAD) && \
+$ GIT_HASH=$(git rev-parse --short HEAD) \
     docker compose -f docker-compose.pi5.yml up -d --build
 ```
 

--- a/webview/docs/build_webview_for_pi5.md
+++ b/webview/docs/build_webview_for_pi5.md
@@ -22,9 +22,10 @@ Navigate to the `webview` directory:
 $ cd /path/to/Anthias/webview
 ```
 
-Start the builder container with the following command:
+Start the builder container with the following commands
 
 ```bash
+export GIT_HASH=$(git rev-parse --short HEAD)
 docker compose -f docker-compose.pi5.yml up -d --build
 ```
 

--- a/webview/docs/build_webview_for_pi5.md
+++ b/webview/docs/build_webview_for_pi5.md
@@ -22,11 +22,11 @@ Navigate to the `webview` directory:
 $ cd /path/to/Anthias/webview
 ```
 
-Start the builder container with the following commands
+Start the builder container with the following command:
 
 ```bash
-export GIT_HASH=$(git rev-parse --short HEAD)
-docker compose -f docker-compose.pi5.yml up -d --build
+$ export GIT_HASH=$(git rev-parse --short HEAD) && \
+    docker compose -f docker-compose.pi5.yml up -d --build
 ```
 
 You should now be able to invoke a run executing either of the following commands:


### PR DESCRIPTION
### Description

This pull request adds the missing step (where an environment variable named `GIT_HASH` should be set properly before building and starting the containers) in the documentation for building a WebView binary for Pi 5.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
