### PR TITLE
fix: copy `tsconfig.json` when building Dockerfile.server in prod

### DIFF
--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -13,6 +13,7 @@ COPY package.json \
     package-lock.json \
     webpack.prod.js \
     webpack.common.js \
+    tsconfig.json \
     /app/
 RUN npm install
 


### PR DESCRIPTION
### Issues Fixed

- Fixes Docker image [build failures](https://github.com/Screenly/Anthias/actions/runs/15859672589/job/44714146183) caused by merging #2359
- Copies `tsconfig.json` in production mode before building

```
#22 ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1
------
 > [node-builder 9/9] RUN npm run build:
1.611 [tsl] ERROR
1.611       TS18002: The 'files' list in config file 'tsconfig.json' is empty.
1.611 ts-loader-default_e3b0c44298fc1c14
```

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
