### PR TITLE
chore(ci): create WebView release via GH CLI

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -199,11 +199,24 @@ jobs:
         with:
           name: webview-${{ matrix.board }}
           path: ./build
-      - name: Create release
-        uses: ncipollo/release-action@v1.11.2
-        with:
-          allowUpdates: true
-          generateReleaseNotes: true
-          prerelease: true
-          artifacts: "build/webview-*.tar.gz,build/webview-*.tar.gz.sha256,build/qt5-*.tar.gz,build/qt5-*.tar.gz.sha256"
-          tag: ${{ github.ref_name }}
+      - name: Create release ${{ matrix.board }}
+        run: |
+          echo "Processing artifacts for board: ${{ matrix.board }}"
+          # Check if release already exists
+          if gh release view "${{ github.ref_name }}" 2>/dev/null; then
+            echo "Release already exists, uploading assets for ${{ matrix.board }}..."
+            gh release upload "${{ github.ref_name }}" \
+              build/webview-*.tar.gz \
+              build/webview-*.tar.gz.sha256 \
+              build/qt5-*.tar.gz \
+              build/qt5-*.tar.gz.sha256
+          else
+            echo "Creating new release for ${{ matrix.board }}..."
+            gh release create "${{ github.ref_name }}" \
+              --prerelease \
+              --generate-notes \
+              build/webview-*.tar.gz \
+              build/webview-*.tar.gz.sha256 \
+              build/qt5-*.tar.gz \
+              build/qt5-*.tar.gz.sha256
+          fi


### PR DESCRIPTION
### Description

Replaced `ncipollo/release-action` with GitHub CLI

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
