### PR TITLE
fix: reload settings when `GET /api/v2/device_settings` gets called

### DIFF
--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 from datetime import timedelta
 from os import getenv, statvfs
 from platform import machine
@@ -200,6 +201,13 @@ class DeviceSettingsViewV2(APIView):
     )
     @authorized
     def get(self, request):
+        try:
+            # Force reload of settings
+            settings.load()
+        except Exception as e:
+            logging.error(f'Failed to reload settings: {str(e)}')
+            # Continue with existing settings if reload fails
+
         return Response({
             'player_name': settings['player_name'],
             'audio_output': settings['audio_output'],


### PR DESCRIPTION
### Issues Fixed

When a backup file gets uploaded and recovered, the changes in settings won't take place until you restart the web server or until Settings page gets accessed via browser.

### Description

- Updated `GET /api/v2/device_settings` so that `settings.load()` gets called.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
