### PR TITLE
fix(install): accept Python >=3.11 on host instead of pinning to 3.11

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -201,11 +201,15 @@ function install_ansible() {
     fi
 
     # Resolve and install the `host` dependency group from pyproject.toml.
-    # uv will fetch a compatible Python automatically (the project requires
-    # >=3.11), so this works on Debian 11 too.
+    # `--python ">=3.11"` overrides the repo's .python-version (3.11) so the
+    # installer accepts whatever interpreter the host already ships — Bookworm
+    # has 3.11, Trixie has 3.13. Without this, uv would insist on 3.11 and
+    # fail on Trixie/Pi 2 (armv7l), where there's no system 3.11 and uv has
+    # no managed download for that arch.
     UV_PROJECT_ENVIRONMENT="${INSTALLER_VENV}" \
         uv sync \
             --project "${ANTHIAS_REPO_DIR}" \
+            --python ">=3.11" \
             --no-default-groups \
             --group host \
             --no-install-project


### PR DESCRIPTION
## Summary
- The repo's `.python-version` pins to `3.11`. Trixie (Debian 13) ships Python 3.13 only, and uv 0.9.17 has no managed-Python download for `armv7l` (Pi 2 32-bit), so `bin/install.sh` aborts on a fresh Pi OS Light Trixie image with `error: No interpreter found for Python 3.11 in managed installations or search path`.
- Pass `--python ">=3.11"` to the installer's `uv sync` to override `.python-version` for that one call. The `host` dependency group (ansible-core, getmac, netifaces2, redis, requests, tenacity) runs fine on 3.13.
- Bookworm hosts (Pi 4/5, current x86 images) keep using their system 3.11 — no behavior change there.

Fixes #2772.

## Test plan
- [ ] Fresh Pi OS Light Trixie on Pi 2: `bash <(curl -sL https://install-anthias.srly.io)` reaches "Run the Anthias Ansible Playbook" without the Python interpreter error.
- [ ] Existing Bookworm host (e.g. Pi 4): re-run installer, confirm `installer_venv` still uses system Python 3.11 and host deps install cleanly.
- [ ] x86 Trixie/Bookworm host: installer completes.

Reproduced the original error locally by uninstalling managed 3.11 and running `uv sync` against this repo with downloads disabled — same `No interpreter found for Python 3.11 …` message. Adding `--python ">=3.11"` makes uv accept the system 3.12/3.13 and the sync succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)