### PR TITLE
fix: disable loading before showing alert for saving settings successfully

### DIFF
--- a/static/src/components/settings.jsx
+++ b/static/src/components/settings.jsx
@@ -360,6 +360,8 @@ export const Settings = () => {
         throw new Error(data.error || 'Failed to save settings')
       }
 
+      setIsLoading(false)
+
       await Swal.fire({
         title: 'Success!',
         text: 'Settings were successfully saved.',
@@ -377,9 +379,11 @@ export const Settings = () => {
       setSettings((prev) => ({ ...prev, currentPassword: '' }))
       // Fetch updated device settings
       dispatch(fetchDeviceSettings())
-      // Reset the form
       e.target.reset()
+      // Reset the form
     } catch (err) {
+      setIsLoading(false)
+
       await Swal.fire({
         title: 'Error!',
         text: err.message || 'Failed to save settings',
@@ -392,8 +396,6 @@ export const Settings = () => {
           confirmButton: 'swal2-confirm',
         },
       })
-    } finally {
-      setIsLoading(false)
     }
   }
 


### PR DESCRIPTION
### Issues Fixed

When settings are saved successfully, the loading flag (which determines whether to show the loading spinner in the _Save Settings_ button or not) is disabled only when the success alert stops displaying.

### Description

We should disable the loading spinner right before the alert is displayed.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
