### PR TITLE
docs: add note that Trixie is not yet supported

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ If applicable, add screenshots to help explain your problem.
 ### Environment
 
 - Device: [e.g., Raspberry Pi 5, Raspberry Pi 4, PC]
-- OS: [e.g., balenaOS, Raspberry Pi OS 64-bit Bookworm]
+- OS: [e.g., balenaOS, Raspberry Pi OS 64-bit Bookworm, Trixie (not supported)]
 - Anthias Version: [e.g., v0.19.0]
 - Installation Method: [e.g., balenaHub, Release Image, Manual Installation]
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ See [this](/docs/installation-options.md) page for options on how to install Ant
 
 ## :white_check_mark: Compatibility
 
+> [!WARNING]
+> Anthias does not currently support devices running Debian Trixie.
+> Please use Debian Bookworm or Raspberry Pi OS Bookworm for the best experience.
+
 ### balenaOS
 
 > [!NOTE]

--- a/docs/installation-options.md
+++ b/docs/installation-options.md
@@ -61,6 +61,10 @@ Starting with [v0.19.0](https://github.com/Screenly/Anthias/releases/tag/v0.19.0
 
 If you'd like more control over your digital signage instance, try installing it on Raspberry Pi OS Lite or Debian.
 
+> [!WARNING]
+> Anthias does not currently support devices running Debian Trixie.
+> Please use Debian Bookworm or Raspberry Pi OS Bookworm for the best experience.
+
 > [!IMPORTANT]
 > When installing on PC (x86) devices, make sure do follow the steps in the [x86 installation guide](/docs/x86-installation.md)
 > so that the installation script will work.

--- a/docs/raspberry-pi5-ssd-install-instructions.md
+++ b/docs/raspberry-pi5-ssd-install-instructions.md
@@ -1,5 +1,9 @@
 # How to install on a Raspberry Pi 5 with PCI-e SSD
 
+> [!WARNING]
+> Anthias does not currently support devices running Debian Trixie.
+> Please use Raspberry Pi OS Bookworm for the best experience.
+
 ## Hardware
 
 The following guide has been tested using a Raspberry Pi 5 with 8GB RAM and a [GeeekPi P33 PoE+PCI-e HAT](https://pipci.jeffgeerling.com/hats/geeekpi-p33-m2-nvme-poe-hat.html).


### PR DESCRIPTION
### Issues Fixed

- Debian Trixie was release on August 9, 2025 while the release of Raspberry Pi OS Trixie was announced on October 2nd.

### Description

- We need to clarify in the docs that installing Anthias on Trixie might not work out of the box.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
