### PR TITLE
docs: fix the Debian iso download link

### DIFF
--- a/docs/x86-installation.md
+++ b/docs/x86-installation.md
@@ -6,8 +6,8 @@ To make sure that the script will work, you need to install Debian 12 in a speci
 
 ## Preparing the Disk Image
 
-You can download the disk image [here](https://www.debian.org/download). The file name should look something
-like `debian-12.x.x-amd64-netinst.iso`.
+You can download the disk image [here](https://cdimage.debian.org/mirror/cdimage/archive/12.11.0/amd64/iso-cd/).
+The file name should look something like `debian-12.x.x-amd64-netinst.iso`.
 
 ## Flashing the Disk Image to a USB Drive
 


### PR DESCRIPTION
### Issues Fixed

Now that Debian 13 has been release, the previous link points to Debian 13 iso which is not compatible with current version of Anthias.

See #2493 for example.

### Description

Update the link to the latest Debian 12 release.

### Checklist

- [ x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
