### PR TITLE
chore: register the `Asset` model to the Django admin site

### DIFF
--- a/anthias_app/admin.py
+++ b/anthias_app/admin.py
@@ -1,3 +1,23 @@
-from django.contrib import admin # noqa F401
+from django.contrib import admin
 
-# Register your models here.
+from anthias_app.models import Asset
+
+
+@admin.register(Asset)
+class AssetAdmin(admin.ModelAdmin):
+    list_display = (
+        'asset_id',
+        'name',
+        'uri',
+        'md5',
+        'start_date',
+        'end_date',
+        'duration',
+        'mimetype',
+        'is_enabled',
+        'is_processing',
+        'is_active',
+        'nocache',
+        'play_order',
+        'skip_asset_check'
+    )

--- a/anthias_app/models.py
+++ b/anthias_app/models.py
@@ -27,6 +27,9 @@ class Asset(models.Model):
     class Meta:
         db_table = 'assets'
 
+    def __str__(self):
+        return self.name
+
     def is_active(self):
         if self.is_enabled and self.start_date and self.end_date:
             current_time = timezone.now()

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -70,6 +70,21 @@ $ MODE=build \
     ./bin/upgrade_containers.sh
 ```
 
+## Django admin site
+
+Create a superuser account:
+
+```bash
+$ export COMPOSE_FILE=docker-compose.dev.yml
+$ docker compose exec anthias-server \
+    python manage.py createsuperuser
+# You will be prompted to enter a username, an email address, and a password.
+```
+
+Once you have created a superuser account, you can open the Django admin site at `http://localhost:8000/admin/` (with a trailing slash)
+and login with the credentials you just created.
+
+
 ## Testing
 ### Running the unit tests
 


### PR DESCRIPTION
### Description

Registered the `Asset` model to the Django admin site so that it will be visible from there.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

### Screenshots

![image](https://github.com/user-attachments/assets/59779629-0f18-4f16-89bb-75391c10f846)