### PR TITLE
fix(viewer): route pi4-64 to mpv and enable HW decode

### DIFF
--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -120,10 +120,13 @@ class TestMediaPlayerProxy(unittest.TestCase):
         for device_type in ['pi1', 'pi2', 'pi3', 'pi4']:
             with self.subTest(device_type=device_type):
                 MediaPlayerProxy.INSTANCE = None
-                with patch(
-                    'viewer.media_player.get_device_type',
-                    return_value=device_type,
-                ), patch.dict('os.environ', {'DEVICE_TYPE': device_type}):
+                with (
+                    patch(
+                        'viewer.media_player.get_device_type',
+                        return_value=device_type,
+                    ),
+                    patch.dict('os.environ', {'DEVICE_TYPE': device_type}),
+                ):
                     with patch.object(
                         VLCMediaPlayer, '__init__', return_value=None
                     ):
@@ -143,9 +146,10 @@ class TestMediaPlayerProxy(unittest.TestCase):
 
     def test_get_instance_returns_mpv_for_pi4_64(self) -> None:
         MediaPlayerProxy.INSTANCE = None
-        with patch(
-            'viewer.media_player.get_device_type', return_value='pi4'
-        ), patch.dict('os.environ', {'DEVICE_TYPE': 'pi4-64'}):
+        with (
+            patch('viewer.media_player.get_device_type', return_value='pi4'),
+            patch.dict('os.environ', {'DEVICE_TYPE': 'pi4-64'}),
+        ):
             instance = MediaPlayerProxy.get_instance()
         self.assertIsInstance(instance, MPVMediaPlayer)
 

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -29,6 +29,7 @@ class TestMPVMediaPlayer(unittest.TestCase):
                 'mpv',
                 '--no-terminal',
                 '--vo=drm',
+                '--hwdec=auto-safe',
                 '--',
                 'file:///test/video.mp4',
             ],
@@ -122,7 +123,7 @@ class TestMediaPlayerProxy(unittest.TestCase):
                 with patch(
                     'viewer.media_player.get_device_type',
                     return_value=device_type,
-                ):
+                ), patch.dict('os.environ', {'DEVICE_TYPE': device_type}):
                     with patch.object(
                         VLCMediaPlayer, '__init__', return_value=None
                     ):
@@ -139,6 +140,14 @@ class TestMediaPlayerProxy(unittest.TestCase):
                 ):
                     instance = MediaPlayerProxy.get_instance()
                 self.assertIsInstance(instance, MPVMediaPlayer)
+
+    def test_get_instance_returns_mpv_for_pi4_64(self) -> None:
+        MediaPlayerProxy.INSTANCE = None
+        with patch(
+            'viewer.media_player.get_device_type', return_value='pi4'
+        ), patch.dict('os.environ', {'DEVICE_TYPE': 'pi4-64'}):
+            instance = MediaPlayerProxy.get_instance()
+        self.assertIsInstance(instance, MPVMediaPlayer)
 
     @patch('viewer.media_player.get_device_type', return_value='pi5')
     def test_get_instance_returns_same_instance(self, _: Any) -> None:

--- a/viewer/media_player.py
+++ b/viewer/media_player.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 from typing import ClassVar
 
@@ -38,7 +39,14 @@ class MPVMediaPlayer(MediaPlayer):
 
     def play(self) -> None:
         self.process = subprocess.Popen(
-            ['mpv', '--no-terminal', '--vo=drm', '--', self.uri],
+            [
+                'mpv',
+                '--no-terminal',
+                '--vo=drm',
+                '--hwdec=auto-safe',
+                '--',
+                self.uri,
+            ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -118,7 +126,14 @@ class MediaPlayerProxy:
     @classmethod
     def get_instance(cls) -> MediaPlayer:
         if cls.INSTANCE is None:
-            if get_device_type() in ['pi1', 'pi2', 'pi3', 'pi4']:
+            # pi4-64 runs Qt6 + linuxfb like pi5/x86, so VLC's GL/GLES2/XCB
+            # outputs have no parent window to draw into. Route it to mpv,
+            # which renders straight to KMS via --vo=drm.
+            is_pi4_64 = os.environ.get('DEVICE_TYPE') == 'pi4-64'
+            if (
+                get_device_type() in ['pi1', 'pi2', 'pi3', 'pi4']
+                and not is_pi4_64
+            ):
                 cls.INSTANCE = VLCMediaPlayer()
             else:
                 cls.INSTANCE = MPVMediaPlayer()


### PR DESCRIPTION
### Issues Fixed

Fixes the pi4-64 viewer crash-loop where VLC fails with `parent window not available` and the viewer container restarts indefinitely.

### Description

The pi4-64 image runs Qt6 + `QT_QPA_PLATFORM=linuxfb` (same stack as pi5/x86), but `MediaPlayerProxy` was still routing pi4-64 to `VLCMediaPlayer` because `lib/device_helper.get_device_type()` reads `/proc/device-tree/model` and can't tell the 32-bit Pi 4 image from the 64-bit one. VLC's GL/GLES2/XCB video outputs all require a parent window that doesn't exist under linuxfb, so it walks the full output list, falls back to caca (which also fails: `Error opening terminal: unknown.`), and the viewer process dies.

Two changes:

- `MediaPlayerProxy.get_instance()` now checks `os.environ['DEVICE_TYPE']` (set to `'pi4-64'` by the image builder per `tools/image_builder/__main__.py`) and routes that build to `MPVMediaPlayer` like pi5/x86. Pi 4 32-bit (`DEVICE_TYPE=pi4`) keeps using VLC.
- Pass `--hwdec=auto-safe` to mpv so it picks V4L2 M2M H.264 HW decode on Pi 4 and VAAPI/VDPAU on x86, with a software fallback elsewhere (Pi 5's BCM2712 dropped the H.264 HW block, so it stays software regardless).

Considered folding video into the Qt6 webview (`QMediaPlayer` or HTML5 `<video>` in QtWebEngine) but research turned up an open Qt 6.7.2 forum thread where the FFmpeg backend can't decode H.264 on Pi 5 at all, the Qt wiki explicitly states QtWebEngine has no HW video decode, and `linuxfb` rules out the only Qt6 HW-decode path that has working blog evidence (`eglfs_kms` + V4L2 DRM-plane sink). Subprocess + mpv is what info-beamer / Arexibo / PiSignage all do on this hardware.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)