### PR TITLE
chore(ci): add pipeline for building x86-compatible WebView

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -20,7 +20,6 @@ on:
 
 jobs:
   build-docker-image:
-    if: github.event_name != 'pull_request'
     name: Build Docker Images (Pi 1-4)
     runs-on: ubuntu-24.04
     steps:
@@ -42,6 +41,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set buildx arguments
+        if: github.event_name != 'pull_request'
         id: prepare
         run: |
           GIT_SHORT_HASH=$(git rev-parse --short HEAD)
@@ -56,6 +56,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Building container
+        if: github.event_name != 'pull_request'
         run: |
           cd webview
           docker buildx build \

--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -127,22 +127,6 @@ jobs:
             ~/tmp/qt-build/qt5-*.tar.gz.sha256 \
             ./build
 
-      - name: Inspect current directory
-        run: |
-          pwd
-          ls -lah ./build
-
-      - name: Create a release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          prerelease: true
-          files: |
-            build/webview-*.tar.gz
-            build/webview-*.tar.gz.sha256
-            build/qt5-*.tar.gz
-            build/qt5-*.tar.gz.sha256
-
       - uses: actions/upload-artifact@v4
         with:
           name: webview-${{ matrix.board }}
@@ -187,21 +171,31 @@ jobs:
             ~/tmp-x86/build/release/webview-*.tar.gz.sha256 \
             ./build
 
-      - name: Inspect current directory
-        run: |
-          pwd
-          ls -lah ./build
-
       - uses: actions/upload-artifact@v4
         with:
           name: webview-x86
           path: ./build
 
+  create-releases:
+    name: Create Releases
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - compile-webview-part-1
+      - compile-webview-part-2
+    matrix:
+      board: ['pi1', 'pi2', 'pi3', 'pi4', 'x86']
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: webview-${{ matrix.board }}
+          path: ./build
       - name: Create a release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           prerelease: true
           files: |
             build/webview-*.tar.gz
             build/webview-*.tar.gz.sha256
+            build/qt5-*.tar.gz
+            build/qt5-*.tar.gz.sha256

--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -10,9 +10,17 @@ on:
       - '!webview/README.md'
     tags:
       - 'WebView-v*'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/build-webview.yaml'
+      - 'webview/**'
+      - '!webview/README.md'
 
 jobs:
   build-docker-image:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -53,8 +61,9 @@ jobs:
             ${{ steps.prepare.outputs.buildx_args }} \
             -t screenly/ose-qt-builder:latest .
 
-  compile-qt:
-    needs: build-docker-image
+  compile-webview-part-1:
+    name: Compile Webview (Pi 1-4)
+    needs: ${{ github.event_name != 'pull_request' && 'build-docker-image' || '' }}
     strategy:
       matrix:
         board: ['pi1', 'pi2', 'pi3', 'pi4']
@@ -136,3 +145,50 @@ jobs:
         with:
           name: webview-${{ matrix.board }}
           path: ~/tmp/qt-build/
+
+  compile-webview-part-2:
+    name: Compile Webview (x86)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set environment variables (to be used in next steps)
+        run: |
+          export GIT_HASH="$(git rev-parse --short HEAD)"
+          export COMPOSE_PROFILES=x86
+          echo "GIT_HASH=$GIT_HASH" >> "$GITHUB_ENV"
+          echo "COMPOSE_PROFILES=$COMPOSE_PROFILES" >> "$GITHUB_ENV"
+
+      - name: Build Docker Image
+        run: |
+          cd webview
+          docker compose build
+
+      - name: Compile WebView
+        run: |
+          cd webview
+          docker compose run builder-x86 /scripts/build_webview.sh
+
+      - name: Copy build artifacts
+        run: |
+          mkdir -p ./build
+          cp ~/tmp-x86/build/release/webview-*.tar.gz \
+            ~/tmp-x86/build/release/webview-*.tar.gz.sha256 \
+            ./build
+
+      - name: Inspect current directory
+        run: |
+          pwd
+          ls -lah ./build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: webview-x86
+          path: ./build

--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -162,8 +162,10 @@ jobs:
 
       - name: Set environment variables (to be used in next steps)
         run: |
-          export GIT_HASH="$(git rev-parse --short HEAD)"
-          export COMPOSE_PROFILES=x86
+          GIT_HASH=""
+          COMPOSE_PROFILES=""
+          GIT_HASH="$(git rev-parse --short HEAD)"
+          COMPOSE_PROFILES="x86"
           echo "GIT_HASH=$GIT_HASH" >> "$GITHUB_ENV"
           echo "COMPOSE_PROFILES=$COMPOSE_PROFILES" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -63,7 +63,7 @@ jobs:
 
   compile-webview-part-1:
     name: Compile Webview (Pi 1-4)
-    needs: ${{ github.event_name != 'pull_request' && 'build-docker-image' || '' }}
+    needs: build-docker-image
     strategy:
       matrix:
         board: ['pi1', 'pi2', 'pi3', 'pi4']

--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -182,8 +182,9 @@ jobs:
     needs:
       - compile-webview-part-1
       - compile-webview-part-2
-    matrix:
-      board: ['pi1', 'pi2', 'pi3', 'pi4', 'x86']
+    strategy:
+      matrix:
+        board: ['pi1', 'pi2', 'pi3', 'pi4', 'x86']
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -21,6 +21,7 @@ on:
 jobs:
   build-docker-image:
     if: github.event_name != 'pull_request'
+    name: Build Docker Images (Pi 1-4)
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -192,3 +193,12 @@ jobs:
         with:
           name: webview-x86
           path: ./build
+
+      - name: Create a release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          files: |
+            build/webview-*.tar.gz
+            build/webview-*.tar.gz.sha256


### PR DESCRIPTION
### Description

- Updates the workflow file so that a x86-compatible WebView binary can be built as well

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).