### PR TITLE
chore(ci): use a dedicated builder for images

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -61,15 +61,27 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+
+      - name: Create and use dedicated builder
+        run: |
+          docker buildx create --use --name multiarch-builder
+          docker buildx inspect --bootstrap
 
       - name: Cache Docker layers
         uses: actions/cache@v4
         id: cache
         with:
           path: /tmp/.buildx-cache/${{ matrix.board }}
-          key: ${{ runner.os }}-buildx-${{ matrix.board }}-${{ github.sha }}
+          key: buildx-${{ matrix.board }}-${{ hashFiles('docker/**/*') }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.board }}-
+            buildx-${{ matrix.board }}-
+
+      - name: Inspect cache before build
+        run: |
+          ls -la /tmp/.buildx-cache/${{ matrix.board }} || true
 
       - name: Login to Docker Hub
         if: success() && github.event_name != 'pull_request'
@@ -79,6 +91,9 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Containers
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
         run: |
           if [ "${{ matrix.board }}" == "pi4" ]; then
             poetry run python -m tools.image_builder \
@@ -95,6 +110,10 @@ jobs:
               --build-target=${{ matrix.board }} \
               --push
           fi
+
+      - name: Inspect cache after build
+        run: |
+          ls -la /tmp/.buildx-cache/${{ matrix.board }} || true
 
   balena:
     if: ${{ github.ref == 'refs/heads/master' }}

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -41,7 +41,11 @@ def build_image(
     context = {}
 
     # Create board-specific cache directory
-    cache_dir = Path('/tmp/.buildx-cache') / board
+    cache_dir = Path('/tmp/.buildx-cache') / (
+        f'{board}-64'
+        if board == 'pi4' and target_platform == 'linux/arm64/v8'
+        else board
+    )
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
     except Exception as e:
@@ -114,6 +118,12 @@ def build_image(
     if dockerfiles_only:
         return
 
+    # Ensure we're using the correct builder
+    try:
+        docker.buildx.inspect('multiarch-builder', bootstrap=True)
+    except:
+        docker.buildx.create(name='multiarch-builder', use=True)
+
     docker.buildx.build(
         context_path='.',
         cache=(not clean_build),
@@ -126,11 +136,13 @@ def build_image(
             'dest': str(cache_dir),
             'mode': 'max',
         } if not clean_build else None,
+        builder='multiarch-builder',
         file=f'docker/Dockerfile.{service}',
         load=True,
         platforms=[target_platform],
         tags=docker_tags,
         push=push,
+        progress='plain',
     )
 
 


### PR DESCRIPTION
### Issues Fixed

- The build times are still not significantly reduced.

### Description

- Used a different strategy for cache keys
- Explicity set `driver-opts` `image` to `moby/buildkit:latest`
- Used a dedicated Buildx builder named "multiarch-builder". A new builder with that name will be created if it doesn't exist yet.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
