### PR TITLE
chore(build): trim runtime apt deps (drop X11/XCB, VLC on Qt6)

### DIFF
--- a/bin/wait.py
+++ b/bin/wait.py
@@ -3,10 +3,12 @@ import time
 import sh
 
 
-# wait for default route
+# Wait for a default route. `ip route` ships in iproute2 (already in
+# the base debian:trixie image); the previous implementation used
+# `route` from net-tools, which was dropped from the runtime apt set.
 def is_routing_up() -> bool:
     try:
-        sh.grep('default', _in=sh.route())
+        sh.grep('default', _in=sh.ip('route'))
         return True
     except sh.ErrorReturnCode_1:
         return False

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -354,19 +354,30 @@ def url_fails(url: str) -> bool:
     If it is streaming
     """
     if urlparse(url).scheme in ('rtsp', 'rtmp'):
+        # ffprobe ships with ffmpeg, which is already in the base
+        # image. Exit code 0 means libavformat could open the stream
+        # and read its header; non-zero means it could not. The
+        # 15s wall-clock cap mirrors the implicit cap mplayer gave us
+        # via `-frames 0` (it would tear down once it had probed the
+        # stream) and prevents a stuck RTSP handshake from hanging
+        # the API request that called us.
         try:
-            run_mplayer = sh.Command('mplayer')(
-                '-identify', '-frames', '0', '-nosound', url
+            sh.Command('ffprobe')(
+                '-v',
+                'quiet',
+                '-show_streams',
+                '-i',
+                url,
+                _timeout=15,
             )
         except sh.CommandNotFound:
             logging.warning(
-                'mplayer is not installed; skipping streaming URL probe'
+                'ffprobe is not installed; skipping streaming URL probe'
             )
             return False
-        for line in run_mplayer.split('\n'):
-            if 'Clip info:' in line:
-                return False
-        return True
+        except (sh.TimeoutException, sh.ErrorReturnCode):
+            return True
+        return False
 
     """
     Try HEAD and GET for URL availability check.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,9 @@
 
 import unittest
 from datetime import datetime
+from unittest.mock import patch
 
+import sh
 from django.test import TestCase
 
 from lib.utils import handler, template_handle_unicode, url_fails
@@ -34,3 +36,29 @@ class URLHelperTest(TestCase):
 
     def test_url_3(self) -> None:
         self.assertFalse(url_fails(uri_))
+
+
+class StreamingURLProbeTest(TestCase):
+    def test_rtsp_ffprobe_success_returns_false(self) -> None:
+        with patch('lib.utils.sh.Command') as mock_command:
+            mock_command.return_value.return_value = ''
+            self.assertFalse(url_fails('rtsp://example.com/stream'))
+            mock_command.assert_called_once_with('ffprobe')
+
+    def test_rtmp_ffprobe_nonzero_exit_returns_true(self) -> None:
+        err = sh.ErrorReturnCode_1('ffprobe', b'', b'cannot open stream')
+        with patch('lib.utils.sh.Command') as mock_command:
+            mock_command.return_value.side_effect = err
+            self.assertTrue(url_fails('rtmp://example.com/live'))
+
+    def test_rtsp_ffprobe_timeout_returns_true(self) -> None:
+        with patch('lib.utils.sh.Command') as mock_command:
+            mock_command.return_value.side_effect = sh.TimeoutException(
+                124, 'ffprobe ...'
+            )
+            self.assertTrue(url_fails('rtsp://example.com/stream'))
+
+    def test_rtsp_ffprobe_missing_returns_false(self) -> None:
+        with patch('lib.utils.sh.Command') as mock_command:
+            mock_command.side_effect = sh.CommandNotFound('ffprobe')
+            self.assertFalse(url_fails('rtsp://example.com/stream'))

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -62,27 +62,26 @@ def build_image(
                 fg='yellow',
             )
 
