### PR TITLE
fix: stick to `pi4` for Anthias version v0.19.5 and older

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -233,6 +233,7 @@ function upgrade_docker_containers() {
 
     sudo -u ${USER} \
         DOCKER_TAG="${DOCKER_TAG}" \
+        GIT_BRANCH="${BRANCH}" \
         "${UPGRADE_SCRIPT_PATH}"
 }
 


### PR DESCRIPTION
### Issues Fixed

- Fixes #2250 

### Description

Updates the installer script so that images can be pulled successfully from Docker Hub.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
