### PR TITLE
chore: revert temporary changes to the Docker image build workflow

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,7 +1,7 @@
 name: Docker Image Build
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
@@ -107,16 +107,19 @@ jobs:
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm/v8 \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           elif [ "${{ matrix.board }}" == "pi4-64" ]; then
             poetry run python -m tools.image_builder \
               --build-target=pi4 \
               --target-platform=linux/arm64/v8 \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           else
             poetry run python -m tools.image_builder \
               --build-target=${{ matrix.board }} \
-              --service=${{ matrix.service }}
+              --service=${{ matrix.service }} \
+              --push
           fi
 
       - name: Inspect cache after build


### PR DESCRIPTION
### Issues Fixed

I temporarily enabled Docker image builds during pull requests for testing purposes.

### Description

This pull request reverts the temporary changes that I did.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
