### PR TITLE
chore(ci): specify repo when running `gh release` subcommands

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -205,9 +205,10 @@ jobs:
         run: |
           echo "Processing artifacts for board: ${{ matrix.board }}"
           # Check if release already exists
-          if gh release view "${{ github.ref_name }}" 2>/dev/null; then
+          if gh release view "${{ github.ref_name }}" --repo ${{ github.repository }} 2>/dev/null; then
             echo "Release already exists, uploading assets for ${{ matrix.board }}..."
             gh release upload "${{ github.ref_name }}" \
+              --repo ${{ github.repository }} \
               build/webview-*.tar.gz \
               build/webview-*.tar.gz.sha256 \
               build/qt5-*.tar.gz \
@@ -215,6 +216,7 @@ jobs:
           else
             echo "Creating new release for ${{ matrix.board }}..."
             gh release create "${{ github.ref_name }}" \
+              --repo ${{ github.repository }} \
               --prerelease \
               --generate-notes \
               build/webview-*.tar.gz \


### PR DESCRIPTION
### Issues Fixed

https://github.com/Screenly/Anthias/actions/runs/16663093121/job/47164704634

```plaintext
  echo "Processing artifacts for board: pi3"
  # Check if release already exists
  if gh release view "WebView-v0.3.12" 2>/dev/null; then
    echo "Release already exists, uploading assets for pi3..."
    gh release upload "WebView-v0.3.12" \
      build/webview-*.tar.gz \
      build/webview-*.tar.gz.sha256 \
      build/qt5-*.tar.gz \
      build/qt5-*.tar.gz.sha256
  else
    echo "Creating new release for pi3..."
    gh release create "WebView-v0.3.12" \
      --prerelease \
      --generate-notes \
      build/webview-*.tar.gz \
      build/webview-*.tar.gz.sha256 \
      build/qt5-*.tar.gz \
      build/qt5-*.tar.gz.sha256
  fi
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
Processing artifacts for board: pi3
Creating new release for pi3...
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

### Description

Specifies a `--repo` option when running `gh release` subcommands

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
