### PR TITLE
feat: add support for Pi 5 devices running balenaOS

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -89,7 +89,7 @@ jobs:
     needs: buildx
     strategy:
       matrix:
-        board: ['pi1', 'pi2', 'pi3', 'pi4']
+        board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi5']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

Adds support for Raspberry Pi 5 devices running **_balenaOS_**.
### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

### Additional Information

* Given that a fleet named screenly_ose/anthias-pi5 already exists (with the correct configuration), the deployment process should succeed.