### PR TITLE
fix: disable editing of duration for video assets

### DIFF
--- a/static/src/components/edit-asset-modal.jsx
+++ b/static/src/components/edit-asset-modal.jsx
@@ -384,6 +384,7 @@ export const EditAssetModal = ({ isOpen, onClose, asset }) => {
                         type="number"
                         value={formData.duration}
                         onChange={handleInputChange}
+                        disabled={formData.mimetype === 'video'}
                       />
                       seconds &nbsp;
                     </div>


### PR DESCRIPTION
### Description

- Disabled editing of duration for video assets

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
