### PR TITLE
chore(ci): fix webview build workflow for Pi 1-4

### DIFF
--- a/webview/build_webview_with_qt5.sh
+++ b/webview/build_webview_with_qt5.sh
@@ -41,8 +41,13 @@ function download_and_extract_qt5() {
     WEBVIEW_DL_URL="$ANTHIAS_RELEASE_URL/download/WebView-v$WEBVIEW_VERSION/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz"
     WEBVIEW_DL_URL_SHA256="$WEBVIEW_DL_URL.sha256"
 
-    curl -sL "$WEBVIEW_DL_URL" -o /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz
-    curl -sL "$WEBVIEW_DL_URL_SHA256" -o /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256
+    if [ ! -f /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz ]; then
+        curl -sL "$WEBVIEW_DL_URL" -o /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz
+    fi
+
+    if [ ! -f /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256 ]; then
+        curl -sL "$WEBVIEW_DL_URL_SHA256" -o /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256
+    fi
 
     cp -n /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz /build/
     cp -n /tmp/qt5-$QT_VERSION-$DEBIAN_VERSION-$DEVICE.tar.gz.sha256 /build/


### PR DESCRIPTION
### Issues Fixed

- The script for building WebView binaries still download Qt 5 even if the files are already downloaded

### Description

- Only do downloads via `curl` if the Qt archives don't exist.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
