### PR TITLE
fix: set target platform of Pi 4 images to `linux/arm64/v8`

### DIFF
--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -73,7 +73,7 @@ def build_image(
     elif service == 'test':
         context.update(get_test_context())
     elif service == 'wifi-connect':
-        context.update(get_wifi_connect_context(target_platform))
+        context.update(get_wifi_connect_context(board, target_platform))
     elif service == 'server':
         if environment == 'development':
             base_apt_dependencies.extend(['nodejs', 'npm'])

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -21,7 +21,7 @@ from tools.image_builder.constants import (
 def build_image(
     service: str,
     board: str,
-    target_platform: str,
+    target_platform: list[str],
     disable_cache_mounts: bool,
     git_hash: str,
     git_short_hash: str,
@@ -111,8 +111,8 @@ def build_image(
             'dest': '/tmp/.buildx-cache',
         },
         file=f'docker/Dockerfile.{service}',
-        load=True,
-        platforms=[target_platform],
+        load=(not push and len(target_platform) == 1),
+        platforms=target_platform,
         tags=docker_tags,
         push=push,
     )

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -22,7 +22,7 @@ def get_build_parameters(build_target: str) -> dict:
         return {
             'board': 'pi4',
             'base_image': 'balenalib/raspberrypi3-debian',
-            'target_platform': 'linux/arm/v8',
+            'target_platform': 'linux/arm64/v8',
         }
     elif build_target == 'pi3':
         return {
@@ -250,12 +250,15 @@ def get_viewer_context(board: str) -> dict:
     }
 
 
-def get_wifi_connect_context(target_platform: str) -> dict:
+def get_wifi_connect_context(board: str, target_platform: str) -> dict:
     if target_platform == 'linux/arm/v6':
         architecture = 'rpi'
-    elif target_platform in ['linux/arm/v7', 'linux/arm/v8']:
+    elif (
+        target_platform in ['linux/arm/v7', 'linux/arm64/v8'] and
+        board != 'pi5'
+    ):
         architecture = 'armv7hf'
-    elif target_platform == 'linux/arm64/v8':
+    elif target_platform == 'linux/arm64/v8' and board == 'pi5':
         architecture = 'aarch64'
     elif target_platform == 'linux/amd64':
         architecture = 'amd64'

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -9,38 +9,41 @@ def get_build_parameters(build_target: str) -> dict:
     default_build_parameters = {
         'board': 'x86',
         'base_image': 'debian',
-        'target_platform': 'linux/amd64',
+        'target_platform': ['linux/amd64'],
     }
 
     if build_target == 'pi5':
         return {
             'board': 'pi5',
             'base_image': 'balenalib/raspberrypi5-debian',
-            'target_platform': 'linux/arm64/v8',
+            'target_platform': ['linux/arm64/v8'],
         }
     if build_target == 'pi4':
         return {
             'board': 'pi4',
             'base_image': 'balenalib/raspberrypi3-debian',
-            'target_platform': 'linux/arm64/v8',
+            'target_platform': [
+                'linux/arm/v8',
+                'linux/arm64/v8',
+            ],
         }
     elif build_target == 'pi3':
         return {
             'board': 'pi3',
             'base_image': 'balenalib/raspberrypi3-debian',
-            'target_platform': 'linux/arm/v7',
+            'target_platform': ['linux/arm/v7'],
         }
     elif build_target == 'pi2':
         return {
             'board': 'pi2',
             'base_image': 'balenalib/raspberry-pi2',
-            'target_platform': 'linux/arm/v6',
+            'target_platform': ['linux/arm/v6'],
         }
     elif build_target == 'pi1':
         return {
             'board': 'pi1',
             'base_image': 'balenalib/raspberry-pi',
-            'target_platform': 'linux/arm/v6',
+            'target_platform': ['linux/arm/v6'],
         }
 
     return default_build_parameters
@@ -250,21 +253,24 @@ def get_viewer_context(board: str) -> dict:
     }
 
 
-def get_wifi_connect_context(board: str, target_platform: str) -> dict:
-    if target_platform == 'linux/arm/v6':
+def get_wifi_connect_context(board: str, target_platform: list[str]) -> dict:
+    # Use the first platform for determining architecture
+    platform = target_platform[0]
+
+    if platform == 'linux/arm/v6':
         architecture = 'rpi'
     elif (
-        target_platform in ['linux/arm/v7', 'linux/arm64/v8'] and
+        platform in ['linux/arm/v7', 'linux/arm/v8', 'linux/arm64/v8'] and
         board != 'pi5'
     ):
         architecture = 'armv7hf'
-    elif target_platform == 'linux/arm64/v8' and board == 'pi5':
+    elif platform == 'linux/arm64/v8' and board == 'pi5':
         architecture = 'aarch64'
-    elif target_platform == 'linux/amd64':
+    elif platform == 'linux/amd64':
         architecture = 'amd64'
     else:
         click.secho(
-            f'Unsupported target platform: {target_platform}',
+            f'Unsupported target platform: {platform}',
             fg='red',
         )
         return {}


### PR DESCRIPTION
### Issues Fixed

* Screenly/Anthias#2196

### Testing

#### For Raspberry Pi 4 Devices Running Raspberry Pi OS (Bookworm)

Run the following commands on your Raspberry Pi 4

```bash
cd && bash <(curl -sL https://raw.githubusercontent.com/nicomiguelino/Anthias/refs/heads/test-fix-pi4-balena-deployment/bin/install.sh)
```

### Description

Target platform for Pi 4 Docker images was changed from `linux/arm/v8` to `linux/arm64/v8`.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
