### PR TITLE
fix: ensure authentication for the device settings endpoint

### DIFF
--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -179,6 +179,7 @@ class DeviceSettingsViewV2(APIView):
             200: DeviceSettingsSerializerV2
         }
     )
+    @authorized
     def get(self, request):
         return Response({
             'player_name': settings['player_name'],


### PR DESCRIPTION
### Issues Fixed

- If basic authentication is enabled, anyone can still access the `/api/v2/device_settings`

### Description

- Adds the `authorized` decorator to the endpoint function

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
