### PR TITLE
chore(ci): include Anthias' OpenAPI schema in the release workflow

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -179,6 +179,6 @@ jobs:
           allowUpdates: true
           generateReleaseNotes: true
           prerelease: true
-          artifacts: "docker-tag,*raspberry*.img.zst,*raspberry*.sha256,*raspberry*.json"
+          artifacts: "docker-tag,*raspberry*.img.zst,*raspberry*.sha256,*raspberry*.json,anthias-api-schema.json"
           tag: ${{ inputs.tag }}
           commit: ${{ inputs.commit }}


### PR DESCRIPTION
### Issues Fixed

- [v0.20.2](https://github.com/Screenly/Anthias/releases/tag/v0.20.2) didn't include `anthias-api-schema.json` when the release was generated automatically. We have to upload it manually for that version.
- The issue started to happen when the workflow file was refactored.

### Description

- Included the generated OpenAPI schema file in the files to be uploaded for a new release

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
