### PR TITLE
chore(ci): do not include `qt5-*` files for `pi5` and `x86` releases

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -219,7 +219,7 @@ jobs:
               --repo ${{ github.repository }} \
               build/webview-*.tar.gz \
               build/webview-*.tar.gz.sha256 \
-              $QT_FILES
+              "$QT_FILES"
           else
             echo "Creating new release for ${{ matrix.board }}..."
             gh release create "${{ github.ref_name }}" \
@@ -228,5 +228,5 @@ jobs:
               --generate-notes \
               build/webview-*.tar.gz \
               build/webview-*.tar.gz.sha256 \
-              $QT_FILES
+              "$QT_FILES"
           fi


### PR DESCRIPTION
### Issues Fixed

https://github.com/Screenly/Anthias/actions/runs/16663622531/job/47166098056

### Description

- Fixed handling of WebView releases
- `qt5-*` files won't be included for Pi 5 and x86 releases.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
