### PR TITLE
fix: replace deprecated balena CLI action with npm installation

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Login to balena
         env:
           BALENA_TOKEN: ${{ secrets.BALENA_TOKEN }}
-        run: balena login --token $BALENA_TOKEN
+        run: balena login --token "$BALENA_TOKEN"
 
       - name: Get base board
         run: |


### PR DESCRIPTION
### Description

Replace the archived balena-labs-research/community-cli-action with direct npm installation of balena-cli. This updates the workflow to:
- Install Node.js 22.21.0
- Install balena-cli v22.4.15 via npm
- Add explicit login step using balena token
- Simplify CLI commands without deprecated action wrapper

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
