### PR TITLE
fix: attempt to fix the CI pipeline for building Docker images

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,6 +20,26 @@ on:
       - '!bin/start_development_server.sh'
       - '!tests/**'
       - '!docker/Dockerfile.dev'
+  # TODO: Remove this after debugging and testing.
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**'
+      - '!webview/**'
+      - '!website/**'
+      - '!.github/workflows/deploy-website.yaml'
+      - '!.github/workflows/build-webview.yaml'
+      - '!.github/workflows/build-balena-disk-image.yaml'
+      - '!.github/workflows/python-lint.yaml'
+      - '!.github/pull_request_template.md'
+      - '!README.md'
+      - '!docs/**'
+      - '!bin/install.sh'
+      - '!bin/upgrade_containers.sh'
+      - '!bin/start_development_server.sh'
+      - '!tests/**'
+      - '!docker/Dockerfile.dev'
 
 jobs:
   run-tests:
@@ -29,7 +49,9 @@ jobs:
     needs: run-tests
     strategy:
       matrix:
-        board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi4-64', 'pi5', 'x86']
+        # TODO: Uncomment line below when ready.
+        # board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi4-64', 'pi5', 'x86']
+        board: ['pi5']
         python-version: ["3.11"]
     runs-on: ubuntu-24.04
 
@@ -71,29 +93,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.board }}
 
-      - name: Login to Docker Hub
-        if: success() && github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # TODO: Uncomment this block when ready.
+      # - name: Login to Docker Hub
+      #   if: success() && github.event_name != 'pull_request'
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Containers
         run: |
           if [ "${{ matrix.board }}" == "pi4" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
-              --target-platform=linux/arm/v8 \
-              --push
+              --target-platform=linux/arm/v8
           elif [ "${{ matrix.board }}" == "pi4-64" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
-              --target-platform=linux/arm64/v8 \
-              --push
+              --target-platform=linux/arm64/v8
           else
             poetry run python -m tools.image_builder \
-              --build-target=${{ matrix.board }} \
-              --push
+              --build-target=${{ matrix.board }}
           fi
 
   balena:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -52,8 +52,7 @@ jobs:
     strategy:
       matrix:
         # TODO: Uncomment line below when ready.
-        # board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi4-64', 'pi5', 'x86']
-        board: ['pi5']
+        board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi4-64', 'pi5', 'x86']
         python-version: ["3.11"]
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -42,11 +42,13 @@ on:
       - '!docker/Dockerfile.dev'
 
 jobs:
-  run-tests:
-    uses: ./.github/workflows/docker-test.yaml
+  # TODO: Uncomment this job when ready.
+  # run-tests:
+  #   uses: ./.github/workflows/docker-test.yaml
 
   buildx:
-    needs: run-tests
+    # TODO: Uncomment this line when ready.
+    # needs: run-tests
     strategy:
       matrix:
         # TODO: Uncomment line below when ready.

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,38 +20,15 @@ on:
       - '!bin/start_development_server.sh'
       - '!tests/**'
       - '!docker/Dockerfile.dev'
-  # TODO: Remove this after debugging and testing.
-  pull_request:
-    branches:
-      - master
-    paths:
-      - '**'
-      - '!webview/**'
-      - '!website/**'
-      - '!.github/workflows/deploy-website.yaml'
-      - '!.github/workflows/build-webview.yaml'
-      - '!.github/workflows/build-balena-disk-image.yaml'
-      - '!.github/workflows/python-lint.yaml'
-      - '!.github/pull_request_template.md'
-      - '!README.md'
-      - '!docs/**'
-      - '!bin/install.sh'
-      - '!bin/upgrade_containers.sh'
-      - '!bin/start_development_server.sh'
-      - '!tests/**'
-      - '!docker/Dockerfile.dev'
 
 jobs:
-  # TODO: Uncomment this job when ready.
-  # run-tests:
-  #   uses: ./.github/workflows/docker-test.yaml
+  run-tests:
+    uses: ./.github/workflows/docker-test.yaml
 
   buildx:
-    # TODO: Uncomment this line when ready.
-    # needs: run-tests
+    needs: run-tests
     strategy:
       matrix:
-        # TODO: Uncomment line below when ready.
         board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi4-64', 'pi5', 'x86']
         python-version: ["3.11"]
     runs-on: ubuntu-24.04
@@ -94,27 +71,29 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.board }}
 
-      # TODO: Uncomment this block when ready.
-      # - name: Login to Docker Hub
-      #   if: success() && github.event_name != 'pull_request'
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Docker Hub
+        if: success() && github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Containers
         run: |
           if [ "${{ matrix.board }}" == "pi4" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
-              --target-platform=linux/arm/v8
+              --target-platform=linux/arm/v8 \
+              --push
           elif [ "${{ matrix.board }}" == "pi4-64" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
-              --target-platform=linux/arm64/v8
+              --target-platform=linux/arm64/v8 \
+              --push
           else
             poetry run python -m tools.image_builder \
-              --build-target=${{ matrix.board }}
+              --build-target=${{ matrix.board }} \
+              --push
           fi
 
   balena:

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -2,12 +2,7 @@
 FROM debian:bookworm AS node-builder
 
 RUN apt-get update && \
-    apt-get -y install --no-install-recommends \
-        python3 \
-        python3-pip \
-        python3-setuptools \
-        python3-wheel \
-        python3-six \
+    apt-get -y install \
         nodejs \
         npm
 


### PR DESCRIPTION
### Issues Fixed

* The GitHub Actions workflow for building the Docker images is broken.
* The build process stops at building the Docker image for the `server` service.

### Description

* Enabled installation of recommended packages when installing `nodejs` and `npm` during the first stage in `Dockerfile.server`.
* See the following CI run for proof: https://github.com/Screenly/Anthias/actions/runs/13185633333

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
