### PR TITLE
chore(ci): bump `actions/upload-artifact` to `v4`

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -98,7 +98,7 @@ jobs:
           docker exec -it qt-builder /webview/build_qt5.sh
           docker rm -f qt-builder
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Release files
           path: ~/tmp/qt-build/

--- a/.github/workflows/generate-openapi-schema.yml
+++ b/.github/workflows/generate-openapi-schema.yml
@@ -105,7 +105,7 @@ jobs:
             --file anthias-api-schema.json
 
       - name: Upload the OpenAPI Schema
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: anthias-api-schema
           path: anthias-api-schema.json


### PR DESCRIPTION
### Description

Bumped `actions/upload-artifact` from `v3` to `v4`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).