### PR TITLE
fix: allow blank values for `player_name` for `PATCH /api/v2/device_settings`

### DIFF
--- a/api/serializers/v2.py
+++ b/api/serializers/v2.py
@@ -87,7 +87,7 @@ class DeviceSettingsSerializerV2(Serializer):
 
 
 class UpdateDeviceSettingsSerializerV2(Serializer):
-    player_name = CharField(required=False)
+    player_name = CharField(required=False, allow_blank=True)
     audio_output = CharField(required=False)
     default_duration = IntegerField(required=False)
     default_streaming_duration = IntegerField(required=False)


### PR DESCRIPTION
### Description

- Allow blank inputs for `player_name` when calling `PATCH /api/v2/device_settings`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
