### PR TITLE
chore(ci): bump Balena CLI to v22.4.4 (follow-up)

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -74,7 +74,7 @@ jobs:
             os download "$BALENA_IMAGE" \
               --output "$BALENA_IMAGE.img" \
               --version default
-          balena_cli_version: 18.1.2
+          balena_cli_version: 22.4.4
 
       - name: balena CLI Action - preload
         uses: balena-labs-research/community-cli-action@1.0.0
@@ -87,7 +87,7 @@ jobs:
               --pin-device-to-release \
               --splash-image ansible/roles/splashscreen/files/splashscreen.png \
               --commit latest
-          balena_cli_version: 18.1.2
+          balena_cli_version: 22.4.4
 
       - name: balena CLI Action - configure
         uses: balena-labs-research/community-cli-action@1.0.0


### PR DESCRIPTION
### Description

This is a follow-up to #2505

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
