### PR TITLE
fix(build): bump WebView to v2026.04.1 for trixie artifacts

### DIFF
--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -125,7 +125,7 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
     # while the new WebView-v* tag is still being cut, since
     # Dockerfile.viewer.j2 will otherwise 404 when fetching the
     # not-yet-published artifact.
-    webview_version = os.environ.get('WEBVIEW_VERSION', '2026.04.0')
+    webview_version = os.environ.get('WEBVIEW_VERSION', '2026.04.1')
     webview_base_url = f'{releases_url}/WebView-v{webview_version}'
 
     is_qt6 = board in ['pi5', 'pi4-64', 'x86']


### PR DESCRIPTION
## Summary
- The Trixie merge (d9ebc805) flipped `debian_version` to `trixie` in `tools/image_builder/__main__.py:119` but left `webview_version` pinned at `2026.04.0`.
- The `WebView-v2026.04.0` release only contains `bookworm-*` assets; the `trixie-*` tarballs (qt5 + webview, all five boards) were published under `WebView-v2026.04.1` earlier today.
- Combined URL `WebView-v2026.04.0/webview-2026.04.0-trixie-<board>.tar.gz` 404s; `sha256sum -c` then sees the HTML body and aborts with "no properly formatted checksum lines found", failing every buildx job. Confirmed in [run 25179831757 / x86](https://github.com/Screenly/Anthias/actions/runs/25179831757/job/73822228535).
- Bump default `webview_version` to `2026.04.1` to match the release that actually has the trixie artifacts.

## Test plan
- [ ] All five `buildx` matrix jobs (pi2, pi3, pi4-64, pi5, x86) succeed on this PR
- [ ] Spot-check one rendered `Dockerfile.viewer` URL points at `WebView-v2026.04.1/webview-2026.04.1-trixie-<board>.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)