### PR TITLE
fix(install): resolve release tags via refs/tags/ in clone_repo

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -177,7 +177,23 @@ function clone_repo() {
     fi
     git -C "${ANTHIAS_REPO_DIR}" fetch --tags origin
     git -C "${ANTHIAS_REPO_DIR}" checkout "${BRANCH}"
-    git -C "${ANTHIAS_REPO_DIR}" reset --hard "origin/${BRANCH}"
+
+    # Releases are pinned via tags (e.g. v0.20.5), which fetch into
+    # refs/tags/ — `origin/v0.20.5` is not a valid ref. Resolve tags
+    # explicitly via refs/tags/${BRANCH} and fall through to
+    # origin/${BRANCH} only for actual branches.
+    local RESET_REF
+    if git -C "${ANTHIAS_REPO_DIR}" show-ref --verify --quiet \
+        "refs/tags/${BRANCH}"; then
+        RESET_REF="refs/tags/${BRANCH}"
+    elif git -C "${ANTHIAS_REPO_DIR}" show-ref --verify --quiet \
+        "refs/remotes/origin/${BRANCH}"; then
+        RESET_REF="origin/${BRANCH}"
+    else
+        echo "error: '${BRANCH}' is neither a tag nor a remote branch" >&2
+        exit 1
+    fi
+    git -C "${ANTHIAS_REPO_DIR}" reset --hard "${RESET_REF}"
 }
 
 function install_ansible() {


### PR DESCRIPTION
### Issues Fixed

Fixes #2786.

### Description

Tagged installs (`v0.20.4`, `v0.20.5`) aborted with:

```
fatal: ambiguous argument 'origin/v0.20.4': unknown revision or path not in the working tree.
```

`clone_repo()` always reset to `origin/${BRANCH}`. Releases are pinned via tags, and `git fetch --tags origin` fetches them into `refs/tags/` — there is no `refs/remotes/origin/<tag>` (that namespace is for remote-tracking branches only), so the reset blew up on every tagged install.

Fix: resolve `${BRANCH}` explicitly — `refs/tags/${BRANCH}` for tags, `origin/${BRANCH}` for branches, hard error if neither exists.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).