### PR TITLE
chore: resolve Docker build warnings for WebView

### DIFF
--- a/webview/Dockerfile
+++ b/webview/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=linux/arm/v7 balenalib/raspberrypi3:bookworm as builder
+ARG BUILDER_BASE_PLATFORM=linux/arm/v7
+FROM --platform=${BUILDER_BASE_PLATFORM} balenalib/raspberrypi3:bookworm AS builder
 
 # There are likely a large number of dependencies that can be stripped out here
 # depending on your needs (and probably in general). My primary objective was just
@@ -193,9 +194,9 @@ COPY --from=builder /lib/ /sysroot/lib/
 COPY --from=builder /usr/include/ /sysroot/usr/include/
 COPY --from=builder /usr/lib/ /sysroot/usr/lib/
 
-ENV BUILD_WEBVIEW 1
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /src/ccache
+ENV BUILD_WEBVIEW=1
+ENV CCACHE_MAXSIZE=10G
+ENV CCACHE_DIR=/src/ccache
 ARG GIT_HASH=0
 ENV GIT_HASH=$GIT_HASH
 


### PR DESCRIPTION
### Issues Fixed

Building the WebView for Raspberry Pi 1-4 gives the following warnings:

```
5 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 196)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 197)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 198)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/arm/v7" (line 1)
```

### Description

Resolves the warnings mentioned above

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
