### PR TITLE
chore(ci): ignore `host_agent.py` when running Docker image builds

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -27,6 +27,7 @@ on:
       - '!tests/**'
       - '!docker/Dockerfile.dev'
       - '!.cursor/**'
+      - '!host_agent.py'
 
 jobs:
   run-tests:


### PR DESCRIPTION
### Issues Fixed

The [Docker Image Build workflow](https://github.com/Screenly/Anthias/actions/workflows/docker-build.yaml) gets triggered when there are changes to `host_agent.py`.

### Description

Because `host_agent.py`doen't live inside a Docker container, we need to update the Docker Image Build workflow so that it doesn't get triggered when the host agent script changes.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
