### PR TITLE
Resolve warnings of testing library

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -79,27 +79,27 @@ class SettingsTest(TestCase):
 
     def test_parse_settings(self):
         with fake_settings(settings1) as (mod_settings, settings):
-            self.assertEquals(settings['player_name'], 'new player')
-            self.assertEquals(settings['show_splash'], False)
-            self.assertEquals(settings['shuffle_playlist'], True)
-            self.assertEquals(settings['debug_logging'], True)
-            self.assertEquals(settings['default_duration'], 45)
+            self.assertEqual(settings['player_name'], 'new player')
+            self.assertEqual(settings['show_splash'], False)
+            self.assertEqual(settings['shuffle_playlist'], True)
+            self.assertEqual(settings['debug_logging'], True)
+            self.assertEqual(settings['default_duration'], 45)
 
     def test_default_settings(self):
         with fake_settings(empty_settings) as (mod_settings, settings):
-            self.assertEquals(
+            self.assertEqual(
                 settings['player_name'],
                 mod_settings.DEFAULTS['viewer']['player_name'])
-            self.assertEquals(
+            self.assertEqual(
                 settings['show_splash'],
                 mod_settings.DEFAULTS['viewer']['show_splash'])
-            self.assertEquals(
+            self.assertEqual(
                 settings['shuffle_playlist'],
                 mod_settings.DEFAULTS['viewer']['shuffle_playlist'])
-            self.assertEquals(
+            self.assertEqual(
                 settings['debug_logging'],
                 mod_settings.DEFAULTS['viewer']['debug_logging'])
-            self.assertEquals(
+            self.assertEqual(
                 settings['default_duration'],
                 mod_settings.DEFAULTS['viewer']['default_duration'])
 


### PR DESCRIPTION
### Description
This PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
