### PR TITLE
chore(ci): add a conditional step for creating a release on tag push

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -8,6 +8,8 @@ on:
       - '.github/workflows/build-webview.yaml'
       - 'webview/**'
       - '!webview/README.md'
+    tags:
+      - 'WebView-v*'
 
 jobs:
   build-docker-image:
@@ -100,6 +102,17 @@ jobs:
             screenly/ose-qt-builder:latest
           docker exec -it qt-builder /webview/build_webview_with_qt5.sh
           docker rm -f qt-builder
+
+      - name: Create a release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          files: |
+            ~/tmp/qt-build/webview-*.tar.gz
+            ~/tmp/qt-build/webview-*.tar.gz.sha256
+            ~/tmp/qt-build/qt*.tar.gz
+            ~/tmp/qt-build/qt*.tar.gz.sha256
 
       - uses: actions/upload-artifact@v4
         with:

--- a/webview/build_webview_with_qt5.sh
+++ b/webview/build_webview_with_qt5.sh
@@ -44,6 +44,9 @@ function download_and_extract_qt5() {
     curl -sL "$WEBVIEW_DL_URL" -o /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz
     curl -sL "$WEBVIEW_DL_URL_SHA256" -o /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256
 
+    cp -n /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz /build/
+    cp -n /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256 /build/
+
     cd /tmp
     sha256sum -c "qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256"
     tar -xzf "qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz" -C "$SRC_DIR"


### PR DESCRIPTION
### Description

- Added a conditional step that creates a GitHub release when a new tag (e.g., `WebView-vM.m.p`) was pushed
- Included Qt 5 binaries/libraries in the archive

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).