### PR TITLE
chore: unify paths used for building front-end code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "sass": "^1.75.0",
         "sass-loader": "^16.0.3",
         "ts-loader": "^9.5.2",
+        "tsconfig-paths-webpack-plugin": "^4.2.0",
         "typescript": "^5.8.3",
         "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
@@ -6922,6 +6923,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7097,6 +7107,35 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "sass": "^1.75.0",
     "sass-loader": "^16.0.3",
     "ts-loader": "^9.5.2",
+    "tsconfig-paths-webpack-plugin": "^4.2.0",
     "typescript": "^5.8.3",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,7 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require("path");
 const webpack = require('webpack');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
   entry: {
@@ -50,13 +51,7 @@ module.exports = {
     ]
   },
   resolve: {
-    alias: {
-      '@/components': path.resolve(__dirname, 'static/src/components'),
-      '@/constants': path.resolve(__dirname, 'static/src/constants.ts'),
-      '@/store': path.resolve(__dirname, 'static/src/store'),
-      '@/sass': path.resolve(__dirname, 'static/sass'),
-      '@/utils': path.resolve(__dirname, 'static/src/utils'),
-    },
+    plugins: [new TsconfigPathsPlugin()],
     extensions: ['.js', '.jsx', '.ts', '.tsx']
   }
 };


### PR DESCRIPTION
### Issues Fixed

It's tedious to update import aliases/paths across multiple files&mdash;`tsconfig.json` & `webpack.common.js`.

**tsconfig.json**

```javascript
{
  "compilerOptions": {
    // ...
    "paths": {
      "@/components/*": ["static/src/components/*"],
      "@/constants": ["static/src/constants.ts"],
      "@/store/*": ["static/src/store/*"],
      "@/sass/*": ["static/sass/*"],
      "@/utils/*": ["static/src/utils/*"],
      "@/types": ["static/src/types.ts"]
    }
  },
  // ...
}
```

**webpack.common.js**

```javascript
module.exports = {
  // ...
  resolve: {
    alias: {
      '@/components': path.resolve(__dirname, 'static/src/components'),
      '@/constants': path.resolve(__dirname, 'static/src/constants.ts'),
      '@/store': path.resolve(__dirname, 'static/src/store'),
      '@/sass': path.resolve(__dirname, 'static/sass'),
      '@/utils': path.resolve(__dirname, 'static/src/utils'),
    },
    extensions: ['.js', '.jsx', '.ts', '.tsx']
  }
};
```

### Description

- Moves all path/alias declarations to `tsconfig.json`
- Installed a Webpack plugin so that the `tsconfig.json` could be used from the Webpack configs

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
