### PR TITLE
fix: redirect `/admin` to `/admin/`

### DIFF
--- a/anthias_django/urls.py
+++ b/anthias_django/urls.py
@@ -14,7 +14,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.shortcuts import redirect
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
 
@@ -28,8 +27,7 @@ class APIDocView(SpectacularRedocView):
 
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('admin', lambda request: redirect('/admin/', permanent=True)),
+    path('admin', admin.site.urls),
     path('', include('anthias_app.urls')),
     path('api/', include('api.urls')),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),

--- a/anthias_django/urls.py
+++ b/anthias_django/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.shortcuts import redirect
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
 
@@ -28,6 +29,7 @@ class APIDocView(SpectacularRedocView):
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('admin', lambda request: redirect('/admin/', permanent=True)),
     path('', include('anthias_app.urls')),
     path('api/', include('api.urls')),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),


### PR DESCRIPTION
### Issues Fixed

`/admin/` will bring users to the Django Admin page while `/admin` will redirect them to somewhere else.

![image](https://github.com/user-attachments/assets/a3e6b7f3-725e-43c7-81cf-807a17aba3f1)

### Description

Updates URL mappings to redirect `/admin` to `/admin/`

![image](https://github.com/user-attachments/assets/c0ea6732-73f4-42db-a9d3-a2fbfd67dd9d)

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
