### PR TITLE
fix(viewer): honor audio_output in mpv and clean up container env

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -16,11 +16,22 @@ chown -f viewer /data/.anthias/latest_anthias_sha
 # Fixes caching in QTWebEngine
 mkdir -p /data/.local/share/AnthiasWebview/QtWebEngine \
     /data/.cache/AnthiasWebview \
+    /data/.cache/fontconfig \
     /data/.pki
 
 chown -Rf viewer /data/.local/share/AnthiasWebview
 chown -Rf viewer /data/.cache/AnthiasWebview/
+chown -Rf viewer /data/.cache/fontconfig
 chown -Rf viewer /data/.pki
+
+# Qt + dbus + various Linux apps look up XDG_RUNTIME_DIR; without it they
+# log warnings and fall back to ad-hoc paths. Provide a per-uid runtime
+# dir owned by the viewer user.
+VIEWER_UID=$(id -u viewer)
+export XDG_RUNTIME_DIR="/run/user/${VIEWER_UID}"
+mkdir -p "${XDG_RUNTIME_DIR}"
+chown viewer:video "${XDG_RUNTIME_DIR}"
+chmod 700 "${XDG_RUNTIME_DIR}"
 
 # Temporary workaround for watchdog
 touch /tmp/anthias.watchdog
@@ -38,14 +49,22 @@ chmod -f 4755 /usr/bin/sudo
 # Prevent it so that the container does not fail
 trap '' 16
 
-# Disable swapping
-echo 0 >  /sys/fs/cgroup/memory/memory.swappiness
+# Disable swapping. Path is cgroup v1 only; cgroup v2 hosts (modern
+# Debian / Ubuntu / Raspberry Pi OS Bookworm) don't expose it, so guard
+# the write to avoid a noisy "No such file or directory" on every boot.
+if [ -w /sys/fs/cgroup/memory/memory.swappiness ]; then
+    echo 0 > /sys/fs/cgroup/memory/memory.swappiness
+fi
 
 # Start viewer.
 # sudo resets PATH to its secure_path, so resolve python via the
 # absolute venv path instead — `python` on PATH would otherwise hit
 # the system interpreter, which has no Anthias deps installed.
-sudo -E -u viewer dbus-run-session /venv/bin/python -m viewer &
+# --preserve-env=XDG_RUNTIME_DIR forces sudo to forward the runtime dir
+# we just set; -E alone is subject to env_check / env_delete and is not
+# guaranteed for XDG_* on Debian's default sudoers.
+sudo --preserve-env=XDG_RUNTIME_DIR -E -u viewer \
+    dbus-run-session /venv/bin/python -m viewer &
 
 # Wait for the viewer
 while true; do

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -8,6 +8,7 @@ from viewer.media_player import (
     MPVMediaPlayer,
     MediaPlayerProxy,
     VLCMediaPlayer,
+    get_alsa_audio_device,
 )
 
 logging.disable(logging.CRITICAL)
@@ -16,6 +17,19 @@ logging.disable(logging.CRITICAL)
 class TestMPVMediaPlayer(unittest.TestCase):
     def setUp(self) -> None:
         self.player = MPVMediaPlayer()
