### PR TITLE
chore(docker): use APT nodejs for all Raspberry Pi boards

### DIFF
--- a/docker/nodejs-install.j2
+++ b/docker/nodejs-install.j2
@@ -1,4 +1,4 @@
-{% if board in ['pi1', 'pi2'] %}
+{% if board in ['pi1', 'pi2', 'pi3', 'pi4'] %}
 RUN apt-get update && \
     apt-get -y install \
         nodejs \


### PR DESCRIPTION
### Issues Fixed

Fixes a Docker image build failure on Raspberry Pi 3 and Pi 4 devices caused by the NodeSource setup script not supporting the `armhf` architecture.

### Description

The NodeSource setup script only supports `amd64` and `arm64` architectures. Raspberry Pi 3 and Pi 4 use `armhf`, which caused the following error during Docker builds:

```
Error: Unsupported architecture: armhf. Only amd64, arm64 are supported.
```

Previously, `pi1` and `pi2` used APT-provided `nodejs`/`npm`, while `pi3` and `pi4` fell through to the NodeSource path. This PR extends the APT install branch to cover all Raspberry Pi boards (`pi1`, `pi2`, `pi3`, `pi4`). The NodeSource path is now only used for non-Pi boards (x86/x86_64).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).