### PR TITLE
feat: force full screen for x86

### DIFF
--- a/webview/src/mainwindow.cpp
+++ b/webview/src/mainwindow.cpp
@@ -1,5 +1,7 @@
 #include <QStandardPaths>
 #include <QWebEngineSettings>
+#include <QGuiApplication>
+#include <QScreen>
 
 #include "mainwindow.h"
 #include "view.h"
@@ -11,6 +13,10 @@ MainWindow::MainWindow() : QMainWindow()
     view->webView->settings()->setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
     view->webView->settings()->setAttribute(QWebEngineSettings::ShowScrollBars, false);
     setCentralWidget(view);
+
+    QRect screenGeometry = QGuiApplication::primaryScreen()->geometry();
+    setGeometry(screenGeometry);
+    showFullScreen();
 }
 
 void MainWindow::loadPage(const QString &uri)


### PR DESCRIPTION
### Issues Fixed

- Using frame buffer for display wouldn't work for x86 devices running balenaOS.
- With #2409, X11 will be used for display.
- Even though it works, the assets are not being displayed properly. They are scaled down to about 5%.

### Description

- This pull request forces full screen in the web view.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
