### PR TITLE
chore(ci): switch to `ncipollo/release-action` for managing WebView releases

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -199,12 +199,11 @@ jobs:
         with:
           name: webview-${{ matrix.board }}
           path: ./build
-      - name: Create a release
-        uses: softprops/action-gh-release@v2
+      - name: Create release
+        uses: ncipollo/release-action@v1.11.2
         with:
+          allowUpdates: true
+          generateReleaseNotes: true
           prerelease: true
-          files: |
-            build/webview-*.tar.gz
-            build/webview-*.tar.gz.sha256
-            build/qt5-*.tar.gz
-            build/qt5-*.tar.gz.sha256
+          artifacts: "build/webview-*.tar.gz,build/webview-*.tar.gz.sha256,build/qt5-*.tar.gz,build/qt5-*.tar.gz.sha256"
+          tag: ${{ github.ref_name }}


### PR DESCRIPTION
### Issues Fixed

* https://github.com/Screenly/Anthias/actions/runs/16660717123/job/47157509138

### Description

* Using `softprops/action-gh-release` with GitHub Actions' Matrix gives errors complaining that the release name already exists.
* This pull request replaces `softprops/action-gh-release` with `ncipollo/release-action`.

### References

* https://github.com/softprops/action-gh-release/issues/375

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
