### PR TITLE
Add screenshot API endpoint with video frame capture

### DIFF
--- a/api/urls/v2.py
+++ b/api/urls/v2.py
@@ -13,6 +13,7 @@ from api.views.v2 import (
     PlaylistOrderViewV2,
     RebootViewV2,
     RecoverViewV2,
+    ScreenshotViewV2,
     ShutdownViewV2,
 )
 
@@ -59,5 +60,10 @@ def get_url_patterns():
             'v2/integrations',
             IntegrationsViewV2.as_view(),
             name='integrations_v2',
+        ),
+        path(
+            'v2/screenshot',
+            ScreenshotViewV2.as_view(),
+            name='screenshot_v2',
         ),
     ]

--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -513,9 +513,7 @@ class ScreenshotViewV2(APIView):
         import sqlite3
         from datetime import datetime, timezone as tz
 
-        db_path = path.join(
-            path.expanduser('~'), '.screenly', 'viewlog.db'
-        )
+        db_path = path.join(path.expanduser('~'), '.screenly', 'viewlog.db')
         if not path.exists(db_path):
             return None, None
 
@@ -556,6 +554,7 @@ class ScreenshotViewV2(APIView):
         file_path = asset.uri
         if not path.isfile(file_path):
             from settings import settings as app_settings
+
             assets_dir = path.join(
                 path.expanduser('~'), app_settings['assetdir']
             )
@@ -577,10 +576,15 @@ class ScreenshotViewV2(APIView):
 
         seek = max(0, int(seek_seconds))
         cmd = [
-            'ffmpeg', '-ss', str(seek),
-            '-i', video_path,
-            '-frames:v', '1',
-            '-q:v', str(max(1, min(31, (100 - quality) * 31 // 100))),
+            'ffmpeg',
+            '-ss',
+            str(seek),
+            '-i',
+            video_path,
+            '-frames:v',
+            '1',
+            '-q:v',
+            str(max(1, min(31, (100 - quality) * 31 // 100))),
         ]
         if width:
             cmd += ['-vf', f'scale={int(width)}:-1']
@@ -588,7 +592,9 @@ class ScreenshotViewV2(APIView):
 
         try:
             result = subprocess.run(
-                cmd, capture_output=True, timeout=10,
+                cmd,
+                capture_output=True,
+                timeout=10,
             )
             if result.returncode == 0 and len(result.stdout) > 100:
                 return result.stdout
@@ -636,9 +642,7 @@ class ScreenshotViewV2(APIView):
                 if width is None:
                     ScreenshotViewV2._cache = jpeg_bytes
                     ScreenshotViewV2._cache_time = now
-                return HttpResponse(
-                    jpeg_bytes, content_type='image/jpeg'
-                )
+                return HttpResponse(jpeg_bytes, content_type='image/jpeg')
 
         # Fallback: framebuffer capture (works for images and web pages)
         try:
@@ -670,15 +674,27 @@ class ScreenshotViewV2(APIView):
 
             if bytes_per_pixel == 4:
                 img = Image.frombytes(
-                    'RGBA', (fb_w, fb_h), raw, 'raw', 'BGRA',
+                    'RGBA',
+                    (fb_w, fb_h),
+                    raw,
+                    'raw',
+                    'BGRA',
                 )
             elif bytes_per_pixel == 3:
                 img = Image.frombytes(
-                    'RGB', (fb_w, fb_h), raw, 'raw', 'BGR',
+                    'RGB',
+                    (fb_w, fb_h),
+                    raw,
+                    'raw',
+                    'BGR',
                 )
             elif bytes_per_pixel == 2:
                 img = Image.frombytes(
-                    'RGB', (fb_w, fb_h), raw, 'raw', 'BGR;16',
+                    'RGB',
+                    (fb_w, fb_h),
+                    raw,
+                    'raw',
+                    'BGR;16',
                 )
             else:
                 return Response(


### PR DESCRIPTION
## Summary

Add `GET /api/v2/screenshot` endpoint that captures what is currently displayed on the screen.

### Problem

On Raspberry Pi 4, VLC uses a hardware video overlay that bypasses the Linux framebuffer (`/dev/fb0`). This means the existing framebuffer-based screenshot approach returns a black image whenever a video asset is playing.

### Solution

The new `ScreenshotViewV2` endpoint:

1. **Checks `viewlog.db`** for the currently playing asset (written by the viewer on every asset start)
2. **If video is playing**: extracts the current frame using `ffmpeg -ss <elapsed> -i <file> -frames:v 1` (scaled to 640px width, JPEG quality 60, ~15KB output)
3. **If image/web page**: falls back to framebuffer capture (`/dev/fb0`) as before
4. **5-second cache** prevents excessive captures from rapid requests

### API

```
GET /api/v2/screenshot
Response: image/jpeg (binary)
```

### Dependencies

- `ffmpeg` (already available in the server container)
- `viewlog.db` in `/data/.screenly/` (shared between viewer and server containers via bind mount)

### Testing

Tested on Raspberry Pi 4 Model B (8GB) with:
- Video assets (MP4) — correctly captures current frame via ffmpeg
- Image assets — correctly captures framebuffer
- Web page assets — correctly captures framebuffer
- Cache behavior — second request within 5s returns cached response