### PR TITLE
fix(webapp): responsive layout + spacing pass across all viewports

### DIFF
--- a/static/sass/_styles.scss
+++ b/static/sass/_styles.scss
@@ -2,22 +2,6 @@
 @import "sweetalert2-overrides";
 @import "form-overrides";
 
-// Transformations
-@mixin rotate($degrees) {
-  -webkit-transform: rotate($degrees);
-  -moz-transform: rotate($degrees);
-  -ms-transform: rotate($degrees);
-  -o-transform: rotate($degrees);
-  transform: rotate($degrees);
-}
-
-// Drop shadows
-@mixin box-shadow($shadow...) {
-  -webkit-box-shadow: $shadow;
-  -moz-box-shadow: $shadow;
-  box-shadow: $shadow;
-}
-
 // Selected text
 @mixin selection {
     ::-moz-selection { @content; }
@@ -29,9 +13,8 @@
   background: $anthias-yellow-3;
 }
 
-$footer-height: 250px;
+$footer-height: 160px;
 $secondary-color: #6c757d;
-$base-line-height: 50px !default;
 
 html {
   position: relative;
@@ -40,8 +23,8 @@ html {
 
 body {
   background-color: $anthias-purple-1;
-  margin-top: 95px;
-  margin-bottom: $footer-height + $base-line-height;
+  margin-top: 5.9375rem;
+  margin-bottom: $footer-height;
   font-family: "Plus Jakarta Sans", Helvetica, Arial, sans-serif;
 }
 
@@ -97,18 +80,26 @@ body {
 
 .modal-dialog {
   max-width: 580px;
-  margin-top: 70px;
+  margin-top: 4.375rem;
+
+  @media (max-width: 575.98px) {
+    margin: 0.5rem;
+    margin-top: 0.5rem;
+  }
 }
 
-label {
+// Forms inside modals and the settings page rely on right-aligned
+// labels so the col-form-label sits flush against its input column.
+.modal label.col-form-label,
+.row.content label.col-form-label {
   text-align: right;
 }
 
 .btn {
-  padding: 12px 24px 12px 24px;
+  padding: 0.75rem 1.5rem;
 
   &:focus {
-    box-shadow: none !important;
+    box-shadow: none;
   }
 }
 
@@ -288,13 +279,13 @@ label {
 
 #footer {
   bottom: 0;
-  height: $footer-height;
+  min-height: $footer-height;
   position: absolute;
   width: 100%;
 
   .logo {
     img {
-      max-height: 50px;
+      max-height: 3.125rem;
     }
   }
 
@@ -319,21 +310,58 @@ label {
 }
 
 h1.page-header {
-  padding-bottom: 9px;
-  margin: 20px 0 30px;
+  padding-bottom: 0.5625rem;
+  margin: 1.25rem 0 1.875rem;
   border-bottom: 1px solid #eee;
   font-weight: bold;
+}
+
+// On narrow viewports the asset table hides Start/End/Duration columns
+// (see active-assets.tsx / asset-row/index.tsx) so Activity + Actions
+// stay reachable. Tighten the action-button cell so the three icons
+// fit alongside the activity toggle on a 360px-wide phone.
+@media (max-width: 767.98px) {
+  .asset_row_btns {
+    padding: 0.5rem 0.25rem;
+
+    button {
+      padding: 0.375rem 0.5rem;
+    }
+  }
+}
+
+@media (max-width: 575.98px) {
+  // The schedule-action buttons in the header (Previous / Next / Add)
+  // already stack via flex-column flex-sm-row; let them fill the column
+  // width instead of staying pinned at 13.125rem.
+  #previous-asset-button,
+  #next-asset-button,
+  #add-asset-button {
+    width: 100%;
+  }
+}
+
+.empty-state-message {
+  color: $secondary-color;
+  text-align: center;
+  padding: 3rem 1rem;
+
+  .empty-state-icon {
+    font-size: 2rem;
+    margin-bottom: 0.75rem;
+    opacity: 0.4;
+  }
 }
 
 section {
   .header {
     color: #fff;
-    padding: 6px 9px;
-    margin-bottom: 9px;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    padding: 0.375rem 0.5625rem;
+    margin-bottom: 0.5625rem;
+    border-top-right-radius: 0.25rem;
+    border-top-left-radius: 0.25rem;
     font-weight: bold;
-    text-shadow: #555 0px 1px 1px !important;
+    text-shadow: #555 0 1px 1px;
     text-transform: uppercase;
   }
 }
@@ -376,48 +404,16 @@ a.nav-link:not(.active) {
 
 }
 
-#request-error {
-  z-index: 10000;
-
-  .alert {
-    margin-left: 300px;
-    width: 500px;
-  }
-}
-
-#add-form {
-  .uri-text {
-    padding-top: 5px;
-    margin-left: 0px;
-    overflow: hidden;
-  }
-}
-
 .modal-footer {
   .status {
     float: left;
-    margin-top: 6px;
+    margin-top: 0.375rem;
   }
 
   .progress {
-    margin-top: 4px;
-    margin-bottom: 0px;
+    margin-top: 0.25rem;
+    margin-bottom: 0;
     width: 69%;
-  }
-}
-
-#backup-section {
-  .progress {
-    margin-top: 5px;
-    width: 50%;
-    margin-bottom: 5px;
-    display: inline-block;
-  }
-}
-
-#assets {
-  table td {
-    line-height: 32px;
   }
 }
 
