### PR TITLE
fix(build): use 64-bit balena base for pi4-64 viewer image

### DIFF
--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -28,7 +28,7 @@ def get_build_parameters(build_target: str) -> dict[str, Any]:
     elif build_target == 'pi4-64':
         return {
             'board': 'pi4',
-            'base_image': 'balenalib/raspberrypi3-debian',
+            'base_image': 'balenalib/raspberrypi3-64-debian',
             'target_platform': 'linux/arm64/v8',
         }
     elif build_target == 'pi3':


### PR DESCRIPTION
## Summary

- The `pi4-64` build target was added in #2767 by copy-pasting the existing `pi4` (armhf) entry and only flipping `target_platform` to `linux/arm64/v8`. `base_image` stayed on `balenalib/raspberrypi3-debian` — the 32-bit family base.
- Buildx silently produces an image that mixes the **armhf userland** with the **arm64 `AnthiasWebview` binary** shipped in the webview tarball. There is no `/lib/ld-linux-aarch64.so.1`, so the moment `viewer/__init__.py` calls `sh.Command('AnthiasWebview')` execv returns ENOENT and the viewer crash-loops.
- This PR switches the `pi4-64` `base_image` to `balenalib/raspberrypi3-64-debian` — the 64-bit sibling of the existing `pi4` entry, keeping the same family-base convention.

Symptom on `latest-pi4-64`:

```
File "/usr/src/app/viewer/__init__.py", line 117, in load_browser
  browser = sh.Command('AnthiasWebview')(_bg=True, _err_to_out=True)
...
FileNotFoundError: [Errno 2] No such file or directory
```

Inspection of `ghcr.io/screenly/anthias-viewer:latest-pi4-64` under qemu confirmed the mismatch:
- `/bin/bash` → ELF**32** ARM
- `libQt6Core.so.6` resolves under `/lib/arm-linux-gnueabihf/...`
- `/usr/local/bin/AnthiasWebview` → ELF**64** AArch64, INTERP `/lib/ld-linux-aarch64.so.1` (absent)

`balenalib/raspberrypi3-64-debian:bookworm` ships `/lib/ld-linux-aarch64.so.1`, fixing the missing-interpreter ENOENT.

## Test plan

- [ ] CI rebuilds and pushes `latest-pi4-64` from this branch.
- [ ] On a Pi 4 64-bit (e.g. `anthias-tester`): `cd ~/anthias && docker compose pull && docker compose up -d` — viewer no longer crash-loops.
- [ ] Inside the new viewer container: `readelf -h /bin/bash` reports ELF64 AArch64; `ldconfig -p | grep libQt6Core` resolves under `/lib/aarch64-linux-gnu/`; `/usr/local/bin/AnthiasWebview --version` does not produce ENOENT.
- [ ] Other build targets (`x86`, `pi5`, `pi4`, `pi3`, etc.) unaffected — this PR only changes the `pi4-64` arm of `get_build_parameters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)