### PR TITLE
chore: add support for building just the WebView binaries

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -96,7 +96,7 @@ jobs:
             -v $(pwd):/webview:ro \
             -e TARGET=${{ matrix.board }} \
             screenly/ose-qt-builder:latest
-          docker exec -it qt-builder /webview/build_qt5.sh
+          docker exec -it qt-builder /webview/build_webview_with_qt5.sh
           docker rm -f qt-builder
 
       - uses: actions/upload-artifact@v4

--- a/webview/Dockerfile.x86
+++ b/webview/Dockerfile.x86
@@ -13,6 +13,7 @@ RUN { \
         build-essential \
         ccache \
         cmake \
+        curl \
         flex \
         freeglut3-dev \
         gawk \

--- a/webview/README.md
+++ b/webview/README.md
@@ -30,7 +30,7 @@ $ docker run -itd \
 You should now be able to invoke a run executing the following command:
 
 ```bash
-$ docker exec -it qt-builder-instance /webview/build_qt5.sh
+$ docker exec -it qt-builder-instance /webview/build_webview_with_qt5.sh
 ```
 
 This will start the process of building QT for *all* Raspberry Pi boards if you don't specify a `TARGET` environment variable.
@@ -59,6 +59,12 @@ You can append the following environment variables to configure the build proces
 $ cd webview
 $ docker compose -f docker-compose.x86.yml up -d --build
 $ docker compose -f docker-compose.x86.yml exec builder /webview/build_x86.sh
+```
+
+By default, the script will use pre-built Qt binaries to speed up the build process. If you want to build Qt from source, you can set the `BUILD_QT` environment variable:
+
+```bash
+$ docker compose -f docker-compose.x86.yml exec -e BUILD_QT=1 builder /webview/build_x86.sh
 ```
 
 The resulting files will be placed in `~/tmp-x86/qt-build/release`.

--- a/webview/build_webview_with_qt5.sh
+++ b/webview/build_webview_with_qt5.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# -*- sh-basic-offset: 4 -*-
+
+set -exuo pipefail
+
+BUILD_TARGET=/build
+SRC=/src
+QT_MAJOR="5"
+QT_MINOR="15"
+QT_BUG_FIX="14"
+QT_VERSION="$QT_MAJOR.$QT_MINOR.$QT_BUG_FIX"
+DEBIAN_VERSION=$(lsb_release -cs)
+MAKE_CORES="$(expr $(nproc) + 2)"
+
+ANTHIAS_RELEASE_URL="https://github.com/Screenly/Anthias/releases"
+WEBVIEW_VERSION="0.3.3"
+
+mkdir -p "$BUILD_TARGET"
+mkdir -p "$SRC"
+
+function fetch_cross_compile_tool () {
+    # The Raspberry Pi Foundation's cross compiling tools are too old so we need newer ones.
+    # References:
+    # * https://github.com/UvinduW/Cross-Compiling-Qt-for-Raspberry-Pi-4
+    # * https://releases.linaro.org/components/toolchain/binaries/latest-7/armv8l-linux-gnueabihf/
+    if [ ! -d "/src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf" ]; then
+        pushd /src/
+        wget -q https://releases.linaro.org/components/toolchain/binaries/7.4-2019.02/arm-linux-gnueabihf/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf.tar.xz
+        tar xf gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf.tar.xz
+        rm gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf.tar.xz
+        popd
+    fi
+}
+
+function download_and_extract_qt5() {
+    local SRC_DIR="$1"
+    local DEVICE="$2"
+
+    WEBVIEW_DL_URL="$ANTHIAS_RELEASE_URL/download/WebView-v$WEBVIEW_VERSION/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz"
+    WEBVIEW_DL_URL_SHA256="$WEBVIEW_DL_URL.sha256"
+
+    curl -sL "$WEBVIEW_DL_URL" -o /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz
+    curl -sL "$WEBVIEW_DL_URL_SHA256" -o /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256
+
+    cd /tmp
+    sha256sum -c "qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256"
+    tar -xzf "qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz" -C "$SRC_DIR"
+}
+
+function build_qt () {
+    # This build process is inspired by
+    # https://www.tal.org/tutorials/building-qt-512-raspberry-pi
+    local SRC_DIR="/src/$1"
+    mkdir -p "$SRC_DIR"/qt${QT_MAJOR}pi
+
+    download_and_extract_qt5 "$SRC_DIR" "$1"
+
+    cp -rf /webview "$SRC_DIR/"
+
+    pushd "$SRC_DIR/webview"
+
+    "$SRC_DIR/qt${QT_MAJOR}pi/bin/qmake"
+    make -j"$MAKE_CORES"
+    make install
+
+    mkdir -p fakeroot/bin fakeroot/share/ScreenlyWebview
+    mv ScreenlyWebview fakeroot/bin/
+    cp -rf /webview/res fakeroot/share/ScreenlyWebview/
+
+    pushd fakeroot
+    tar cfz "$BUILD_TARGET/webview-$QT_VERSION-$DEBIAN_VERSION-$1-$GIT_HASH.tar.gz" .
+    popd
+
+    pushd "$BUILD_TARGET"
+    sha256sum "webview-$QT_VERSION-$DEBIAN_VERSION-$1-$GIT_HASH.tar.gz" > "webview-$QT_VERSION-$DEBIAN_VERSION-$1-$GIT_HASH.tar.gz.sha256"
+    popd
+}
+
+fetch_cross_compile_tool
+
+if [ ! "${TARGET-}" ]; then
+    # Let's work our way through all Pis in order of relevance
+    for device in pi4 pi3 pi2 pi1; do
+        build_qt "$device"
+    done
+else
+    build_qt "$TARGET"
+fi
+

--- a/webview/build_x86.sh
+++ b/webview/build_x86.sh
@@ -18,6 +18,23 @@ QT_PATCH='3'
 QT_VERSION="${QT_MAJOR}.${QT_MINOR}.${QT_PATCH}"
 QT6_HOST_STAGING_PATH="/usr/local/qt6"
 
+ANTHIAS_RELEASE_URL="https://github.com/Screenly/Anthias/releases"
+WEBVIEW_VERSION="0.3.3"
+
+function download_and_extract_qt6() {
+    local WEBVIEW_DL_URL="$ANTHIAS_RELEASE_URL/download/WebView-v$WEBVIEW_VERSION/qt6-$QT_VERSION-$DEBIAN_VERSION-x86.tar.gz"
+    local WEBVIEW_DL_URL_SHA256="$WEBVIEW_DL_URL.sha256"
+
+    mkdir -p /usr/local
+
+    cd /tmp
+    curl -sL "$WEBVIEW_DL_URL" -o "qt6-$QT_VERSION-$DEBIAN_VERSION-x86.tar.gz"
+    curl -sL "$WEBVIEW_DL_URL_SHA256" -o "qt6-$QT_VERSION-$DEBIAN_VERSION-x86.tar.gz.sha256"
+
+    sha256sum -c "qt6-$QT_VERSION-$DEBIAN_VERSION-x86.tar.gz.sha256"
+    tar -xzf "qt6-$QT_VERSION-$DEBIAN_VERSION-x86.tar.gz" -C /usr/local
+}
+
 function install_qt() {
     QT_RELEASES_URL="https://download.qt.io/archive/qt"
     QT_DOWNLOAD_BASE_URL="${QT_RELEASES_URL}/${QT_MAJOR}.${QT_MINOR}/${QT_VERSION}/submodules"
@@ -116,8 +133,15 @@ function create_webview_archive() {
 }
 
 function main() {
-    install_qt
-    create_qt_archive
+    mkdir -p /build/release
+
+    if [ "${BUILD_QT:-0}" -eq 1 ]; then
+        install_qt
+        create_qt_archive
+    else
+        download_and_extract_qt6
+    fi
+
     create_webview_archive
 }
 

--- a/webview/src/mainwindow.cpp
+++ b/webview/src/mainwindow.cpp
@@ -8,7 +8,7 @@
 MainWindow::MainWindow() : QMainWindow()
 {
     view = new View(this);
-    view -> settings() -> setAttribute(QWebEngineSettings::LocalStorageEnabled, false);
+    view -> settings() -> setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
     view -> settings() -> setAttribute(QWebEngineSettings::ShowScrollBars, false);
     setCentralWidget(view);
 }


### PR DESCRIPTION
### Issues Fixed

Building Qt from source can be a bit time-consuming, so we'll just be using the prebuilt Qt binaries from the Anthias releases.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
