### PR TITLE
api: handle default assets in `PATCH /api/v2/device_settings`

### DIFF
--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -11,6 +11,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from anthias_app.helpers import add_default_assets, remove_default_assets
 from anthias_app.models import Asset
 from api.helpers import (
     AssetCreationError,
@@ -348,6 +349,10 @@ class DeviceSettingsViewV2(APIView):
             if 'show_splash' in data:
                 settings['show_splash'] = data['show_splash']
             if 'default_assets' in data:
+                if data['default_assets'] and not settings['default_assets']:
+                    add_default_assets()
+                elif not data['default_assets'] and settings['default_assets']:
+                    remove_default_assets()
                 settings['default_assets'] = data['default_assets']
             if 'shuffle_playlist' in data:
                 settings['shuffle_playlist'] = data['shuffle_playlist']


### PR DESCRIPTION
### Description

- Updated `PATCH /api/v2/device_settings` so that default assets can be created or removed

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