+
+        self.patch_settings = patch('viewer.media_player.settings')
+        self.patch_device_type = patch(
+            'viewer.media_player.get_device_type', return_value='pi4'
+        )
+
+        self.mock_settings = self.patch_settings.start()
+        self.mock_settings.__getitem__.return_value = 'hdmi'
+        self.patch_device_type.start()
+
+    def tearDown(self) -> None:
+        self.patch_settings.stop()
+        self.patch_device_type.stop()
 
     @patch('viewer.media_player.subprocess.Popen')
     def test_play_invokes_popen_with_expected_args(
@@ -30,12 +44,30 @@ class TestMPVMediaPlayer(unittest.TestCase):
                 '--no-terminal',
                 '--vo=drm',
                 '--hwdec=auto-safe',
+                '--audio-device=alsa/default:CARD=vc4hdmi0',
                 '--',
                 'file:///test/video.mp4',
             ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+
+    @patch('viewer.media_player.subprocess.Popen')
+    def test_play_uses_local_audio_device_when_configured(
+        self, mock_popen: Any
+    ) -> None:
+        self.mock_settings.__getitem__.return_value = 'local'
+        self.player.set_asset('file:///test/video.mp4', 30)
+        self.player.play()
+
+        args, _ = mock_popen.call_args
+        self.assertIn('--audio-device=alsa/plughw:CARD=Headphones', args[0])
+
+    @patch('viewer.media_player.subprocess.Popen')
+    def test_play_reloads_settings_each_call(self, mock_popen: Any) -> None:
+        self.player.set_asset('file:///test/video.mp4', 30)
+        self.player.play()
+        self.mock_settings.load.assert_called_once()
 
     @patch('viewer.media_player.subprocess.Popen')
     def test_is_playing_returns_true_when_process_running(
@@ -77,6 +109,63 @@ class TestMPVMediaPlayer(unittest.TestCase):
 
         mock_process.terminate.assert_called_once()
         self.assertIsNone(self.player.process)
+
+
+class TestGetAlsaAudioDevice(unittest.TestCase):
+    def setUp(self) -> None:
+        self.patch_settings = patch('viewer.media_player.settings')
+        self.mock_settings = self.patch_settings.start()
+
+    def tearDown(self) -> None:
+        self.patch_settings.stop()
+
+    def test_local_on_pi5_uses_hdmi_card(self) -> None:
+        self.mock_settings.__getitem__.return_value = 'local'
+        with patch('viewer.media_player.get_device_type', return_value='pi5'):
+            self.assertEqual(get_alsa_audio_device(), 'default:CARD=vc4hdmi0')
+
+    def test_local_on_other_pi_uses_headphones(self) -> None:
+        self.mock_settings.__getitem__.return_value = 'local'
+        for device_type in ['pi1', 'pi2', 'pi3', 'pi4']:
+            with self.subTest(device_type=device_type):
+                with patch(
+                    'viewer.media_player.get_device_type',
+                    return_value=device_type,
+                ):
+                    self.assertEqual(
+                        get_alsa_audio_device(),
+                        'plughw:CARD=Headphones',
+                    )
+
+    def test_hdmi_on_pi4_pi5_uses_vc4hdmi0(self) -> None:
+        self.mock_settings.__getitem__.return_value = 'hdmi'
+        for device_type in ['pi4', 'pi5']:
+            with self.subTest(device_type=device_type):
+                with patch(
+                    'viewer.media_player.get_device_type',
+                    return_value=device_type,
+                ):
+                    self.assertEqual(
+                        get_alsa_audio_device(),
+                        'default:CARD=vc4hdmi0',
+                    )
+
+    def test_hdmi_on_pi1_pi2_pi3_uses_vc4hdmi(self) -> None:
+        self.mock_settings.__getitem__.return_value = 'hdmi'
+        for device_type in ['pi1', 'pi2', 'pi3']:
+            with self.subTest(device_type=device_type):
+                with patch(
+                    'viewer.media_player.get_device_type',
+                    return_value=device_type,
+                ):
+                    self.assertEqual(
+                        get_alsa_audio_device(), 'default:CARD=vc4hdmi'
+                    )
+
+    def test_hdmi_on_x86_falls_back_to_hid(self) -> None:
+        self.mock_settings.__getitem__.return_value = 'hdmi'
+        with patch('viewer.media_player.get_device_type', return_value='x86'):
+            self.assertEqual(get_alsa_audio_device(), 'default:CARD=HID')
 
 
 class TestVLCMediaPlayer(unittest.TestCase):

--- a/viewer/media_player.py
+++ b/viewer/media_player.py
@@ -11,6 +11,21 @@ from settings import settings
 VIDEO_TIMEOUT = 20  # secs
 
 
+def get_alsa_audio_device() -> str:
+    if settings['audio_output'] == 'local':
+        if get_device_type() == 'pi5':
+            return 'default:CARD=vc4hdmi0'
+
+        return 'plughw:CARD=Headphones'
+    else:
+        if get_device_type() in ['pi4', 'pi5']:
+            return 'default:CARD=vc4hdmi0'
+        elif get_device_type() in ['pi1', 'pi2', 'pi3']:
+            return 'default:CARD=vc4hdmi'
+        else:
+            return 'default:CARD=HID'
+
+
 class MediaPlayer:
     def __init__(self) -> None:
         pass
@@ -38,12 +53,16 @@ class MPVMediaPlayer(MediaPlayer):
         self.uri = uri
 
     def play(self) -> None:
+        # Re-read settings each play so the audio_output dropdown takes
+        # effect without a viewer restart, matching VLCMediaPlayer.
+        settings.load()
         self.process = subprocess.Popen(
             [
                 'mpv',
                 '--no-terminal',
                 '--vo=drm',
                 '--hwdec=auto-safe',
+                f'--audio-device=alsa/{get_alsa_audio_device()}',
                 '--',
                 self.uri,
             ],
@@ -69,37 +88,16 @@ class VLCMediaPlayer(MediaPlayer):
     def __init__(self) -> None:
         MediaPlayer.__init__(self)
 
-        options = self.__get_options()
+        options = [f'--alsa-audio-device={get_alsa_audio_device()}']
         self.instance = vlc.Instance(options)
         self.player = self.instance.media_player_new()
 
         self.player.audio_output_set('alsa')
 
-    def get_alsa_audio_device(self) -> str:
-        if settings['audio_output'] == 'local':
-            if get_device_type() == 'pi5':
-                return 'default:CARD=vc4hdmi0'
-
-            return 'plughw:CARD=Headphones'
-        else:
-            if get_device_type() in ['pi4', 'pi5']:
-                return 'default:CARD=vc4hdmi0'
-            elif get_device_type() in ['pi1', 'pi2', 'pi3']:
-                return 'default:CARD=vc4hdmi'
-            else:
-                return 'default:CARD=HID'
-
-    def __get_options(self) -> list[str]:
-        return [
-            f'--alsa-audio-device={self.get_alsa_audio_device()}',
-        ]
-
     def set_asset(self, uri: str, duration: int | str) -> None:
         self.player.set_mrl(uri)
         settings.load()
-        self.player.audio_output_device_set(
-            'alsa', self.get_alsa_audio_device()
-        )
+        self.player.audio_output_device_set('alsa', get_alsa_audio_device())
         # Use synchronous parse() to pre-load file metadata before play() is
         # called. parse_with_options() is async and returns before metadata is
         # ready, which negates the pre-loading benefit and causes the same


### PR DESCRIPTION
### Issues Fixed

Follow-up to #2774. Cleans up the remaining warnings in the viewer container log and restores a behaviour that silently regressed on mpv boards.

### Description

Two related changes in one PR per offline discussion:

**1. `MPVMediaPlayer` now honours `settings['audio_output']`.**

`VLCMediaPlayer` passed `--alsa-audio-device=...` and respected the "Audio output" UI dropdown ('hdmi' vs 'local'). `MPVMediaPlayer` passed nothing, so the dropdown was a silent no-op on pi5, x86, and (after #2774) pi4-64.

- Lifted `get_alsa_audio_device()` from `VLCMediaPlayer` to module level so both players share it.
- `MPVMediaPlayer.play()` now passes `--audio-device=alsa/<card>` and reloads `settings` on each call so the user can flip the dropdown without a viewer restart, matching VLC's behaviour.

**2. `bin/start_viewer.sh` env hygiene.**

Three log-noise sources, none of them new but all visible in the recent pi4-64 viewer.log:

- `/sys/fs/cgroup/memory/memory.swappiness: No such file or directory` — cgroup v1 path on cgroup v2 hosts (modern Bookworm). Guarded the write with `[ -w ... ]` so it's a no-op where the file doesn't exist.
- `Fontconfig error: No writable cache directories` — `mkdir`/`chown` `/data/.cache/fontconfig` so Qt/QtWebEngine has a writable cache (`HOME=/data` is set in compose).
- `error: XDG_RUNTIME_DIR is invalid or not set in the environment` — set `/run/user/$(id -u viewer)`, create + chown it. Used `sudo --preserve-env=XDG_RUNTIME_DIR` because `-E` alone is subject to Debian's `env_check` and isn't guaranteed to forward `XDG_*`.

### Test coverage

- `TestGetAlsaAudioDevice` — direct unit tests for every branch (local on pi5, local on pi1-pi4, hdmi on pi4/pi5, hdmi on pi1-pi3, hdmi fallback on x86).
- `TestMPVMediaPlayer` — updated `test_play_invokes_popen_with_expected_args` for the new arg, added `test_play_uses_local_audio_device_when_configured` and `test_play_reloads_settings_each_call`.
- VLC tests unchanged behaviourally (the helper just moved).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)