### PR TITLE
api: write new endpoint for info about the Balena integration

### DIFF
--- a/api/serializers/v2.py
+++ b/api/serializers/v2.py
@@ -84,3 +84,13 @@ class DeviceSettingsSerializerV2(Serializer):
     shuffle_playlist = BooleanField()
     use_24_hour_clock = BooleanField()
     debug_logging = BooleanField()
+
+
+class IntegrationsSerializerV2(Serializer):
+    is_balena = BooleanField()
+    balena_device_id = CharField(required=False)
+    balena_app_id = CharField(required=False)
+    balena_app_name = CharField(required=False)
+    balena_supervisor_version = CharField(required=False)
+    balena_host_os_version = CharField(required=False)
+    balena_device_name_at_init = CharField(required=False)

--- a/api/tests/test_v2_endpoints.py
+++ b/api/tests/test_v2_endpoints.py
@@ -2,6 +2,7 @@
 Tests for V2 API endpoints.
 """
 from unittest import mock
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
@@ -51,3 +52,50 @@ class DeviceSettingsViewV2Test(TestCase):
 
         for key, expected_value in expected_values.items():
             self.assertEqual(response.data[key], expected_value)
+
+
+class TestIntegrationsViewV2(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.integrations_url = reverse('api:integrations_v2')
+
+    @patch('api.views.v2.is_balena_app')
+    @patch('api.views.v2.getenv')
+    def test_integrations_balena_environment(
+        self,
+        mock_getenv,
+        mock_is_balena
+    ):
+        # Mock Balena environment
+        mock_is_balena.side_effect = lambda: True
+        mock_getenv.side_effect = lambda x: {
+            'BALENA_DEVICE_UUID': 'test-device-uuid',
+            'BALENA_APP_ID': 'test-app-id',
+            'BALENA_APP_NAME': 'test-app-name',
+            'BALENA_SUPERVISOR_VERSION': 'test-supervisor-version',
+            'BALENA_HOST_OS_VERSION': 'test-host-os-version',
+            'BALENA_DEVICE_NAME_AT_INIT': 'test-device-name',
+        }.get(x)
+
+        response = self.client.get(self.integrations_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'is_balena': True,
+            'balena_device_id': 'test-device-uuid',
+            'balena_app_id': 'test-app-id',
+            'balena_app_name': 'test-app-name',
+            'balena_supervisor_version': 'test-supervisor-version',
+            'balena_host_os_version': 'test-host-os-version',
+            'balena_device_name_at_init': 'test-device-name',
+        })
+
+    @patch('api.views.v2.is_balena_app')
+    def test_integrations_non_balena_environment(self, mock_is_balena):
+        # Mock non-Balena environment
+        mock_is_balena.side_effect = lambda: False
+
+        response = self.client.get(self.integrations_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'is_balena': False,
+        })

--- a/api/urls/v2.py
+++ b/api/urls/v2.py
@@ -9,6 +9,7 @@ from api.views.v2 import (
     DeviceSettingsViewV2,
     FileAssetViewV2,
     InfoViewV2,
+    IntegrationsViewV2,
     PlaylistOrderViewV2,
     RebootViewV2,
     RecoverViewV2,
@@ -53,5 +54,10 @@ def get_url_patterns():
             'v2/info',
             InfoViewV2.as_view(),
             name='info_v2',
+        ),
+        path(
+            'v2/integrations',
+            IntegrationsViewV2.as_view(),
+            name='integrations_v2',
         ),
     ]


### PR DESCRIPTION
### Description

- Creates a new endpoint that returns data similar to those in the integrations page

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
