### PR TITLE
api: update `GET /api/v2/device_settings` response

### DIFF
--- a/api/serializers/v2.py
+++ b/api/serializers/v2.py
@@ -85,6 +85,7 @@ class DeviceSettingsSerializerV2(Serializer):
     shuffle_playlist = BooleanField()
     use_24_hour_clock = BooleanField()
     debug_logging = BooleanField()
+    username = CharField()
 
 
 class UpdateDeviceSettingsSerializerV2(Serializer):

--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -214,6 +214,10 @@ class DeviceSettingsViewV2(APIView):
             'shuffle_playlist': settings['shuffle_playlist'],
             'use_24_hour_clock': settings['use_24_hour_clock'],
             'debug_logging': settings['debug_logging'],
+            'username': (
+                settings['user'] if settings['auth_backend'] == 'auth_basic'
+                else ''
+            ),
         })
 
     def update_auth_settings(self, data, auth_backend, current_pass_correct):


### PR DESCRIPTION
### Description

- Updated `GET /api/v2/device_settings` so that `username` will be included in the response

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
