### PR TITLE
fix(viewer): pre-parse media to reduce VLC playback startup gap

### DIFF
--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -71,6 +71,36 @@ class TestMPVMediaPlayer(unittest.TestCase):
         self.assertIsNone(self.player.process)
 
 
+class TestVLCMediaPlayer(unittest.TestCase):
+    def setUp(self):
+        with patch.object(VLCMediaPlayer, '__init__', return_value=None):
+            self.player = VLCMediaPlayer()
+
+        self.mock_media = MagicMock()
+        self.mock_vlc_player = MagicMock()
+        self.mock_vlc_player.get_media.return_value = self.mock_media
+        self.player.player = self.mock_vlc_player
+
+        self.patch_settings = patch('viewer.media_player.settings')
+        self.patch_device_type = patch(
+            'viewer.media_player.get_device_type', return_value='pi4'
+        )
+
+        self.mock_settings = self.patch_settings.start()
+        self.mock_settings.__getitem__.return_value = 'hdmi'
+        self.patch_device_type.start()
+
+    def tearDown(self):
+        self.patch_settings.stop()
+        self.patch_device_type.stop()
+
+    def test_set_asset_invokes_parse(self):
+        self.player.set_asset('file:///test/video.mp4', 30)
+
+        self.mock_vlc_player.get_media.assert_called_once()
+        self.mock_media.parse.assert_called_once()
+
+
 class TestMediaPlayerProxy(unittest.TestCase):
     def setUp(self):
         MediaPlayerProxy.INSTANCE = None

--- a/viewer/media_player.py
+++ b/viewer/media_player.py
@@ -92,6 +92,10 @@ class VLCMediaPlayer(MediaPlayer):
         self.player.audio_output_device_set(
             'alsa', self.get_alsa_audio_device()
         )
+        # Use synchronous parse() to pre-load file metadata before play() is
+        # called. parse_with_options() is async and returns before metadata is
+        # ready, which negates the pre-loading benefit and causes the same
+        # startup gap we're trying to reduce.
         self.player.get_media().parse()
 
     def play(self):

--- a/viewer/media_player.py
+++ b/viewer/media_player.py
@@ -92,6 +92,7 @@ class VLCMediaPlayer(MediaPlayer):
         self.player.audio_output_device_set(
             'alsa', self.get_alsa_audio_device()
         )
+        self.player.get_media().parse()
 
     def play(self):
         self.player.play()


### PR DESCRIPTION
### Issues Fixed

- Partially addresses Screenly/Anthias#2735
- Reduces the blank screen gap between video transitions on Pi 1-4

### Description

Calls `get_media().parse()` in `VLCMediaPlayer.set_asset()` to pre-load file metadata before `play()` is invoked. This gives VLC a head start on opening the file and reading codec info, reducing the startup delay that causes the visible blank screen between slides.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).