### PR TITLE
fix(ci): pin bun-builder stage to BUILDPLATFORM for 32-bit ARM

### DIFF
--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -1,5 +1,23 @@
 {% if environment == 'production' %}
-FROM oven/bun:1.3.13-slim AS bun-builder
+{# bun ships no 32-bit binaries at all — its release artifacts cover
+   only {linux,darwin,windows}-{x64,aarch64}, so a target-platform
+   build (linux/arm/v6/v7/v8 for pi1/2/3 and pi4-32) can't pull this
+   image when bun-builder inherits the target platform. Pin the stage
+   to $BUILDPLATFORM so it always runs on the build host instead: bun
+   is only used here to compile JS/CSS into the platform-independent
+   /app/static/dist/ that the next stage COPYs in, so the host
+   architecture doesn't matter. This also avoids a slow QEMU-emulated
+   `bun run build` on arm64 hosts.
+
+   Implication: building production images for 32-bit ARM requires an
+   amd64 or arm64 builder, which is what CI uses. The constraint is
+   bun itself, not Docker — there's no 32-bit bun binary to fall back
+   to even outside of Docker, so building this image on a pi3 was
+   never going to work. If device-local builds ever become a hard
+   requirement we'd need to either drop bun (e.g. back to Node, which
+   still ships armv7 binaries) or check `static/dist/` into the
+   image / a cache and skip this stage entirely. #}
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.13-slim AS bun-builder
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
Follow-up to #2755. With the uv image manifest fix in place, master's buildx matrix (run [24966475721](https://github.com/Screenly/Anthias/actions/runs/24966475721)) surfaced a second 32-bit ARM blocker:

```
ERROR: failed to resolve source metadata for docker.io/oven/bun:1.3.13-slim:
       no match for platform in manifest: not found
```

`oven/bun` publishes only `linux/amd64` and `linux/arm64` manifests, so a target-platform build (`linux/arm/v7` for pi3, `linux/arm/v8` 32-bit for pi4, `linux/arm/v6` for pi1/pi2) can't pull the image at all.

## Fix

The `bun-builder` stage in `Dockerfile.server.j2` only exists to compile JS/CSS into `/app/static/dist/`. Its output is platform-independent — the next stage `COPY`s the dist tree into the target image. So pin the stage to `$BUILDPLATFORM` and let it always run natively on the build host, regardless of the target. This also avoids a slow QEMU-emulated `bun run build` on the arm64 builder.

```diff
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.13-slim AS bun-builder
-FROM oven/bun:1.3.13-slim AS bun-builder
```

## Implication: 32-bit ARM production images must be cross-compiled

Worth being explicit: **bun ships no 32-bit binaries at all**, anywhere. The bun v1.3.13 release artifacts cover `{linux,darwin,windows}` × `{x64, aarch64}` only — no `armv7`, no `armv6`, no `i386`, no `armhf`. So this fix doesn't enable building production images on a pi3 directly; the constraint is bun itself, not Docker. There's no 32-bit bun binary to fall back to even outside of Docker, so even `bun install && bun run build` on the device would fail without this image. Cross-compiling from an amd64 or arm64 builder (which is what CI does on `ubuntu-24.04` runners) is the only viable path.

This isn't a regression — pre-rebrand npm/webpack had the same need for a JS toolchain on the build host, just less explicit. Building production images on the device itself was never supported.

If device-local builds ever become a hard requirement, the only paths are:

- Drop bun in favor of a runtime that does ship 32-bit binaries (Node still ships `armv7`), or
- Check `static/dist/` into the image / a cache and remove the bun-builder stage entirely.

Out of scope for this PR.

## Scope

The development branch's `COPY --from=oven/bun:1.3.13-slim /usr/local/bin/bun` is **genuinely platform-dependent** (it copies the bun binary into the runtime image) and **not exercised by the production CI matrix**, so it's deliberately left alone — fixing it would require a different pattern, and there is no 32-bit bun binary to copy in anyway.

## Test plan

- [ ] CI: every `buildx (pi*, server, …)` job in the matrix passes the bun stage
- [ ] CI: `publish-latest` job runs after buildx completes
- [ ] After merge: `screenly/anthias-server:latest-x86` and `screenly/anthias-server:latest-pi3` advance together to the new commit (via the atomic retag from #2755)

Refs #2754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)