### PR TITLE
fix(viewer): use v4l2m2m-copy for Pi 4 HW decode, not drm-copy

### DIFF
--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -54,13 +54,15 @@ class TestMPVMediaPlayer(unittest.TestCase):
         )
 
     @patch('viewer.media_player.subprocess.Popen')
-    def test_play_uses_drm_copy_hwdec_on_pi4_64(self, mock_popen: Any) -> None:
+    def test_play_uses_v4l2m2m_copy_hwdec_on_pi4_64(
+        self, mock_popen: Any
+    ) -> None:
         self.player.set_asset('file:///test/video.mp4', 30)
         with patch.dict('os.environ', {'DEVICE_TYPE': 'pi4-64'}):
             self.player.play()
 
         args, _ = mock_popen.call_args
-        self.assertIn('--hwdec=drm-copy,auto-safe', args[0])
+        self.assertIn('--hwdec=v4l2m2m-copy', args[0])
 
     @patch('viewer.media_player.subprocess.Popen')
     def test_play_uses_local_audio_device_when_configured(

--- a/viewer/media_player.py
+++ b/viewer/media_player.py
@@ -57,14 +57,17 @@ class MPVMediaPlayer(MediaPlayer):
         # effect without a viewer restart, matching VLCMediaPlayer.
         settings.load()
 
-        # mpv's `auto-safe` whitelist is essentially {vaapi,vdpau,nvdec,
-        # videotoolbox,mediacodec,dxva2,d3d11va}-copy — none of which
-        # exist on a Pi 4. The Pi 4's H.264 block is exposed via
-        # DRM-PRIME / h264_v4l2m2m, which auto-safe excludes, so on
-        # pi4-64 mpv silently falls back to CPU decode and drops frames
-        # at 1080p. Prefer drm-copy there and fall back to auto-safe.
+        # The Pi 4's H.264/HEVC block is reached through libavcodec's
+        # `h264_v4l2m2m` (and siblings) wrapper decoders, exposed in mpv
+        # as `--hwdec=v4l2m2m-copy`. It is *not* a hwaccel attached to
+        # the standard `h264` decoder, so it is not in mpv's auto-safe
+        # whitelist (see vd_lavc.c hwdec_autoprobe_info) — `auto-safe`
+        # silently falls through to the software h264 decoder, which
+        # the Cortex-A72 can't keep up with at 1080p. Name it
+        # explicitly on pi4-64; mpv falls back to software on its own
+        # if v4l2m2m-copy fails to init.
         is_pi4_64 = os.environ.get('DEVICE_TYPE') == 'pi4-64'
-        hwdec = 'drm-copy,auto-safe' if is_pi4_64 else 'auto-safe'
+        hwdec = 'v4l2m2m-copy' if is_pi4_64 else 'auto-safe'
 
         self.process = subprocess.Popen(
             [


### PR DESCRIPTION
### Issues Fixed

Follow-up to #2777 — pi4-64 still drops video frames because the hwdec value chosen there does not actually engage the Pi 4 hardware codec.

### Description

#2777 set `--hwdec=drm-copy,auto-safe` on pi4-64, but neither value engages the Pi 4 H.264 block:

- **`drm-copy`** maps to libavcodec's `AV_HWDEVICE_TYPE_DRM` hwaccel, which is used by V4L2-stateless / DRM-PRIME drivers (cedrus etc.). The Pi 4's hardware codec is the V4L2 **stateful** M2M API, which ffmpeg exposes as the `h264_v4l2m2m` *wrapper decoder* — not a hwaccel attached to the standard `h264` decoder. Confirmed against the arm64 bookworm viewer image: `mpv --hwdec=help` lists no `h264-drm` / `h264-drm-copy` entries, only `h264_v4l2m2m-v4l2m2m-copy`.
- **`auto-safe`** walks mpv's whitelist in `vd_lavc.c` `hwdec_autoprobe_info` (vaapi/vdpau/nvdec/dxva2/d3d11va/videotoolbox/mediacodec/drm/mmal + `-copy` variants). v4l2m2m is deliberately *not* in that list — wrapper decoders only register via explicit selection — so auto-safe falls through to software h264, which the Cortex-A72 can't keep up with at 1080p.

Switch pi4-64 to `--hwdec=v4l2m2m-copy`. mpv falls back to software on its own if v4l2m2m-copy fails to init, so no explicit tail is needed. Other boards (pi5, x86) keep `auto-safe` unchanged.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).