### PR TITLE
fix: adding a YouTube asset fails

### DIFF
--- a/api/serializers/mixins.py
+++ b/api/serializers/mixins.py
@@ -71,10 +71,13 @@ class CreateAssetSerializerMixin:
 
         if "video" in asset['mimetype']:
             if int(data.get('duration')) == 0:
-                duration = get_video_duration(uri).total_seconds()
-                asset['duration'] = (
-                    duration if version == 'v2' else int(duration)
-                )
+                original_mimetype = data.get('mimetype')
+
+                if original_mimetype != 'youtube_asset':
+                    duration = get_video_duration(uri).total_seconds()
+                    asset['duration'] = (
+                        duration if version == 'v2' else int(duration)
+                    )
             else:
                 raise AssetCreationError(
                     'Duration must be zero for video assets.'

--- a/static/src/components/add-asset-modal/file-upload-utils.ts
+++ b/static/src/components/add-asset-modal/file-upload-utils.ts
@@ -61,7 +61,7 @@ export const getDurationForMimetype = (
   defaultDuration: number,
   defaultStreamingDuration: number,
 ): number => {
-  if (mimetype === 'video') {
+  if (['video', 'youtube_asset'].includes(mimetype)) {
     return 0
   } else if (mimetype === 'streaming') {
     return defaultStreamingDuration


### PR DESCRIPTION
### Issues Fixed

Adding an asset using a YouTube link fails.

### Description

Fixed handling of YouTube URLs in front-end and back-end so that the asset can be created successfully.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
