### PR TITLE
chore: disable Redux DevTools in production

### DIFF
--- a/static/src/store/index.js
+++ b/static/src/store/index.js
@@ -1,9 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { assetsReducer, assetModalReducer } from '@/store/assets'
 
+const environment = process.env.ENVIRONMENT || 'production'
+
 export const store = configureStore({
   reducer: {
     assets: assetsReducer,
     assetModal: assetModalReducer,
   },
+  devTools: environment === 'development',
 })

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,5 +1,6 @@
 const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
+const webpack = require('webpack');
 
 module.exports = merge(common, {
   devtool: "source-map",
@@ -8,4 +9,9 @@ module.exports = merge(common, {
     contentBase: "./static/dist",
     hot: true,
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.ENVIRONMENT': JSON.stringify('development')
+    })
+  ]
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,6 +1,12 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const webpack = require('webpack');
 
 module.exports = merge(common, {
   mode: 'production',
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.ENVIRONMENT': JSON.stringify('production')
+    })
+  ]
 });


### PR DESCRIPTION
### Issues Fixed

If the [Redux DevTools](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en) extension is installed (for instance, in Chrome), the extension is enabled even if the web UI is in production.

### Description

Updated settings so that Redux DevTools will be enabled in development and disabled in production.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
