### PR TITLE
ci: switch primary registry to ghcr, drop legacy srly-ose namespace

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -37,6 +37,15 @@ jobs:
 
   buildx:
     needs: run-tests
+    # Scoped per-job (not at workflow level) so `run-tests` and any
+    # future read-only job don't inherit `packages: write`. `buildx`
+    # needs it so `docker login ghcr.io` with GITHUB_TOKEN can push
+    # ghcr.io/screenly/anthias-*. `contents: read` is the implicit
+    # default but pinned explicitly so a future workflow edit can't
+    # silently lose checkout access.
+    permissions:
+      contents: read
+      packages: write
     strategy:
       # Don't cancel sibling jobs on the first failure: any platform that
       # has already finished building its image will have pushed the
@@ -106,6 +115,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        if: success() && github.event_name == 'push'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build Container
         env:
           DOCKER_BUILDKIT: 1
@@ -132,13 +149,31 @@ jobs:
   # checks every <short-hash>-<board> tag is resolvable before any
   # retag fires, so a missing source tag fails the job before it
   # mutates the registry. `imagetools create` re-points the registry
-  # tag to the existing manifest without re-uploading layers, so the
-  # full ~98 retags (7 boards × 7 services × 2 namespaces) finish in
-  # under two minutes.
+  # tag to the existing manifest without re-uploading layers, and each
+  # call is wrapped in 5-attempt exponential backoff so a transient
+  # 429 / 5xx doesn't strand latest-* half-mirrored.
+  #
+  # Two registries: `ghcr.io/screenly/anthias-*` is the new primary
+  # (rate-limit-friendly, free unlimited storage for public packages,
+  # auth via the workflow-issued GITHUB_TOKEN with `packages: write`).
+  # `screenly/anthias-*` on Docker Hub stays in the loop as a parallel
+  # mirror during the migration window so devices that haven't yet
+  # picked up the compose-template flip keep getting `latest-*`
+  # advanced. GHCR is mirrored first so the canonical source is up to
+  # date even if Docker Hub flakes on a later retag. The legacy
+  # `screenly/srly-ose-*` namespace was dropped: every device that
+  # has run `upgrade_containers.sh` since 2023-02 (b9998438) is on
+  # `screenly/anthias-*` already, so the parallel `srly-ose-*` push
+  # was buying no real back-compat in exchange for half the manifest
+  # GETs (one of two reasons d568602's publish hit Docker Hub's 429).
   publish-latest:
     needs: buildx
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
+    # See `buildx.permissions` above for rationale; same scoping reason.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -152,13 +187,44 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Mirror short-hash tags to latest-<board>
         run: |
           set -euo pipefail
           GIT_SHORT_HASH=$(git rev-parse --short=7 HEAD)
           BOARDS=(pi1 pi2 pi3 pi4 pi4-64 pi5 x86)
           SERVICES=(server celery redis viewer wifi-connect)
-          NAMESPACES=(screenly/anthias screenly/srly-ose)
+          # GHCR first so the canonical primary is current even if the
+          # Docker Hub mirror later in the loop flakes.
+          NAMESPACES=(ghcr.io/screenly/anthias screenly/anthias)
+
+          # Wrap a registry op in 5 attempts of exponential backoff
+          # (2s, 4s, 8s, 16s) so a transient 429 / 5xx doesn't strand
+          # `latest-*` half-mirrored. Both `imagetools inspect` and
+          # `imagetools create` are idempotent: inspect is read-only,
+          # and create overwrites the tag with the same manifest
+          # digest on retry.
+          retry() {
+            local attempt
+            for attempt in 1 2 3 4 5; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "${attempt}" -lt 5 ]; then
+                local delay=$((2 ** attempt))
+                echo "Attempt ${attempt} failed; retrying in ${delay}s..." >&2
+                sleep "${delay}"
+              fi
+            done
+            echo "Giving up after 5 attempts: $*" >&2
+            return 1
+          }
 
           echo "::group::Preflight: verify every <short-hash>-<board> source tag exists"
           for namespace in "${NAMESPACES[@]}"; do
@@ -166,7 +232,7 @@ jobs:
               for board in "${BOARDS[@]}"; do
                 src="${namespace}-${service}:${GIT_SHORT_HASH}-${board}"
                 echo "Verifying ${src}"
-                docker buildx imagetools inspect --raw "${src}" >/dev/null
+                retry docker buildx imagetools inspect --raw "${src}" >/dev/null
               done
             done
           done
