### PR TITLE
fix: don't show Device Name in Integrations page if blank

### DIFF
--- a/static/src/components/integrations.jsx
+++ b/static/src/components/integrations.jsx
@@ -50,11 +50,13 @@ export const Integrations = () => {
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <th scope="row">Device Name</th>
-                  <td>{data.balena_device_name_at_init}</td>
-                  <td>The name of the device on first initialisation.</td>
-                </tr>
+                {data.balena_device_name_at_init && (
+                  <tr>
+                    <th scope="row">Device Name</th>
+                    <td>{data.balena_device_name_at_init}</td>
+                    <td>The name of the device on first initialisation.</td>
+                  </tr>
+                )}
                 <tr>
                   <th scope="row">Device UUID</th>
                   <td>{data.balena_device_id}</td>


### PR DESCRIPTION
### Issues Fixed

For Anthias instances installed using release images, Device Name is being shown in the Integrations page even if it's blank.

![image](https://github.com/user-attachments/assets/d690a359-38c0-457c-aa35-093bcd249b32)

### Description

- Updates the Integration pages so that Device Name won't be shown if it's blank

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
