### PR TITLE
feat: include host username in info API endpoint

### DIFF
--- a/api/tests/test_info_endpoints.py
+++ b/api/tests/test_info_endpoints.py
@@ -110,8 +110,13 @@ class InfoEndpointsTest(TestCase):
         'api.views.v2.get_node_ip',
         return_value='192.168.1.100 10.0.0.50'
     )
+    @mock.patch(
+        'api.views.v2.getenv',
+        return_value='testuser'
+    )
     def test_info_v2_endpoint(
         self,
+        getenv_mock,
         get_node_ip_mock,
         mac_address_mock,
         virtual_memory_mock,
@@ -142,7 +147,8 @@ class InfoEndpointsTest(TestCase):
             get_uptime_mock,
             virtual_memory_mock,
             mac_address_mock,
-            get_node_ip_mock
+            get_node_ip_mock,
+            getenv_mock
         ])
 
         # Assert response data
@@ -167,6 +173,7 @@ class InfoEndpointsTest(TestCase):
                 'available': 7168
             },
             'ip_addresses': ['http://192.168.1.100', 'http://10.0.0.50'],
-            'mac_address': '00:11:22:33:44:55'
+            'mac_address': '00:11:22:33:44:55',
+            'host_user': 'testuser'
         }
         self._assert_response_data(data, expected_data)

--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -462,7 +462,8 @@ class InfoViewV2(InfoViewMixin):
                     'ip_addresses': {
                         'type': 'array', 'items': {'type': 'string'}
                     },
-                    'mac_address': {'type': 'string'}
+                    'mac_address': {'type': 'string'},
+                    'host_user': {'type': 'string'}
                 }
             }
         }
@@ -488,6 +489,7 @@ class InfoViewV2(InfoViewMixin):
             'memory': self.get_memory(),
             'ip_addresses': self.get_ip_addresses(),
             'mac_address': get_node_mac_address(),
+            'host_user': getenv('HOST_USER'),
         })
 
 


### PR DESCRIPTION
### Description

Adds a `host_user` field in the response body of `GET /api/v2/info`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
