### PR TITLE
fix: install `nodejs` and `npm` dependencies

### DIFF
--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -1,9 +1,13 @@
 {% if environment == 'production' %}
 FROM debian:bookworm AS node-builder
 
-RUN \
-    apt-get update && \
+RUN apt-get update && \
     apt-get -y install --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        python3-six \
         nodejs \
         npm
 


### PR DESCRIPTION
### Issues Fixed

Docker image builds are failing in CI. See the following CI run for details: https://github.com/Screenly/Anthias/actions/runs/13162811771

### Description

* Updated the server Dockerfile to install dependencies of `nodejs` and `npm`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
