### PR TITLE
fix: include player name in page titles

### DIFF
--- a/static/src/components/home.tsx
+++ b/static/src/components/home.tsx
@@ -34,10 +34,13 @@ export const ScheduleOverview = () => {
   };
 
   useEffect(() => {
-    document.title = 'Schedule Overview';
+    const title = playerName
+      ? `${playerName} · Schedule Overview`
+      : 'Schedule Overview';
+    document.title = title;
     dispatch(fetchAssets());
     fetchPlayerName();
-  }, [dispatch]);
+  }, [dispatch, playerName]);
 
   // Initialize tooltips
   useEffect(() => {

--- a/static/src/components/integrations.tsx
+++ b/static/src/components/integrations.tsx
@@ -10,15 +10,33 @@ export const Integrations = () => {
     balena_host_os_version: '',
     balena_device_name_at_init: '',
   });
+  const [playerName, setPlayerName] = useState('');
 
   useEffect(() => {
-    document.title = 'Integrations';
-    fetch('/api/v2/integrations')
-      .then((response) => response.json())
-      .then((data) => {
-        setData(data);
-      });
+    const fetchData = async () => {
+      try {
+        const [integrationsResponse, settingsResponse] = await Promise.all([
+          fetch('/api/v2/integrations'),
+          fetch('/api/v2/device_settings'),
+        ]);
+
+        const [integrationsData, settingsData] = await Promise.all([
+          integrationsResponse.json(),
+          settingsResponse.json(),
+        ]);
+
+        setData(integrationsData);
+        setPlayerName(settingsData.player_name ?? '');
+      } catch {}
+    };
+
+    fetchData();
   }, []);
+
+  useEffect(() => {
+    const title = playerName ? `${playerName} · Integrations` : 'Integrations';
+    document.title = title;
+  }, [playerName]);
 
   return (
     <div className="container">

--- a/static/src/components/settings/index.tsx
+++ b/static/src/components/settings/index.tsx
@@ -26,10 +26,16 @@ export const Settings = () => {
   );
 
   useEffect(() => {
-    document.title = 'Settings';
     dispatch(fetchSettings());
     dispatch(fetchDeviceModel());
   }, [dispatch]);
+
+  useEffect(() => {
+    const title = settings.playerName
+      ? `${settings.playerName} · Settings`
+      : 'Settings';
+    document.title = title;
+  }, [settings.playerName]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value, type, checked } = e.target;


### PR DESCRIPTION
### Issues Fixed

- The page title is no longer displayed in the browser tab.
- https://forums.screenly.io/t/anthias-web-ui-custom-html-title/6436

### Description

This pull request adds the player name to page titles for the following&mdash;home, integrations, settings, and system info.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

### Screenshots

![image](https://github.com/user-attachments/assets/86a19da5-fa35-4854-ab55-7c48859e9f5c)
![image](https://github.com/user-attachments/assets/4fde6940-65b8-435d-87d4-cd9b6c454b71)
![image](https://github.com/user-attachments/assets/03f323b2-4131-46b1-a1a7-3b0c90734316)
![image](https://github.com/user-attachments/assets/92df44c6-429a-4f76-874a-4187fea259e7)