### PR TITLE
fix: downgrade `sh` from 2.2.2 to 1.8

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -31,7 +31,7 @@ pyzmq==23.2.1
 redis==3.5.3
 requests[security]==2.32.3
 tenacity==9.0.0
-sh==2.2.2
+sh==1.8
 six==1.17.0
 urllib3==2.5.0
 wheel==0.38.1

--- a/requirements/requirements.viewer.txt
+++ b/requirements/requirements.viewer.txt
@@ -21,6 +21,6 @@ pyzmq==23.2.1
 redis==3.5.3
 requests[security]==2.32.3
 tenacity==9.0.0
-sh==2.2.2
+sh==1.8
 uptime==3.0.1
 urllib3==2.5.0


### PR DESCRIPTION
### Issues Fixed

Fixes #2520

### Description

Merging the PR that upgrades `sh` from 1.8 to 2.2.2 broke the viewer. More details can be found at #2516.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
