### PR TITLE
chore: add Cursor rules for discouraging `any` or `unknown` in TS

### DIFF
--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -14,3 +14,4 @@ on how to run them.
   - Third-party imports
   - Imports from other files in the project
 - Separate import groups with blank lines.
+- Do not use `any` or `unknown` for types.


### PR DESCRIPTION
### Issues Fixed

Cursor agents keep generating TS code with `any` (and in some cases, `unknown`), which defeats the purpose of using TypeScript.

### Description

Added a Cursor rule for disallowing `any` or `unknown` when generating TypeScript code

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
