### PR TITLE
fix: specify unit (MB) for the memory values in system info page

### DIFF
--- a/static/src/components/system-info.jsx
+++ b/static/src/components/system-info.jsx
@@ -123,22 +123,22 @@ export const SystemInfo = () => {
                 <td>
                   <Skeleton isLoading={isLoading}>
                     <div>
-                      Total: <strong>{memory.total}</strong>
+                      Total: <strong>{memory.total} MB</strong>
                     </div>
                     <div>
-                      Used: <strong>{memory.used}</strong>
+                      Used: <strong>{memory.used} MB</strong>
                     </div>
                     <div>
-                      Free: <strong>{memory.free}</strong>
+                      Free: <strong>{memory.free} MB</strong>
                     </div>
                     <div>
-                      Shared: <strong>{memory.shared}</strong>
+                      Shared: <strong>{memory.shared} MB</strong>
                     </div>
                     <div>
-                      Buff: <strong>{memory.buff}</strong>
+                      Buff: <strong>{memory.buff} MB</strong>
                     </div>
                     <div>
-                      Available: <strong>{memory.available}</strong>
+                      Available: <strong>{memory.available} MB</strong>
                     </div>
                   </Skeleton>
                 </td>


### PR DESCRIPTION
### Issues Fixed

The System Info page doesn't specify the unit (whether it's KB, MB, or GB) for the memory values.

### Description

- Update the System Info page so that the unit is specified (i.e., MB).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

### Screenshots

#### Before

![image](https://github.com/user-attachments/assets/aa5da977-cc00-420c-b174-e78ce5cc885d)

#### After

![image](https://github.com/user-attachments/assets/fb6cb69f-3449-4e57-a849-3e5a83b014be)
