### PR TITLE
chore(ci): fix path wildcards used for uploading release artifacts

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -127,11 +127,21 @@ jobs:
               "release_date": $RELEASE_DATE
             }' > "$(date -I)-$BALENA_IMAGE.json"
 
+      - name: List files before upload
+        run: |
+          echo "Current directory contents:"
+          ls -la
+          echo "Files matching pattern:"
+          ls -la ./*raspberry*
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: balena-images
-          path: "*raspberry*.img.zst,*raspberry*.sha256,*raspberry*.json"
+          name: balena-images-${{ matrix.board }}
+          path: |
+            ./*raspberry*.img.zst
+            ./*raspberry*.sha256
+            ./*raspberry*.json
 
       - name: Attest
         uses: actions/attest-build-provenance@v1
@@ -159,8 +169,9 @@ jobs:
       - name: Download balena images
         uses: actions/download-artifact@v4
         with:
-          name: balena-images
+          pattern: balena-images-*
           path: .
+          merge-multiple: true
 
       - name: Create release
         uses: ncipollo/release-action@v1.11.2


### PR DESCRIPTION
### Issues Fixed

- https://github.com/Screenly/Anthias/actions/runs/15717904106

### Description

- Updated the value of `path` for the "Upload artifacts" step

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
