### PR TITLE
fix: restore "Upgrade Anthias" section in Settings page

### DIFF
--- a/static/src/components/settings/index.tsx
+++ b/static/src/components/settings/index.tsx
@@ -26,6 +26,7 @@ export const Settings = () => {
     (state: RootState) => state.settings,
   );
   const [upToDate, setUpToDate] = useState<boolean>(true);
+  const [isBalena, setIsBalena] = useState<boolean>(false);
 
   useEffect(() => {
     dispatch(fetchSettings());
@@ -37,6 +38,12 @@ export const Settings = () => {
       .then((res) => res.json())
       .then((data) => {
         setUpToDate(data.up_to_date);
+      });
+
+    fetch('/api/v2/integrations')
+      .then((res) => res.json())
+      .then((data) => {
+        setIsBalena(data.is_balena);
       });
   }, []);
 
@@ -197,7 +204,7 @@ export const Settings = () => {
         </div>
       </div>
 
-      {!upToDate && <Update />}
+      {!upToDate && !isBalena && <Update />}
 
       <Backup />
       <SystemControls />

--- a/static/src/components/settings/index.tsx
+++ b/static/src/components/settings/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Swal from 'sweetalert2';
 import { RootState, AppDispatch } from '@/types';
@@ -18,17 +18,27 @@ import { DefaultDurations } from '@/components/settings/default-durations';
 import { AudioOutput } from '@/components/settings/audio-output';
 import { DateFormat } from '@/components/settings/date-format';
 import { ToggleableSetting } from '@/components/settings/toggleable-setting';
+import { Update } from '@/components/settings/update';
 
 export const Settings = () => {
   const dispatch = useDispatch<AppDispatch>();
   const { settings, deviceModel, isLoading } = useSelector(
     (state: RootState) => state.settings,
   );
+  const [upToDate, setUpToDate] = useState<boolean>(true);
 
   useEffect(() => {
     dispatch(fetchSettings());
     dispatch(fetchDeviceModel());
   }, [dispatch]);
+
+  useEffect(() => {
+    fetch('/api/v2/info')
+      .then((res) => res.json())
+      .then((data) => {
+        setUpToDate(data.up_to_date);
+      });
+  }, []);
 
   useEffect(() => {
     const title = settings.playerName
@@ -186,6 +196,8 @@ export const Settings = () => {
           </form>
         </div>
       </div>
+
+      {!upToDate && <Update />}
 
       <Backup />
       <SystemControls />

--- a/static/src/components/settings/update.tsx
+++ b/static/src/components/settings/update.tsx
@@ -2,12 +2,17 @@ import { useEffect, useState } from 'react';
 
 export const Update = () => {
   const [ipAddresses, setIpAddresses] = useState<string[]>([]);
+  const [hostUser, setHostUser] = useState<string>('<USER>');
 
   useEffect(() => {
     fetch('/api/v2/info')
       .then((res) => res.json())
       .then((data) => {
         setIpAddresses(data.ip_addresses);
+
+        if (data.host_user) {
+          setHostUser(data.host_user);
+        }
       });
   }, []);
 
@@ -38,7 +43,9 @@ export const Update = () => {
                 <ul>
                   {ipAddresses.map((ipAddress) => (
                     <li key={ipAddress}>
-                      <code>ssh USER@{ipAddress}</code>
+                      <code>
+                        ssh {hostUser}@{ipAddress}
+                      </code>
                     </li>
                   ))}
                 </ul>
@@ -46,7 +53,7 @@ export const Update = () => {
             ) : (
               <li>
                 Open up a terminal and SSH to this device using the following
-                command &mdash; <code>ssh USER@IP_ADDRESS</code>
+                command &mdash; <code>ssh {hostUser}@IP_ADDRESS</code>
               </li>
             )}
             <li>

--- a/static/src/components/settings/update.tsx
+++ b/static/src/components/settings/update.tsx
@@ -36,8 +36,8 @@ export const Update = () => {
               Open up a terminal and SSH to this device using any of the
               following commands:
               <ul>
-                {ipAddresses.map((ipAddress, index) => (
-                  <li key={index}>
+                {ipAddresses.map((ipAddress) => (
+                  <li key={ipAddress}>
                     <code>ssh USER@{ipAddress}</code>
                   </li>
                   ))}

--- a/static/src/components/settings/update.tsx
+++ b/static/src/components/settings/update.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+
+export const Update = () => {
+  const [ipAddresses, setIpAddresses] = useState<string[]>([]);
+
+  useEffect(() => {
+    // TODO: Fetch IP addresses from the API.
+    setIpAddresses(['192.168.1.100', '192.168.1.101']);
+  }, []);
+
+  return (
+    <>
+      <div className="row py-2 mt-4">
+        <div className="col-12">
+          <h4 className="page-header text-white">
+            <b>Update Anthias</b>
+          </h4>
+        </div>
+      </div>
+      <div className="row content px-3">
+        <div id="upgrade-section" className="col-12 my-3">
+          <p>Do the following steps to update Anthias:</p>
+          <ul>
+            <li>
+              Go to the{' '}
+              <a href="#backup-section" className="text-danger">
+                backup section
+              </a>{' '}
+              and click <em>Get Backup</em>.
+            </li>
+            <li>
+              Open up a terminal and SSH to this device using any of the
+              following commands:
+              <ul>
+                {ipAddresses.map((ipAddress, index) => (
+                  <li key={index}>
+                    <code>ssh {ipAddress}</code>
+                  </li>
+                ))}
+              </ul>
+            </li>
+            <li>
+              Go to the project root directory &mdash;{' '}
+              <code>cd ~/screenly</code>
+            </li>
+            <li>
+              Run the following upgrade script &mdash;{' '}
+              <code>./bin/run_upgrade.sh</code>. The script is essentially a
+              wrapper around the install script, so it will prompt you with the
+              same questions as when you first installed Anthias.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/static/src/components/settings/update.tsx
+++ b/static/src/components/settings/update.tsx
@@ -4,8 +4,11 @@ export const Update = () => {
   const [ipAddresses, setIpAddresses] = useState<string[]>([]);
 
   useEffect(() => {
-    // TODO: Fetch IP addresses from the API.
-    setIpAddresses(['192.168.1.100', '192.168.1.101']);
+    fetch('/api/v2/info')
+      .then((res) => res.json())
+      .then((data) => {
+        setIpAddresses(data.ip_addresses);
+      });
   }, []);
 
   return (
@@ -28,17 +31,25 @@ export const Update = () => {
               </a>{' '}
               and click <em>Get Backup</em>.
             </li>
+            {ipAddresses.length > 0 ? (
             <li>
               Open up a terminal and SSH to this device using any of the
               following commands:
               <ul>
                 {ipAddresses.map((ipAddress, index) => (
                   <li key={index}>
-                    <code>ssh {ipAddress}</code>
+                    <code>ssh USER@{ipAddress}</code>
                   </li>
-                ))}
-              </ul>
-            </li>
+                  ))}
+                </ul>
+              </li>
+            ) : (
+              <li>
+                Open up a terminal and SSH to this device using the following
+                command &mdash;{' '}
+                <code>ssh USER@IP_ADDRESS</code>
+              </li>
+            )}
             <li>
               Go to the project root directory &mdash;{' '}
               <code>cd ~/screenly</code>

--- a/static/src/components/settings/update.tsx
+++ b/static/src/components/settings/update.tsx
@@ -32,22 +32,21 @@ export const Update = () => {
               and click <em>Get Backup</em>.
             </li>
             {ipAddresses.length > 0 ? (
-            <li>
-              Open up a terminal and SSH to this device using any of the
-              following commands:
-              <ul>
-                {ipAddresses.map((ipAddress) => (
-                  <li key={ipAddress}>
-                    <code>ssh USER@{ipAddress}</code>
-                  </li>
+              <li>
+                Open up a terminal and SSH to this device using any of the
+                following commands:
+                <ul>
+                  {ipAddresses.map((ipAddress) => (
+                    <li key={ipAddress}>
+                      <code>ssh USER@{ipAddress}</code>
+                    </li>
                   ))}
                 </ul>
               </li>
             ) : (
               <li>
                 Open up a terminal and SSH to this device using the following
-                command &mdash;{' '}
-                <code>ssh USER@IP_ADDRESS</code>
+                command &mdash; <code>ssh USER@IP_ADDRESS</code>
               </li>
             )}
             <li>


### PR DESCRIPTION
### Issues Fixed

The "Upgrade Anthias" section in the Settings page disappeared when the front-end was migrated to React.

### Description

- Restored the "Upgrade Anthias" section in the Settings page
- Renamed "Upgrade Anthias" to "Update Anthias"

### Dependencies

- There must be a way for the IP addresses to be retrieved via the REST API.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

### Screenshots

![image](https://github.com/user-attachments/assets/49928904-e47f-4e6b-bca8-ff2223b227c6)
![Screenshot from 2025-06-30 22-14-25](https://github.com/user-attachments/assets/90ef0504-b464-4b77-95f1-a95d2714cee3)