### PR TITLE
Implement playback viewlog tracking

### DIFF
--- a/api/tests/test_info_endpoints.py
+++ b/api/tests/test_info_endpoints.py
@@ -47,7 +47,7 @@ class InfoEndpointsTest(TestCase):
 
         # Assert response data
         expected_data = {
-            'viewlog': 'Not yet implemented',
+            'viewlog': 'No data',
             'loadavg': 0.11,
             'free_space': '15G',
             'display_power': 'off',
@@ -128,7 +128,7 @@ class InfoEndpointsTest(TestCase):
 
         # Assert response data
         expected_data = {
-            'viewlog': 'Not yet implemented',
+            'viewlog': 'No data',
             'loadavg': 0.25,
             'free_space': '20G',
             'display_power': 'on',

--- a/api/views/v2.py
+++ b/api/views/v2.py
@@ -426,7 +426,20 @@ class InfoViewV2(InfoViewMixin):
             200: {
                 'type': 'object',
                 'properties': {
-                    'viewlog': {'type': 'string'},
+                    'viewlog': {
+                        'oneOf': [
+                            {
+                                'type': 'object',
+                                'properties': {
+                                    'asset_id': {'type': 'string'},
+                                    'asset_name': {'type': 'string'},
+                                    'mimetype': {'type': 'string'},
+                                    'started_at': {'type': 'string'},
+                                },
+                            },
+                            {'type': 'string'},
+                        ],
+                    },
                     'loadavg': {'type': 'number'},
                     'free_space': {'type': 'string'},
                     'display_power': {'type': ['string', 'null']},
@@ -463,7 +476,7 @@ class InfoViewV2(InfoViewMixin):
     )
     @authorized
     def get(self, request):
-        viewlog = 'Not yet implemented'
+        viewlog = self._get_viewlog()
 
         # Calculate disk space
         slash = statvfs('/')

--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -234,7 +234,7 @@ def _init_viewlog_db():
     db_path = _get_viewlog_db_path()
     try:
         conn = sqlite3.connect(db_path, timeout=5)
-        conn.execute('''
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS viewlog (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 asset_id TEXT NOT NULL,
@@ -244,7 +244,7 @@ def _init_viewlog_db():
                 started_at TEXT NOT NULL,
                 duration INTEGER DEFAULT 0
             )
-        ''')
+        """)
         conn.commit()
         conn.close()
     except Exception as e:


### PR DESCRIPTION
## Summary

Implement the previously stubbed-out viewlog feature. The viewer now logs every asset playback to a SQLite database (`viewlog.db`), and the `/api/v2/info` endpoint returns the last played asset instead of `"Not yet implemented"`.

### Problem

The `/api/v2/info` endpoint has a `viewlog` field that has always returned `"Not yet implemented"`. There's no way to know what the player is currently displaying or what it last played.

### Solution

**Viewer side** (`viewer/__init__.py`):
- On startup, creates `~/.screenly/viewlog.db` with a `viewlog` table
- Every time an asset starts playing in `asset_loop()`, writes a record with:
  - `asset_id`, `asset_name`, `mimetype`, `uri`, `started_at` (UTC ISO), `duration`

**API side** (`api/views/mixins.py`, `api/views/v2.py`):
- `InfoViewMixin._get_viewlog()` reads the most recent entry from `viewlog.db`
- Returns a dict with asset details, or `"No data"` if empty/missing
- Updated OpenAPI schema to reflect the actual response format

### API Response (before → after)

Before:
```json
{ "viewlog": "Not yet implemented", ... }
```

After:
```json
{
  "viewlog": {
    "asset_id": "abc123",
    "asset_name": "My Video",
    "mimetype": "video",
    "started_at": "2024-01-15T12:00:00+00:00"
  },
  ...
}
```

Or when no playback has occurred:
```json
{ "viewlog": "No data", ... }
```

### How It Works

The `viewlog.db` file lives in `~/.screenly/` which is shared between the viewer and server containers via the `/data/.screenly` bind mount. The viewer writes, the server reads.

### Test plan

- [ ] Start player with assets — verify `viewlog.db` is created and populated
- [ ] Call `GET /api/v2/info` — verify `viewlog` field contains last played asset details
- [ ] Call info endpoint on fresh install — verify `viewlog` returns `"No data"`
- [ ] Updated existing tests to expect `"No data"` instead of `"Not yet implemented"`