### PR TITLE
Enable HEVC hardware decoding on Balena

### DIFF
--- a/docker-compose.balena.yml.tmpl
+++ b/docker-compose.balena.yml.tmpl
@@ -44,6 +44,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     privileged: true
+    devices:
+      - "/dev/dri:/dev/dri"
     restart: always
     shm_size: ${SHM_SIZE}
     volumes:

--- a/docs/balena-fleet-deployment.md
+++ b/docs/balena-fleet-deployment.md
@@ -46,6 +46,31 @@ $ balena env add BALENA_HOST_CONFIG_gpu_mem $GPU_MEM_VALUE --fleet $FLEET_NAME
 $ balena env add BALENA_HOST_CONFIG_dtoverlay vc4-kms-v3d --fleet $FLEET_NAME
 ```
 
+If you plan to play HEVC/H.265 videos, add the Raspberry Pi HEVC V4L2 overlay so
+that the kernel exposes the hardware decoder nodes to the containers:
+
+```bash
+$ balena env add BALENA_HOST_CONFIG_dtoverlay 'vc4-kms-v3d,rpivid-v4l2' --fleet $FLEET_NAME
+```
+
+> [!NOTE]
+> When you set the value again with the command above, balenaCloud will update
+> the existing `BALENA_HOST_CONFIG_dtoverlay` entry instead of creating a new
+> one. You can also edit it from the dashboard and append `,rpivid-v4l2`
+> manually.
+
+After the device reboots with the updated device tree overlays, the
+`anthias-viewer` service automatically maps `/dev/dri` inside the container. You
+can verify the kernel nodes are present by opening a shell on the device and
+running the following command:
+
+```bash
+$ balena ssh $DEVICE_HOSTNAME "ls /dev/dri /dev/video1[0-1]"
+```
+
+Seeing the DRM and V4L2 nodes confirms the HEVC decoder is available to the
+containerised video player.
+
 If your display does have overscan issues like having a black border around the
 screen, you can disable overscan by running the following command:
 


### PR DESCRIPTION
## Summary
- document the balena host configuration needed to expose the Raspberry Pi HEVC decoder to Anthias containers
- mount the DRM device tree into the anthias-viewer service so hardware decoding is accessible during playback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee83aeffb08330b217a2eb73fa36bb