### PR TITLE
feat: restyle toggle switches for consistency

### DIFF
--- a/static/sass/_styles.scss
+++ b/static/sass/_styles.scss
@@ -125,22 +125,46 @@ label {
   }
 }
 
-.switch-material.switch-light {
-  input ~ span {
-    a {
-      background-color: #FFFFFF !important;
-      border: 1px solid rgba(0, 0, 0, 0.26);
-      box-shadow: none !important;
-      top: -0.125em;
+#app {
+  %switch-material-base {
+    > span {
+      &:before,
+      &:after {
+        background: none;
+      }
+    }
+
+    label {
+      &:after {
+        background: none;
+      }
     }
   }
 
-  input:checked ~ span {
-    box-shadow: inset 0 0 0 30px $anthias-yellow-4 !important;
-    a {
-      background-color: $anthias-yellow-3 !important;
-      border: none;
+  .switch-material.switch-light {
+    input {
+      ~ span a {
+        background-color: #FFFFFF;
+        border: 1px solid rgba(0, 0, 0, 0.26);
+        box-shadow: none;
+        top: -0.125em;
+        outline: none;
+      }
+
+      &:checked ~ span {
+        box-shadow: inset 0 0 0 30px $anthias-yellow-4;
+
+        a {
+          background-color: $anthias-yellow-3;
+          border: none;
+        }
+      }
     }
+  }
+
+  .switch-light.switch-material,
+  .switch-toggle.switch-material {
+    @extend %switch-material-base;
   }
 }
 


### PR DESCRIPTION
### Issues Fixed

The toggle switches in the home page and the settings page are styled inconsistently:
- Emits a blue circle (with a ripple effect) when the switch is toggled.
- The outline of the circular part of the toggle switch becomes black when toggled.

### Description

We have to restyle those toggle switches to remove those so that it's as minimal as it could get.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