@@ -179,7 +245,7 @@ jobs:
                 src="${namespace}-${service}:${GIT_SHORT_HASH}-${board}"
                 dst="${namespace}-${service}:latest-${board}"
                 echo "Mirroring ${src} -> ${dst}"
-                docker buildx imagetools create -t "${dst}" "${src}"
+                retry docker buildx imagetools create -t "${dst}" "${src}"
               done
             done
           done

--- a/docker-compose.balena.dev.yml.tmpl
+++ b/docker-compose.balena.dev.yml.tmpl
@@ -3,7 +3,7 @@
 version: "2"
 services:
   anthias-wifi-connect:
-    image: screenly/anthias-wifi-connect:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-wifi-connect:${GIT_SHORT_HASH}-${BOARD}
     build:
       context: .
       dockerfile: ./docker/Dockerfile.wifi-connect
@@ -21,7 +21,7 @@ services:
       io.balena.features.firmware: "1"
 
   anthias-server:
-    image: screenly/anthias-server:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-server:${GIT_SHORT_HASH}-${BOARD}
     build:
       context: .
       dockerfile: ./docker/Dockerfile.server
@@ -43,7 +43,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   anthias-viewer:
-    image: screenly/anthias-viewer:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-viewer:${GIT_SHORT_HASH}-${BOARD}
     build:
       context: .
       dockerfile: ./docker/Dockerfile.viewer
@@ -65,7 +65,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   anthias-celery:
-    image: screenly/anthias-celery:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-celery:${GIT_SHORT_HASH}-${BOARD}
     build:
       context: .
       dockerfile: ./docker/Dockerfile.celery
@@ -85,7 +85,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   redis:
-    image: screenly/anthias-redis:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-redis:${GIT_SHORT_HASH}-${BOARD}
     build:
       context: .
       dockerfile: ./docker/Dockerfile.redis

--- a/docker-compose.balena.yml.tmpl
+++ b/docker-compose.balena.yml.tmpl
@@ -3,7 +3,7 @@
 version: "2"
 services:
   anthias-wifi-connect:
-    image: screenly/anthias-wifi-connect:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-wifi-connect:${GIT_SHORT_HASH}-${BOARD}
     depends_on:
       - anthias-viewer
     environment:
@@ -18,7 +18,7 @@ services:
       io.balena.features.firmware: "1"
 
   anthias-server:
-    image: screenly/anthias-server:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-server:${GIT_SHORT_HASH}-${BOARD}
     ports:
       - 80:8080
     environment:
@@ -37,7 +37,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   anthias-viewer:
-    image: screenly/anthias-viewer:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-viewer:${GIT_SHORT_HASH}-${BOARD}
     depends_on:
       - anthias-server
     environment:
@@ -56,7 +56,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   anthias-celery:
-    image: screenly/anthias-celery:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-celery:${GIT_SHORT_HASH}-${BOARD}
     depends_on:
       - anthias-server
       - redis
@@ -73,7 +73,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   redis:
-    image: screenly/anthias-redis:${GIT_SHORT_HASH}-${BOARD}
+    image: ghcr.io/screenly/anthias-redis:${GIT_SHORT_HASH}-${BOARD}
     ports:
       - 127.0.0.1:6379:6379
     restart: always

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -2,7 +2,7 @@
 
 services:
   anthias-wifi-connect:
-    image: screenly/anthias-wifi-connect:${DOCKER_TAG}-${DEVICE_TYPE}
+    image: ghcr.io/screenly/anthias-wifi-connect:${DOCKER_TAG}-${DEVICE_TYPE}
     build:
       context: .
       dockerfile: docker/Dockerfile.wifi-connect
@@ -21,7 +21,7 @@ services:
         target: /run/dbus/system_bus_socket
 
   anthias-server:
-    image: screenly/anthias-server:${DOCKER_TAG}-${DEVICE_TYPE}
+    image: ghcr.io/screenly/anthias-server:${DOCKER_TAG}-${DEVICE_TYPE}
     build:
       context: .
       dockerfile: docker/Dockerfile.server
@@ -51,7 +51,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   anthias-viewer:
-    image: screenly/anthias-viewer:${DOCKER_TAG}-${DEVICE_TYPE}
+    image: ghcr.io/screenly/anthias-viewer:${DOCKER_TAG}-${DEVICE_TYPE}
     build:
       context: .
       dockerfile: docker/Dockerfile.viewer
