### PR TITLE
fix(upgrade): pin docker pull platform off DEVICE_TYPE

### DIFF
--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -53,6 +53,19 @@ else
     exit 1
 fi
 
+# Pin the pull platform off DEVICE_TYPE rather than letting Docker
+# auto-detect from the host. Docker 29.4.x on Trixie has been observed
+# advertising `linux/arm/v8` (32-bit ARMv8) on aarch64 Pi 4 hosts, which
+# doesn't match the single-platform `linux/arm64/v8` manifest we publish
+# for `pi4-64` and breaks `docker compose pull`. We already know the
+# correct platform from DEVICE_TYPE, so just set it explicitly. `-E`
+# below propagates this into the sudo'd `docker compose` invocations.
+case "$DEVICE_TYPE" in
+    pi5|pi4-64) export DOCKER_DEFAULT_PLATFORM="linux/arm64" ;;
+    pi3|pi2)    export DOCKER_DEFAULT_PLATFORM="linux/arm/v7" ;;
+    x86)        export DOCKER_DEFAULT_PLATFORM="linux/amd64" ;;
+esac
+
 if [[ -n $(docker ps | grep srly-ose) ]]; then
     # @TODO: Rename later
     set +e


### PR DESCRIPTION
### Issues Fixed

Reported on a Pi 4 running 64-bit Raspberry Pi OS Trixie with Docker Engine 29.4.2:

```
$ docker compose pull
Error response from daemon: no matching manifest for linux/arm/v8 in the manifest list entries: no match for platform in manifest: not found
```

`uname -m` is `aarch64`, `dpkg --print-architecture` is `arm64`, `docker info` reports `Architecture: aarch64`, and the GHCR manifest for `latest-pi4-64` exposes a clean `arm64/linux` entry — yet the daemon requests `linux/arm/v8` (32-bit ARMv8) and fails to match. `docker pull --platform linux/arm64 …` succeeds, confirming this is host-platform auto-detect on Docker 29.4.x mis-classifying the host.

### Description

`bin/upgrade_containers.sh` already derives `DEVICE_TYPE` from `/proc/device-tree/model`, so we know the correct platform without trusting Docker's host detection. Set `DOCKER_DEFAULT_PLATFORM` explicitly:

- `pi4-64`, `pi5` → `linux/arm64`
- `pi2`, `pi3` → `linux/arm/v7`
- `x86` → `linux/amd64`

The existing `sudo -E docker compose pull` propagates the export. No build-pipeline / image-builder change needed — the published manifests are correct.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).