### PR TITLE
chore(ci): bump `actions/cache` to `v4`

### DIFF
--- a/.github/workflows/generate-openapi-schema.yml
+++ b/.github/workflows/generate-openapi-schema.yml
@@ -77,7 +77,7 @@ jobs:
           poetry install --only=docker-image-builder
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: /tmp/.buildx-cache


### PR DESCRIPTION
### Description

Bumps `actions/cache` from `v3` to `v4`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).