### PR TITLE
fix: error: "'<' not supported between instances of 'str' and 'datetime.datetime'"

### DIFF
--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -63,6 +63,7 @@ class AssetListViewV2(APIView):
 
         active_asset_ids = get_active_asset_ids()
         asset = Asset.objects.create(**serializer.data)
+        asset.refresh_from_db()
 
         if asset.is_active():
             active_asset_ids.insert(asset.play_order, asset.asset_id)


### PR DESCRIPTION
### Issues Fixed

* #2190 

### Description

* The an `Asset` instance is created, the `start_date` and `end_date` are still read as `str`s.
* We need to refresh the `asset` from the database.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

### Additional Information

Include any additional information that you think is necessary for this pull request, including screenshots of the changes that you have made.
