### PR TITLE
Revert "feat: add WebView support for zoom level in web pages"

### DIFF
--- a/webview/src/mainwindow.cpp
+++ b/webview/src/mainwindow.cpp
@@ -13,9 +13,9 @@ MainWindow::MainWindow() : QMainWindow()
     setCentralWidget(view);
 }
 
-void MainWindow::loadPage(const QString &uri, qreal zoomFactor)
+void MainWindow::loadPage(const QString &uri)
 {
-    view->loadPage(uri, zoomFactor);
+    view->loadPage(uri);
 }
 
 void MainWindow::loadImage(const QString &uri)

--- a/webview/src/mainwindow.h
+++ b/webview/src/mainwindow.h
@@ -13,7 +13,7 @@ class MainWindow : public QMainWindow
         explicit MainWindow();
 
     public slots:
-        void loadPage(const QString &uri, qreal zoomFactor);
+        void loadPage(const QString &uri);
         void loadImage(const QString &uri);
 
     private:

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -30,7 +30,7 @@ View::View(QWidget* parent) : QWidget(parent)
     nextImage = QImage();
 }
 
-void View::loadPage(const QString &uri, qreal zoomFactor)
+void View::loadPage(const QString &uri)
 {
     qDebug() << "Type: Webpage";
 
@@ -43,7 +43,6 @@ void View::loadPage(const QString &uri, qreal zoomFactor)
             qDebug() << "Web page loaded successfully";
             webView->setVisible(true);
             webView->clearFocus();
-            webView->setZoomFactor(zoomFactor);
         } else {
             qDebug() << "Web page failed to load";
         }

--- a/webview/src/view.h
+++ b/webview/src/view.h
@@ -16,7 +16,7 @@ public:
     explicit View(QWidget* parent);
     QWebEngineView* webView;  // Made public for MainWindow access
 
-    void loadPage(const QString &uri, qreal zoomFactor);
+    void loadPage(const QString &uri);
     void loadImage(const QString &uri);
 
 protected:


### PR DESCRIPTION
### Description

- Reverts Screenly/Anthias#2378
- The WebView doesn't wait for the next webpage to preload.
- Say that web asset A and web asset B have zoom levels of 1.25 and 2.00, respectively. The playback of those assets won't be smooth, as if they're glitching and unexpectedly zooming in and out.
- A new PR will be create that will include the changes in this PR plus the necessary fixes.