### PR TITLE
fix: adjust the width of date and time fileds in Edit Asset form

### DIFF
--- a/static/sass/_styles.scss
+++ b/static/sass/_styles.scss
@@ -433,13 +433,6 @@ input[name="file_upload"] {
   left: 0;
 }
 
-.end_date, .start_date, .loop_date {
-  input {
-    float: left;
-    width: 47%;
-  }
-}
-
 .bootstrap-timepicker table td input {
   border: 1px solid #ced4da;
   border-radius: .25rem;

--- a/static/src/components/edit-asset-modal/date-fields.tsx
+++ b/static/src/components/edit-asset-modal/date-fields.tsx
@@ -9,7 +9,7 @@ export const DateFields = ({
     <div id="manul_date">
       <div className="form-group row start_date">
         <label className="col-4 col-form-label">Start Date</label>
-        <div className="controls col-7">
+        <div className="controls col-7 d-flex">
           <input
             className="form-control date shadow-none"
             name="start_date_date"
@@ -29,7 +29,7 @@ export const DateFields = ({
       </div>
       <div className="form-group row end_date">
         <label className="col-4 col-form-label">End Date</label>
-        <div className="controls col-7">
+        <div className="controls col-7 d-flex">
           <input
             className="form-control date shadow-none"
             name="end_date_date"


### PR DESCRIPTION
### Issues Fixed

The start and end date fields in the Edit Asset form looks crammed. Those inputs needs to be a bit wider to avoid the date values overflowing.

![image](https://github.com/user-attachments/assets/291fa8fd-e04f-493a-a944-01efc3cfc299)

### Description

Increased the width of start and end date input fields.

![image](https://github.com/user-attachments/assets/60c25710-c5c6-4cf5-9f3e-5c2976e6663d)

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
