### PR TITLE
fix(ci): fixes workflow for Docker image builds

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.3
+          version: 2.1.3
           virtualenvs-create: true
           virtualenvs-in-project: false
           virtualenvs-path: ~/.venv

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,7 +1,7 @@
 name: Docker Image Build
 
 on:
-  push:
+  pull_request:
     branches:
       - master
     paths:
@@ -107,19 +107,16 @@ jobs:
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm/v8 \
-              --service=${{ matrix.service }} \
-              --push
+              --service=${{ matrix.service }}
           elif [ "${{ matrix.board }}" == "pi4-64" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm64/v8 \
-              --service=${{ matrix.service }} \
-              --push
+              --service=${{ matrix.service }}
           else
             poetry run python -m tools.image_builder \
               --build-target=${{ matrix.board }} \
-              --service=${{ matrix.service }} \
-              --push
+              --service=${{ matrix.service }}
           fi
 
       - name: Inspect cache after build

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,7 +1,7 @@
 name: Docker Image Build
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
@@ -107,16 +107,19 @@ jobs:
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm/v8 \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           elif [ "${{ matrix.board }}" == "pi4-64" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm64/v8 \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           else
             poetry run python -m tools.image_builder \
               --build-target=${{ matrix.board }} \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           fi
 
       - name: Inspect cache after build


### PR DESCRIPTION
### Issues Fixed

- The Docker Image Build workflow fails to build the images and stops at the step where Poetry is being installed via GitHub Actions.

### Description

- Bumps Poetry version used in `snok/install-poetry@v1` to 2.1.3.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
