### PR TITLE
fix(build): skip libraspberrypi0 for pi4-64 (arm64) builds

### DIFF
--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -80,7 +80,13 @@ def build_image(
         'sqlite3',
     ]
 
-    if board in ['pi1', 'pi2', 'pi3', 'pi4']:
+    # libraspberrypi0 ships only in the armhf raspberrypi3-debian apt repo;
+    # the arm64 sibling used by pi4-64 doesn't carry it, so exclude it
+    # there (matches how get_viewer_context already gates the package).
+    if (
+        board in ['pi1', 'pi2', 'pi3', 'pi4']
+        and target_platform != 'linux/arm64/v8'
+    ):
         base_apt_dependencies.extend(['libraspberrypi0'])
 
     # DEVICE_TYPE inside the container needs to be 'pi4-64' for the 64-bit


### PR DESCRIPTION
## Summary

After #2770 switched the `pi4-64` base to the arm64 balena sibling, the **server / celery / test** pi4-64 builds started failing in `apt-get install` with:

```
E: Unable to locate package libraspberrypi0
```

`libraspberrypi0` is only published for armhf in the `balenalib/raspberrypi3-debian` repo; the 64-bit `balenalib/raspberrypi3-64-debian` repo doesn't carry it — which is why pi5 and x86 builds never installed it. (`get_viewer_context` already excludes it via the `is_qt6` branch in `tools/image_builder/utils.py`.)

The package was being unconditionally added in `tools/image_builder/__main__.py`:

```python
if board in ['pi1', 'pi2', 'pi3', 'pi4']:
    base_apt_dependencies.extend(['libraspberrypi0'])
```

Pre-#2770 this happened to match only armhf boards. But `pi4-64` keeps `board == 'pi4'` — the build pipeline routes the 64-bit variant via `target_platform`, not a separate `board` name — so the same branch was taken for the arm64 build. Gate on `target_platform` too so arm64 pi4 skips the package.

## Test plan

- [ ] CI: pi4-64 server / celery / test buildx jobs go from red to green.
- [ ] Other boards (pi1/pi2/pi3/armhf-pi4) still install `libraspberrypi0`.
- [ ] pi5 / x86 builds unchanged (those `board` values aren't in the gating list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)