@@ -430,12 +426,6 @@ input[name="file_upload"] {
   left: 0;
 }
 
-.bootstrap-timepicker table td input {
-  border: 1px solid #ced4da;
-  border-radius: .25rem;
-  width: 39px !important;
-}
-
 .duration {
   .controls {
     display: flex;
@@ -445,7 +435,7 @@ input[name="file_upload"] {
   input {
     float: left;
     width: 24%;
-    margin-right: 5px;
+    margin-right: 0.3125rem;
   }
 }
 
@@ -454,9 +444,9 @@ input[name="file_upload"] {
 }
 
 .form-actions {
-  padding: 20px 20px;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  padding: 1.25rem 1.25rem;
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
   background-color: $anthias-purple-4;
 
   a, span {
@@ -472,116 +462,58 @@ input[name="file_upload"] {
 
 .filedrop {
   position: relative;
-  border: 3px dashed #ccc;
-  padding: 50px;
+  border: 0.1875rem dashed #ccc;
+  padding: 3.125rem;
   text-align: center;
   color: #888;
-  border-radius: 7px;
-}
-
-#file_upload_label {
-  position: absolute;
-  top: 5px;
-  left: 105px;
-  right: 0;
-  @include ellip();
-}
-
-.accordion-inner {
-  padding: 9px 0 0 0;
-}
-
-.accordion-group {
-  border: none;
-}
-
-@mixin rota($angle,$time) {
-  @each $prefix in webkit moz ms o {
-    -#{$prefix}-transition: all $time linear;
-    -#{$prefix}-transform: rotate($angle);
-  }
-  transition: all $time linear;
-  transform: rotate($angle);
-}
-
-.unrotated {
-  @include rota(0deg, .15s);
-}
-
-.rotated {
-  @include rota(90deg, .15s);
-}
-
-.nocache-toggle {
-  padding-top: 0 !important;
-}
-
-.advanced-accordion {
-  display: none;
-}
-
-.modal-body {
-  max-height: 600px !important;
-}
-
-.ui-sortable-helper {
-  background: #fff;
-}
-
-.asset-icon {
-  margin-left: 5px;
-}
-
-#inactive-assets i.fa-grip-vertical {
-  display: none;
+  border-radius: 0.4375rem;
 }
 
 .asset_row_name {
   @include ellip();
-  max-width: 290px;
-  min-width: 290px;
+  // On mobile, drop both bounds so Activity + Actions can claim the
+  // space they need; the @media block below restores the wider name
+  // column once Start/End/Duration columns are visible again.
+  max-width: 8rem;
+  min-width: 0;
   img {
     cursor: move;
   }
 }
 
+@media (min-width: 768px) {
+  .asset_row_name {
+    max-width: 18.125rem;
+    min-width: 12.5rem;
+  }
+}
+
 .asset_row_btns {
-  padding: 12px 8px 10px 8px !important;
+  padding: 0.75rem 0.5rem 0.625rem;
   white-space: nowrap;
 
   button {
-    padding: 7px 10px;
+    padding: 0.4375rem 0.625rem;
   }
 }
 
 .table {
   td {
-    vertical-align: middle !important;
-  }
-
-  .processing-message {
-    width: 117px;
-    margin-bottom: 2px;
+    vertical-align: middle;
   }
 }
 
-.terminal {
-  background-color: #000 !important;
+.terminal,
+.terminal:hover,
+.terminal:active,
+.terminal:focus {
+  background-color: #000;
   border: none;
   color: #00ff00;
-  padding: 8px;
+  padding: 0.5rem;
   font-family: courier new, Helvetica, Arial, sans-serif;
   font-weight: bold;
-
-  &:hover, &:active, &:focus {
-    background-color: #000 !important;
-    border: none;
-    color: #00ff00;
-    padding: 8px;
-    font-family: courier new, Helvetica, Arial, sans-serif;
-    font-weight: bold;
-    box-shadow: none !important;
-    outline: 0 !important;
-    -webkit-appearance: none;
-  }
+  box-shadow: none;
+  outline: 0;
+  appearance: none;
 }

--- a/static/sass/_sweetalert2-overrides.scss
+++ b/static/sass/_sweetalert2-overrides.scss
@@ -58,6 +58,18 @@ $swal2-cancel-hover-color: #5a6268;
       &:hover {
         background-color: $anthias-yellow-3;
       }
+
+      // Destructive confirmations (delete / reboot / shutdown) override
+      // the default yellow CTA so a misclick on a destructive action
+      // is visually distinct from "Save" elsewhere in the app.
+      &.swal2-confirm-danger {
+        color: #fff;
+        background-color: $swal2-error-color;
+
+        &:hover {
+          background-color: darken($swal2-error-color, 5%);
+        }
+      }
     }
 
     .swal2-cancel {

--- a/static/src/components/active-assets.tsx
+++ b/static/src/components/active-assets.tsx
@@ -77,13 +77,22 @@ export const ActiveAssetsTable = ({ onEditAsset }: ActiveAssetsTableProps) => {
           <thead>
             <tr>
               <th className="fw-bold asset_row_name">Name</th>
-              <th className="fw-bold" style={{ width: '21%' }}>
+              <th
+                className="fw-bold d-none d-md-table-cell"
+                style={{ width: '21%' }}
+              >
                 Start
               </th>
-              <th className="fw-bold" style={{ width: '21%' }}>
+              <th
+                className="fw-bold d-none d-lg-table-cell"
+                style={{ width: '21%' }}
+              >
                 End
               </th>
-              <th className="fw-bold" style={{ width: '13%' }}>
+              <th
+                className="fw-bold d-none d-lg-table-cell"
+                style={{ width: '13%' }}
+              >
                 Duration
               </th>
               <th className="fw-bold" style={{ width: '7%' }}>

--- a/static/src/components/add-asset-modal/index.tsx
+++ b/static/src/components/add-asset-modal/index.tsx
@@ -86,7 +86,7 @@ export const AddAssetModal = ({
       }}
     >
       <div
-        className="modal-dialog"
+        className="modal-dialog modal-dialog-centered modal-dialog-scrollable"
         role="document"
         ref={modalRef}
         style={{
@@ -162,7 +162,7 @@ export const AddAssetModal = ({
               </div>
             </div>
           </div>
-          <div className="modal-footer">
+          <div className="modal-footer flex-column-reverse flex-sm-row">
             <div
               className="status"
               style={{

--- a/static/src/components/asset-row/index.tsx
+++ b/static/src/components/asset-row/index.tsx
@@ -121,8 +121,8 @@ export const AssetRow = forwardRef<HTMLTableRowElement, AssetRowProps>(
             </span>
           </td>
           <td
-            style={{ width: '21%', maxWidth: '200px' }}
-            className="text-truncate"
+            style={{ width: '21%', maxWidth: '12.5rem' }}
+            className="text-truncate d-none d-md-table-cell"
             data-bs-toggle="tooltip"
             data-bs-placement="top"
             title={formatDate(props.startDate, dateFormat, use24HourClock)}
@@ -130,8 +130,8 @@ export const AssetRow = forwardRef<HTMLTableRowElement, AssetRowProps>(
             {formatDate(props.startDate, dateFormat, use24HourClock)}
           </td>
           <td
-            style={{ width: '21%', maxWidth: '200px' }}
-            className="text-truncate"
+            style={{ width: '21%', maxWidth: '12.5rem' }}
+            className="text-truncate d-none d-lg-table-cell"
             data-bs-toggle="tooltip"
             data-bs-placement="top"
             title={formatDate(props.endDate, dateFormat, use24HourClock)}
@@ -139,8 +139,8 @@ export const AssetRow = forwardRef<HTMLTableRowElement, AssetRowProps>(
             {formatDate(props.endDate, dateFormat, use24HourClock)}
           </td>
           <td
-            style={{ width: '13%', maxWidth: '150px' }}
-            className={classNames('text-truncate')}
+            style={{ width: '13%', maxWidth: '9.375rem' }}
+            className="text-truncate d-none d-lg-table-cell"
             data-bs-toggle="tooltip"
             data-bs-placement="top"
             title={formatDuration(props.duration)}

--- a/static/src/components/asset-row/utils.ts
+++ b/static/src/components/asset-row/utils.ts
@@ -124,7 +124,7 @@ export const handleDelete = async (
       popup: 'swal2-popup',
       title: 'swal2-title',
       htmlContainer: 'swal2-html-container',
-      confirmButton: 'swal2-confirm',
+      confirmButton: 'swal2-confirm swal2-confirm-danger',
       cancelButton: 'swal2-cancel',
       actions: 'swal2-actions',
     },

--- a/static/src/components/edit-asset-modal/date-fields.tsx
+++ b/static/src/components/edit-asset-modal/date-fields.tsx
@@ -20,17 +20,18 @@ export const DateFields = ({
     <div id="manul_date">
       <div className="row mb-3 start_date">
         <label className="col-4 col-form-label">Start Date</label>
-        <div className="controls col-7 d-flex">
+        <div className="controls col-8 d-flex flex-wrap flex-sm-nowrap gap-2">
           <input
-            className="form-control date shadow-none"
+            className="form-control date shadow-none flex-grow-1"
+            style={{ minWidth: '8rem' }}
             name="start_date_date"
             type="date"
             value={startDateDate}
             onChange={(e) => handleDateChange(e, 'startDate')}
-            style={{ marginRight: '5px' }}
           />
           <input
-            className="form-control time shadow-none"
+            className="form-control time shadow-none flex-grow-1"
+            style={{ minWidth: '6rem' }}
             name="start_date_time"
             type="time"
             value={startDateTime}
@@ -40,17 +41,18 @@ export const DateFields = ({
       </div>
       <div className="row mb-3 end_date">
         <label className="col-4 col-form-label">End Date</label>
-        <div className="controls col-7 d-flex">
+        <div className="controls col-8 d-flex flex-wrap flex-sm-nowrap gap-2">
           <input
-            className="form-control date shadow-none"
+            className="form-control date shadow-none flex-grow-1"
+            style={{ minWidth: '8rem' }}
             name="end_date_date"
             type="date"
             value={endDateDate}
             onChange={(e) => handleDateChange(e, 'endDate')}
-            style={{ marginRight: '5px' }}
           />
           <input
-            className="form-control time shadow-none"
+            className="form-control time shadow-none flex-grow-1"
+            style={{ minWidth: '6rem' }}
             name="end_date_time"
             type="time"
             value={endDateTime}

--- a/static/src/components/edit-asset-modal/duration-field.tsx
+++ b/static/src/components/edit-asset-modal/duration-field.tsx
@@ -12,7 +12,7 @@ export const DurationField = ({
   return (
     <div className="row mb-3 duration">
       <label className="col-4 col-form-label">Duration</label>
-      <div className="col-7 controls">
+      <div className="col-8 controls d-flex align-items-center gap-2">
         <input
           className="form-control shadow-none"
           name="duration"
@@ -21,7 +21,7 @@ export const DurationField = ({
           onChange={handleInputChange}
           disabled={formData.mimetype === 'video'}
         />
-        seconds &nbsp;
+        <span>seconds</span>
       </div>
     </div>
   )

--- a/static/src/components/edit-asset-modal/index.tsx
+++ b/static/src/components/edit-asset-modal/index.tsx
@@ -178,7 +178,7 @@ export const EditAssetModal = ({
       }}
     >
       <div
-        className="modal-dialog"
+        className="modal-dialog modal-dialog-centered modal-dialog-scrollable"
         role="document"
         style={{
           transition: 'transform 0.3s ease-in-out',
@@ -241,11 +241,11 @@ export const EditAssetModal = ({
                   endDateTime={endDateTime}
                   handleDateChange={handleDateChange}
                 />
-                <ScheduleFields formData={formData} setFormData={setFormData} />
                 <DurationField
                   formData={formData}
                   handleInputChange={handleInputChange}
                 />
+                <ScheduleFields formData={formData} setFormData={setFormData} />
                 <AdvancedFields
                   formData={formData}
                   handleInputChange={handleInputChange}

--- a/static/src/components/edit-asset-modal/modal-footer.tsx
+++ b/static/src/components/edit-asset-modal/modal-footer.tsx
@@ -35,7 +35,7 @@ export const ModalFooter = ({
   setIsSubmitting,
 }: ModalFooterProps) => {
   return (
-    <div className="modal-footer">
+    <div className="modal-footer flex-column-reverse flex-sm-row">
       <div className="float-start progress active" style={{ display: 'none' }}>
         <div className="bar progress-bar-striped progress-bar progress-bar-animated"></div>
       </div>

--- a/static/src/components/edit-asset-modal/name-field.tsx
+++ b/static/src/components/edit-asset-modal/name-field.tsx
@@ -9,7 +9,7 @@ export const NameField = ({ formData, handleInputChange }: NameFieldProps) => {
   return (
     <div className="row mb-3 name">
       <label className="col-4 col-form-label">Name</label>
-      <div className="col-7">
+      <div className="col-8">
         <input
           className="form-control shadow-none"
           name="name"

--- a/static/src/components/edit-asset-modal/play-for-field.tsx
+++ b/static/src/components/edit-asset-modal/play-for-field.tsx
@@ -23,7 +23,7 @@ export const PlayForField = ({
   return (
     <div className="row mb-3 loop_date">
       <label className="col-4 col-form-label">Play for</label>
-      <div className="controls col-7">
+      <div className="controls col-8">
         <select
           className="form-control shadow-none form-select"
           id="loop_times"

--- a/static/src/components/edit-asset-modal/schedule-fields.tsx
+++ b/static/src/components/edit-asset-modal/schedule-fields.tsx
@@ -77,7 +77,7 @@ export const ScheduleFields = ({
       <div className="row mb-3">
         <label className="col-4 col-form-label">Days of week</label>
         <div className="col-8">
-          <div className="d-flex flex-wrap align-items-center">
+          <div className="d-flex flex-wrap align-items-center gap-1">
             {DAYS.map((d) => {
               const isOnlyChecked =
                 formData.play_days.length === 1 &&
@@ -85,7 +85,7 @@ export const ScheduleFields = ({
               return (
                 <label
                   key={d.value}
-                  className="form-check form-check-inline me-2 mb-1"
+                  className="form-check form-check-inline m-0"
                   title={
                     isOnlyChecked
                       ? 'At least one day must be selected'
@@ -114,18 +114,24 @@ export const ScheduleFields = ({
       <div className="row mb-3">
         <label className="col-4 col-form-label">Time of day</label>
         <div className="col-8">
-          <label className="form-check mb-2">
+          <div className="form-check d-flex align-items-center mb-2">
             <input
               type="checkbox"
-              className="form-check-input"
+              className="form-check-input me-2 mt-0"
+              id="restrict-time-toggle"
               checked={restrictTimeEnabled}
               onChange={toggleRestrictTime}
               aria-label="Restrict time of day"
             />
-            <span className="form-check-label">Restrict to a daily window</span>
-          </label>
+            <label
+              htmlFor="restrict-time-toggle"
+              className="form-check-label mb-0"
+            >
+              Restrict to a daily window
+            </label>
+          </div>
           {restrictTimeEnabled && (
-            <div className="d-flex align-items-center">
+            <div className="d-flex align-items-center flex-wrap gap-2">
               <input
                 className="form-control time shadow-none"
                 type="time"
@@ -134,9 +140,9 @@ export const ScheduleFields = ({
                   handleTimeChange('play_time_from', e.target.value)
                 }
                 aria-label="Play time from"
-                style={{ marginRight: '5px', maxWidth: '150px' }}
+                style={{ maxWidth: '9.375rem' }}
               />
-              <span className="me-2">to</span>
+              <span>to</span>
               <input
                 className="form-control time shadow-none"
                 type="time"
@@ -145,7 +151,7 @@ export const ScheduleFields = ({
                   handleTimeChange('play_time_to', e.target.value)
                 }
                 aria-label="Play time to"
-                style={{ maxWidth: '150px' }}
+                style={{ maxWidth: '9.375rem' }}
               />
             </div>
           )}

--- a/static/src/components/footer.tsx
+++ b/static/src/components/footer.tsx
@@ -1,85 +1,79 @@
 export const Footer = () => {
+  const starsBadgeUrl = (() => {
+    const url = new URL('https://img.shields.io/github/stars/Screenly/Anthias')
+    const params = new URLSearchParams({
+      style: 'for-the-badge',
+      labelColor: '#EBF0F4',
+      color: '#FFE11A',
+      logo: 'github',
+      logoColor: 'black',
+    })
+    url.search = params.toString()
+    return url.toString()
+  })()
+
   return (
     <footer id="footer" className="bg-dark">
-      <div className="container">
-        <div className="row">
-          <div className="col-6 small text-white mt-5 mb-5">
-            <span>
-              Want to get more out of your digital signage?{' '}
-              <a
-                className="brand"
-                href="https://www.screenly.io/?utm_source=Anthias&utm_medium=root-page&utm_campaign=UI"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <strong>Try Screenly</strong>
-              </a>
-            </span>
-          </div>
-          <div id="screenly-logo" className="col-12 row m-2 ms-0 me-0">
-            <div className="links offset-3 col-6 text-center justify-content-center align-self-center">
-              <a
-                href="/api/docs/"
-                target="_blank"
-                className="me-4 small"
-                rel="noopener noreferrer"
-              >
-                API
-              </a>
-              <a
-                href="https://anthias.screenly.io/#faq?utm_source=Anthias&utm_medium=footer&utm_campaign=UI"
-                target="_blank"
-                className="me-4 small"
-                rel="noopener noreferrer"
-              >
-                FAQ
-              </a>
-              <a
-                href="https://screenly.io/?utm_source=Anthias&utm_medium=footer&utm_campaign=UI"
-                target="_blank"
-                className="me-4 small"
-                rel="noopener noreferrer"
-              >
-                Screenly.io
-              </a>
-              <a
-                href="https://forums.screenly.io/"
-                target="_blank"
-                className="me-4 small"
-                rel="noopener noreferrer"
-              >
-                Support
-              </a>
-            </div>
-
-            <div
-              id="github-stars"
-              className="col-3 text-end justify-content-center align-self-center"
+      <div className="container py-4">
+        <div className="row align-items-center gy-3">
+          <div className="col-12 col-lg-4 small text-white">
+            Want to get more out of your digital signage?{' '}
+            <a
+              className="brand"
+              href="https://www.screenly.io/?utm_source=Anthias&utm_medium=root-page&utm_campaign=UI"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              <a
-                href="https://github.com/Screenly/Anthias"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <img
-                  alt="GitHub Repo stars"
-                  src={(() => {
-                    const url = new URL(
-                      'https://img.shields.io/github/stars/Screenly/Anthias',
-                    )
-                    const params = new URLSearchParams({
-                      style: 'for-the-badge',
-                      labelColor: '#EBF0F4',
-                      color: '#FFE11A',
-                      logo: 'github',
-                      logoColor: 'black',
-                    })
-                    url.search = params.toString()
-                    return url.toString()
-                  })()}
-                />
-              </a>
-            </div>
+              <strong>Try Screenly</strong>
+            </a>
+          </div>
+
+          <div className="links col-12 col-lg-5 d-flex flex-wrap justify-content-center justify-content-lg-start gap-3">
+            <a
+              href="/api/docs/"
+              target="_blank"
+              className="small"
+              rel="noopener noreferrer"
+            >
+              API
+            </a>
+            <a
+              href="https://anthias.screenly.io/#faq?utm_source=Anthias&utm_medium=footer&utm_campaign=UI"
+              target="_blank"
+              className="small"
+              rel="noopener noreferrer"
+            >
+              FAQ
+            </a>
+            <a
+              href="https://screenly.io/?utm_source=Anthias&utm_medium=footer&utm_campaign=UI"
+              target="_blank"
+              className="small"
+              rel="noopener noreferrer"
+            >
+              Screenly.io
+            </a>
+            <a
+              href="https://forums.screenly.io/"
+              target="_blank"
+              className="small"
+              rel="noopener noreferrer"
+            >
+              Support
+            </a>
+          </div>
+
+          <div
+            id="github-stars"
+            className="col-12 col-lg-3 d-flex justify-content-center justify-content-lg-end"
+          >
+            <a
+              href="https://github.com/Screenly/Anthias"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img alt="GitHub Repo stars" src={starsBadgeUrl} />
+            </a>
           </div>
         </div>
       </div>

--- a/static/src/components/home.tsx
+++ b/static/src/components/home.tsx
@@ -86,7 +86,7 @@ export const ScheduleOverview = () => {
         onAddAsset={handleAddAsset}
       />
 
-      <span id="assets">
+      <div id="assets">
         <ActiveAssetsSection
           activeAssetsCount={activeAssets.length}
           onEditAsset={handleEditAsset}
@@ -98,7 +98,7 @@ export const ScheduleOverview = () => {
           onEditAsset={handleEditAsset}
           onAddAssetClick={handleAddAsset}
         />
-      </span>
+      </div>
 
       <AddAssetModal
         isOpen={isModalOpen}

--- a/static/src/components/http-404.tsx
+++ b/static/src/components/http-404.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
+import { Link } from 'react-router'
 
 const Http404: React.FC = () => {
   return (
@@ -30,6 +31,9 @@ const Http404: React.FC = () => {
                 <br />
                 had its name changed, or is temporarily unavailable.
               </p>
+              <Link to="/" className="btn btn-primary btn-long">
+                Back to Schedule Overview
+              </Link>
             </div>
           </div>
         </div>

--- a/static/src/components/inactive-assets.tsx
+++ b/static/src/components/inactive-assets.tsx
@@ -14,13 +14,22 @@ export const InactiveAssetsTable = ({
         <thead>
           <tr>
             <th className="text-secondary fw-bold asset_row_name">Name</th>
-            <th className="text-secondary fw-bold" style={{ width: '21%' }}>
+            <th
+              className="text-secondary fw-bold d-none d-md-table-cell"
+              style={{ width: '21%' }}
+            >
               Start
             </th>
-            <th className="text-secondary fw-bold" style={{ width: '21%' }}>
+            <th
+              className="text-secondary fw-bold d-none d-lg-table-cell"
+              style={{ width: '21%' }}
+            >
               End
             </th>
-            <th className="text-secondary fw-bold" style={{ width: '13%' }}>
+            <th
+              className="text-secondary fw-bold d-none d-lg-table-cell"
+              style={{ width: '13%' }}
+            >
               Duration
             </th>
             <th className="text-secondary fw-bold" style={{ width: '7%' }}>

--- a/static/src/components/integrations.tsx
+++ b/static/src/components/integrations.tsx
@@ -47,7 +47,21 @@ export const Integrations = () => {
           </h4>
         </div>
       </div>
-      <div className="row content" style={{ minHeight: '60vh' }}>
+      <div className="row content">
+        {!data.is_balena && (
+          <div className="col-12">
+            <div className="empty-state-message">
+              <div className="empty-state-icon">⚙</div>
+              <div className="fw-semibold mb-1 text-dark">
+                No integrations are enabled
+              </div>
+              <small>
+                Integrations appear here when this device is provisioned through
+                a supported platform (e.g. balena).
+              </small>
+            </div>
+          </div>
+        )}
         {data.is_balena && (
           <div id="balena-section" className="col-12">
             <h4 className="page-header">

--- a/static/src/components/settings/backup.tsx
+++ b/static/src/components/settings/backup.tsx
@@ -147,8 +147,18 @@ export const Backup = () => {
         </div>
       </div>
       <div className="row content px-3">
-        <div id="backup-section" className="col-12 my-3">
-          <div className="text-end">
+        <div
+          id="backup-section"
+          className="col-12 my-3 d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3"
+        >
+          <div className="flex-grow-1">
+            <div className="fw-semibold">Back up or restore</div>
+            <small className="text-muted">
+              Download a snapshot of your assets and settings, or restore from a
+              previous backup file.
+            </small>
+          </div>
+          <div className="d-flex flex-wrap justify-content-md-end gap-2">
             <input
               name="backup_upload"
               style={{ display: 'none' }}
@@ -157,7 +167,7 @@ export const Backup = () => {
             />
             <button
               id="btn-backup"
-              className="btn btn-long btn-info me-2"
+              className="btn btn-long btn-info"
               onClick={handleBackup}
               disabled={isUploading}
             >

--- a/static/src/components/settings/index.tsx
+++ b/static/src/components/settings/index.tsx
@@ -116,7 +116,7 @@ export const Settings = () => {
       <div className="row content px-3">
         <div className="col-12 my-3">
           <form onSubmit={handleSubmit} className="row">
-            <div className="col-6 d-flex flex-column justify-content-between">
+            <div className="col-12 col-md-6 d-flex flex-column justify-content-between">
               <PlayerName
                 settings={settings}
                 handleInputChange={handleInputChange}
@@ -141,7 +141,7 @@ export const Settings = () => {
               <Authentication />
             </div>
 
-            <div className="col-6 d-flex flex-column justify-content-start">
+            <div className="col-12 col-md-6 d-flex flex-column justify-content-start">
               <ToggleableSetting
                 settings={settings}
                 handleInputChange={handleInputChange}

--- a/static/src/components/settings/system-controls.tsx
+++ b/static/src/components/settings/system-controls.tsx
@@ -47,7 +47,7 @@ export const SystemControls = () => {
         popup: 'swal2-popup',
         title: 'swal2-title',
         htmlContainer: 'swal2-html-container',
-        confirmButton: 'swal2-confirm',
+        confirmButton: 'swal2-confirm swal2-confirm-danger',
         cancelButton: 'swal2-cancel',
         actions: 'swal2-actions',
       },
@@ -102,10 +102,17 @@ export const SystemControls = () => {
         </div>
       </div>
       <div className="row content px-3">
-        <div className="col-12 my-3">
-          <div className="text-end">
+        <div className="col-12 my-3 d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+          <div className="flex-grow-1">
+            <div className="fw-semibold">Power controls</div>
+            <small className="text-muted">
+              Reboot or shut down the device. The screen will go blank until the
+              device is powered back on.
+            </small>
+          </div>
+          <div className="d-flex flex-wrap justify-content-md-end gap-2">
             <button
-              className="btn btn-danger btn-long me-2"
+              className="btn btn-danger btn-long"
               type="button"
               onClick={handleReboot}
             >

--- a/static/src/components/system-info.tsx
+++ b/static/src/components/system-info.tsx
@@ -195,7 +195,16 @@ export const SystemInfo = () => {
               <tr>
                 <th scope="row">MAC Address</th>
                 <td>
-                  <Skeleton isLoading={isLoading}>{macAddress}</Skeleton>
+                  <Skeleton isLoading={isLoading}>
+                    {macAddress &&
+                    macAddress.toLowerCase().startsWith('unable') ? (
+                      <span className="text-muted fst-italic">
+                        {macAddress}
+                      </span>
+                    ) : (
+                      macAddress
+                    )}
+                  </Skeleton>
                 </td>
               </tr>
             </tbody>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,9 @@
 <head>
   <meta charset="UTF-8">
   <link href="{% static 'dist/css/anthias.css' %}" type="text/css" rel="stylesheet"/>
-  <link href="https://fonts.googleapis.com/css?family=Plus Jakarta Sans" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link href="/static/favicons/apple-touch-icon-57x57.png" rel="apple-touch-icon-precomposed" sizes="57x57"/>
   <link href="/static/favicons/apple-touch-icon-114x114.png" rel="apple-touch-icon-precomposed" sizes="114x114"/>
   <link href="/static/favicons/apple-touch-icon-72x72.png" rel="apple-touch-icon-precomposed" sizes="72x72"/>


### PR DESCRIPTION
## Summary

Audit-driven cleanup of the React frontend after a usability review across **desktop / tablet / mobile / xs** viewports. Touches CSS only where the existing rules were actively breaking layouts; everything else is component-level reflow with Bootstrap responsive utilities.

## Reachability fixes (high impact)

- **Edit Asset modal** — drop the unconditional `.advanced-accordion { display: none }` so the **Disable cache** toggle is reachable again.
- **Asset table** — `Start` shown ≥md, `End` / `Duration` shown ≥lg; the Activity toggle and the download / edit / delete action buttons stay visible on phones and tablets instead of being pushed off-screen by a 6-column table.
- **Settings card** — `col-12 col-md-6`; the form column and switches column now stack on mobile instead of fighting for 150px each.
- **404 page** — adds a “Back to Schedule Overview” CTA so users aren't stranded.
- **Integrations page** — renders an empty-state message when not on a supported platform instead of a blank 60vh card.

## Visual / hierarchy

- **Destructive sweetalert** (delete asset, reboot, shutdown) now uses a red `swal2-confirm-danger` variant so it can't be confused with the yellow “Save” CTA used everywhere else.
- **Footer** reflows to single column on phones; GitHub-stars badge no longer overlaps the SCREENLY.IO link.
- **Backup** and **System Controls** cards now have a description column on the left so the card body isn't an empty white block.
- **Edit Asset** field order: Duration sits next to End Date; schedule restrictions (Days of week / Time of day) come after.
- Days-of-week row uses `gap-1`, no more lone “Sun” wrapping to a second line in the 580px modal.
- “Time of day” toggle is now inline with its label.
- Modal footers reverse on mobile so **Save** sits above **Cancel**.
- Modal uses `modal-dialog-centered modal-dialog-scrollable` so very tall edit forms scroll inside the dialog instead of pushing the footer past the viewport on phones.
- Date + time inputs in `date-fields` wrap on mobile and stay side-by-side on ≥sm.
- System Info “Unable to retrieve MAC address.” rendered muted + italic to read as a fallback rather than a real value.

## Hygiene

- **Fix Plus Jakarta Sans Google Fonts URL** — had an unencoded space, so the font silently fell back to Helvetica. Switched to `css2` + `preconnect` with weights 400/500/600/700.
- Drop dead SCSS rules from the pre-React era (`#request-error`, `#assets table td line-height`, `.bootstrap-timepicker`, `#file_upload_label`, `#inactive-assets i.fa-grip-vertical`, `.unrotated`/`.rotated`/`.nocache-toggle`/`.asset-icon`/`.advanced-accordion`, `.ui-sortable-helper`, `.accordion-inner`/`.accordion-group`, `@mixin rotate/box-shadow/rota`).
- Convert ~all `px` values to `rem` in `_styles.scss`.
- Remove unnecessary `!important` declarations.
- `<span id="assets">` → `<div id="assets">` (was wrapping block-level content in a span).

## Screenshots

Before / after pairs are staged locally at `/tmp/audit-shots/`. I'll drag them into the sections below from the GitHub web UI so they upload to GitHub's user-attachments rather than committing them to the repo.

### Schedule Overview — mobile (390px)
| Before | After |
|---|---|
| _drop `before-home-mobile.png`_ | _drop `after-home-mobile.png`_ |

### Schedule Overview — tablet (820px)
| Before | After |
|---|---|
| _drop `before-home-tablet.png`_ | _drop `after-home-tablet.png`_ |

### Settings — mobile (390px)
| Before | After |
|---|---|
| _drop `before-settings-mobile.png`_ | _drop `after-settings-mobile.png`_ |

### Settings — desktop (1440px)
| Before | After |
|---|---|
| _drop `before-settings-desktop.png`_ | _drop `after-settings-desktop.png`_ |

### Integrations (not on Balena)
| Before | After |
|---|---|
| _drop `before-integrations.png`_ | _drop `after-integrations.png`_ |

### Delete confirm
| Before | After |
|---|---|
| _drop `before-delete-popover.png`_ | _drop `after-delete-popover.png`_ |

### Edit Asset modal — desktop
| Before | After |
|---|---|
| _drop `before-edit-modal-desktop.png`_ | _drop `after-edit-modal-desktop.png`_ |

### Edit Asset modal — mobile (390px)
| Before | After |
|---|---|
| _drop `before-edit-modal-mobile.png`_ | _drop `after-edit-modal-mobile.png`_ |

### System Info — mobile
| Before | After |
|---|---|
| _drop `before-system-info-mobile.png`_ | _drop `after-system-info-mobile.png`_ |

### 404
| Before | After |
|---|---|
| _drop `before-404.png`_ | _drop `after-404.png`_ |

### New / after-only
- `after-edit-modal-restrict-time.png` — schedule restrictions: time-of-day inputs now inline
- `after-reboot-popover.png` — Reboot confirm now red

## Test plan

- [x] `bun run lint:check` clean
- [x] `bun run format:check` clean
- [x] `bun test` — 27/27 pass
- [x] Manually exercised all routes at 1440 / 820 / 390 / 320 px in a headless Chromium pass; before/after diffs above
- [ ] CI passes
- [ ] Manual smoke on a real device (Pi / x86) — recommend a reviewer click through Add Asset → Upload, Edit Asset → Disable cache, Reboot confirm