### PR TITLE
api: make response fields for the integrations endpoint nullable

### DIFF
--- a/api/serializers/v2.py
+++ b/api/serializers/v2.py
@@ -115,9 +115,9 @@ class UpdateDeviceSettingsSerializerV2(Serializer):
 
 class IntegrationsSerializerV2(Serializer):
     is_balena = BooleanField()
-    balena_device_id = CharField(required=False)
-    balena_app_id = CharField(required=False)
-    balena_app_name = CharField(required=False)
-    balena_supervisor_version = CharField(required=False)
-    balena_host_os_version = CharField(required=False)
-    balena_device_name_at_init = CharField(required=False)
+    balena_device_id = CharField(required=False, allow_null=True)
+    balena_app_id = CharField(required=False, allow_null=True)
+    balena_app_name = CharField(required=False, allow_null=True)
+    balena_supervisor_version = CharField(required=False, allow_null=True)
+    balena_host_os_version = CharField(required=False, allow_null=True)
+    balena_device_name_at_init = CharField(required=False, allow_null=True)

--- a/api/tests/test_v2_endpoints.py
+++ b/api/tests/test_v2_endpoints.py
@@ -339,4 +339,10 @@ class TestIntegrationsViewV2(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {
             'is_balena': False,
+            'balena_device_id': None,
+            'balena_app_id': None,
+            'balena_app_name': None,
+            'balena_supervisor_version': None,
+            'balena_host_os_version': None,
+            'balena_device_name_at_init': None,
         })


### PR DESCRIPTION
### Issues Fixed

- Some Balena-related environment variables might not be present, which could result to `getenv` calls returning `null`.

### Description

- Made the all response fields for the `/api/v2/integrations` endpoint nullable to prevent schema-related errors

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
