### PR TITLE
chore: migrate Node.js from v18.x to v22.x

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,7 +1,7 @@
 name: Docker Image Build
 
 on:
-  push:
+  pull_request:
     branches:
       - master
     paths:
@@ -107,19 +107,16 @@ jobs:
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm/v8 \
-              --service=${{ matrix.service }} \
-              --push
+              --service=${{ matrix.service }}
           elif [ "${{ matrix.board }}" == "pi4-64" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm64/v8 \
-              --service=${{ matrix.service }} \
-              --push
+              --service=${{ matrix.service }}
           else
             poetry run python -m tools.image_builder \
               --build-target=${{ matrix.board }} \
-              --service=${{ matrix.service }} \
-              --push
+              --service=${{ matrix.service }}
           fi
 
       - name: Inspect cache after build

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,7 +1,7 @@
 name: Docker Image Build
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
@@ -107,16 +107,19 @@ jobs:
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm/v8 \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           elif [ "${{ matrix.board }}" == "pi4-64" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm64/v8 \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           else
             poetry run python -m tools.image_builder \
               --build-target=${{ matrix.board }} \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           fi
 
       - name: Inspect cache after build

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -1,19 +1,7 @@
 {% if environment == 'production' %}
 FROM debian:bookworm AS node-builder
 
-{% if board in ['pi1', 'pi2'] %}
-RUN apt-get update && \
-    apt-get -y install \
-        nodejs \
-        npm
-{% else %}
-RUN apt-get update && \
-    apt-get -y install \
-        curl \
-        ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get -y install nodejs
-{% endif %}
+{% include 'nodejs-install.j2' %}
 
 RUN mkdir -p /app
 WORKDIR /app
@@ -50,19 +38,7 @@ COPY --from=node-builder \
     /app/static/dist/ \
     /usr/src/app/static/dist/
 {% else %}
-{% if board in ['pi1', 'pi2'] %}
-RUN apt-get update && \
-    apt-get -y install \
-        nodejs \
-        npm
-{% else %}
-RUN apt-get update && \
-    apt-get -y install \
-        curl \
-        ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get -y install nodejs
-{% endif %}
+{% include 'nodejs-install.j2' %}
 {% endif %}
 
 ENV GIT_HASH={{ git_hash }}

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -5,8 +5,14 @@ RUN apt-get update && \
     apt-get -y install \
         curl \
         ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get -y install nodejs
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
+    export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+    nvm install --lts && \
+    nvm use --lts && \
+    nvm alias default lts/* && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/node" /usr/local/bin/node && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/npm" /usr/local/bin/npm
 
 RUN mkdir -p /app
 WORKDIR /app
@@ -47,8 +53,14 @@ RUN apt-get update && \
     apt-get -y install \
         curl \
         ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get -y install nodejs
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
+    export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+    nvm install --lts && \
+    nvm use --lts && \
+    nvm alias default lts/* && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/node" /usr/local/bin/node && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/npm" /usr/local/bin/npm
 {% endif %}
 
 ENV GIT_HASH={{ git_hash }}

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -1,19 +1,19 @@
 {% if environment == 'production' %}
 FROM debian:bookworm AS node-builder
 
+{% if board in ['pi1', 'pi2'] %}
+RUN apt-get update && \
+    apt-get -y install \
+        nodejs \
+        npm
+{% else %}
 RUN apt-get update && \
     apt-get -y install \
         curl \
-        ca-certificates \
-        libatomic1 && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
-    export NVM_DIR="$HOME/.nvm" && \
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-    nvm install --lts && \
-    nvm use --lts && \
-    nvm alias default lts/* && \
-    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/node" /usr/local/bin/node && \
-    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/npm" /usr/local/bin/npm
+        ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get -y install nodejs
+{% endif %}
 
 RUN mkdir -p /app
 WORKDIR /app
@@ -24,11 +24,11 @@ COPY package.json \
     webpack.common.js \
     tsconfig.json \
     /app/
-RUN /usr/local/bin/npm install
+RUN npm install
 
 COPY ./static/sass/*.scss /app/static/sass/
 COPY ./static/src/ /app/static/src/
-RUN /usr/local/bin/npm run build
+RUN npm run build
 
 {% endif %}
 {% include 'Dockerfile.base.j2' %}
@@ -50,19 +50,19 @@ COPY --from=node-builder \
     /app/static/dist/ \
     /usr/src/app/static/dist/
 {% else %}
+{% if board in ['pi1', 'pi2'] %}
+RUN apt-get update && \
+    apt-get -y install \
+        nodejs \
+        npm
+{% else %}
 RUN apt-get update && \
     apt-get -y install \
         curl \
-        ca-certificates \
-        libatomic1 && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
-    export NVM_DIR="$HOME/.nvm" && \
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-    nvm install --lts && \
-    nvm use --lts && \
-    nvm alias default lts/* && \
-    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/node" /usr/local/bin/node && \
-    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/npm" /usr/local/bin/npm
+        ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get -y install nodejs
+{% endif %}
 {% endif %}
 
 ENV GIT_HASH={{ git_hash }}

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -23,11 +23,15 @@ COPY package.json \
     webpack.common.js \
     tsconfig.json \
     /app/
-RUN npm install
+RUN export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+    npm install
 
 COPY ./static/sass/*.scss /app/static/sass/
 COPY ./static/src/ /app/static/src/
-RUN npm run build
+RUN export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+    npm run build
 
 {% endif %}
 {% include 'Dockerfile.base.j2' %}

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -4,7 +4,8 @@ FROM debian:bookworm AS node-builder
 RUN apt-get update && \
     apt-get -y install \
         curl \
-        ca-certificates && \
+        ca-certificates \
+        libatomic1 && \
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
     export NVM_DIR="$HOME/.nvm" && \
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
@@ -23,15 +24,11 @@ COPY package.json \
     webpack.common.js \
     tsconfig.json \
     /app/
-RUN export NVM_DIR="$HOME/.nvm" && \
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-    npm install
+RUN /usr/local/bin/npm install
 
 COPY ./static/sass/*.scss /app/static/sass/
 COPY ./static/src/ /app/static/src/
-RUN export NVM_DIR="$HOME/.nvm" && \
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-    npm run build
+RUN /usr/local/bin/npm run build
 
 {% endif %}
 {% include 'Dockerfile.base.j2' %}
@@ -56,7 +53,8 @@ COPY --from=node-builder \
 RUN apt-get update && \
     apt-get -y install \
         curl \
-        ca-certificates && \
+        ca-certificates \
+        libatomic1 && \
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
     export NVM_DIR="$HOME/.nvm" && \
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -3,8 +3,10 @@ FROM debian:bookworm AS node-builder
 
 RUN apt-get update && \
     apt-get -y install \
-        nodejs \
-        npm
+        curl \
+        ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get -y install nodejs
 
 RUN mkdir -p /app
 WORKDIR /app
@@ -40,6 +42,13 @@ WORKDIR /usr/src/app
 COPY --from=node-builder \
     /app/static/dist/ \
     /usr/src/app/static/dist/
+{% else %}
+RUN apt-get update && \
+    apt-get -y install \
+        curl \
+        ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get -y install nodejs
 {% endif %}
 
 ENV GIT_HASH={{ git_hash }}

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -34,19 +34,19 @@ RUN --mount=type=cache,target=/var/cache/apt \
         {% endif %}
     {% endfor %}
 
+{% if board in ['pi1', 'pi2'] %}
+RUN apt-get update && \
+    apt-get -y install \
+        nodejs \
+        npm
+{% else %}
 RUN apt-get update && \
     apt-get -y install \
         curl \
-        ca-certificates \
-        libatomic1 && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
-    export NVM_DIR="$HOME/.nvm" && \
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-    nvm install --lts && \
-    nvm use --lts && \
-    nvm alias default lts/* && \
-    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/node" /usr/local/bin/node && \
-    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/npm" /usr/local/bin/npm
+        ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get -y install nodejs
+{% endif %}
 
 # @TODO: Uncomment the lines below when test_add_asset_streaming is fixed.
 # WORKDIR /opt/ffmpeg

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -38,8 +38,14 @@ RUN apt-get update && \
     apt-get -y install \
         curl \
         ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get -y install nodejs
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
+    export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+    nvm install --lts && \
+    nvm use --lts && \
+    nvm alias default lts/* && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/node" /usr/local/bin/node && \
+    ln -sf "$NVM_DIR/versions/node/$(nvm version)/bin/npm" /usr/local/bin/npm
 
 # @TODO: Uncomment the lines below when test_add_asset_streaming is fixed.
 # WORKDIR /opt/ffmpeg

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -37,7 +37,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
 RUN apt-get update && \
     apt-get -y install \
         curl \
-        ca-certificates && \
+        ca-certificates \
+        libatomic1 && \
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
     export NVM_DIR="$HOME/.nvm" && \
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -34,6 +34,13 @@ RUN --mount=type=cache,target=/var/cache/apt \
         {% endif %}
     {% endfor %}
 
+RUN apt-get update && \
+    apt-get -y install \
+        curl \
+        ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get -y install nodejs
+
 # @TODO: Uncomment the lines below when test_add_asset_streaming is fixed.
 # WORKDIR /opt/ffmpeg
 # COPY --from=builder /opt/ffmpeg/ffserver ./

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -34,19 +34,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
         {% endif %}
     {% endfor %}
 
-{% if board in ['pi1', 'pi2'] %}
-RUN apt-get update && \
-    apt-get -y install \
-        nodejs \
-        npm
-{% else %}
-RUN apt-get update && \
-    apt-get -y install \
-        curl \
-        ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get -y install nodejs
-{% endif %}
+{% include 'nodejs-install.j2' %}
 
 # @TODO: Uncomment the lines below when test_add_asset_streaming is fixed.
 # WORKDIR /opt/ffmpeg

--- a/docker/nodejs-install.j2
+++ b/docker/nodejs-install.j2
@@ -1,0 +1,13 @@
+{% if board in ['pi1', 'pi2'] %}
+RUN apt-get update && \
+    apt-get -y install \
+        nodejs \
+        npm
+{% else %}
+RUN apt-get update && \
+    apt-get -y install \
+        curl \
+        ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get -y install nodejs
+{% endif %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1887,13 +1887,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
       "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5357,10 +5355,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10663,12 +10662,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -93,9 +93,6 @@ def build_image(
         context.update(get_test_context())
     elif service == 'wifi-connect':
         context.update(get_wifi_connect_context(target_platform))
-    elif service == 'server':
-        if environment == 'development':
-            base_apt_dependencies.extend(['nodejs', 'npm'])
 
     generate_dockerfile(service, {
         'base_image': base_image,

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -90,8 +90,6 @@ def get_test_context() -> dict:
             'libcups2',
             'libxcomposite1',
             'libxdamage1',
-            'nodejs',
-            'npm',
         ],
         'chrome_dl_url': chrome_dl_url,
         'chromedriver_dl_url': chromedriver_dl_url,


### PR DESCRIPTION
### Issues Fixed

Node.js v18.x already reached its EOL.

### Description

This PR bumps Node.js version to v22.x.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
