### PR TITLE
chore(ci): fix missing RPi Imager JSON URL

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -49,7 +49,7 @@ jobs:
           python ../raspberry_pi_imager/bin/build-pi-imager-json.py > _site/rpi-imager.json
 
           # Make sure it's valid
-          cat _site/rpi-imager.json | jq
+          jq . < _site/rpi-imager.json
 
           # Copy in static files.
           cp -rf assets _site/

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -33,12 +33,25 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+
+      - run: pip install requests==2.32.3
+
       - name: Build website
         run: |
           cd website
           mkdir -p _site
 
-          # Copy in static files. This is to be migrated to Hugo later.
+          # Build Raspberry Pi Imager JSON
+          python ../raspberry_pi_imager/bin/build-pi-imager-json.py > _site/rpi-imager.json
+
+          # Make sure it's valid
+          cat _site/rpi-imager.json | jq
+
+          # Copy in static files.
           cp -rf assets _site/
           cp index.html _site/
 

--- a/raspberry_pi_imager/bin/build-pi-imager-json.py
+++ b/raspberry_pi_imager/bin/build-pi-imager-json.py
@@ -30,15 +30,16 @@ def get_asset_list(release_tag):
     )
 
     for url in response.json()['assets']:
-        if url['browser_download_url'].endswith('.zip'):
-            asset_urls.append(url['browser_download_url'])
+        download_url = url['browser_download_url']
+        if download_url.endswith('.zst'):
+            asset_urls.append(download_url)
 
     return asset_urls
 
 
 def retrieve_and_patch_json(url):
     image_json = requests.get(
-            url.replace('.zip', '.json'),
+            url.replace('.img.zst', '.json'),
             headers=GITHUB_HEADERS
     ).json()
 

--- a/website/README.md
+++ b/website/README.md
@@ -8,7 +8,7 @@ To run the website locally:
 
 ```bash
 # Start the development server
-docker-compose -f docker-compose.website.yml up --build
+docker compose -f docker-compose.website.yml up --build
 
 # The website will be available at:
 # http://localhost:8080


### PR DESCRIPTION
### Issues Fixed

- https://github.com/Screenly/Quality-Control/actions/runs/14985155822/job/42097579393
  - Unable to access `https://anthias.screenly.io/rpi-imager.json`.

### Description

- Fixed the website deployment workflow so that it would include the `rpi-imager.json` again
- Fixed the Python script that generates the JSON so that it would include the `.zst` images in the list

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
