### PR TITLE
chore(ci): automatically generate release notes when creating a new release

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -114,6 +114,7 @@ jobs:
       - uses: ncipollo/release-action@v1.11.2
         with:
           allowUpdates: true
+          generateReleaseNotes: true
           prerelease: true
           artifacts: "*raspberry*.zip,*raspberry*.sha256,*raspberry*.json"
           tag: ${{ inputs.tag }}


### PR DESCRIPTION
### Description

- It can be tiresome to write release notes from scratch. It would be better if a release note will be generated and that it can be edited later if needed.
- This PR aims to reduce manual busy work when creating releases.
- Configures the workflow that builds Balena disk images to generate release notes when creating a new release

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
