### PR TITLE
chore(ci): modify workflow for creating a new release

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -33,10 +33,6 @@ jobs:
     uses: ./.github/workflows/generate-openapi-schema.yml
     permissions:
       contents: write
-    with:
-      release: true
-      tag: ${{ inputs.tag }}
-      commit: ${{ inputs.commit }}
 
   balena-build-images:
     strategy:
@@ -152,6 +148,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: docker-tag
+          path: .
+
+      - name: Download OpenAPI schema
+        uses: actions/download-artifact@v4
+        with:
+          name: anthias-api-schema
           path: .
 
       - name: Download balena images

--- a/.github/workflows/generate-openapi-schema.yml
+++ b/.github/workflows/generate-openapi-schema.yml
@@ -42,20 +42,6 @@ on:
       - '!tests/**'
       - '!.cursor/**'
   workflow_call:
-    inputs:
-      release:
-        description: 'Upload the OpenAPI schema as a release artifact'
-        required: true
-        type: boolean
-      tag:
-        description: 'Tag to be used for the release'
-        required: true
-        type: string
-      commit:
-        description: 'Commit or branch name'
-        required: false
-        type: string
-        default: 'master'
 
 jobs:
   generate-openapi-schema:
@@ -116,15 +102,3 @@ jobs:
         with:
           name: anthias-api-schema
           path: anthias-api-schema.json
-
-      - name: Upload the OpenAPI Schema as a release artifact
-        if: github.event_name == 'workflow_dispatch' && inputs.release == true
-        uses: ncipollo/release-action@v1.11.2
-        with:
-          allowUpdates: true
-          generateReleaseNotes: true
-          prerelease: true
-          artifacts: anthias-api-schema.json
-          tag: ${{ inputs.tag }}
-          commit: ${{ inputs.commit }}
-


### PR DESCRIPTION
### Description

Updated the release for creating a new release so that creating a GitHub release will only be called once.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
