### PR TITLE
draft: inject identifiers to web asset URLs

### DIFF
--- a/webview/ScreenlyWebview.pro
+++ b/webview/ScreenlyWebview.pro
@@ -5,7 +5,8 @@ CONFIG += c++11
 
 SOURCES += src/main.cpp \
     src/mainwindow.cpp \
-    src/view.cpp
+    src/view.cpp \
+    src/requestinterceptor.cpp
 
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH =
@@ -15,4 +16,5 @@ include(src/deployment.pri)
 
 HEADERS += \
     src/mainwindow.h \
-    src/view.h
+    src/view.h \
+    src/requestinterceptor.h

--- a/webview/src/requestinterceptor.cpp
+++ b/webview/src/requestinterceptor.cpp
@@ -1,0 +1,29 @@
+#include "requestinterceptor.h"
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+#include <QProcessEnvironment>
+
+RequestInterceptor::RequestInterceptor(QObject* parent)
+    : QWebEngineUrlRequestInterceptor(parent)
+{
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    hostname = env.value("ANTHIAS_HOSTNAME").toUtf8();
+    version = env.value("ANTHIAS_VERSION").toUtf8();
+    mac = env.value("ANTHIAS_MAC").toUtf8();
+}
+
+void RequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo &info)
+{
+    if (!hostname.isEmpty()) {
+        info.setHttpHeader("X-Anthias-hostname", hostname);
+    }
+    if (!version.isEmpty()) {
+        info.setHttpHeader("X-Anthias-version", version);
+    }
+    if (!mac.isEmpty()) {
+        info.setHttpHeader("X-Anthias-mac", mac);
+    }
+}
+#endif
+
+

--- a/webview/src/requestinterceptor.h
+++ b/webview/src/requestinterceptor.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+#include <QObject>
+#include <QByteArray>
+#include <QWebEngineUrlRequestInfo>
+#include <QWebEngineUrlRequestInterceptor>
+
+class RequestInterceptor : public QWebEngineUrlRequestInterceptor
+{
+public:
+    explicit RequestInterceptor(QObject* parent = nullptr);
+    void interceptRequest(QWebEngineUrlRequestInfo &info) override;
+
+private:
+    QByteArray hostname;
+    QByteArray version;
+    QByteArray mac;
+};
+#endif
+
+


### PR DESCRIPTION
### Issues Fixed

- #2412

### Description

- Configures the WebView to include Anthias hostname, version, and MAC address in the request header
- Support for including data (i.e., the identifiers mentioned above) via URL parameters will be supported in this PR (in future commits).

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
