### PR TITLE
fix: add `eno` in the list of supported network interface prefixes

### DIFF
--- a/host_agent.py
+++ b/host_agent.py
@@ -30,6 +30,7 @@ SUPPORTED_INTERFACES = (
     'eth',
     'wlp',
     'enp',
+    'eno',
 )
 
 


### PR DESCRIPTION
### Issues Fixed

Fixes #2609

### Description

- Adds `eno` in the list of supported network interface prefixes, which is used when retrieving the device's IP address(es)

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
