### PR TITLE
chore(ci): disable grouping of Python Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    groups:
-      pip:
-        patterns:
-          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Description

- Ungroups `pip`-type Dependabot PRs
- There are some cases where bumping a Python dependency can cause failures during build time or runtime.
- Handling a large PR in this situation might be a bit convoluted.
- This is currently not the case for Node.js/JavaScript-type Dependabot PRs, as those changes only affects the frontend.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
