### PR TITLE
fix: only display a web asset when it has finished loading

### DIFF
--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -33,10 +33,27 @@ View::View(QWidget* parent) : QWidget(parent)
 void View::loadPage(const QString &uri)
 {
     qDebug() << "Type: Webpage";
-    webView->setVisible(true);
+
+    // Clear current image if any
+    currentImage = QImage();
+
+    // Keep web view hidden until fully loaded
+    webView->setVisible(false);
+
+    // Connect to loadFinished signal
+    connect(webView->page(), &QWebEnginePage::loadFinished, this, [=](bool ok) {
+        if (ok) {
+            qDebug() << "Web page loaded successfully";
+            webView->setVisible(true);
+            webView->clearFocus();
+        } else {
+            qDebug() << "Web page failed to load";
+        }
+    }, Qt::SingleShotConnection);  // Disconnect after first signal
+
+    // Load the page
     webView->stop();
     webView->load(QUrl(uri));
-    webView->clearFocus();
 }
 
 void View::loadImage(const QString &preUri)

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -40,7 +40,8 @@ void View::loadPage(const QString &uri)
     // Keep web view hidden until fully loaded
     webView->setVisible(false);
 
-    // Connect to loadFinished signal
+    // Connect to loadFinished signal with version-specific code
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     connect(webView->page(), &QWebEnginePage::loadFinished, this, [=](bool ok) {
         if (ok) {
             qDebug() << "Web page loaded successfully";
@@ -50,6 +51,17 @@ void View::loadPage(const QString &uri)
             qDebug() << "Web page failed to load";
         }
     }, Qt::SingleShotConnection);  // Disconnect after first signal
+#else
+    connect(webView->page(), &QWebEnginePage::loadFinished, this, [=](bool ok) {
+        if (ok) {
+            qDebug() << "Web page loaded successfully";
+            webView->setVisible(true);
+            webView->clearFocus();
+        } else {
+            qDebug() << "Web page failed to load";
+        }
+    });
+#endif
 
     // Load the page
     webView->stop();

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -38,7 +38,6 @@ void View::loadPage(const QString &uri)
     currentImage = QImage();
 
     // Connect to loadFinished signal with version-specific code
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     connect(webView->page(), &QWebEnginePage::loadFinished, this, [=](bool ok) {
         if (ok) {
             qDebug() << "Web page loaded successfully";
@@ -47,16 +46,9 @@ void View::loadPage(const QString &uri)
         } else {
             qDebug() << "Web page failed to load";
         }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     }, Qt::SingleShotConnection);  // Disconnect after first signal
 #else
-    connect(webView->page(), &QWebEnginePage::loadFinished, this, [=](bool ok) {
-        if (ok) {
-            qDebug() << "Web page loaded successfully";
-            webView->setVisible(true);
-            webView->clearFocus();
-        } else {
-            qDebug() << "Web page failed to load";
-        }
     });
 #endif
 

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -37,9 +37,6 @@ void View::loadPage(const QString &uri)
     // Clear current image if any
     currentImage = QImage();
 
-    // Keep web view hidden until fully loaded
-    webView->setVisible(false);
-
     // Connect to loadFinished signal with version-specific code
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     connect(webView->page(), &QWebEnginePage::loadFinished, this, [=](bool ok) {
@@ -71,7 +68,6 @@ void View::loadPage(const QString &uri)
 void View::loadImage(const QString &preUri)
 {
     qDebug() << "Type: Image";
-    webView->setVisible(false);
 
     QFileInfo fileInfo = QFileInfo(preUri);
     QString src;
@@ -93,6 +89,7 @@ void View::loadImage(const QString &preUri)
     {
         qDebug() << "Black page";
         currentImage = QImage();
+        webView->setVisible(false);
         update();
         return;
     }
@@ -116,7 +113,10 @@ void View::loadImage(const QString &preUri)
 
             if (newImage.loadFromData(data)) {
                 qDebug() << "Successfully loaded image. Size:" << newImage.size();
-                currentImage = newImage;
+                nextImage = newImage;
+                // Only hide web view and update current image after the new image is loaded
+                webView->setVisible(false);
+                currentImage = nextImage;
                 update();
             } else {
                 qDebug() << "Failed to load image from data";
@@ -150,8 +150,6 @@ void View::paintEvent(QPaintEvent*)
             scaledSize.height()
         );
         painter.drawImage(targetRect, currentImage);
-    } else {
-        qDebug() << "No image to paint";
     }
 }
 


### PR DESCRIPTION
### Issues Fixed

#2253 fixed #2051, but let's say you have the following playlist items (in order):

- Image Asset 1
- Web Asset 1
- Image Asset 2
- Web Asset 2

When Web Asset 2 is about to be displayed, Web Asset 1 can still be seen for a quick moment.

### Description

Waits for a web asset to be finished (loading) before showing it.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
