### PR TITLE
fix: enable Docker image push when building via buildx

### DIFF
--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -114,10 +114,8 @@ def build_image(
         load=True,
         platforms=[target_platform],
         tags=docker_tags,
+        push=push,
     )
-
-    if push:
-        docker.push(docker_tags)
 
 
 @click.command()


### PR DESCRIPTION
### Issues Fixed

Fixes the issue that occurs during Docker image builds. Here's a sample CI run: https://github.com/Screenly/Anthias/actions/runs/12642167521

### Description

This quick fix is an attempt to resolve the Docker image build issue.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).