### PR TITLE
docs(issue-template): mark Trixie as supported in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ If applicable, add screenshots to help explain your problem.
 ### Environment
 
 - Device: [e.g., Raspberry Pi 5, Raspberry Pi 4, PC]
-- OS: [e.g., balenaOS, Raspberry Pi OS 64-bit Bookworm, Trixie (not supported)]
+- OS: [e.g., balenaOS, Raspberry Pi OS 64-bit Bookworm, Trixie]
 - Anthias Version: [e.g., v0.19.0]
 - Installation Method: [e.g., balenaHub, Release Image, Manual Installation]
 


### PR DESCRIPTION
### Issues Fixed

N/A

### Description

Removes the `(not supported)` qualifier from the Trixie OS example in the bug report template, since Trixie is now a supported platform.

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).