### PR TITLE
fix: make the minimum width of the settings buttons wider

### DIFF
--- a/static/sass/_styles.scss
+++ b/static/sass/_styles.scss
@@ -102,7 +102,7 @@ label {
 }
 
 .btn-long {
-  min-width: 180px;
+  min-width: 13.125rem;
 }
 
 .btn-primary {


### PR DESCRIPTION
### Description

- Made the width of the buttons in the settings page wider so that the look and feel is consistent across all sections

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

### Screenshots

#### Before

![image](https://github.com/user-attachments/assets/93377d4b-3d8d-4f14-bb86-a58e3fdb1297)

#### After

![image](https://github.com/user-attachments/assets/5ef1729e-c779-4d09-b614-b8c2f6fae89d)