### PR TITLE
fix(build): cross-build pi4-64 / pi5 webview as arm64 via QEMU

### DIFF
--- a/webview/docker-compose.yml
+++ b/webview/docker-compose.yml
@@ -1,11 +1,20 @@
+# Each builder declares its own `platform:` so that `docker buildx bake`
+# honors it as the target platform — without this pin the bake builds
+# whatever the runner's native arch is, and `qmake6 && make` inside
+# build_webview.sh then produces a binary of the wrong architecture for
+# the ARM64 boards. The Build Webview workflow registers QEMU before
+# baking, so the non-native targets cross-build via emulation.
 services:
   builder-x86:
     profiles:
       - x86
     image: webview-builder-x86
+    platform: linux/amd64
     build:
       context: .
       dockerfile: docker/Dockerfile.x86
+      platforms:
+        - linux/amd64
     environment:
       - BOARD=x86
     tty: true
@@ -19,9 +28,12 @@ services:
     profiles:
       - pi5
     image: webview-builder-pi5
+    platform: linux/arm64
     build:
       context: .
       dockerfile: docker/Dockerfile.pi5
+      platforms:
+        - linux/arm64
     environment:
       - BOARD=pi5
     tty: true
@@ -36,9 +48,12 @@ services:
     profiles:
       - pi4-64
     image: webview-builder-pi4-64
+    platform: linux/arm64
     build:
       context: .
       dockerfile: docker/Dockerfile.pi4
+      platforms:
+        - linux/arm64
     environment:
       - BOARD=pi4-64
     tty: true


### PR DESCRIPTION
### Issues Fixed

`anthias-viewer-1` on Pi 4 64-bit / Pi 5 currently crashloops with `OSError: [Errno 8] Exec format error` when `load_browser` invokes `AnthiasWebview` — the `webview-2026.04.1-trixie-pi4-64.tar.gz` and `pi5` tarballs in [WebView-v2026.04.1](https://github.com/Screenly/Anthias/releases/tag/WebView-v2026.04.1) shipped with x86-64 ELFs instead of arm64 (all three Qt6 board tarballs share BuildID `b5a6440a8c1...`).

### Description

Root cause: `webview/docker-compose.yml` had no `platform:` pin on the bake targets, so the `Build Webview` workflow's `compile-webview-part-2` job (matrix: `pi5`, `pi4-64`, `x86`) compiled all three Qt6 boards on its native amd64 runner — `qmake6 && make` then produced amd64 binaries that got packaged under arm64 board names. The workflow already runs `setup-qemu-action` before bake, so the emulation path was wired up but never engaged.

Fix: add `platform: linux/arm64` to `builder-pi4-64` and `builder-pi5` (and `linux/amd64` to `builder-x86` for symmetry). Verified locally with `docker buildx bake --print`: each target now reports the correct platform, and `docker image inspect` of the rebuilt images confirms `arm64/linux`.

The Qt5 boards (`pi2`, `pi3`) are unaffected — they go through `compile-webview-part-1` which uses a real cross-toolchain, not this compose file.

Out-of-band: the [WebView-v2026.04.1](https://github.com/Screenly/Anthias/releases/tag/WebView-v2026.04.1) release assets for `pi4-64` and `pi5` were rebuilt locally via this corrected pipeline and re-uploaded with `gh release upload --clobber`. Re-downloaded and verified end-to-end: both tarballs now contain `ELF 64-bit LSB pie executable, ARM aarch64`, sha256 matches.

The viewer image's `buildcache-pi4-64` / `buildcache-pi5` tags on GHCR were also deleted out-of-band, so the next push to master will rebuild the curl layer (which is keyed on RUN-command text, not URL contents) from scratch and pick up the corrected tarball.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)