### PR TITLE
chore(ci): add support for generating pre-built Pi 5 balenaOS images

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -24,7 +24,7 @@ jobs:
   balena-build-images:
     strategy:
       matrix:
-        board: ['pi1', 'pi2', 'pi3', 'pi4']
+        board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi5']
     runs-on: ubuntu-20.04
     permissions:
       contents: write
@@ -44,6 +44,8 @@ jobs:
             echo "BALENA_IMAGE=raspberrypi3" >> $GITHUB_ENV
           elif [ "${{ matrix.board }}" == 'pi4' ]; then
             echo "BALENA_IMAGE=raspberrypi4-64" >> $GITHUB_ENV
+          elif [ "${{ matrix.board }}" == 'pi5' ]; then
+            echo "BALENA_IMAGE=raspberrypi5" >> $GITHUB_ENV
           fi
 
       - name: balena CLI Action - download


### PR DESCRIPTION
### Description

This pull request contains changes to the Balena disk image workflow.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).