### PR TITLE
fix: black screen after each image

### DIFF
--- a/webview/src/mainwindow.cpp
+++ b/webview/src/mainwindow.cpp
@@ -8,17 +8,17 @@
 MainWindow::MainWindow() : QMainWindow()
 {
     view = new View(this);
-    view -> settings() -> setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
-    view -> settings() -> setAttribute(QWebEngineSettings::ShowScrollBars, false);
+    view->webView->settings()->setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
+    view->webView->settings()->setAttribute(QWebEngineSettings::ShowScrollBars, false);
     setCentralWidget(view);
 }
 
 void MainWindow::loadPage(const QString &uri)
 {
-    view -> loadPage(uri);
+    view->loadPage(uri);
 }
 
-void MainWindow:: loadImage(const QString &uri)
+void MainWindow::loadImage(const QString &uri)
 {
-    view -> loadImage(uri);
+    view->loadImage(uri);
 }

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -4,38 +4,53 @@
 #include <QStandardPaths>
 #include <QEventLoop>
 #include <QTimer>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QImage>
+#include <QPainter>
 
 #include "view.h"
 
 
-View::View(QWidget* parent) : QWebEngineView(parent)
+View::View(QWidget* parent) : QWidget(parent)
 {
+    webView = new QWebEngineView(this);
+    webView->setVisible(false);
+
     connect(
-        QWebEngineView::page(),
+        webView->page(),
         SIGNAL(authenticationRequired(QNetworkReply*,QAuthenticator*)),
         this,
         SLOT(handleAuthRequest(QNetworkReply*,QAuthenticator*))
     );
+
     pre_loader = new QWebEnginePage;
+    networkManager = new QNetworkAccessManager(this);
+    currentImage = QImage();
+    nextImage = QImage();
 }
 
 void View::loadPage(const QString &uri)
 {
     qDebug() << "Type: Webpage";
-    stop();
-    load(QUrl(uri));
-    clearFocus();
+    webView->setVisible(true);
+    webView->stop();
+    webView->load(QUrl(uri));
+    webView->clearFocus();
 }
 
 void View::loadImage(const QString &preUri)
 {
     qDebug() << "Type: Image";
+    webView->setVisible(false);
+
     QFileInfo fileInfo = QFileInfo(preUri);
     QString src;
 
     if (fileInfo.isFile())
     {
         qDebug() << "Location: Local File";
+        qDebug() << "File path:" << fileInfo.absoluteFilePath();
 
         QUrl url;
         url.setScheme("http");
@@ -43,10 +58,14 @@ void View::loadImage(const QString &preUri)
         url.setPath("/screenly_assets/" + fileInfo.fileName());
 
         src = url.toString();
+        qDebug() << "Generated URL:" << src;
     }
     else if (preUri == "null")
     {
         qDebug() << "Black page";
+        currentImage = QImage();
+        update();
+        return;
     }
     else
     {
@@ -54,33 +73,68 @@ void View::loadImage(const QString &preUri)
         src = preUri;
     }
 
-    qDebug() << "Current src: " + src;
+    qDebug() << "Loading image from:" << src;
 
-    QString script = "window.setimg=function(n){var o=new Image;o.onload=function()"
-                     "{document.body.style.backgroundSize=o.width>window.innerWidth||o.height>window.innerHeight?\"contain\":\"auto\","
-                     "document.body.style.backgroundImage=\"url('\"+n+\"')\","
-                     "document.body.style.opacity=\"1\"},"
-                     "o.onerror=function(){document.body.style.opacity=\"1\"},"
-                     "document.body.style.opacity=\"0.5\","
-                     "o.src=n};";
-    QString styles = "background: #000 center no-repeat; transition: opacity 0.3s ease-in-out";
+    // Start loading the next image
+    QNetworkRequest request(src);
+    QNetworkReply* reply = networkManager->get(request);
 
-    // Don't stop the current view, let it stay visible
-    pre_loader->setHtml("<html><head><script>" + script + "</script></head><body style='" + styles + "'><script>window.setimg(\"" + src + "\");</script></body></html>");
+    connect(reply, &QNetworkReply::finished, this, [=]() {
+        if (reply->error() == QNetworkReply::NoError) {
+            QImage newImage;
+            QByteArray data = reply->readAll();
+            qDebug() << "Received image data size:" << data.size();
 
-    connect(pre_loader, &QWebEnginePage::loadFinished, this, [=](bool result){
-        if (result)
-        {
-            pre_loader->toHtml([&](const QString &result){
-                setHtml(result);
-            });
+            if (newImage.loadFromData(data)) {
+                qDebug() << "Successfully loaded image. Size:" << newImage.size();
+                currentImage = newImage;
+                update();
+            } else {
+                qDebug() << "Failed to load image from data";
+            }
+        } else {
+            qDebug() << "Network error:" << reply->errorString();
         }
+        reply->deleteLater();
     });
+
+    connect(reply, &QNetworkReply::errorOccurred, this, [=](QNetworkReply::NetworkError error) {
+        qDebug() << "Network error occurred:" << error;
+        qDebug() << "Error string:" << reply->errorString();
+    });
+}
+
+void View::paintEvent(QPaintEvent*)
+{
+    QPainter painter(this);
+    painter.fillRect(rect(), Qt::black);
+
+    if (!currentImage.isNull()) {
+        qDebug() << "Painting image. Size:" << currentImage.size();
+        QSize scaledSize = currentImage.size();
+        scaledSize.scale(size(), Qt::KeepAspectRatio);
+        QRect targetRect = QRect(QPoint(0, 0), size());
+        targetRect = QRect(
+            (width() - scaledSize.width()) / 2,
+            (height() - scaledSize.height()) / 2,
+            scaledSize.width(),
+            scaledSize.height()
+        );
+        painter.drawImage(targetRect, currentImage);
+    } else {
+        qDebug() << "No image to paint";
+    }
+}
+
+void View::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    webView->setGeometry(rect());
 }
 
 void View::handleAuthRequest(QNetworkReply* reply, QAuthenticator* auth)
 {
     Q_UNUSED(reply)
     Q_UNUSED(auth)
-    load(QUrl::fromLocalFile(QStandardPaths::locate(QStandardPaths::AppDataLocation, "res/access_denied.html")));
+    webView->load(QUrl::fromLocalFile(QStandardPaths::locate(QStandardPaths::AppDataLocation, "res/access_denied.html")));
 }

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -57,17 +57,21 @@ void View::loadImage(const QString &preUri)
     qDebug() << "Current src: " + src;
 
     QString script = "window.setimg=function(n){var o=new Image;o.onload=function()"
-                     "{document.body.style.backgroundSize=o.width>window.innerWidth||o.height>window.innerHeight?\"contain\":\"auto\",document.body.style.backgroundImage=\"url('\"+n+\"')\"},o.src=n};";
-    QString styles = "background: #000 center no-repeat";
+                     "{document.body.style.backgroundSize=o.width>window.innerWidth||o.height>window.innerHeight?\"contain\":\"auto\","
+                     "document.body.style.backgroundImage=\"url('\"+n+\"')\","
+                     "document.body.style.opacity=\"1\"},"
+                     "o.onerror=function(){document.body.style.opacity=\"1\"},"
+                     "document.body.style.opacity=\"0.5\","
+                     "o.src=n};";
+    QString styles = "background: #000 center no-repeat; transition: opacity 0.3s ease-in-out";
 
-    stop();
-    pre_loader -> setHtml("<html><head><script>" + script + "</script></head><body style='" + styles + "'><script>window.setimg(\"" + src + "\");</script></body></html>");
-    clearFocus();
+    // Don't stop the current view, let it stay visible
+    pre_loader->setHtml("<html><head><script>" + script + "</script></head><body style='" + styles + "'><script>window.setimg(\"" + src + "\");</script></body></html>");
 
     connect(pre_loader, &QWebEnginePage::loadFinished, this, [=](bool result){
         if (result)
         {
-            pre_loader -> toHtml([&](const QString &result){
+            pre_loader->toHtml([&](const QString &result){
                 setHtml(result);
             });
         }

--- a/webview/src/view.h
+++ b/webview/src/view.h
@@ -1,20 +1,27 @@
 #pragma once
 
+#include <QWidget>
 #include <QWebEngineView>
 #include <QWebEnginePage>
-#include <QWidget>
 #include <QEventLoop>
 #include <QNetworkReply>
+#include <QNetworkAccessManager>
+#include <QImage>
 
-class View : public QWebEngineView
+class View : public QWidget
 {
     Q_OBJECT
 
 public:
     explicit View(QWidget* parent);
+    QWebEngineView* webView;  // Made public for MainWindow access
 
     void loadPage(const QString &uri);
     void loadImage(const QString &uri);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private slots:
     void handleAuthRequest(QNetworkReply*, QAuthenticator*);
@@ -22,4 +29,7 @@ private slots:
 private:
     QWebEnginePage* pre_loader;
     QEventLoop pre_loader_loop;
+    QNetworkAccessManager* networkManager;
+    QImage currentImage;
+    QImage nextImage;
 };


### PR DESCRIPTION
### Issues Fixed

- Fixes #2051

### Description

- This is an attempt to avoid a gap (in a form of a black screen) between assets.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
