### PR TITLE
fix: remove right margin off of Shutdown button in Settings page

### DIFF
--- a/static/src/components/settings.jsx
+++ b/static/src/components/settings.jsx
@@ -754,7 +754,7 @@ export const Settings = () => {
               Reboot
             </button>
             <button
-              className="btn btn-danger btn-long mr-2"
+              className="btn btn-danger btn-long"
               type="button"
               onClick={handleShutdown}
             >


### PR DESCRIPTION
### Description

Removed excess right margin from the Shutdown button in the settings page for consistency

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

### Screenshots

### Before

![image](https://github.com/user-attachments/assets/c853f865-0819-4437-b2a4-d93f4428450d)

### After

![image](https://github.com/user-attachments/assets/9acad49e-2d8f-4807-96ec-ad89d2f7eaf3)
