### PR TITLE
chore(ci): switch back to using `softprops/action-gh-release`

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -199,34 +199,12 @@ jobs:
         with:
           name: webview-${{ matrix.board }}
           path: ./build
-      - name: Create release ${{ matrix.board }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "Processing artifacts for board: ${{ matrix.board }}"
-
-          # Determine which Qt files to include based on board
-          if [[ "${{ matrix.board }}" =~ ^(pi1|pi2|pi3|pi4)$ ]]; then
-            QT_FILES="build/qt5-*.tar.gz build/qt5-*.tar.gz.sha256"
-          else
-            QT_FILES=""
-          fi
-
-          # Check if release already exists
-          if gh release view "${{ github.ref_name }}" --repo ${{ github.repository }} 2>/dev/null; then
-            echo "Release already exists, uploading assets for ${{ matrix.board }}..."
-            gh release upload "${{ github.ref_name }}" \
-              --repo ${{ github.repository }} \
-              build/webview-*.tar.gz \
-              build/webview-*.tar.gz.sha256 \
-              "$QT_FILES"
-          else
-            echo "Creating new release for ${{ matrix.board }}..."
-            gh release create "${{ github.ref_name }}" \
-              --repo ${{ github.repository }} \
-              --prerelease \
-              --generate-notes \
-              build/webview-*.tar.gz \
-              build/webview-*.tar.gz.sha256 \
-              "$QT_FILES"
-          fi
+      - name: Create a release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          files: |
+            build/webview-*.tar.gz
+            build/webview-*.tar.gz.sha256
+            build/qt5-*.tar.gz
+            build/qt5-*.tar.gz.sha256


### PR DESCRIPTION
### Description

Switched back to using `softprops/action-gh-release`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
