### PR TITLE
chore(ci): bump Balena CLI to v22.4.4

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -98,7 +98,7 @@ jobs:
               "$BALENA_IMAGE.img" \
               --config-network=ethernet  \
               --fleet screenly_ose/anthias-${{ matrix.board }}
-          balena_cli_version: 18.1.2
+          balena_cli_version: 22.4.4
 
       - name: Package up image
         run: |


### PR DESCRIPTION
### Issues Fixed

As seen in [this CI run](https://github.com/Screenly/Anthias/actions/runs/17734950081/job/50394297084):

```plaintext
This version of the balena CLI (18.1.2) has expired: please upgrade.
388 days have passed since the release of CLI version 19.0.0.
See deprecation policy at: https://git.io/JRHUW#deprecation-policy
```

### Description

Bumps Balena CLI used in the workflow from `v18.1.2` to `v22.4.4`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
