### PR TITLE
chore(viewer): remove dead Balena pre-wait and unused wait_for_node_ip

### DIFF
--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -10,12 +10,9 @@ from typing import Any
 import django
 import pydbus
 import sh as sh
-from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from settings import ReplySender, settings
-from viewer.constants import BALENA_IP_RETRY_DELAY as BALENA_IP_RETRY_DELAY
 from viewer.constants import EMPTY_PL_DELAY as EMPTY_PL_DELAY
-from viewer.constants import MAX_BALENA_IP_RETRIES as MAX_BALENA_IP_RETRIES
 from viewer.constants import SERVER_WAIT_TIMEOUT as SERVER_WAIT_TIMEOUT
 from viewer.constants import SPLASH_DELAY as SPLASH_DELAY
 from viewer.constants import SPLASH_PAGE_URL as SPLASH_PAGE_URL
@@ -36,9 +33,6 @@ django.setup()
 
 from lib.utils import (  # noqa: E402
     connect_to_redis,
-    get_balena_device_info,
-    get_node_ip,
-    is_balena_app,
     string_to_bool,
     url_fails,
 )
@@ -285,15 +279,6 @@ def setup() -> None:
     browser_bus = bus.get('anthias.webview', '/Anthias')
 
 
-def wait_for_node_ip(seconds: int) -> None:
-    for _ in range(seconds):
-        try:
-            get_node_ip()
-            break
-        except Exception:
-            sleep(1)
-
-
 def start_loop() -> None:
     global loop_is_stopped
 
@@ -324,14 +309,6 @@ def main() -> None:
     scheduler = Scheduler()
 
     if settings['show_splash']:
-        if is_balena_app():
-            for attempt in Retrying(
-                stop=stop_after_attempt(MAX_BALENA_IP_RETRIES),
-                wait=wait_fixed(BALENA_IP_RETRY_DELAY),
-            ):
-                with attempt:
-                    get_balena_device_info()
-
         view_webpage(SPLASH_PAGE_URL)
         sleep(SPLASH_DELAY)
 

--- a/viewer/constants.py
+++ b/viewer/constants.py
@@ -6,6 +6,4 @@ EMPTY_PL_DELAY = 5  # secs
 STANDBY_SCREEN = f'http://{LISTEN}:{PORT}/static/img/standby.png'
 SPLASH_PAGE_URL = f'http://{LISTEN}:{PORT}/splash-page'
 
-MAX_BALENA_IP_RETRIES = 90
-BALENA_IP_RETRY_DELAY = 1
 SERVER_WAIT_TIMEOUT = 60


### PR DESCRIPTION
## Summary

Removes two pieces of viewer startup code that don't do what they look like they do, addressing **Part B** of #2803.

### What's removed

- **The 90-iteration Balena pre-wait** (`viewer/__init__.py`'s `main()` block under `if settings['show_splash']: if is_balena_app():`) — called `get_balena_device_info()` up to 90 times with the result discarded, supposedly to gate the splash on Balena reachability. The actual splash IPs come from the server-side `splash_page` view (`anthias_app/views.py:57-75`) which calls `get_node_ip()` at render time and has no awareness of whether the viewer's pre-wait succeeded. Net effect was up to a 90-second startup stall with no guarantee of valid IPs after.
- **`wait_for_node_ip`** — defined at `viewer/__init__.py:288-294` but never called (`grep -r wait_for_node_ip` returns only the definition).
- **Now-unused imports**: `tenacity.{Retrying, stop_after_attempt, wait_fixed}`, `lib.utils.{is_balena_app, get_balena_device_info, get_node_ip}`.
- **Now-unused constants**: `MAX_BALENA_IP_RETRIES`, `BALENA_IP_RETRY_DELAY` from `viewer/constants.py`.

Pure deletion — no logic changes, no behavior changes other than removing a startup stall on Balena devices.

### Why this is safe

IP discovery is already wired end-to-end through the server: `splash_page` view → `get_node_ip` → `host_agent.py` (for non-Balena) or the Balena supervisor (for Balena). The viewer's participation was residual and the deleted block was demonstrably broken (discarded result + no shared state with the actual render path).

### `tenacity` is not removed from viewer deps

`lib/utils.py` still imports `tenacity` for the host-agent IP path used by the server-side `splash_page` view. The viewer imports `lib.utils` for `connect_to_redis`, `string_to_bool`, and `url_fails`, so dropping `tenacity` from the viewer's pyproject group would break the import at module load. That cleanup is a separate refactor (or naturally falls out once Part A of #2803 removes the viewer's `url_fails` import).

## Test plan

- [x] `uv run ruff check viewer/__init__.py viewer/constants.py` — passes
- [x] `python -m py_compile viewer/__init__.py viewer/constants.py` — passes
- [x] No test files reference any of the deleted symbols (`grep -rn "wait_for_node_ip\|MAX_BALENA\|BALENA_IP_RETRY" tests/` is empty)
- [ ] CI Python test suite runs on this PR
- [ ] **Verification on a Balena device:** boot fresh; confirm splash renders with real IPs (not "Unknown") within a reasonable window. If "Unknown" persists, the server-side robustness fix from issue #2803 (host_agent IP caching or splash-side retry) is the right next step — the fix belongs server-side, not back in the viewer.

Refs #2803 (Part B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)