### PR TITLE
ci(sbom): version SBOMs by SHA on master, by tag on releases

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'bun.lock'
       - 'uv.lock'
+    tags:
+      - 'v*'
 
 jobs:
   run-tests:
@@ -29,6 +31,7 @@ jobs:
         env:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: 'LCkvzm8qaL'
+          COMPONENT_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
           LOCK_FILE: 'bun.lock'
           AUGMENT: true
           UPLOAD: true
@@ -56,6 +59,7 @@ jobs:
         env:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: 'Vhc4zm8pdV'
+          COMPONENT_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
           LOCK_FILE: 'uv.lock'
           AUGMENT: true
           UPLOAD: true


### PR DESCRIPTION
## Summary
- Master pushes were failing the SBOM workflow with `SBOM already exists for this component version` because `COMPONENT_VERSION` was unset on the sbomify action — every rolling-release run uploaded under the same effective version. Fix by setting `COMPONENT_VERSION` per push: `github.sha` on master, `github.ref_name` on a `v*` tag.
- Adds a `tags: ['v*']` filter so a release tag always rebuilds and uploads SBOMs (the `paths` filter is bypassed for tag pushes, so this is safe to combine with the existing master path filter).
- Result: only git tags constitute a product release version on sbomify; everything between releases is recorded under its SHA so dedup never collides.

Fixes the failure in [run 25170869276](https://github.com/Screenly/Anthias/actions/runs/25170869276/job/73790137421).

## Test plan
- [ ] Merge and confirm next master push to `bun.lock` / `uv.lock` produces an SBOM versioned with the merge commit SHA.
- [ ] Cut a `v*` tag and confirm both `js-sbom` and `python-sbom` jobs run and upload with the tag name as the component version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)