### PR TITLE
feat: add support for compute module devices

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -184,11 +184,11 @@ function install_ansible() {
 function set_device_type() {
     if [ ! -f /proc/device-tree/model ] && [ "$(uname -m)" = "x86_64" ]; then
         export DEVICE_TYPE="x86"
-    elif grep -qF "Raspberry Pi 5" /proc/device-tree/model; then
+    elif grep -qF "Raspberry Pi 5" /proc/device-tree/model || grep -qF "Compute Module 5" /proc/device-tree/model; then
         export DEVICE_TYPE="pi5"
-    elif grep -qF "Raspberry Pi 4" /proc/device-tree/model; then
+    elif grep -qF "Raspberry Pi 4" /proc/device-tree/model || grep -qF "Compute Module 4" /proc/device-tree/model; then
         export DEVICE_TYPE="pi4"
-    elif grep -qF "Raspberry Pi 3" /proc/device-tree/model; then
+    elif grep -qF "Raspberry Pi 3" /proc/device-tree/model || grep -qF "Compute Module 3" /proc/device-tree/model; then
         export DEVICE_TYPE="pi3"
     elif grep -qF "Raspberry Pi 2" /proc/device-tree/model; then
         export DEVICE_TYPE="pi2"

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -29,15 +29,15 @@ fi
 # Detect Raspberry Pi version
 if [ ! -f /proc/device-tree/model ] && [ "$(uname -m)" = "x86_64" ]; then
     export DEVICE_TYPE="x86"
-elif grep -qF "Raspberry Pi 5" /proc/device-tree/model; then
+elif grep -qF "Raspberry Pi 5" /proc/device-tree/model || grep -qF "Compute Module 5" /proc/device-tree/model; then
     export DEVICE_TYPE="pi5"
-elif grep -qF "Raspberry Pi 4" /proc/device-tree/model; then
+elif grep -qF "Raspberry Pi 4" /proc/device-tree/model || grep -qF "Compute Module 4" /proc/device-tree/model; then
     if [ "$(getconf LONG_BIT)" = "64" ]; then
         export DEVICE_TYPE="pi4-64"
     else
         export DEVICE_TYPE="pi4"
     fi
-elif grep -qF "Raspberry Pi 3" /proc/device-tree/model; then
+elif grep -qF "Raspberry Pi 3" /proc/device-tree/model || grep -qF "Compute Module 3" /proc/device-tree/model; then
     export DEVICE_TYPE="pi3"
 elif grep -qF "Raspberry Pi 2" /proc/device-tree/model; then
     export DEVICE_TYPE="pi2"

--- a/lib/device_helper.py
+++ b/lib/device_helper.py
@@ -31,11 +31,11 @@ def get_device_type():
         with open('/proc/device-tree/model') as file:
             content = file.read()
 
-            if 'Raspberry Pi 5' in content:
+            if 'Raspberry Pi 5' in content or 'Compute Module 5' in content:
                 return 'pi5'
-            elif 'Raspberry Pi 4' in content:
+            elif 'Raspberry Pi 4' in content or 'Compute Module 4' in content:
                 return 'pi4'
-            elif 'Raspberry Pi 3' in content:
+            elif 'Raspberry Pi 3' in content or 'Compute Module 3' in content:
                 return 'pi3'
             elif 'Raspberry Pi 2' in content:
                 return 'pi2'


### PR DESCRIPTION
### Issues Fixed

* https://github.com/Screenly/Anthias/issues/2217

### Description

Updated checks across relevant files in the codebase so that Raspberry Pi compute module devices would be supported as well

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

### Additional Information

* See https://forums.screenly.io/t/challenges-with-installing-anthias-on-pi-5/1704 for details.
