### PR TITLE
fix: raise an error when duration is non-zero for video assets

### DIFF
--- a/api/serializers/mixins.py
+++ b/api/serializers/mixins.py
@@ -74,6 +74,8 @@ class CreateAssetSerializerMixin:
                 asset['duration'] = (
                     duration if version == 'v2' else int(duration)
                 )
+            else:
+                raise Exception("Duration must be zero for video assets.")
         else:
             # Crashes if it's not an int. We want that.
             duration = data.get(


### PR DESCRIPTION
### Issues Fixed

Creating a video asset via `POST /api/v2/assets` fails and gives the following errors:

```bash
{
“error”: “Invalid file path. Failed to add asset.”
}
```

As seen in this [forum post](https://forums.screenly.io/t/error-with-creating-asset/6473), the user did two endpoint calls.

The first call (i.e.,  `POST /api/v2/file_asset`) was successful.
The second call (`POST /api/v2/assets`) failed.

The root cause is the non-zero value given to the duration in the request body for `POST /api/v2/assets`. Take note that a asset is being given a duration similar to the uploaded video's.

### Description

This pull request modifies the `POST /api/v2/assets` endpoint so that it will fail gracefully when a non-zero duration for a video asset is given to the request body.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
