### PR TITLE
chore(ci): exclude the `tests` label when generating release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,7 @@ changelog:
     labels:
       - webview
       - chore
+      - tests
   categories:
     - title: Bug Fixes 🐞
       labels:
@@ -23,3 +24,4 @@ changelog:
         labels:
           - webview
           - chore
+          - tests


### PR DESCRIPTION
### Description

Updates `release.yml` so that the pull requests with a `tests` label will be excluded when generating release notes.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
