### PR TITLE
chore(ci): updated paths for files to be uploaded to a new release

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -103,16 +103,21 @@ jobs:
           docker exec -it qt-builder /webview/build_webview_with_qt5.sh
           docker rm -f qt-builder
 
+      - name: Inspect build directory
+        run: |
+          ls -lah ~/tmp/qt-build
+
       - name: Create a release
+        working-directory: ~/tmp/qt-build
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           prerelease: true
           files: |
-            ~/tmp/qt-build/webview-*.tar.gz
-            ~/tmp/qt-build/webview-*.tar.gz.sha256
-            ~/tmp/qt-build/qt*.tar.gz
-            ~/tmp/qt-build/qt*.tar.gz.sha256
+            webview-*.tar.gz
+            webview-*.tar.gz.sha256
+            qt5-*.tar.gz
+            qt5-*.tar.gz.sha256
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -108,16 +108,15 @@ jobs:
           ls -lah ~/tmp/qt-build
 
       - name: Create a release
-        working-directory: ~/tmp/qt-build
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           prerelease: true
           files: |
-            webview-*.tar.gz
-            webview-*.tar.gz.sha256
-            qt5-*.tar.gz
-            qt5-*.tar.gz.sha256
+            ~/tmp/qt-build/webview-*.tar.gz
+            ~/tmp/qt-build/webview-*.tar.gz.sha256
+            ~/tmp/qt-build/qt5-*.tar.gz
+            ~/tmp/qt-build/qt5-*.tar.gz.sha256
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Issues Fixed

See this [CI run](https://github.com/Screenly/Anthias/actions/runs/13875686684) for details.

### Description

* Added a step that inspects the directory where the WebView files are built
* Updated paths for files to be uploaded to a new release

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

