### PR TITLE
chore(ci): remove duplicate `getMimetype` definition

### DIFF
--- a/static/src/components/asset-modal/use-asset-form.js
+++ b/static/src/components/asset-modal/use-asset-form.js
@@ -12,7 +12,7 @@ import {
   getMimetype,
   getDurationForMimetype,
   getDefaultDates,
-} from './file-upload-utils'
+} from '@/components/asset-modal/file-upload-utils'
 
 /**
  * Custom hook for asset form handling

--- a/static/src/store/assets/asset-modal-slice.js
+++ b/static/src/store/assets/asset-modal-slice.js
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import { addAsset } from './assets-list-slice'
+import { getMimetype } from '@/components/asset-modal/file-upload-utils'
 
 // Async thunks for API operations
 export const uploadFile = createAsyncThunk(
@@ -130,49 +131,6 @@ export const fetchDeviceSettings = createAsyncThunk(
     }
   },
 )
-
-// Helper functions
-const getMimetype = (filename) => {
-  const viduris = ['rtsp', 'rtmp']
-  const mimetypes = [
-    [['jpe', 'jpg', 'jpeg', 'png', 'pnm', 'gif', 'bmp'], 'image'],
-    [['avi', 'mkv', 'mov', 'mpg', 'mpeg', 'mp4', 'ts', 'flv'], 'video'],
-  ]
-  const domains = [[['www.youtube.com', 'youtu.be'], 'youtube_asset']]
-
-  // Check if it's a streaming URL
-  const scheme = filename.split(':')[0].toLowerCase()
-  if (viduris.includes(scheme)) {
-    return 'streaming'
-  }
-
-  // Check if it's a domain-specific asset
-  try {
-    const domain = filename.split('//')[1].toLowerCase().split('/')[0]
-    for (const [domainList, type] of domains) {
-      if (domainList.includes(domain)) {
-        return type
-      }
-    }
-  } catch (e) {
-    // Invalid URL format
-  }
-
-  // Check file extension
-  try {
-    const ext = filename.split('.').pop().toLowerCase()
-    for (const [extList, type] of mimetypes) {
-      if (extList.includes(ext)) {
-        return type
-      }
-    }
-  } catch (e) {
-    // No extension found
-  }
-
-  // Default to webpage
-  return 'webpage'
-}
 
 const getDurationForMimetype = (
   mimetype,


### PR DESCRIPTION
### Description

Removed duplicate `getMimetype` function definition from `asset-modal-slice.js`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