@@ -79,7 +79,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   anthias-celery:
-    image: screenly/anthias-celery:${DOCKER_TAG}-${DEVICE_TYPE}
+    image: ghcr.io/screenly/anthias-celery:${DOCKER_TAG}-${DEVICE_TYPE}
     build:
       context: .
       dockerfile: docker/Dockerfile.celery
@@ -103,7 +103,7 @@ services:
       io.balena.features.supervisor-api: '1'
 
   redis:
-    image: screenly/anthias-redis:${DOCKER_TAG}-${DEVICE_TYPE}
+    image: ghcr.io/screenly/anthias-redis:${DOCKER_TAG}-${DEVICE_TYPE}
     build:
       context: .
       dockerfile: docker/Dockerfile.redis

--- a/docker/Dockerfile.base.j2
+++ b/docker/Dockerfile.base.j2
@@ -19,3 +19,4 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # https://github.com/balena-io-library/base-images/issues/562
 RUN c_rehash
 
+{% include 'labels.j2' %}

--- a/docker/Dockerfile.redis.j2
+++ b/docker/Dockerfile.redis.j2
@@ -19,5 +19,7 @@ ENV GIT_BRANCH={{ git_branch }}
 RUN sed -i 's/^bind.*/bind 0.0.0.0/g' /etc/redis/redis.conf
 RUN sed -i 's/^protected-mode.*/protected-mode no/g' /etc/redis/redis.conf
 
+{% include 'labels.j2' %}
+
 CMD ["redis-server", "--protected-mode", "no"]
 

--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -70,4 +70,6 @@ WORKDIR /usr/src/app
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app/
 
+{% include 'labels.j2' %}
+
 CMD ["bash", "./bin/start_viewer.sh"]

