### PR TITLE
revert: restore Docker build workflow to push on master

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,7 +1,7 @@
 name: Docker Image Build
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:
@@ -105,7 +105,8 @@ jobs:
         run: |
           poetry run python -m tools.image_builder \
             --build-target=${{ matrix.board }} \
-            --service=${{ matrix.service }}
+            --service=${{ matrix.service }} \
+            --push
 
       - name: Inspect cache after build
         run: |


### PR DESCRIPTION
### Description

Revert temporary changes to the Docker build workflow:
- Change trigger from pull_request back to push
- Re-enable image pushing with --push flag

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
