### PR TITLE
api: update `PATCH /api/v2/device_settings`

### DIFF
--- a/api/serializers/v2.py
+++ b/api/serializers/v2.py
@@ -3,6 +3,7 @@ from drf_spectacular.utils import OpenApiTypes, extend_schema_field
 from rest_framework.serializers import (
     BooleanField,
     CharField,
+    ChoiceField,
     DateTimeField,
     IntegerField,
     ModelSerializer,
@@ -100,8 +101,15 @@ class UpdateDeviceSettingsSerializerV2(Serializer):
     username = CharField(required=False, allow_blank=True)
     password = CharField(required=False, allow_blank=True)
     password_2 = CharField(required=False, allow_blank=True)
-    auth_backend = CharField(required=False, allow_blank=True)
-    current_password = CharField(required=False)
+    auth_backend = ChoiceField(
+        required=False,
+        allow_blank=True,
+        choices=[
+            ('', 'No authentication'),
+            ('auth_basic', 'Basic authentication'),
+        ],
+    )
+    current_password = CharField(required=False, allow_blank=True)
 
 
 class IntegrationsSerializerV2(Serializer):


### PR DESCRIPTION
### Description

Updated `PATCH /api/v2/device_settings` and modified the following fields:

- `current_password` now allows blank values
- `auth_backend` is now restricted to the following values&mdash;an empty string, `auth_basic`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
