### PR TITLE
api: add new fields to the `GET /api/v2/info` endpoint response

### DIFF
--- a/api/views/mixins.py
+++ b/api/views/mixins.py
@@ -1,9 +1,12 @@
 import uuid
 from base64 import b64encode
+from datetime import timedelta
 from inspect import cleandoc
 from mimetypes import guess_extension, guess_type
 from os import path, remove, statvfs
+from platform import machine
 
+import psutil
 from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from hurry.filesize import size
 from rest_framework import status
@@ -19,10 +22,14 @@ from api.serializers.mixins import (
     ShutdownViewSerializerMixin,
 )
 from celery_tasks import reboot_anthias, shutdown_anthias
-from lib import backup_helper, diagnostics
+from lib import (
+    backup_helper,
+    device_helper,
+    diagnostics,
+)
 from lib.auth import authorized
 from lib.github import is_up_to_date
-from lib.utils import connect_to_redis
+from lib.utils import connect_to_redis, get_node_mac_address
 from settings import ZmqPublisher, settings
 
 r = connect_to_redis()
@@ -290,6 +297,41 @@ class AssetsControlViewMixin(APIView):
 
 
 class InfoViewMixin(APIView):
+    def get_anthias_version(self):
+        git_branch = diagnostics.get_git_branch()
+        git_short_hash = diagnostics.get_git_short_hash()
+
+        return '{}@{}'.format(
+            git_branch,
+            git_short_hash,
+        )
+
+    def get_device_model(self):
+        device_model = device_helper.parse_cpu_info().get('model')
+
+        if device_model is None and machine() == 'x86_64':
+            device_model = 'Generic x86_64 Device'
+
+        return device_model
+
+    def get_uptime(self):
+        system_uptime = timedelta(seconds=diagnostics.get_uptime())
+        return {
+            'days': system_uptime.days,
+            'hours': round(system_uptime.seconds / 3600, 2),
+        }
+
+    def get_memory(self):
+        virtual_memory = psutil.virtual_memory()
+        return {
+            'total': virtual_memory.total >> 20,
+            'used': virtual_memory.used >> 20,
+            'free': virtual_memory.free >> 20,
+            'shared': virtual_memory.shared >> 20,
+            'buff': virtual_memory.buffers >> 20,
+            'available': virtual_memory.available >> 20
+        }
+
     @extend_schema(
         summary='Get system information',
         responses={
@@ -299,15 +341,51 @@ class InfoViewMixin(APIView):
                     'viewlog': {'type': 'string'},
                     'loadavg': {'type': 'number'},
                     'free_space': {'type': 'string'},
-                    'display_power': {'type': 'string'},
-                    'up_to_date': {'type': 'boolean'}
+                    'display_power': {'type': ['string', 'null']},
+                    'up_to_date': {'type': 'boolean'},
+                    'anthias_version': {'type': 'string'},
+                    'device_model': {'type': 'string'},
+                    'uptime': {
+                        'type': 'object',
+                        'properties': {
+                            'days': {'type': 'integer'},
+                            'hours': {'type': 'number'}
+                        }
+                    },
+                    'memory': {
+                        'type': 'object',
+                        'properties': {
+                            'total': {'type': 'integer'},
+                            'used': {'type': 'integer'},
+                            'free': {'type': 'integer'},
+                            'shared': {'type': 'integer'},
+                            'buff': {'type': 'integer'},
+                            'available': {'type': 'integer'}
+                        }
+                    },
+                    'mac_address': {'type': 'string'}
                 },
                 'example': {
                     'viewlog': 'Not yet implemented',
                     'loadavg': 0.1,
                     'free_space': '10G',
                     'display_power': 'on',
-                    'up_to_date': True
+                    'up_to_date': True,
+                    'anthias_version': 'main@a1b2c3d',
+                    'device_model': 'Generic x86_64 Device',
+                    'uptime': {
+                        'days': 1,
+                        'hours': 12.5
+                    },
+                    'memory': {
+                        'total': 8192,
+                        'used': 4096,
+                        'free': 4096,
+                        'shared': 0,
+                        'buff': 1024,
+                        'available': 7168
+                    },
+                    'mac_address': '00:11:22:33:44:55'
                 }
             }
         }
@@ -326,5 +404,10 @@ class InfoViewMixin(APIView):
             'loadavg': diagnostics.get_load_avg()['15 min'],
             'free_space': free_space,
             'display_power': display_power,
-            'up_to_date': is_up_to_date()
+            'up_to_date': is_up_to_date(),
+            'anthias_version': self.get_anthias_version(),
+            'device_model': self.get_device_model(),
+            'uptime': self.get_uptime(),
+            'memory': self.get_memory(),
+            'mac_address': get_node_mac_address(),
         })

--- a/api/views/mixins.py
+++ b/api/views/mixins.py
@@ -1,12 +1,9 @@
 import uuid
 from base64 import b64encode
-from datetime import timedelta
 from inspect import cleandoc
 from mimetypes import guess_extension, guess_type
 from os import path, remove, statvfs
-from platform import machine
 
-import psutil
 from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from hurry.filesize import size
 from rest_framework import status
