### PR TITLE
chore(ci): use `zstd` instead of `zip` for compressing Balena images

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -34,6 +34,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install zstd
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zstd
+
       - name: Get base board
         run: |
           if [ "${{ matrix.board }}" == 'pi1' ]; then
@@ -85,10 +90,8 @@ jobs:
       - name: Package up image
         run: |
           sha256sum "$BALENA_IMAGE.img" >> "$(date -I)-$BALENA_IMAGE.sha256"
-          zip -9 \
-            "$(date -I)-$BALENA_IMAGE.zip" \
-            "$BALENA_IMAGE.img"
-          sha256sum "$(date -I)-$BALENA_IMAGE.zip" >> \
+          zstd -19 -T0 "$BALENA_IMAGE.img" -o "$(date -I)-$BALENA_IMAGE.img.zst"
+          sha256sum "$(date -I)-$BALENA_IMAGE.img.zst" >> \
             "$(date -I)-$BALENA_IMAGE.sha256"
 
           # Build Raspberry Pi Imager metadata
@@ -96,8 +99,8 @@ jobs:
             --arg BOARD "${{ matrix.board }}" \
             --arg IMAGE_SHA256 "$(sha256sum "$BALENA_IMAGE.img" | cut -d ' ' -f 1)" \
             --arg IMAGE_SIZE "$(wc -c < "$BALENA_IMAGE.img" | xargs)" \
-            --arg DOWNLOAD_SHA256 "$(sha256sum "$(date -I)-$BALENA_IMAGE.zip" | cut -d ' ' -f 1)" \
-            --arg DOWNLOAD_SIZE "$(wc -c < "$(date -I)-$BALENA_IMAGE.zip" | xargs)" \
+            --arg DOWNLOAD_SHA256 "$(sha256sum "$(date -I)-$BALENA_IMAGE.img.zst" | cut -d ' ' -f 1)" \
+            --arg DOWNLOAD_SIZE "$(wc -c < "$(date -I)-$BALENA_IMAGE.img.zst" | xargs)" \
             --arg RELEASE_DATE "$(date -I)" \
             '{
               "name": ("Anthias (" + $BOARD + ")"),
@@ -116,11 +119,11 @@ jobs:
           allowUpdates: true
           generateReleaseNotes: true
           prerelease: true
-          artifacts: "*raspberry*.zip,*raspberry*.sha256,*raspberry*.json"
+          artifacts: "*raspberry*.img.zst,*raspberry*.sha256,*raspberry*.json"
           tag: ${{ inputs.tag }}
           commit: ${{ inputs.commit }}
 
       - name: Attest
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: '${{ github.workspace }}/*raspberry*.zip'
+          subject-path: '${{ github.workspace }}/*raspberry*.img.zst'


### PR DESCRIPTION
### Description

Replaced `zip` with `zstd` for compressing Balena disk images

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
