### PR TITLE
chore(ci): fix permission issues when creating webview releases

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -70,10 +70,6 @@ jobs:
       matrix:
         board: ['pi1', 'pi2', 'pi3', 'pi4']
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -186,6 +182,10 @@ jobs:
       matrix:
         board: ['pi1', 'pi2', 'pi3', 'pi4', 'x86']
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
### Issues Fixed

- Sample CI Run: https://github.com/Screenly/Anthias/actions/runs/13877662361/job/38832103974

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
