### PR TITLE
fix: add missing spaces and punctuations

### DIFF
--- a/static/src/components/empty-asset-message.jsx
+++ b/static/src/components/empty-asset-message.jsx
@@ -2,9 +2,11 @@ export const EmptyAssetMessage = ({ onAddAssetClick }) => {
   return (
     <div className="table-assets-help-text">
       Currently there are no assets.
+      {' '}
       <a className="add-asset-button" href="#" onClick={onAddAssetClick}>
         Add asset
-      </a>{' '}
+      </a>
+      {' '}
       now.
     </div>
   )

--- a/static/src/components/empty-asset-message.jsx
+++ b/static/src/components/empty-asset-message.jsx
@@ -1,7 +1,7 @@
 export const EmptyAssetMessage = ({ onAddAssetClick }) => {
   return (
     <div className="table-assets-help-text">
-      Currently there are no assets.
+      Currently, there are no assets.
       {' '}
       <a className="add-asset-button" href="#" onClick={onAddAssetClick}>
         Add asset


### PR DESCRIPTION
### Description

Added missing spaces and punctuation to the message that shows up when there are not assets

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

### Screenshots

#### Before

![image](https://github.com/user-attachments/assets/392ad70d-911a-4207-b999-e90ca998fa48)

#### After

![image](https://github.com/user-attachments/assets/e9495685-4a2c-4ff0-ace7-8db0cafaf20e)