### PR TITLE
fix(build): force bun's prod JSX runtime so the React app mounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "anthias",
   "version": "1.0.0",
   "scripts": {
-    "build:js": "bun build ./static/src/index.tsx --outfile=./static/dist/js/anthias.js --target=browser --minify --define process.env.NODE_ENV='\"production\"' --define process.env.ENVIRONMENT='\"production\"'",
+    "build:js": "bun build ./static/src/index.tsx --outfile=./static/dist/js/anthias.js --target=browser --production --define process.env.ENVIRONMENT='\"production\"'",
     "build:css": "bunx sass static/sass/anthias.scss static/dist/css/anthias.css --style=compressed --quiet-deps --silence-deprecation=import,global-builtin,color-functions,if-function",
     "build": "bun run build:js && bun run build:css",
     "dev:js": "bun build ./static/src/index.tsx --outfile=./static/dist/js/anthias.js --target=browser --sourcemap=linked --watch --define process.env.NODE_ENV='\"development\"' --define process.env.ENVIRONMENT='\"development\"'",


### PR DESCRIPTION
## Summary

The prod bundle was emitting `jsxDEV(...)` calls. At runtime those resolve to `react/jsx-dev-runtime`, which under `NODE_ENV=production` exports `jsxDEV = void 0` — so React threw `Uncaught TypeError: o is not a function` the instant it tried to render and the page came up blank.

`--define process.env.NODE_ENV='"production"'` only does string substitution in bundled code; it doesn't reach bun's transpiler, so bun kept picking the dev JSX runtime. Switching to bun's built-in `--production` flag sets `NODE_ENV=production` at the transpiler level (so it emits `jsx`/`jsxs`) and also enables minification, which is why `--minify` and the NODE_ENV define drop out.

The bug only surfaced after a clean `bun install --frozen-lockfile` — exactly what the prod Dockerfile does — so it bit production images while a dev workspace with a long-lived `node_modules` happened to mask it.

## Test plan

- [x] Reproduced in the bun-builder image: same byte-for-byte 526,277-byte bundle the user reported, with 6-arg `jsxDEV` calls and a `Tooltip` import that lands `o` on `void 0` after minification.
- [x] With this fix, a clean `bun install --frozen-lockfile && bun run build` inside `oven/bun:1.3.13-slim` produces a 514,587-byte bundle, 0 `jsxDEV(` calls, 2-arg `jsx` calls.
- [x] Loaded `/` against the dev container in headless Chromium with the fixed bundle: zero `pageerror`, zero failed requests, navbar + schedule overview render.
- [ ] CI rebuilds prod images on this PR and a smoke check on a real device confirms the homepage renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)