### PR TITLE
fix: installing Anthias in Bullseye

### DIFF
--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -40,6 +40,21 @@
     executable: "/home/{{ lookup('env', 'USER') }}/installer_venv/bin/pip"
     requirements: "/home/{{ lookup('env', 'USER') }}/screenly/requirements/requirements.host.txt"
     extra_args: "--no-cache-dir --upgrade"
+  when: ansible_distribution_major_version | int >= 12
+
+- name: Install pip dependencies (Debian 11 and older)
+  ansible.builtin.pip:
+    executable: "/home/{{ lookup('env', 'USER') }}/installer_venv/bin/pip"
+    name:
+      - ansible-core==2.15.9
+      - docker==6.0.0
+      - getmac==0.9.4
+      - netifaces2==0.0.22
+      - redis==4.3.4
+      - "requests[security]==2.32.3"
+      - tenacity==9.0.0
+    extra_args: "--no-cache-dir --upgrade"
+  when: ansible_distribution_major_version | int <= 11
 
 - name: Remove screenly_utils.sh
   ansible.builtin.file:

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -15,6 +15,7 @@ GITHUB_RAW_URL="https://raw.githubusercontent.com/Screenly/Anthias"
 DOCKER_TAG="latest"
 UPGRADE_SCRIPT_PATH="${ANTHIAS_REPO_DIR}/bin/upgrade_containers.sh"
 ARCHITECTURE=$(uname -m)
+DISTRO_VERSION=$(lsb_release -rs)
 
 INTRO_MESSAGE=(
     "Anthias requires a dedicated Raspberry Pi and an SD card."
@@ -121,7 +122,6 @@ function initialize_locales() {
 function install_packages() {
     display_section "Install Packages via APT"
 
-    local DISTRO_VERSION=$(lsb_release -rs)
     local APT_INSTALL_ARGS=(
         "git"
         "libffi-dev"
@@ -160,7 +160,11 @@ function install_ansible() {
     display_section "Install Ansible"
 
     REQUIREMENTS_URL="$GITHUB_RAW_URL/$BRANCH/requirements/requirements.host.txt"
-    ANSIBLE_VERSION=$(curl -s $REQUIREMENTS_URL | grep ansible)
+    if [ "$DISTRO_VERSION" -le 11 ]; then
+        ANSIBLE_VERSION="ansible-core==2.15.9"
+    else
+        ANSIBLE_VERSION=$(curl -s $REQUIREMENTS_URL | grep ansible)
+    fi
 
     SUDO_ARGS=()
 

--- a/requirements/requirements.host.txt
+++ b/requirements/requirements.host.txt
@@ -1,6 +1,6 @@
 # vim: ft=requirements
 
-ansible-core==2.17.7
+ansible-core==2.15.9
 docker==6.0.0
 getmac==0.9.4
 netifaces2==0.0.22

--- a/requirements/requirements.host.txt
+++ b/requirements/requirements.host.txt
@@ -1,6 +1,6 @@
 # vim: ft=requirements
 
-ansible-core==2.15.9
+ansible-core==2.18.3
 docker==6.0.0
 getmac==0.9.4
 netifaces2==0.0.22


### PR DESCRIPTION
### Issues Fixed

- Fixes #2233

### Description

- Reverts `ansible-core` from `2.17.7` to `2.15.9` for Bullseye and older
- Bumps `ansible-core` to `2.18.3` for Bookworm

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
