### PR TITLE
fix(server): unblock migrations + fix upstream version check

### DIFF
--- a/anthias_django/settings.py
+++ b/anthias_django/settings.py
@@ -250,7 +250,18 @@ SPECTACULAR_SETTINGS = {
     ],
 }
 
-# `django-dbbackup` settings
-DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
-DBBACKUP_STORAGE_OPTIONS = {'location': '/data/.anthias/backups'}
+# django-dbbackup v5 moved storage config under Django 5's STORAGES
+# dict; defining STORAGES replaces the framework defaults entirely.
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+    },
+    'dbbackup': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+        'OPTIONS': {'location': '/data/.anthias/backups'},
+    },
+}
 DBBACKUP_HOSTNAME = 'anthias'

--- a/lib/github.py
+++ b/lib/github.py
@@ -84,32 +84,33 @@ def remote_branch_available(branch: str | None) -> bool | None:
     if remote_branch_cache is not None:
         return bool(remote_branch_cache == '1')
 
+    # Use the direct branch endpoint (200 = exists, 404 = missing) so we
+    # don't silently fail once the repo passes 30 branches: GitHub's
+    # /branches list is alphabetically paginated and dropped `master` off
+    # the first page once auto-generated branches piled up.
     try:
         resp = requests_get(
-            'https://api.github.com/repos/screenly/anthias/branches',
-            headers={
-                'Accept': 'application/vnd.github.loki-preview+json',
-            },
+            f'https://api.github.com/repos/screenly/anthias/branches/{branch}',
             timeout=DEFAULT_REQUESTS_TIMEOUT,
         )
+    except exceptions.RequestException as exc:
+        handle_github_error(exc, 'remote branch availability')
+        return None
+
+    if resp.status_code == 404:
+        r.set('remote-branch-available', '0')
+        r.expire('remote-branch-available', REMOTE_BRANCH_STATUS_TTL)
+        return False
+
+    try:
         resp.raise_for_status()
     except exceptions.RequestException as exc:
         handle_github_error(exc, 'remote branch availability')
         return None
 
-    found = False
-    for github_branch in resp.json():
-        if github_branch['name'] == branch:
-            found = True
-            break
-
-    # Cache and return the result
-    if found:
-        r.set('remote-branch-available', '1')
-    else:
-        r.set('remote-branch-available', '0')
+    r.set('remote-branch-available', '1')
     r.expire('remote-branch-available', REMOTE_BRANCH_STATUS_TTL)
-    return found
+    return True
 
 
 def fetch_remote_hash() -> tuple[str | None, bool]:


### PR DESCRIPTION
Two unrelated server-stack regressions surfacing on the latest deploy. One fatal, one silent. Bundled as a hotfix PR since both are small, contained, and would otherwise need separate cycles.

## 1. dbbackup blocks `manage.py migrate` (fatal)

`django-dbbackup` was bumped to 5.3.0 in #2768 alongside the Django 5 LTS upgrade. v5 dropped the legacy `DBBACKUP_STORAGE` / `DBBACKUP_STORAGE_OPTIONS` keys in favor of Django 5's `STORAGES` dict and now raises `RuntimeError` on import if either legacy key is present:

```
File ".../dbbackup/settings.py", line 13, in <module>
    raise RuntimeError(msg)
RuntimeError: The settings DBBACKUP_STORAGE and DBBACKUP_STORAGE_OPTIONS
have been deprecated in favor of using Django Storages configuration.
```

This blocks every `manage.py` invocation — most visibly `migrate` during `anthias-server` container startup — because dbbackup's management commands import the package at registration time.

Migrate the config into `STORAGES['dbbackup']`. Defining `STORAGES` replaces Django's framework defaults entirely, so `default` and `staticfiles` are restated even though they match the global defaults — without them, file uploads and WhiteNoise-served static files would lose their backends.

## 2. Version check silently broken (non-fatal but wrong)

`lib/github.py:remote_branch_available()` listed all branches via `GET /repos/screenly/anthias/branches` and scanned the response for a name match. That endpoint paginates at 30 results, sorted alphabetically. Once auto-generated branches (`claude/*`, `dependabot/*`, `renovate/*`) pushed the count past 30, `master` fell off the first page and the lookup returned `False`. Every `fetch_remote_hash()` call then logged:

```
Remote Git branch not available
Unable to get latest version from GitHub
```

…and `is_up_to_date()` short-circuited to `True` regardless of actual upstream state. Confirmed: the repo currently has **81 branches**, and `master` is not in the first 30 alphabetically:

```
$ curl -s https://api.github.com/repos/screenly/anthias/branches | jq 'length'
30
$ curl -s 'https://api.github.com/repos/screenly/anthias/branches?per_page=100' | jq 'length'
81
$ curl -s https://api.github.com/repos/screenly/anthias/branches | jq '[.[].name] | index("master")'
null
```

Switch to the per-branch endpoint `GET /repos/.../branches/{branch}`: 200 if it exists, 404 if not, no pagination. 404 is a clean negative and is cached without triggering the generic error backoff; other non-200s still flow through `handle_github_error()`.

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [ ] CI green (Django + DB tests cover the STORAGES path indirectly via management-command import)
- [ ] On a deployed device: confirm `anthias-server` starts past `Running migration...` without the RuntimeError
- [ ] On a deployed device: `Update Available` banner reflects actual upstream state (no longer always-up-to-date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)