### PR TITLE
chore: fix API docs warnings

### DIFF
--- a/api/serializers/mixins.py
+++ b/api/serializers/mixins.py
@@ -1,5 +1,8 @@
 import uuid
+from inspect import cleandoc
 from os import path, rename
+
+from rest_framework.serializers import CharField, Serializer
 
 from lib.utils import (
     download_video_from_youtube,
@@ -99,3 +102,27 @@ class CreateAssetSerializerMixin:
             raise Exception("Could not retrieve file. Check the asset URL.")
 
         return asset
+
+
+class PlaylistOrderSerializerMixin(Serializer):
+    ids = CharField(
+        write_only=True,
+        help_text=cleandoc(
+            """
+            Comma-separated list of asset IDs in the order
+            they should be played. For example:
+
+            `793406aa1fd34b85aa82614004c0e63a,1c5cfa719d1f4a9abae16c983a18903b,9c41068f3b7e452baf4dc3f9b7906595`
+            """
+        ),
+    )
+
+
+class BackupViewSerializerMixin(Serializer):
+    pass
+
+class RebootViewSerializerMixin(Serializer):
+    pass
+
+class ShutdownViewSerializerMixin(Serializer):
+    pass

--- a/api/serializers/v2.py
+++ b/api/serializers/v2.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
+from drf_spectacular.utils import OpenApiTypes, extend_schema_field
 from rest_framework.serializers import (
     BooleanField,
     CharField,
@@ -6,6 +7,7 @@ from rest_framework.serializers import (
     IntegerField,
     ModelSerializer,
     Serializer,
+    SerializerMethodField,
 )
 
 from anthias_app.models import Asset
@@ -14,6 +16,12 @@ from api.serializers.mixins import CreateAssetSerializerMixin
 
 
 class AssetSerializerV2(ModelSerializer, CreateAssetSerializerMixin):
+    is_active = SerializerMethodField()
+
+    @extend_schema_field(OpenApiTypes.BOOL)
+    def get_is_active(self, obj):
+        return obj.is_active()
+
     class Meta:
         model = Asset
         fields = [

--- a/api/views/mixins.py
+++ b/api/views/mixins.py
@@ -12,6 +12,12 @@ from rest_framework.views import APIView
 
 from anthias_app.models import Asset
 from api.helpers import save_active_assets_ordering
+from api.serializers.mixins import (
+    BackupViewSerializerMixin,
+    PlaylistOrderSerializerMixin,
+    RebootViewSerializerMixin,
+    ShutdownViewSerializerMixin,
+)
 from celery_tasks import reboot_anthias, shutdown_anthias
 from lib import backup_helper, diagnostics
 from lib.auth import authorized
@@ -50,6 +56,7 @@ class BackupViewMixin(APIView):
         * asset metadata (e.g. name, duration, play order, status),
           which is stored in a SQLite database
         """),
+        request=BackupViewSerializerMixin,
         responses={
             201: {
                 'type': 'string',
@@ -112,6 +119,8 @@ class RecoverViewMixin(APIView):
 
 
 class RebootViewMixin(APIView):
+    serializer_class = RebootViewSerializerMixin
+
     @extend_schema(summary='Reboot system')
     @authorized
     def post(self, request):
@@ -120,6 +129,8 @@ class RebootViewMixin(APIView):
 
 
 class ShutdownViewMixin(APIView):
+    serializer_class = ShutdownViewSerializerMixin
+
     @extend_schema(summary='Shut down system')
     @authorized
     def post(self, request):
@@ -236,24 +247,8 @@ class AssetContentViewMixin(APIView):
 class PlaylistOrderViewMixin(APIView):
     @extend_schema(
         summary='Update playlist order',
-        request={
-            'application/x-www-form-urlencoded': {
-                'type': 'object',
-                'properties': {
-                    'ids': {
-                        'type': 'string',
-                        'description': cleandoc(
-                            """
-                            Comma-separated list of asset IDs in the order
-                            they should be played. For example:
-
-                            `793406aa1fd34b85aa82614004c0e63a,1c5cfa719d1f4a9abae16c983a18903b,9c41068f3b7e452baf4dc3f9b7906595`
-                            """
-                        )
-                    }
-                },
-            }
-        }
+        request=PlaylistOrderSerializerMixin,
+        responses={204: None}
     )
     @authorized
     def post(self, request):


### PR DESCRIPTION
### Issues Fixed

Given that I'm starting Anthias in development mode, I'm getting the following output when I access `http://localhost:8000/api/docs/` from my browser:

```
anthias-server-1  | 2025-04-17T20:41:04.204481706Z [17/Apr/2025 20:41:04] "GET /api/docs/ HTTP/1.0" 200 727
anthias-server-1  | 2025-04-17T20:41:04.255157863Z /usr/src/app/api/serializers/v2.py: Warning [AssetListViewV2 > AssetSerializerV2]: unable to resolve type hint for function "is_active". Consider using a type hint or @extend_schema_field. Defaulting to string.
anthias-server-1  | 2025-04-17T20:41:04.259849129Z /usr/src/app/api/views/v2.py: Error [PlaylistOrderViewV2]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
anthias-server-1  | 2025-04-17T20:41:04.260066282Z /usr/src/app/api/views/v2.py: Error [BackupViewV2]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
anthias-server-1  | 2025-04-17T20:41:04.261682795Z /usr/src/app/api/views/v2.py: Error [RebootViewV2]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
anthias-server-1  | 2025-04-17T20:41:04.262123007Z /usr/src/app/api/views/v2.py: Error [ShutdownViewV2]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
anthias-server-1  | 2025-04-17T20:41:04.275034013Z [17/Apr/2025 20:41:04] "GET /api/schema/ HTTP/1.0" 200 13873
```

### Description

Provide a brief description of the changes that you have made.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
