### PR TITLE
fix: change unit for memory from MB to MiB

### DIFF
--- a/static/src/components/system-info.jsx
+++ b/static/src/components/system-info.jsx
@@ -123,22 +123,22 @@ export const SystemInfo = () => {
                 <td>
                   <Skeleton isLoading={isLoading}>
                     <div>
-                      Total: <strong>{memory.total} MB</strong>
+                      Total: <strong>{memory.total} MiB</strong>
                     </div>
                     <div>
-                      Used: <strong>{memory.used} MB</strong>
+                      Used: <strong>{memory.used} MiB</strong>
                     </div>
                     <div>
-                      Free: <strong>{memory.free} MB</strong>
+                      Free: <strong>{memory.free} MiB</strong>
                     </div>
                     <div>
-                      Shared: <strong>{memory.shared} MB</strong>
+                      Shared: <strong>{memory.shared} MiB</strong>
                     </div>
                     <div>
-                      Buff: <strong>{memory.buff} MB</strong>
+                      Buff: <strong>{memory.buff} MiB</strong>
                     </div>
                     <div>
-                      Available: <strong>{memory.available} MB</strong>
+                      Available: <strong>{memory.available} MiB</strong>
                     </div>
                   </Skeleton>
                 </td>


### PR DESCRIPTION
### Issues Fixed

- System memory values are obtained from the back-end in bytes.
- Those values were bit shifted by 20 digits to the right.
- Since bit shift operations were done, it's more appropriate to use MiB instead of MB.

### Description

- Change the unit for system memory from megabytes (MB) to mebibytes (MiB). More details can be found [here](https://www.iec.ch/prefixes-binary-multiples).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

### Screenshots

#### Before

![image](https://github.com/user-attachments/assets/ae7c072c-932a-416e-9a40-7230222c0b26)

#### After

![image](https://github.com/user-attachments/assets/dd9a94d3-336a-48ae-afc2-1b708b4d390a)