@@ -24,12 +21,11 @@ from api.serializers.mixins import (
 from celery_tasks import reboot_anthias, shutdown_anthias
 from lib import (
     backup_helper,
-    device_helper,
     diagnostics,
 )
 from lib.auth import authorized
 from lib.github import is_up_to_date
-from lib.utils import connect_to_redis, get_node_mac_address
+from lib.utils import connect_to_redis
 from settings import ZmqPublisher, settings
 
 r = connect_to_redis()
@@ -297,41 +293,6 @@ class AssetsControlViewMixin(APIView):
 
 
 class InfoViewMixin(APIView):
-    def get_anthias_version(self):
-        git_branch = diagnostics.get_git_branch()
-        git_short_hash = diagnostics.get_git_short_hash()
-
-        return '{}@{}'.format(
-            git_branch,
-            git_short_hash,
-        )
-
-    def get_device_model(self):
-        device_model = device_helper.parse_cpu_info().get('model')
-
-        if device_model is None and machine() == 'x86_64':
-            device_model = 'Generic x86_64 Device'
-
-        return device_model
-
-    def get_uptime(self):
-        system_uptime = timedelta(seconds=diagnostics.get_uptime())
-        return {
-            'days': system_uptime.days,
-            'hours': round(system_uptime.seconds / 3600, 2),
-        }
-
-    def get_memory(self):
-        virtual_memory = psutil.virtual_memory()
-        return {
-            'total': virtual_memory.total >> 20,
-            'used': virtual_memory.used >> 20,
-            'free': virtual_memory.free >> 20,
-            'shared': virtual_memory.shared >> 20,
-            'buff': virtual_memory.buffers >> 20,
-            'available': virtual_memory.available >> 20
-        }
-
     @extend_schema(
         summary='Get system information',
         responses={
@@ -342,50 +303,7 @@ class InfoViewMixin(APIView):
                     'loadavg': {'type': 'number'},
                     'free_space': {'type': 'string'},
                     'display_power': {'type': ['string', 'null']},
-                    'up_to_date': {'type': 'boolean'},
-                    'anthias_version': {'type': 'string'},
-                    'device_model': {'type': 'string'},
-                    'uptime': {
-                        'type': 'object',
-                        'properties': {
-                            'days': {'type': 'integer'},
-                            'hours': {'type': 'number'}
-                        }
-                    },
-                    'memory': {
-                        'type': 'object',
-                        'properties': {
-                            'total': {'type': 'integer'},
-                            'used': {'type': 'integer'},
-                            'free': {'type': 'integer'},
-                            'shared': {'type': 'integer'},
-                            'buff': {'type': 'integer'},
-                            'available': {'type': 'integer'}
-                        }
-                    },
-                    'mac_address': {'type': 'string'}
-                },
-                'example': {
-                    'viewlog': 'Not yet implemented',
-                    'loadavg': 0.1,
-                    'free_space': '10G',
-                    'display_power': 'on',
-                    'up_to_date': True,
-                    'anthias_version': 'main@a1b2c3d',
-                    'device_model': 'Generic x86_64 Device',
-                    'uptime': {
-                        'days': 1,
-                        'hours': 12.5
-                    },
-                    'memory': {
-                        'total': 8192,
-                        'used': 4096,
-                        'free': 4096,
-                        'shared': 0,
-                        'buff': 1024,
-                        'available': 7168
-                    },
-                    'mac_address': '00:11:22:33:44:55'
+                    'up_to_date': {'type': 'boolean'}
                 }
             }
         }
@@ -404,10 +322,5 @@ class InfoViewMixin(APIView):
             'loadavg': diagnostics.get_load_avg()['15 min'],
             'free_space': free_space,
             'display_power': display_power,
-            'up_to_date': is_up_to_date(),
-            'anthias_version': self.get_anthias_version(),
-            'device_model': self.get_device_model(),
-            'uptime': self.get_uptime(),
-            'memory': self.get_memory(),
-            'mac_address': get_node_mac_address(),
+            'up_to_date': is_up_to_date()
         })

--- a/api/views/mixins.py
+++ b/api/views/mixins.py
@@ -19,10 +19,7 @@ from api.serializers.mixins import (
     ShutdownViewSerializerMixin,
 )
 from celery_tasks import reboot_anthias, shutdown_anthias
-from lib import (
-    backup_helper,
-    diagnostics,
-)
+from lib import backup_helper, diagnostics
 from lib.auth import authorized
 from lib.github import is_up_to_date
 from lib.utils import connect_to_redis
@@ -302,8 +299,15 @@ class InfoViewMixin(APIView):
                     'viewlog': {'type': 'string'},
                     'loadavg': {'type': 'number'},
                     'free_space': {'type': 'string'},
-                    'display_power': {'type': ['string', 'null']},
+                    'display_power': {'type': 'string'},
                     'up_to_date': {'type': 'boolean'}
+                },
+                'example': {
+                    'viewlog': 'Not yet implemented',
+                    'loadavg': 0.1,
+                    'free_space': '10G',
+                    'display_power': 'on',
+                    'up_to_date': True
                 }
             }
         }


### PR DESCRIPTION
### Description

Updates the `GET /api/v2/info` endpoint so that the response includes the following new fields:

- Memory
- Uptime
- Device Model
- Anthias Version
- MAC Address

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
