### PR TITLE
fix(ansible): map pi4-64 device_type to arm64 docker (regression from #2779)

### DIFF
--- a/ansible/roles/system/tasks/docker.yml
+++ b/ansible/roles/system/tasks/docker.yml
@@ -20,29 +20,38 @@
 
 - name: Set system_architecture
   ansible.builtin.set_fact:
-    system_architecture: >-
-      {{
-        'amd64' if ansible_architecture == 'x86_64'
-        else ('arm64' if device_type in ['pi4', 'pi5']
-                          and ansible_userspace_bits == '64'
-        else 'armhf')
-      }}
+    # Map every validated device_type (see site.yml) to a dpkg
+    # architecture. Exhaustive by design: an unmapped device_type
+    # raises rather than falling through to a default. The previous
+    # form used `device_type in ['pi4', 'pi5']`, which silently
+    # missed `pi4-64` after #2779 renamed the value, and every Pi 4
+    # ran an upgrade resolving to armhf as a result.
+    system_architecture: "{{ docker_arch_by_device_type[device_type] }}"
+  vars:
+    docker_arch_by_device_type:
+      x86: amd64
+      pi5: arm64
+      pi4-64: arm64
+      pi3: armhf
+      pi2: armhf
 
 - name: Add Docker repo
-  ansible.builtin.lineinfile:
-    path: /etc/apt/sources.list.d/docker.list
-    create: true
-    line: >-
-      deb [arch={{ system_architecture }}
-      signed-by=/etc/apt/keyrings/docker.asc]
-      https://download.docker.com/linux/debian
-      {{ ansible_distribution_release }} stable
-    state: present
+  # copy, not lineinfile, so a stale `[arch=...]` entry from an earlier
+  # run is rewritten rather than left sitting alongside the correct one.
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/docker.list
+    content: >
+      deb [arch={{ system_architecture }} signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable
     owner: root
     group: root
-    mode: "0644"
+    # World-readable required so the `_apt` user can read the source list.
+    mode: "0644"  # NOSONAR
 
 - name: Install Docker
+  # On hosts already running the wrong arch, apt swaps automatically:
+  # docker-ce is Multi-Arch: foreign so requesting `:arm64` removes
+  # the `:armhf` install (and pulls dependencies in the new arch).
   ansible.builtin.apt:
     name:
       - docker-ce:{{ system_architecture }}


### PR DESCRIPTION
### Issues Fixed

Fixes a regression introduced in #2779 (Trixie upgrade, merged 2026-04-30): every Pi 4 host that runs `bin/run_upgrade.sh` after that PR merged has `docker-ce` silently swapped from `arm64` to `armhf`, which then breaks `docker compose pull` (manifest mismatch against `latest-pi4-64`) and SIGSYS-kills containers under the default seccomp profile.

#### How we got here

`#2779` renamed the Pi 4 `DEVICE_TYPE` from `pi4` to `pi4-64` in `bin/install.sh`, `bin/upgrade_containers.sh`, and the env validator in `ansible/site.yml`. It missed the conditional in `ansible/roles/system/tasks/docker.yml`, which kept testing `device_type in ['pi4', 'pi5']`. The literal `pi4` is no longer a valid value, so the test never matches on Pi 4 hardware and the expression falls through to its default (`armhf`).

Confirmed on a live Pi 4 device via `/var/log/apt/history.log`:

```
2026-04-28 14:01:05  install docker-ce:arm64=5:29.4.1   ← worked
2026-05-02 17:08:43  install docker-ce:armhf=5:29.4.2   ← regression
```

The 32-bit daemon then mis-advertises its host platform as `linux/arm/v8`, so the next `docker compose pull` fails with `no matching manifest for linux/arm/v8` (the published `latest-pi4-64` image is single-platform `linux/arm64/v8`). Even with `--platform linux/arm64`, runc's seccomp filter SIGSYS-kills containers on basic syscalls (`brk`/214, `set_tid_address`/96) because the 32-bit daemon's libseccomp linkage mis-translates the JSON profile's per-syscall ALLOW rules for the aarch64 ABI. `--security-opt seccomp=unconfined` confirms the seccomp filter is the only blocker.

### Description

Two-line behavior fix in `docker.yml`:

1. **Replace the typo'd conditional with an explicit `device_type` -> dpkg-arch dict.** Exhaustive by design — an unmapped `device_type` raises rather than silently falling through, so a future rename of any device_type catches at the playbook layer instead of misinstalling docker.

   ```yaml
   docker_arch_by_device_type:
     x86: amd64
     pi5: arm64
     pi4-64: arm64
     pi3: armhf
     pi2: armhf
   ```

2. **Manage `/etc/apt/sources.list.d/docker.list` with `copy` rather than `lineinfile`.** Devices that picked up the regression have both an `[arch=arm64]` and an `[arch=armhf]` line from prior runs — `lineinfile` is additive. `copy` rewrites the file authoritatively each run.

#### Self-heal of already-broken devices

After this fix, `Install Docker` requests `docker-ce:arm64` explicitly. `docker-ce` is `Multi-Arch: foreign`, so apt removes the conflicting `:armhf` install (and its arch-pinned dependencies — `containerd.io:armhf`, `docker-buildx-plugin:armhf`, etc.) as part of the swap. No explicit purge step is needed; verified via `--check --diff` on a regressed device:

```
The following packages will be REMOVED:
  containerd.io:armhf docker-buildx-plugin:armhf docker-ce:armhf
  docker-ce-cli:armhf docker-compose-plugin:armhf nftables:armhf
The following NEW packages will be installed:
  containerd.io docker-buildx-plugin docker-ce docker-ce-cli
  docker-compose-plugin nftables
```

#### Cross-platform impact

| device_type | Pre-fix `system_architecture` | Post-fix |
|---|---|---|
| `x86` | amd64 | amd64 |
| `pi5` | arm64 | arm64 |
| **`pi4-64`** | **armhf (bug)** | **arm64 (fixed)** |
| `pi3` | armhf | armhf |
| `pi2` | armhf | armhf |

Only `pi4-64` changes behavior; every other device_type resolves to the same arch as before.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices. (Verified via `--check --diff` on a regressed Pi 4 — apt swap and docker.list rewrite both produce the expected diff.)
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

### Follow-up

Closes #2814 (the platform-pin workaround in `bin/upgrade_containers.sh` that I opened earlier — superseded once we identified the regression as the root cause; the platform pin would only have papered over the manifest match step, the seccomp kill at runtime would still happen).