### PR TITLE
fix: '3.5mm jack' should not be an option for the Raspberry Pi 5

### DIFF
--- a/static/src/components/settings.jsx
+++ b/static/src/components/settings.jsx
@@ -22,7 +22,7 @@ export const Settings = () => {
     use24HourClock: false,
     debugLogging: false,
   })
-
+  const [deviceModel, setDeviceModel] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [prevAuthBackend, setPrevAuthBackend] = useState('')
   const [isUploading, setIsUploading] = useState(false)
@@ -331,6 +331,14 @@ export const Settings = () => {
           confirmButtonColor: '#dc3545',
         })
       })
+
+    // Fetch device model
+    fetch('/api/v2/info')
+      .then((res) => res.json())
+      .then((data) => {
+        setDeviceModel(data.device_model || '')
+      })
+      .catch(() => {})
   }, [])
 
   const handleInputChange = (e) => {
@@ -481,7 +489,9 @@ export const Settings = () => {
                   onChange={handleInputChange}
                 >
                   <option value="hdmi">HDMI</option>
-                  <option value="local">3.5mm jack</option>
+                  {!deviceModel.includes('Raspberry Pi 5') && (
+                    <option value="local">3.5mm jack</option>
+                  )}
                 </select>
               </div>
 


### PR DESCRIPTION
### Issues Fixed

- Raspberry Pi 5 doesn't have a **_3.5mm jack_**, yet it appears as an option for **_Audio output_**.

### Description

- Update the `Settings` component so that **_3.5mm jack_** won't be displayed as a drop-down option for Raspberry Pi 5 devices.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
