### PR TITLE
fix(viewer): pin mpv to 1080p on pi4-64/pi5 to fix video playback

### DIFF
--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -54,7 +54,7 @@ class TestMPVMediaPlayer(unittest.TestCase):
         )
 
     @patch('viewer.media_player.subprocess.Popen')
-    def test_play_uses_v4l2m2m_copy_hwdec_on_pi4_64(
+    def test_play_pins_1080p_mode_on_pi4_64(
         self, mock_popen: Any
     ) -> None:
         self.player.set_asset('file:///test/video.mp4', 30)
@@ -62,7 +62,34 @@ class TestMPVMediaPlayer(unittest.TestCase):
             self.player.play()
 
         args, _ = mock_popen.call_args
-        self.assertIn('--hwdec=v4l2m2m-copy', args[0])
+        self.assertIn('--drm-mode=1920x1080@60', args[0])
+        self.assertIn('--vd-lavc-threads=4', args[0])
+        self.assertIn('--hwdec=auto-safe', args[0])
+        self.assertNotIn('--hwdec=v4l2m2m-copy', args[0])
+
+    @patch('viewer.media_player.subprocess.Popen')
+    def test_play_pins_1080p_mode_on_pi5(
+        self, mock_popen: Any
+    ) -> None:
+        self.player.set_asset('file:///test/video.mp4', 30)
+        with patch.dict('os.environ', {'DEVICE_TYPE': 'pi5'}):
+            self.player.play()
+
+        args, _ = mock_popen.call_args
+        self.assertIn('--drm-mode=1920x1080@60', args[0])
+        self.assertIn('--vd-lavc-threads=4', args[0])
+
+    @patch('viewer.media_player.subprocess.Popen')
+    def test_play_does_not_pin_mode_on_x86(
+        self, mock_popen: Any
+    ) -> None:
+        self.player.set_asset('file:///test/video.mp4', 30)
+        with patch.dict('os.environ', {'DEVICE_TYPE': 'x86'}):
+            self.player.play()
+
+        args, _ = mock_popen.call_args
+        self.assertNotIn('--drm-mode=1920x1080@60', args[0])
+        self.assertNotIn('--vd-lavc-threads=4', args[0])
 
     @patch('viewer.media_player.subprocess.Popen')
     def test_play_uses_local_audio_device_when_configured(

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -54,9 +54,7 @@ class TestMPVMediaPlayer(unittest.TestCase):
         )
 
     @patch('viewer.media_player.subprocess.Popen')
-    def test_play_pins_1080p_mode_on_pi4_64(
-        self, mock_popen: Any
-    ) -> None:
+    def test_play_pins_1080p_mode_on_pi4_64(self, mock_popen: Any) -> None:
         self.player.set_asset('file:///test/video.mp4', 30)
         with patch.dict('os.environ', {'DEVICE_TYPE': 'pi4-64'}):
             self.player.play()
@@ -68,9 +66,7 @@ class TestMPVMediaPlayer(unittest.TestCase):
         self.assertNotIn('--hwdec=v4l2m2m-copy', args[0])
 
     @patch('viewer.media_player.subprocess.Popen')
-    def test_play_pins_1080p_mode_on_pi5(
-        self, mock_popen: Any
-    ) -> None:
+    def test_play_pins_1080p_mode_on_pi5(self, mock_popen: Any) -> None:
         self.player.set_asset('file:///test/video.mp4', 30)
         with patch.dict('os.environ', {'DEVICE_TYPE': 'pi5'}):
             self.player.play()
@@ -80,9 +76,7 @@ class TestMPVMediaPlayer(unittest.TestCase):
         self.assertIn('--vd-lavc-threads=4', args[0])
 
     @patch('viewer.media_player.subprocess.Popen')
-    def test_play_does_not_pin_mode_on_x86(
-        self, mock_popen: Any
-    ) -> None:
+    def test_play_does_not_pin_mode_on_x86(self, mock_popen: Any) -> None:
         self.player.set_asset('file:///test/video.mp4', 30)
         with patch.dict('os.environ', {'DEVICE_TYPE': 'x86'}):
             self.player.play()

--- a/viewer/media_player.py
+++ b/viewer/media_player.py
@@ -55,24 +55,25 @@ class MPVMediaPlayer(MediaPlayer):
         # effect without a viewer restart, matching VLCMediaPlayer.
         settings.load()
 
-        # The Pi 4's H.264/HEVC block is reached through libavcodec's
-        # `h264_v4l2m2m` (and siblings) wrapper decoders, exposed in mpv
-        # as `--hwdec=v4l2m2m-copy`. It is *not* a hwaccel attached to
-        # the standard `h264` decoder, so it is not in mpv's auto-safe
-        # whitelist (see vd_lavc.c hwdec_autoprobe_info) — `auto-safe`
-        # silently falls through to the software h264 decoder, which
-        # the Cortex-A72 can't keep up with at 1080p. Name it
-        # explicitly on pi4-64; mpv falls back to software on its own
-        # if v4l2m2m-copy fails to init.
-        is_pi4_64 = os.environ.get('DEVICE_TYPE') == 'pi4-64'
-        hwdec = 'v4l2m2m-copy' if is_pi4_64 else 'auto-safe'
+        # Pin to 1080p on Pi4-64/Pi5: mpv's default --drm-mode=preferred
+        # reads the connector's EDID-preferred mode (4K on most modern
+        # TVs) and runs CPU zimg upscale, which drops below real-time
+        # on the A72. Software decode of 1080p H.264 fits 4 cores fine.
+        device_type = os.environ.get('DEVICE_TYPE', '')
+        extra_args: list[str] = []
+        if device_type in ('pi4-64', 'pi5'):
+            extra_args = [
+                '--drm-mode=1920x1080@60',
+                '--vd-lavc-threads=4',
+            ]
 
         self.process = subprocess.Popen(
             [
                 'mpv',
                 '--no-terminal',
                 '--vo=drm',
-                f'--hwdec={hwdec}',
+                '--hwdec=auto-safe',
+                *extra_args,
                 f'--audio-device=alsa/{get_alsa_audio_device()}',
                 '--',
                 self.uri,


### PR DESCRIPTION
## Summary

- Pin `--drm-mode=1920x1080@60` on `pi4-64`/`pi5` so mpv's `--vo=drm` doesn't pick the connector's EDID-preferred 4K mode and run a CPU zimg upscale.
- Drop `--hwdec=v4l2m2m-copy` on `pi4-64`; the `bcm2835-codec` stateful mem2mem driver on trixie's kernel hangs the decoder before the first CAPTURE buffer.
- Use `--hwdec=auto-safe` everywhere; software 1080p H.264 decode comfortably fits 4 A72 cores. Add `--vd-lavc-threads=4`.

## Why video was broken

On a `pi4-64` with a 4K display, mpv was launched as the production code intended (`--vo=drm --hwdec=v4l2m2m-copy`) and exhibited two stacked failures:

1. **`v4l2m2m-copy` hung** before producing the first frame. Decoder negotiation completed (`/dev/video10`, H264→YU12), then `VIDIOC_DQBUF` never returned. Reproduced consistently across `mpv 0.40` + ffmpeg 7.1.2 on Debian trixie kernel.
2. **CPU upscale was the bottleneck even with software decode.** With `--vo=drm` on a 4K connector, mpv inserted `[vo/drm] using 3 threads for scaling … Using zimg`. Playback ran at ~1/4 real-time with audio drifting up to 13s ahead in a 15s window.

A pure decode benchmark (`--vo=null --no-audio --untimed`) finished a 45s clip in 16.8s — i.e., the A72 has ~2.7× headroom for 1080p H.264 decode in isolation. Decode was never the issue; the upscale was.

## The fix

Pinning the connector to 1080p (matching the typical source resolution) eliminates the upscale. `--hwdec=auto-safe` falls through to software, dodging the v4l2m2m hang. Test results on the same Pi4-64 / 4K display:

| flags | reached in 15s | A-V drift | drops |
|---|---|---|---|
| `--vo=drm --hwdec=v4l2m2m-copy` (current prod) | stalled | n/a | n/a |
| `--vo=drm --hwdec=auto-safe` (pre-fix) | `00:00:02` | +12s | 21 |
| **`--vo=drm --drm-mode=1920x1080@60 --hwdec=auto-safe --vd-lavc-threads=4`** | **`00:00:13`** | **±0.000** | **39 over 13s** |

Real-time playback, A-V in sync. The 4K TV's internal scaler handles the 1080p→panel mapping with no visible loss at signage viewing distance.

Pi5 takes the same code path via `MediaPlayerProxy` (lines 138–156) and gets the same flags. x86 is unchanged — it has a different display stack and works fine without pinning.

## Considered but not included

- **Capping HDMI to 1080p in cmdline.txt via Ansible.** Tested — the mpv flag alone is sufficient; the cmdline cap added no measurable improvement to playback. Skipped to keep the change scoped to the viewer code and avoid rewriting users' boot config.
- **Suspending webview's Chromium renderers during video.** Would reduce the residual `Dropped: 39` figure further by removing CPU/V3D contention, but breaks the seamless transition story (the user's explicit goal). Left as a follow-up.

## Test plan

- [x] Pi4-64 + 4K display: scheduled video assets play in real time, in sync
- [x] Pi4-64 + 4K display: web pages and image assets continue to render correctly
- [ ] Pi5 + 4K display: validate the same flags work (same mode-pick mechanism applies)
- [ ] Pi5 + 1080p display: validate `--drm-mode=1920x1080@60` is accepted by the connector
- [ ] x86: regression check — code path unchanged, but worth confirming on a dev machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)