### PR TITLE
chore(ci): enable generation of release notes for OpenAPI workflow

### DIFF
--- a/.github/workflows/generate-openapi-schema.yml
+++ b/.github/workflows/generate-openapi-schema.yml
@@ -120,6 +120,7 @@ jobs:
         uses: ncipollo/release-action@v1.11.2
         with:
           allowUpdates: true
+          generateReleaseNotes: true
           prerelease: true
           artifacts: anthias-api-schema.json
           tag: ${{ inputs.tag }}


### PR DESCRIPTION
### Issues Fixed

When the [**Build Balena Disk Images**](https://github.com/Screenly/Anthias/actions/workflows/build-balena-disk-image.yaml) gets triggered, it calls the [**Generate OpenAPI Schema**](https://github.com/Screenly/Anthias/actions/workflows/generate-openapi-schema.yml) workflow first, which creates a release.

However, that a release gets created from the OpenAPI workflow, [generateReleaseNotes](https://github.com/ncipollo/release-action#:~:text=generateReleaseNotes) is not enabled. It's only enabled when called from the **Build Balena Disk Images** workflow.

### Description

Since the OpenAPI workflow gets called first, it's important to enable automatic release generation from there as well.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
