### PR TITLE
fix: Current Password field not showing if basic auth is enabled

### DIFF
--- a/static/src/components/settings/authentication.jsx
+++ b/static/src/components/settings/authentication.jsx
@@ -4,12 +4,25 @@ import { updateSetting } from '@/store/settings'
 
 export const Authentication = () => {
   const dispatch = useDispatch()
-  const { settings, prevAuthBackend } = useSelector((state) => state.settings)
+  const { settings, prevAuthBackend, hasSavedBasicAuth } = useSelector(
+    (state) => state.settings,
+  )
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target
     dispatch(
       updateSetting({ name, value: type === 'checkbox' ? checked : value }),
+    )
+  }
+
+  const showCurrentPassword = () => {
+    // Show current password if:
+    // 1. Current auth is Basic AND hasSavedBasicAuth is true (switching between Basic states)
+    // 2. Current auth is Disabled AND hasSavedBasicAuth is true (switching from Basic to Disabled)
+    return (
+      hasSavedBasicAuth &&
+      (settings.authBackend === 'auth_basic' ||
+        prevAuthBackend === 'auth_basic')
     )
   }
 
@@ -34,7 +47,7 @@ export const Authentication = () => {
       {(settings.authBackend === 'auth_basic' ||
         (settings.authBackend === '' && prevAuthBackend === 'auth_basic')) && (
         <>
-          {prevAuthBackend === 'auth_basic' && (
+          {showCurrentPassword() && (
             <div className="form-group" id="curpassword_group">
               <label className="small text-secondary">
                 <small>Current Password</small>

--- a/static/src/store/settings/index.js
+++ b/static/src/store/settings/index.js
@@ -169,6 +169,7 @@ const initialState = {
   },
   deviceModel: '',
   prevAuthBackend: '',
+  hasSavedBasicAuth: false,
   isLoading: false,
   isUploading: false,
   uploadProgress: 0,
@@ -207,6 +208,8 @@ const settingsSlice = createSlice({
       })
       .addCase(fetchSettings.fulfilled, (state, action) => {
         state.settings = { ...state.settings, ...action.payload }
+        state.prevAuthBackend = action.payload.authBackend
+        state.hasSavedBasicAuth = action.payload.authBackend === 'auth_basic'
         state.isLoading = false
       })
       .addCase(fetchSettings.rejected, (state, action) => {
@@ -225,6 +228,7 @@ const settingsSlice = createSlice({
       .addCase(updateSettings.fulfilled, (state) => {
         state.isLoading = false
         state.settings.currentPassword = ''
+        state.hasSavedBasicAuth = state.settings.authBackend === 'auth_basic'
       })
       .addCase(updateSettings.rejected, (state, action) => {
         state.isLoading = false


### PR DESCRIPTION
### Issues Fixed

In the Settings page:

- The Current Password field doesn't show up when the Settings page loads, given that basic authentication is enabled.

### Description

- Updated the condition(s) for showing the Current Password field

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