--- a/docker/labels.j2
+++ b/docker/labels.j2
@@ -1,0 +1,19 @@
+{# OCI image labels (https://specs.opencontainers.org/image-spec/annotations/).
+   `image.source` is the load-bearing one for GitHub Container Registry:
+   GHCR uses it to link the package to its source repo, which makes the
+   package inherit the repo's visibility and grants repo collaborators
+   push/delete access. Without it, packages stay private even when the
+   repo is public, and the package page on GitHub has no link back. #}
+{% set service_descriptions = {
+    'server': 'Anthias web server (uvicorn + Django + Channels)',
+    'celery': 'Anthias background task worker (asset downloads, cleanup, display power)',
+    'redis': 'Redis broker for Anthias Celery and Channels',
+    'viewer': 'Anthias display/viewer service',
+    'wifi-connect': 'Anthias WiFi captive-portal helper',
+    'test': 'Anthias test runner',
+} %}
+LABEL org.opencontainers.image.source="https://github.com/Screenly/Anthias"
+LABEL org.opencontainers.image.url="https://anthias.screenly.io"
+LABEL org.opencontainers.image.licenses="GPL-2.0"
+LABEL org.opencontainers.image.title="anthias-{{ service }}"
+LABEL org.opencontainers.image.description="{{ service_descriptions.get(service, 'Anthias ' + service) }}"

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -109,6 +109,7 @@ def build_image(
             'git_branch': git_branch,
             'git_hash': git_hash,
             'git_short_hash': git_short_hash,
+            'service': service,
             'target_platform': target_platform,
             **context,
         },
@@ -239,8 +240,22 @@ def main(
 
     # Build Docker images
     for service_name in services_to_build:
-        # Define tag components
-        namespaces = ['screenly/anthias', 'screenly/srly-ose']
+        # Define tag components.
+        #
+        # GHCR is listed first because it is the primary, canonical source
+        # for Anthias images going forward — `bin/upgrade_containers.sh`
+        # regenerates compose from `docker-compose.yml.tmpl`, so flipping
+        # the template (separate change) flips every device on next
+        # upgrade. Docker Hub stays in the list as a parallel push during
+        # the migration window so devices that haven't yet picked up the
+        # template flip keep getting `latest-*` advanced.
+        #
+        # The legacy `screenly/srly-ose-*` namespace was dropped: every
+        # device that has run `upgrade_containers.sh` since 2023-02
+        # (b9998438) is on `screenly/anthias-*`, and stale `srly-ose-*`
+        # `latest-*` mirroring (one of two reasons d568602 hit Docker
+        # Hub's 429) gives no real back-compat in exchange.
+        namespaces = ['ghcr.io/screenly/anthias', 'screenly/anthias']
         version_suffix = (
             f'{board}-64'
             if board == 'pi4' and platform == 'linux/arm64/v8'


### PR DESCRIPTION
## Summary
Make **`ghcr.io/screenly/anthias-*`** the canonical source for Anthias images. Docker Hub's `screenly/anthias-*` becomes a parallel mirror during the migration window. The legacy `screenly/srly-ose-*` namespace is dropped entirely (matrix push + `latest-*` mirror). The three compose templates are flipped to ghcr in the same change so devices pick it up on the next `bin/upgrade_containers.sh` run.

## What ships
- `tools/image_builder/__main__.py` — `namespaces = ['ghcr.io/screenly/anthias', 'screenly/anthias']`. GHCR first → primary; Docker Hub stays in the loop as the migration-window mirror. Also passes `'service': service` into the Jinja context for the description label.
- `.github/workflows/docker-build.yaml` — adds **job-scoped** `permissions: { contents: read, packages: write }` on `buildx` and `publish-latest` (so `run-tests` doesn't inherit; addresses Sonar `githubactions:S8233`), a second `Login to GitHub Container Registry` step in both jobs, and re-introduces the namespaces array in the mirror loop (GHCR first, Docker Hub second). Retry-with-backoff seatbelt from 8099a14a is preserved.
- `docker/labels.j2` — new shared partial emitting the OCI image labels (`source`, `url`, `licenses`, `title`, `description`). `org.opencontainers.image.source` is the load-bearing one for GHCR — it auto-links the package to the source repo on first push.
- `docker/Dockerfile.{base,redis,viewer}.j2` — include the new partial. base covers server / celery / wifi-connect / test; redis and viewer have their own production-stage FROM and include directly.
- `docker-compose.yml.tmpl`, `docker-compose.balena.yml.tmpl`, `docker-compose.balena.dev.yml.tmpl` — 15 `image:` lines flipped from `screenly/anthias-*` to `ghcr.io/screenly/anthias-*`. Devices regenerate compose on every `upgrade_containers.sh` run, so this propagates automatically.

## Why drop srly-ose entirely
`docker-compose.yml.tmpl` has pointed installs at `screenly/anthias-*` since 2023-02 (b9998438), and `bin/upgrade_containers.sh` regenerates compose from the template on every upgrade. Any device that has run an upgrade in the past three years is on `screenly/anthias-*`. The parallel `srly-ose-*` push was buying no real back-compat in exchange for half the manifest GETs (one of the two reasons d568602's publish hit Docker Hub's 429 on retag #52).

## ⚠️ Pre-merge action required
Set the **`Screenly` org's default-new-package visibility to Public** at https://github.com/organizations/Screenly/settings/packages **before merging**. The five new packages (`anthias-server`, `anthias-celery`, `anthias-redis`, `anthias-viewer`, `anthias-wifi-connect`) get created on first push from CI; if the org default is private, devices will fail to pull with 401/403. The `image.source` label auto-links the packages to this repo but doesn't set visibility on its own.

## ⚠️ Migration-window risk
Between merge and `publish-latest` completion (~80 min for the matrix to finish), `ghcr.io/screenly/anthias-*:latest-<board>` tags don't exist yet. Devices that run `bin/upgrade_containers.sh` in that window will fail to pull from ghcr and stay on existing containers (no automatic Docker Hub fallback in compose). They'll pull successfully on the next upgrade attempt after CI finishes. **Merge during a low-fleet-upgrade window.**

## Phase 3 (separate PR, months from now)
Stop publishing `latest-*` to Docker Hub once enough fleet has rotated through an upgrade. `<short-hash>-<board>` tags on Docker Hub stay forever for explicit pins.

## Test plan
- [ ] First push to master after merge: `buildx` matrix pushes `<sha>-<board>` to both registries
- [ ] `publish-latest` mirrors `latest-<board>` to both registries (~70 retags total)
- [ ] After publish: 5 new packages appear under https://github.com/orgs/Screenly/packages — confirm `org.opencontainers.image.source` linked them to this repo and visibility is public
- [ ] `docker pull ghcr.io/screenly/anthias-server:latest-pi5` works without auth
- [ ] On a device: `bin/upgrade_containers.sh` regenerates compose with `ghcr.io/...` images and pulls them successfully
- [ ] Existing Docker Hub pulls still work for any unmigrated explicit pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)