### PR TITLE
chore(ci): don't trigger builds when OpenAPI workflow was changed

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -13,6 +13,7 @@ on:
       - '!.github/workflows/build-webview.yaml'
       - '!.github/workflows/build-balena-disk-image.yaml'
       - '!.github/workflows/python-lint.yaml'
+      - '!.github/workflows/generate-openapi-schema.yml'
       - '!.github/pull_request_template.md'
       - '!CONTRIBUTING.md'
       - '!README.md'


### PR DESCRIPTION
### Description

The [Docker Image Build workflow](https://github.com/Screenly/Anthias/actions/workflows/docker-build.yaml) was modified so that it won't be triggered when [generate-openapi-schema.yml](https://github.com/Screenly/Anthias/actions/workflows/generate-openapi-schema.yml) gets changed.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
