### PR TITLE
feat: increase SweetAlert2 timer durations from 2s to 3.5s

### DIFF
--- a/static/src/components/asset-row.jsx
+++ b/static/src/components/asset-row.jsx
@@ -14,6 +14,7 @@ import { useDispatch } from 'react-redux'
 import { css } from '@/utils'
 
 import { toggleAssetEnabled, fetchAssets } from '@/store/assets'
+import { SWEETALERT_TIMER } from '@/constants'
 
 const tooltipStyles = css`
   .tooltip {
@@ -339,7 +340,7 @@ export const AssetRow = forwardRef((props, ref) => {
               title: 'Deleted!',
               text: 'Asset has been deleted.',
               icon: 'success',
-              timer: 2000,
+              timer: SWEETALERT_TIMER,
               showConfirmButton: false,
               customClass: {
                 popup: 'swal2-popup',

--- a/static/src/components/settings.jsx
+++ b/static/src/components/settings.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { fetchDeviceSettings } from '@/store/assets/asset-modal-slice'
 import Swal from 'sweetalert2'
+
+import { fetchDeviceSettings } from '@/store/assets/asset-modal-slice'
+import { SWEETALERT_TIMER } from '@/constants'
 
 export const Settings = () => {
   const dispatch = useDispatch()
@@ -118,7 +120,7 @@ export const Settings = () => {
           text:
             typeof data === 'string' ? data : 'Backup uploaded successfully',
           icon: 'success',
-          timer: 2000,
+          timer: SWEETALERT_TIMER,
           showConfirmButton: false,
           customClass: {
             popup: 'swal2-popup',
@@ -240,7 +242,7 @@ export const Settings = () => {
           title: 'Success!',
           text: successMessage,
           icon: 'success',
-          timer: 2000,
+          timer: SWEETALERT_TIMER,
           showConfirmButton: false,
           customClass: {
             popup: 'swal2-popup',
@@ -362,7 +364,7 @@ export const Settings = () => {
         title: 'Success!',
         text: 'Settings were successfully saved.',
         icon: 'success',
-        timer: 2000,
+        timer: SWEETALERT_TIMER,
         showConfirmButton: false,
         customClass: {
           popup: 'swal2-popup',

--- a/static/src/constants.js
+++ b/static/src/constants.js
@@ -1,0 +1,1 @@
+export const SWEETALERT_TIMER = 3500

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,6 +47,7 @@ module.exports = {
   resolve: {
     alias: {
       '@/components': path.resolve(__dirname, 'static/src/components'),
+      '@/constants': path.resolve(__dirname, 'static/src/constants.js'),
       '@/store': path.resolve(__dirname, 'static/src/store'),
       '@/sass': path.resolve(__dirname, 'static/sass'),
       '@/utils': path.resolve(__dirname, 'static/src/utils'),


### PR DESCRIPTION
### Issues Fixed

SweetAlert2 alerts for confirming the result of deleting assets or saving player settings are only showed for 2 seconds.

### Description

- Increased the alert timer duration from 2 seconds to 3.5 seconds.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
