### PR TITLE
chore(ci): add a pipeline for building pi5-compatible webview

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -152,9 +152,11 @@ jobs:
           GIT_HASH="$(git rev-parse --short HEAD)"
           COMPOSE_PROFILES="${{ matrix.board }}"
 
-          echo "GIT_HASH=$GIT_HASH" >> "$GITHUB_ENV"
-          echo "COMPOSE_PROFILES=$COMPOSE_PROFILES" >> "$GITHUB_ENV"
-          echo "COMPOSE_BAKE=true" >> "$GITHUB_ENV"
+          {
+            echo "GIT_HASH=$GIT_HASH"
+            echo "COMPOSE_PROFILES=$COMPOSE_PROFILES"
+            echo "COMPOSE_BAKE=true"
+          } >> "$GITHUB_ENV"
 
       - name: Build Docker Image
         run: |
@@ -179,7 +181,7 @@ jobs:
           path: ./build
 
   create-releases:
-    name: Create Releases
+    name: Create a Release
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - compile-webview-part-1

--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -129,8 +129,11 @@ jobs:
           path: ~/tmp/qt-build/
 
   compile-webview-part-2:
-    name: Compile Webview (x86)
+    name: Compile Webview (pi5, x86)
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        board: ['pi5', 'x86']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,14 +144,17 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set environment variables (to be used in next steps)
+      - name: Set environment variables
         run: |
           GIT_HASH=""
           COMPOSE_PROFILES=""
+
           GIT_HASH="$(git rev-parse --short HEAD)"
-          COMPOSE_PROFILES="x86"
+          COMPOSE_PROFILES="${{ matrix.board }}"
+
           echo "GIT_HASH=$GIT_HASH" >> "$GITHUB_ENV"
           echo "COMPOSE_PROFILES=$COMPOSE_PROFILES" >> "$GITHUB_ENV"
+          echo "COMPOSE_BAKE=true" >> "$GITHUB_ENV"
 
       - name: Build Docker Image
         run: |
@@ -158,18 +164,18 @@ jobs:
       - name: Compile WebView
         run: |
           cd webview
-          docker compose run builder-x86 /scripts/build_webview.sh
+          docker compose run builder-${{ matrix.board }} /scripts/build_webview.sh
 
       - name: Copy build artifacts
         run: |
           mkdir -p ./build
-          cp ~/tmp-x86/build/release/webview-*.tar.gz \
-            ~/tmp-x86/build/release/webview-*.tar.gz.sha256 \
+          cp ~/tmp-${{ matrix.board }}/build/release/webview-*.tar.gz \
+            ~/tmp-${{ matrix.board }}/build/release/webview-*.tar.gz.sha256 \
             ./build
 
       - uses: actions/upload-artifact@v4
         with:
-          name: webview-x86
+          name: webview-${{ matrix.board }}
           path: ./build
 
   create-releases:
@@ -180,7 +186,7 @@ jobs:
       - compile-webview-part-2
     strategy:
       matrix:
-        board: ['pi1', 'pi2', 'pi3', 'pi4', 'x86']
+        board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi5', 'x86']
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
### Description

- Adds support for building a WebView binary compatible with the Raspberry Pi 5
- Sets `COMPOSE_BAKE=true` for x86 and Raspberry Pi 5 builds

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).