### PR TITLE
fix: unblock docker-build CI and the viewer/celery regressions it gated

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         board: ['pi1', 'pi2', 'pi3', 'pi4', 'pi4-64', 'pi5', 'x86']
-        service: ['server', 'celery', 'redis', 'websocket', 'nginx', 'viewer', 'wifi-connect']
+        service: ['server', 'celery', 'redis', 'viewer', 'wifi-connect']
         python-version: ["3.11"]
     runs-on: ubuntu-24.04
 
@@ -157,7 +157,7 @@ jobs:
           set -euo pipefail
           GIT_SHORT_HASH=$(git rev-parse --short=7 HEAD)
           BOARDS=(pi1 pi2 pi3 pi4 pi4-64 pi5 x86)
-          SERVICES=(server celery redis websocket nginx viewer wifi-connect)
+          SERVICES=(server celery redis viewer wifi-connect)
           NAMESPACES=(screenly/anthias screenly/srly-ose)
 
           echo "::group::Preflight: verify every <short-hash>-<board> source tag exists"

--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -43,8 +43,11 @@ trap '' 16
 # Disable swapping
 echo 0 >  /sys/fs/cgroup/memory/memory.swappiness
 
-# Start viewer
-sudo -E -u viewer dbus-run-session python -m viewer &
+# Start viewer.
+# sudo resets PATH to its secure_path, so resolve python via the
+# absolute venv path instead — `python` on PATH would otherwise hit
+# the system interpreter, which has no Anthias deps installed.
+sudo -E -u viewer dbus-run-session /venv/bin/python -m viewer &
 
 # Wait for the viewer
 while true; do

--- a/lib/diagnostics.py
+++ b/lib/diagnostics.py
@@ -1,33 +1,56 @@
 #!/usr/bin/env python
 
 import os
+import subprocess
+import sys
 from datetime import datetime
-
-import cec
 
 from lib import device_helper
 
 from . import utils
 
 
+_CEC_QUERY_SCRIPT = """
+import sys
+try:
+    import cec
+    cec.init()
+    tv = cec.Device(cec.CECDEVICE_TV)
+except Exception:
+    sys.stdout.write('CEC error')
+    sys.exit(0)
+try:
+    sys.stdout.write('True' if tv.is_on() else 'False')
+except IOError:
+    sys.stdout.write('Unknown')
+"""
+
+
 def get_display_power() -> str | bool:
     """
-    Queries the TV using CEC
-    """
-    tv_status: str | bool = False
+    Queries the TV using CEC.
 
+    The CEC stack can block inside libcec (no HDMI link, TV asleep,
+    adapter unresponsive) in a C call that ignores Python signals,
+    which would tie up the celery worker until it hits its hard
+    time_limit and gets SIGKILL'd. Run the query in a subprocess so
+    we can enforce a timeout and recover cleanly.
+    """
     try:
-        cec.init()
-        tv = cec.Device(cec.CECDEVICE_TV)
-    except Exception:
+        result = subprocess.run(
+            [sys.executable, '-c', _CEC_QUERY_SCRIPT],
+            capture_output=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
         return 'CEC error'
 
-    try:
-        tv_status = tv.is_on()
-    except IOError:
-        return 'Unknown'
-
-    return tv_status
+    output = result.stdout.decode('utf-8', errors='replace').strip()
+    if output == 'True':
+        return True
+    if output == 'False':
+        return False
+    return output or 'CEC error'
 
 
 def get_uptime() -> float:


### PR DESCRIPTION
## Summary

The `docker-build` workflow has been failing on every master push since f421130b (Apr 27) because the matrix still references the `websocket` and `nginx` services even though their Dockerfiles were deleted in that PR. `publish-latest-tag` is gated on the full matrix passing, so the floating `latest-<board>` tags are stuck on a pre-f421130b SHA that's also post-ee12387b. Fresh installs land in the worst possible window and surface two real regressions:

- **Viewer dies on `import django`.** `bin/start_viewer.sh:47` runs `python -m viewer` via `sudo -E -u viewer`. ee12387b moved Python deps from system site-packages into `/venv`, but `sudo` strips `PATH` to its `secure_path` even with `-E`, so `python` resolves to `/usr/bin/python3` (no Anthias deps). Pin `/venv/bin/python` so sudo's PATH reset is a no-op.
- **Celery worker SIGKILL'd every 5 minutes.** `lib/diagnostics.get_display_power()` calls `cec.init()`/`tv.is_on()` directly. libcec can block in a C call that ignores Python signals (TV asleep, HDMI link dropped), so the 30s hard `time_limit` kills the worker. Run the cec query in a subprocess with `subprocess.run(..., timeout=10)`. The secondary `_Code.co_positions` log spam is billiard's broken traceback formatter and goes away once the hang stops.

Drop `websocket` and `nginx` from the matrix + `SERVICES=(...)` mirror list so CI can publish again. Once a build lands, `latest-<board>` will roll forward to a post-f421130b image where the uvicorn server serves statics itself and both fixes above are baked in.

## Test plan

- [ ] CI: `docker-build` workflow goes green (no more 404 on `Dockerfile.websocket`/`.nginx`).
- [ ] CI: `publish-latest-tag` runs and mirrors `<sha>-<board>` → `latest-<board>` for all 7 boards × 5 services.
- [ ] On a Pi 4 (post-merge): `docker compose pull && docker compose up -d --force-recreate` brings server, viewer, and celery up clean. Display renders the playlist instead of staying black.
- [ ] `docker compose logs anthias-viewer` shows no `ModuleNotFoundError: No module named 'django'`.
- [ ] `docker compose logs anthias-celery` no longer shows `Hard time limit (30s) exceeded for celery_tasks.get_display_power` or the `_Code object has no attribute 'co_positions'` traceback every 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)