### PR TITLE
chore: add cursor rules for running commands inside a Docker container

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -34,6 +34,15 @@ alwaysApply: true
 
 # Code Generation
 
-- Do not include comments when generating Python, SCSS, and TypeScript code.
+- Exclude comments when generating Python, SCSS, and TypeScript code.
+
+# Docker
+
+- All code runs inside Docker containers.
+- In development, prefix commands with Docker:
+
+  ```bash
+  docker compose -f docker-compose.dev.yml exec anthias-server npm install
+  ```
 
 


### PR DESCRIPTION
### Issues Fixed

The Cursor agent tries to run commands as if Anthias runs directly in host

### Description

Added a new Cursor rule to prefix such commands with Docker commands

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
