### PR TITLE
chore(ci): specify `GH_TOKEN`

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -200,6 +200,8 @@ jobs:
           name: webview-${{ matrix.board }}
           path: ./build
       - name: Create release ${{ matrix.board }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Processing artifacts for board: ${{ matrix.board }}"
           # Check if release already exists


### PR DESCRIPTION
### Description

Specifies GitHub token when creating release via GitHub CLI in a workflow

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
