### PR TITLE
Fix HDMI audio detection on Pi4 with dual HDMI ports

### DIFF
--- a/viewer/media_player.py
+++ b/viewer/media_player.py
@@ -69,6 +69,7 @@ def _detect_hdmi_audio_device():
     Uses sysdefault instead of default for reliable audio output.
     """
     import os
+
     for port, card_name in [
         ('card1-HDMI-A-1', 'vc4hdmi0'),
         ('card1-HDMI-A-2', 'vc4hdmi1'),
@@ -80,15 +81,16 @@ def _detect_hdmi_audio_device():
                     if f.read().strip() == 'connected':
                         logging.info(
                             'Detected connected HDMI: %s -> '
-                            'sysdefault:CARD=%s', port, card_name,
+                            'sysdefault:CARD=%s',
+                            port,
+                            card_name,
                         )
                         return f'sysdefault:CARD={card_name}'
         except OSError:
             pass
 
     logging.warning(
-        'No connected HDMI detected, '
-        'falling back to sysdefault:CARD=vc4hdmi0',
+        'No connected HDMI detected, falling back to sysdefault:CARD=vc4hdmi0',
     )
     return 'sysdefault:CARD=vc4hdmi0'
 


### PR DESCRIPTION
## Summary

- Pi4 has two HDMI ports (HDMI-A-1 / HDMI-A-2), but VLC audio always targets `default:CARD=vc4hdmi0` regardless of which port has a display connected. This causes **no audio** when using HDMI-A-2.
- The `default:CARD=` ALSA device name can be unreliable when PulseAudio or dmix is involved.

## Changes

- Add `_detect_hdmi_audio_device()` function that reads `/sys/class/drm/cardN-HDMI-A-N/status` to detect which HDMI port is connected
- Switch from `default:CARD=` to `sysdefault:CARD=` for direct hardware access
- Apply auto-detection for Pi4 and Pi5 HDMI output
- Headphones and Pi1-3 paths are unchanged

## Test plan

- [x] Tested on Pi4 Model B Rev 1.5, Raspberry Pi OS, single HDMI connected to HDMI-A-1
- [x] Audio plays correctly through HDMI
- [x] Fallback works when no HDMI status file is found
- [ ] Needs testing with HDMI-A-2 only
- [ ] Needs testing on Pi5