### PR TITLE
fix: integrations page not showing up on Balena instances

### DIFF
--- a/api/serializers/v2.py
+++ b/api/serializers/v2.py
@@ -120,4 +120,8 @@ class IntegrationsSerializerV2(Serializer):
     balena_app_name = CharField(required=False, allow_null=True)
     balena_supervisor_version = CharField(required=False, allow_null=True)
     balena_host_os_version = CharField(required=False, allow_null=True)
-    balena_device_name_at_init = CharField(required=False, allow_null=True)
+    balena_device_name_at_init = CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+    )


### PR DESCRIPTION
### Issues Fixed

The following issue happens when Anthias is installed via the release images, which are pinned to specific releases.

```
GET /api/v2/integrations
```

```
HTTP 500 Internal Server Error
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "error": "{'balena_device_name_at_init': [ErrorDetail(string='This field may not be blank.', code='blank')]}"
}
```

### Description

Modified `balena_device_name_at_init` to allow blank values.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
