### PR TITLE
chore(ci): set GIT_HASH to a short commit hash

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -33,12 +33,14 @@ jobs:
       - name: Set buildx arguments
         id: prepare
         run: |
+          GIT_SHORT_HASH=$(git rev-parse --short HEAD)
+
           {
             echo "buildx_args=--cache-from \"screenly/ose-qt-builder:latest\" \
             --output \"type=image,push=true\" \
             --build-arg \"BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')\" \
-            --build-arg \"GIT_HASH=$GITHUB_SHA\" \
-            --build-arg \"GIT_SHORT_HASH=$(git rev-parse --short HEAD)\" \
+            --build-arg \"GIT_HASH=$GIT_SHORT_HASH\" \
+            --build-arg \"GIT_SHORT_HASH=$GIT_SHORT_HASH\" \
             --build-arg \"GIT_BRANCH=$GITHUB_REF_NAME\""
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### Issues Fixed

Sets `GIT_HASH` to the shorter version of the current commit hash

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).