### PR TITLE
fix(ci): use correct balena fleet slug for pi4

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -69,12 +69,16 @@ jobs:
         run: |
           if [ "${{ matrix.board }}" == 'pi2' ]; then
             echo "BALENA_IMAGE=raspberry-pi2" >> "$GITHUB_ENV"
+            echo "FLEET_SLUG=anthias-pi2" >> "$GITHUB_ENV"
           elif [ "${{ matrix.board }}" == 'pi3' ]; then
             echo "BALENA_IMAGE=raspberrypi3" >> "$GITHUB_ENV"
+            echo "FLEET_SLUG=anthias-pi3" >> "$GITHUB_ENV"
           elif [ "${{ matrix.board }}" == 'pi4-64' ]; then
             echo "BALENA_IMAGE=raspberrypi4-64" >> "$GITHUB_ENV"
+            echo "FLEET_SLUG=anthias-pi4" >> "$GITHUB_ENV"
           elif [ "${{ matrix.board }}" == 'pi5' ]; then
             echo "BALENA_IMAGE=raspberrypi5" >> "$GITHUB_ENV"
+            echo "FLEET_SLUG=anthias-pi5" >> "$GITHUB_ENV"
           fi
 
       - name: Download OS image
@@ -87,7 +91,7 @@ jobs:
         run: |
           balena preload \
             "$BALENA_IMAGE.img" \
-            --fleet screenly_ose/anthias-${{ matrix.board }} \
+            --fleet "screenly_ose/$FLEET_SLUG" \
             --pin-device-to-release \
             --splash-image ansible/roles/splashscreen/files/splashscreen.png \
             --commit latest
@@ -97,7 +101,7 @@ jobs:
           balena os configure \
             "$BALENA_IMAGE.img" \
             --config-network=ethernet \
-            --fleet screenly_ose/anthias-${{ matrix.board }}
+            --fleet "screenly_ose/$FLEET_SLUG"
 
       - name: Package up image
         run: |


### PR DESCRIPTION
### Issues Fixed

Balena disk-image deploy for Raspberry Pi 4 was failing because the workflow targeted a non-existent fleet (`screenly_ose/anthias-pi4-64`).

### Description

The matrix board value (`pi4-64`) was interpolated directly into the balena fleet name in `balena preload` and `balena os configure`, producing `screenly_ose/anthias-pi4-64`. The actual fleet is `screenly_ose/anthias-pi4`.

Mapped each matrix board to an explicit `FLEET_SLUG` env var alongside the existing `BALENA_IMAGE` mapping. `pi4-64` now maps to `anthias-pi4`; the others (`pi2`, `pi3`, `pi5`) keep their current 1:1 names.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).