### PR TITLE
chore: install the ARM64 version of Docker for Pi 4 running 64-bit

### DIFF
--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -277,12 +277,17 @@
   register: debian_name
   changed_when: false
 
+- name: Check system bit width
+  ansible.builtin.command: getconf LONG_BIT
+  register: system_bits
+  changed_when: false
+
 - name: Set architecture
   ansible.builtin.set_fact:
     architecture: >-
       {{
         'amd64' if ansible_architecture == 'x86_64'
-        else ('arm64' if ansible_architecture == 'aarch64' and device_type == 'pi4'
+        else ('arm64' if device_type == 'pi4' and system_bits.stdout == '64'
         else 'armhf')
       }}
   when: |

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -279,7 +279,12 @@
 
 - name: Set architecture
   ansible.builtin.set_fact:
-    architecture: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'armhf' }}"
+    architecture: >-
+      {{
+        'amd64' if ansible_architecture == 'x86_64'
+        else ('arm64' if ansible_architecture == 'aarch64' and device_type == 'pi4'
+        else 'armhf')
+      }}
   when: |
     device_type == "pi1" or
     device_type == "pi2" or

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -32,7 +32,11 @@ if [ ! -f /proc/device-tree/model ] && [ "$(uname -m)" = "x86_64" ]; then
 elif grep -qF "Raspberry Pi 5" /proc/device-tree/model; then
     export DEVICE_TYPE="pi5"
 elif grep -qF "Raspberry Pi 4" /proc/device-tree/model; then
-    export DEVICE_TYPE="pi4"
+    if [ "$(getconf LONG_BIT)" = "64" ]; then
+        export DEVICE_TYPE="pi4-64"
+    else
+        export DEVICE_TYPE="pi4"
+    fi
 elif grep -qF "Raspberry Pi 3" /proc/device-tree/model; then
     export DEVICE_TYPE="pi3"
 elif grep -qF "Raspberry Pi 2" /proc/device-tree/model; then


### PR DESCRIPTION
### Description

* Updates the installer so that an `arm64` version of Docker will be installed for Pi 4 devices running Raspberry Pi OS Lite.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
