### PR TITLE
chore(ci): fix caching of Docker image builds

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -66,11 +66,10 @@ jobs:
         uses: actions/cache@v4
         id: cache
         with:
-          path: /tmp/.buildx-cache
+          path: /tmp/.buildx-cache/${{ matrix.board }}
           key: ${{ runner.os }}-buildx-${{ matrix.board }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.board }}-
-            ${{ runner.os }}-buildx-
 
       - name: Login to Docker Hub
         if: success() && github.event_name != 'pull_request'

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -57,11 +57,10 @@ jobs:
         uses: actions/cache@v4
         id: cache
         with:
-          path: /tmp/.buildx-cache
+          path: /tmp/.buildx-cache/test
           key: ${{ runner.os }}-buildx-test-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-test-
-            ${{ runner.os }}-buildx-
 
       - name: Set up Docker Buildx
         id: buildx

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -1,7 +1,8 @@
-import click
 import os
-import pygit2
 from pathlib import Path
+
+import click
+import pygit2
 from python_on_whales import docker
 
 from tools.image_builder.constants import (
@@ -44,7 +45,10 @@ def build_image(
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
     except Exception as e:
-        click.secho(f'Warning: Failed to create cache directory: {e}', fg='yellow')
+        click.secho(
+            f'Warning: Failed to create cache directory: {e}',
+            fg='yellow'
+        )
 
     base_apt_dependencies = [
         'build-essential',


### PR DESCRIPTION
### Issues Fixed

- Cache restores are not strict for certain platforms.
  - For instance, for a Pi 5 build, if there's a cache miss on the first pattern (e.g., `[runner_os]-buildx-pi5-[sha]`), the next less-specific pattern will be considered (i.e., `[runner_os]-buildx-*`), which is problematic as an x86 or Pi 4 cache (for instance) can be restored.

### Description

- Ensures that there are dedicated cache directories for each of the supported platforms (Pi 1-4, Pi 5, x86)

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