+    # Runtime-only base set. Compilers and *-dev headers live in the
+    # uv-builder stage (docker/uv-builder.j2); the runtime image gets
+    # the venv COPY'd in pre-built, so anything builder-only would just
+    # be dead weight here. `libcec6` is the runtime SONAME the cec
+    # Python wheel (built in uv-builder) dlopens at import time.
+    # `python3-gi` stays because pydbus does `from gi.repository import
+    # GLib, Gio` at import — viewer's `--system-site-packages` venv
+    # picks it up from the system site-packages.
     base_apt_dependencies = [
-        'build-essential',
         'cec-utils',
         'curl',
         'ffmpeg',
         'git',
-        'ifupdown',
-        'libcec-dev',
-        'libffi-dev',
-        'libssl-dev',
+        'libcec6',
         'lsb-release',
-        'mplayer',
-        'net-tools',
         'procps',
         'psmisc',
-        'python3-dev',
         'python3-gi',
-        'python3-pil',
         'python3-pip',
         'python3-setuptools',
-        'python3-simplejson',
         'python-is-python3',
         'sudo',
         'sqlite3',

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -65,17 +65,22 @@ def build_image(
     # Runtime-only base set. Compilers and *-dev headers live in the
     # uv-builder stage (docker/uv-builder.j2); the runtime image gets
     # the venv COPY'd in pre-built, so anything builder-only would just
-    # be dead weight here. `libcec6` is the runtime SONAME the cec
-    # Python wheel (built in uv-builder) dlopens at import time.
-    # `python3-gi` stays because pydbus does `from gi.repository import
-    # GLib, Gio` at import — viewer's `--system-site-packages` venv
-    # picks it up from the system site-packages.
+    # be dead weight here. `libcec7` is the runtime SONAME the cec
+    # Python wheel (built in uv-builder) dlopens at import time —
+    # debian:trixie shipped libcec 7.0 (Ubuntu still has libcec6, easy
+    # to mix up). `iproute2` is needed by bin/wait.py — debian:trixie's
+    # base image ships neither iproute2 nor net-tools by default, so
+    # we install it explicitly. `python3-gi` stays because pydbus does
+    # `from gi.repository import GLib, Gio` at import — viewer's
+    # `--system-site-packages` venv picks it up from the system
+    # site-packages.
     base_apt_dependencies = [
         'cec-utils',
         'curl',
         'ffmpeg',
         'git',
-        'libcec6',
+        'iproute2',
+        'libcec7',
         'lsb-release',
         'procps',
         'psmisc',

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -141,7 +141,7 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
     qt_major_version = qt_version.split('.')[0]
 
     # Viewer-only apt deps. The shared runtime set (cec-utils, curl,
-    # ffmpeg, git, libcec6, procps, psmisc, python-is-python3,
+    # ffmpeg, git, libcec7, procps, psmisc, python-is-python3,
     # python3-gi, python3-pip, python3-setuptools, sqlite3, sudo,
     # plus libraspberrypi0 on 32-bit Pi boards) is installed by
     # Dockerfile.base.j2 in a layer that server (and test) also use,

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -212,6 +212,13 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
         'libvpx-dev',
         'libwebp-dev',
         'libxkbcommon0',
+        # The prebuilt WebView binary dlopens libharfbuzz-subset.so.0
+        # (Chromium's font-subsetting path). It's pulled in
+        # transitively by qt6-webengine-dev on Qt6 boards but nothing
+        # on Qt5 brings it, so the lib was simply missing on pi2/pi3
+        # in production (pre-existing bug, not a regression here).
+        # 200 KB, easier to just install everywhere than gate on board.
+        'libharfbuzz-subset0',
         'python3-netifaces',
         'fonts-wqy-zenhei',
     ]

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -140,13 +140,27 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
 
     qt_major_version = qt_version.split('.')[0]
 
-    # Viewer-only apt deps. The shared set (build-essential, curl, ffmpeg,
-    # git, libcec-dev, libffi-dev, libssl-dev, net-tools, procps,
-    # psmisc, python-is-python3, python3-dev, python3-gi, python3-pip,
-    # python3-setuptools, sqlite3, sudo, plus libraspberrypi0 on 32-bit
-    # Pi boards) is installed by Dockerfile.base.j2 in a layer that
-    # server (and test) also use, so it dedups across images. Anything
-    # listed here is unique to the viewer image.
+    # Viewer-only apt deps. The shared runtime set (cec-utils, curl,
+    # ffmpeg, git, libcec6, procps, psmisc, python-is-python3,
+    # python3-gi, python3-pip, python3-setuptools, sqlite3, sudo,
+    # plus libraspberrypi0 on 32-bit Pi boards) is installed by
+    # Dockerfile.base.j2 in a layer that server (and test) also use,
+    # so it dedups across images. Anything listed here is unique to
+    # the viewer image.
+    #
+    # Most of the long *-dev list this file used to carry was needed
+    # to *build* Qt + the WebView. Now that both ship as prebuilt
+    # tarballs (downloaded in Dockerfile.viewer.j2) the runtime image
+    # only needs the .so files those binaries link against — i.e. the
+    # non -dev runtime libs. The list below is the still-being-trimmed
+    # remainder; expect more to fall off as ldd-driven cleanup
+    # continues.
+    #
+    # X11/XCB packages are intentionally absent: the WebView is
+    # configured with `-no-xcb -no-xcb-xlib -qpa eglfs` (see
+    # webview/build_qt{5,6}.sh) and runs under QT_QPA_PLATFORM=linuxfb
+    # straight on KMS/DRM, so Qt has no X code path to dlopen. mpv
+    # uses --vo=drm. Same reason there's nothing wayland-related here.
     viewer_extra_apt_dependencies = [
         'ca-certificates',
         'dbus-daemon',
@@ -197,42 +211,16 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
         'libudev-dev',
         'libvpx-dev',
         'libwebp-dev',
-        'libx11-dev',
-        'libx11-xcb-dev',
-        'libx11-xcb1',
-        'libxcb-glx0-dev',
-        'libxcb-icccm4',
-        'libxcb-icccm4-dev',
-        'libxcb-image0',
-        'libxcb-image0-dev',
-        'libxcb-keysyms1',
-        'libxcb-keysyms1-dev',
-        'libxcb-randr0-dev',
-        'libxcb-render-util0',
-        'libxcb-render-util0-dev',
-        'libxcb-shape0-dev',
-        'libxcb-shm0',
-        'libxcb-shm0-dev',
-        'libxcb-sync-dev',
-        'libxcb-sync1',
-        'libxcb-xfixes0-dev',
-        'libxcb-xinerama0',
-        'libxcb-xinerama0-dev',
-        'libxcb1',
-        'libxcb1-dev',
-        'libxext-dev',
-        'libxi-dev',
-        'libxkbcommon-dev',
-        'libxrender-dev',
-        'libxslt1-dev',
-        'libxss-dev',
-        'libxtst-dev',
+        'libxkbcommon0',
         'python3-netifaces',
         'fonts-wqy-zenhei',
-        'vlc',
     ]
 
     if is_qt6:
+        # pi4-64/pi5/x86 use mpv (--vo=drm) for video. VLC is
+        # deliberately *not* installed: MediaPlayerProxy in
+        # viewer/media_player.py routes Qt6 boards to MPVMediaPlayer,
+        # so VLC would just be ~80–100 MB of dead weight here.
         viewer_extra_apt_dependencies.extend(
             [
                 'mpv',
@@ -249,11 +237,13 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
         # libgst-dev / libsqlite0-dev / libsrtp0-dev were dropped in
         # trixie — libsqlite3-dev and libsrtp2-dev are already in the
         # main viewer apt list above; libgstreamer1.0-dev is Qt 5-only
-        # and is added in the extend() below.
+        # and is added in the extend() below. VLC is Qt5-only because
+        # MediaPlayerProxy only routes pi2/pi3 to VLCMediaPlayer.
         viewer_extra_apt_dependencies.extend(
             [
                 'libgstreamer1.0-dev',
                 'qt5-image-formats-plugins',
+                'vlc',
             ]
         )
 

--- a/viewer/media_player.py
+++ b/viewer/media_player.py
@@ -3,8 +3,6 @@ import os
 import subprocess
 from typing import ClassVar
 
-import vlc
-
 from lib.device_helper import get_device_type
 from settings import settings
 
@@ -101,6 +99,12 @@ class VLCMediaPlayer(MediaPlayer):
     def __init__(self) -> None:
         MediaPlayer.__init__(self)
 
+        # Imported here so Qt6 boards (which route to MPVMediaPlayer
+        # via MediaPlayerProxy) don't need libvlc available just to
+        # load this module.
+        import vlc
+
+        self._vlc = vlc
         options = [f'--alsa-audio-device={get_alsa_audio_device()}']
         self.instance = vlc.Instance(options)
         self.player = self.instance.media_player_new()
@@ -125,9 +129,9 @@ class VLCMediaPlayer(MediaPlayer):
 
     def is_playing(self) -> bool:
         return self.player.get_state() in [
-            vlc.State.Playing,
-            vlc.State.Buffering,
-            vlc.State.Opening,
+            self._vlc.State.Playing,
+            self._vlc.State.Buffering,
+            self._vlc.State.Opening,
         ]
 
 


### PR DESCRIPTION
## Summary

Slim down what lands in the runtime images. Most of the apt list was either builder-only headers, cargo from when Qt + the WebView were compiled in-image, or packages with zero callers in the tree.

**Base list (server, viewer, test):**
- Drop `build-essential`, `libffi-dev`, `libssl-dev`, `python3-dev` — already installed in the `uv-builder` stage; the runtime image COPYs the venv pre-built, so the compiler and headers aren't needed there.
- Drop `python3-pil`, `python3-simplejson`, `ifupdown`, `net-tools` — no imports / no callers anywhere.
- Drop `mplayer` (~50 MB) and swap `lib.utils.url_fails` to `ffprobe`, which already ships via the `ffmpeg` package. Adds a 15s timeout so a stuck RTSP handshake can't hang the API request.
- Swap `libcec-dev` → `libcec7` (the runtime SONAME the `cec` Python wheel — built in `uv-builder` — dlopens at import). Trixie ships libcec 7.0, not 6.0.
- Add `iproute2` and rewrite `bin/wait.py` to use `ip route` instead of `net-tools`' `route`. Verified `debian:trixie` ships neither by default, so iproute2 must be explicit.

**Viewer extras:**
- Move `vlc` into the Qt5-only branch. `MediaPlayerProxy` in `viewer/media_player.py` only routes pi2/pi3 through `VLCMediaPlayer`; pi4-64 / pi5 / x86 use `mpv`. The `import vlc` at module top is also moved into `VLCMediaPlayer.__init__`, so Qt6 boards never need libvlc just to load the module.
- Drop the entire X11 / XCB family (`libx11*`, `libxcb-*` + variants, `libxext-dev`, `libxi-dev`, `libxrender-dev`, `libxss-dev`, `libxtst-dev`). `webview/build_qt{5,6}.sh` configures Qt with `-no-xcb -no-xcb-xlib -qpa eglfs`, the Dockerfile sets `QT_QPA_PLATFORM=linuxfb`, and `mpv` uses `--vo=drm` — so Qt has no X path of its own. Most of these come back transitively on Qt6 (qtwebengine bundles Chromium which links X11), but the explicit drop saves ~15 packages on Qt5 boards.
- Swap `libxkbcommon-dev` → `libxkbcommon0` (still needed by Qt's eglfs evdev for keyboard layouts, but only the runtime variant).
- Add `libharfbuzz-subset0`. The prebuilt WebView dlopens `libharfbuzz-subset.so.0`; on Qt6 this comes in transitively via qt6-webengine-dev, but Qt5 brings nothing that pulls it. Pre-existing bug — `latest-pi3` in production is also shipping with this lib missing. 200 KB; easier to install on every board than gate by Qt version.

## Verification

Built `pi3` (Qt5/armv7), `pi4-64` (Qt6/arm64), and `x86` (Qt6) viewer images plus the x86 server and test images. `ldd /usr/local/bin/AnthiasWebview` reports **zero missing libs** on all three viewer images (vs. 1 missing on production pi3 due to the harfbuzz issue). Authoritative `docker save` size deltas:

| Image | production | this PR | Δ |
|---|---|---|---|
| pi3 viewer (Qt5) | 685 MB | 594 MB | **−91 MB** |
| pi4-64 viewer (Qt6) | 750 MB | 611 MB | **−139 MB** |
| x86 viewer (Qt6) | 768 MB | 623 MB | **−145 MB** |
| x86 server | 502 MB | 355 MB | **−147 MB** |

Smoke tests on each viewer:
- `pydbus`, `cec`, `pydbus`, `netifaces`, `gi.repository.GLib` all import cleanly
- `ip route` returns the default gateway (verifies the wait.py code path)
- `ffprobe -version` runs (verifies the url_fails replacement)
- `vlc` present on Qt5 only; `mpv` present on Qt6 only — confirms the conditional split

121 non-integration tests pass against the test image. `lib.utils.url_fails` exercised against an unreachable RTSP URL — ffprobe correctly returns `True` (URL fails) within the 15s timeout. New `StreamingURLProbeTest` cases mock `sh.Command('ffprobe')` and cover the success / non-zero exit / timeout / `CommandNotFound` paths.

## Review feedback addressed

- **Defer `import vlc`** — moved into `VLCMediaPlayer.__init__` so Qt6 boards (which use `MPVMediaPlayer`) don't need libvlc to load the viewer module.
- **`libcec6` → `libcec7` in the docstring** of `tools/image_builder/utils.py` — matches the package the base image actually installs.
- **Tests for the new `ffprobe` branch** in `lib.utils.url_fails` — added `StreamingURLProbeTest` covering all four exits.

**Follow-ups (deferred — need `ldd` against the unpacked WebView/Qt artifact to derive the right runtime SONAMEs):**
- Replace `qt6-base-dev` / `qt6-webengine-dev` with their runtime libs + `qt6-webengine-data`.
- Trim the remaining `lib*-dev` wall in viewer extras.

## Test plan

- [ ] CI passes (ruff, format, mypy, python tests)
- [ ] Boot pi3, pi4-64, pi5, x86 viewer images on real hardware — confirm webview launches and renders content
- [ ] Confirm pi3 video playback still works through VLC
- [ ] Confirm pi4-64 / pi5 / x86 video playback still works through mpv (HW-decoded on pi4-64)
- [ ] Sanity-check the API request that calls \`url_fails\` with a real RTSP stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)