### PR TITLE
chore(ci): replace NPM `lint` script with `lint:check` and `lint:fix`

### DIFF
--- a/.github/workflows/javascript-lint.yaml
+++ b/.github/workflows/javascript-lint.yaml
@@ -32,7 +32,7 @@ jobs:
         run: npm ci
 
       - name: Run ESLint
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Run Prettier
         run: npm run format:check

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -126,6 +126,26 @@ $ docker compose -f docker-compose.dev.yml exec anthias-server \
 Making changes to the JavaScript, JSX, or SCSS files will automatically trigger a recompilation,
 generating the corresponding JavaScript and CSS files.
 
+### Formatting and linting JavaScript code
+
+To run the linting and formatting checks on the JavaScript code, run the following command:
+
+```bash
+$ docker compose -f docker-compose.dev.yml exec anthias-server \
+    npm run lint:check
+$ docker compose -f docker-compose.dev.yml exec anthias-server \
+    npm run format:check
+```
+
+If you want to fix the linting errors and formatting issues, run the following command:
+
+```bash
+$ docker compose -f docker-compose.dev.yml exec anthias-server \
+    npm run lint:fix
+$ docker compose -f docker-compose.dev.yml exec anthias-server \
+    npm run format:fix
+```
+
 ### Closing the transpiler
 
 Just press `Ctrl-C` to close Webpack in development mode.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "webpack --watch --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
-    "lint": "eslint static/src",
+    "lint:check": "eslint static/src",
+    "lint:fix": "eslint static/src --fix",
     "format:check": "prettier --check static/src",
     "format:fix": "prettier --write static/src"
   },


### PR DESCRIPTION
### Description

Replaced `npm run lint` with `npm run lint:check` and `npm run lint:fix`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
