### PR TITLE
fix(youtube): move download to a Celery task and detect URLs in frontend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,8 @@ module = [
     "pydbus",
     "sh",
     "vlc",
+    "yt_dlp",
+    "yt_dlp.*",
 ]
 ignore_missing_imports = true
 

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -7,10 +7,8 @@ import re
 import socket
 import string
 from datetime import datetime, timedelta
-from os import getenv, path, utime
+from os import getenv, utime
 from platform import machine
-from subprocess import call, check_output
-from threading import Thread
 from time import sleep
 from typing import Any
 from urllib.parse import urlparse
@@ -27,7 +25,6 @@ from tenacity import (
     wait_fixed,
 )
 
-from anthias_server.app.models import Asset
 from anthias_server.settings import settings
 
 arch = machine()
@@ -637,68 +634,6 @@ def url_fails(url: str) -> bool:
         pass
 
     return True
-
-
-def download_video_from_youtube(
-    uri: str,
-    asset_id: str,
-) -> tuple[str, str, int]:
-    name = check_output(['yt-dlp', '-O', 'title', uri])
-    info = json.loads(check_output(['yt-dlp', '-j', uri]))
-    duration = info['duration']
-
-    # Write into settings['assetdir'] so cleanup() (which sweeps the same
-    # path) sees these files; otherwise a custom assetdir would leak
-    # orphaned YouTube downloads in $HOME/anthias_assets.
-    location = path.join(settings['assetdir'], f'{asset_id}.mp4')
-    thread = YoutubeDownloadThread(location, uri, asset_id)
-    thread.daemon = True
-    thread.start()
-
-    return location, str(name.decode('utf-8')), duration
-
-
-class YoutubeDownloadThread(Thread):
-    def __init__(
-        self,
-        location: str,
-        uri: str,
-        asset_id: str,
-    ) -> None:
-        Thread.__init__(self)
-        self.location = location
-        self.uri = uri
-        self.asset_id = asset_id
-
-    def run(self) -> None:
-        call(
-            [
-                'yt-dlp',
-                '-S',
-                'vcodec:h264,fps,res:1080,acodec:m4a',
-                '-o',
-                self.location,
-                self.uri,
-            ]
-        )
-
-        try:
-            asset = Asset.objects.get(asset_id=self.asset_id)
-            asset.is_processing = False
-            asset.save()
-        except Asset.DoesNotExist:
-            logging.warning('Asset %s not found', self.asset_id)
-            return
-
-        # Imported lazily so the viewer container (which does not
-        # ship channels/channels-redis) can still import anthias_common.utils.
-        from asgiref.sync import async_to_sync
-        from channels.layers import get_channel_layer
-
-        async_to_sync(get_channel_layer().group_send)(
-            'ws_server',
-            {'type': 'asset.update', 'asset_id': self.asset_id},
-        )
 
 
 def template_handle_unicode(value: Any) -> str:

--- a/src/anthias_common/youtube.py
+++ b/src/anthias_common/youtube.py
@@ -1,0 +1,81 @@
+"""YouTube asset helpers shared across the frontend, the API
+serializers, and the Celery worker.
+
+Centralised here so URL detection, the on-disk destination path, and
+the Celery dispatch are computed identically everywhere. The previous
+layout sprinkled equivalent logic across two serializers and missed
+the frontend create view entirely (see ``app/views.assets_create``),
+which is how YouTube URLs pasted into the Add modal silently became
+``mimetype='webpage'`` instead of triggering a download.
+"""
+
+from __future__ import annotations
+
+from os import path
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from anthias_server.settings import AnthiasSettings
+
+
+_YOUTUBE_HOSTS = frozenset(
+    {
+        'youtube.com',
+        'www.youtube.com',
+        'm.youtube.com',
+        'music.youtube.com',
+        'youtu.be',
+    }
+)
+
+
+def is_youtube_url(uri: str) -> bool:
+    """True when *uri* points at a recognised YouTube hostname.
+
+    Substring sniffing (`'youtube' in uri`) was rejected: it would
+    match decoy hosts like ``evil.com/?youtube`` and miss the short
+    ``youtu.be`` form. Parsing the hostname keeps the check anchored
+    to the URL's authority component.
+    """
+    if not uri:
+        return False
+    try:
+        parsed = urlparse(uri.strip())
+    except ValueError:
+        return False
+    if parsed.scheme not in ('http', 'https'):
+        return False
+    host = (parsed.hostname or '').lower()
+    return host in _YOUTUBE_HOSTS
+
+
+def youtube_destination_path(
+    asset_id: str,
+    settings: 'AnthiasSettings | None' = None,
+) -> str:
+    """Resolve where the downloaded mp4 will land.
+
+    Picks ``settings['assetdir']`` so ``cleanup()`` (which sweeps that
+    same directory) recognises the final file as referenced. A custom
+    assetdir would otherwise leak orphaned downloads in
+    ``$HOME/anthias_assets`` after a failed run.
+    """
+    if settings is None:
+        # Lazy import to avoid pulling Django settings into modules
+        # that only need is_youtube_url.
+        from anthias_server.settings import settings as _settings
+
+        settings = _settings
+    return path.join(settings['assetdir'], f'{asset_id}.mp4')
+
+
+def dispatch_download(asset_id: str, source_uri: str) -> None:
+    """Queue the Celery worker to fetch *source_uri* into the row.
+
+    Lazy import keeps the celery_tasks module out of import paths
+    that don't need it (e.g. the viewer or anthias_common itself).
+    """
+    from anthias_server.celery_tasks import download_youtube_asset
+
+    download_youtube_asset.delay(asset_id, source_uri)

--- a/src/anthias_server/api/serializers/mixins.py
+++ b/src/anthias_server/api/serializers/mixins.py
@@ -7,10 +7,10 @@ from rest_framework.serializers import CharField, Serializer
 
 from anthias_server.api.errors import AssetCreationError
 from anthias_common.utils import (
-    download_video_from_youtube,
     get_video_duration,
     url_fails,
 )
+from anthias_common.youtube import youtube_destination_path
 from anthias_server.settings import settings
 
 from . import (
@@ -21,6 +21,14 @@ from . import (
 
 class CreateAssetSerializerMixin:
     unique_name: bool = False
+    # Source URL of an in-flight YouTube asset, set by prepare_asset
+    # when ``mimetype == 'youtube_asset'``. The view reads this after
+    # Asset.objects.create() to dispatch download_youtube_asset.delay
+    # with the freshly persisted row's id. Stashing it here (instead
+    # of inside the asset dict) keeps Asset.objects.create from
+    # choking on an unknown column. None means "not a YouTube asset"
+    # and the view skips the dispatch.
+    _pending_youtube_uri: str | None = None
 
     def prepare_asset(
         self,
@@ -64,35 +72,44 @@ class CreateAssetSerializerMixin:
             rename(uri, new_uri)
             uri = new_uri
 
-        if 'youtube_asset' in asset['mimetype']:
-            (uri, asset['name'], asset['duration']) = (
-                download_video_from_youtube(uri, asset['asset_id'])
-            )
+        # Exact match — substring `'youtube_asset' in mimetype`
+        # would also fire on `not_youtube_asset` and crash on a
+        # missing/None mimetype. Both bugs were inherited from the
+        # pre-celery code path.
+        is_youtube = asset['mimetype'] == 'youtube_asset'
+        if is_youtube:
+            # Defer the download to download_youtube_asset (Celery).
+            # The row lands with mimetype='video', is_processing set,
+            # uri at the eventual local path, and a placeholder
+            # duration that the task overwrites with the real value.
+            # The viewer treats local files whose path doesn't exist
+            # yet as not-displayable, so the in-flight row is silently
+            # skipped during rotation.
             asset['mimetype'] = 'video'
             asset['is_processing'] = True if version == 'v2' else 1
+            asset['duration'] = 0
+            self._pending_youtube_uri = uri
+            uri = youtube_destination_path(asset['asset_id'], settings)
 
         asset['uri'] = uri
 
-        if 'video' in asset['mimetype']:
+        if 'video' in asset['mimetype'] and not is_youtube:
             duration_raw = data.get('duration')
             if duration_raw is not None and int(duration_raw) == 0:
-                original_mimetype = data.get('mimetype')
-
-                if original_mimetype != 'youtube_asset':
-                    video_duration = get_video_duration(uri)
-                    if video_duration is None:
-                        raise AssetCreationError(
-                            f'Could not determine duration of video {uri!r}'
-                        )
-                    duration = video_duration.total_seconds()
-                    asset['duration'] = (
-                        duration if version == 'v2' else int(duration)
+                video_duration = get_video_duration(uri)
+                if video_duration is None:
+                    raise AssetCreationError(
+                        f'Could not determine duration of video {uri!r}'
                     )
+                duration = video_duration.total_seconds()
+                asset['duration'] = (
+                    duration if version == 'v2' else int(duration)
+                )
             else:
                 raise AssetCreationError(
                     'Duration must be zero for video assets.'
                 )
-        else:
+        elif not is_youtube:
             # Crashes if it's not an int. We want that.
             duration = data.get('duration', settings['default_duration'])
 
@@ -121,7 +138,16 @@ class CreateAssetSerializerMixin:
             if field in data:
                 asset[field] = data[field]
 
-        if not asset['skip_asset_check'] and url_fails(asset['uri']):
+        # Skip the reachability probe for in-flight YouTube rows: the
+        # local mp4 path is the *future* destination, the file does
+        # not exist yet, and url_fails on a schemeless path is a
+        # silent no-op anyway. Asserting that explicitly prevents a
+        # future url_fails change from breaking the create flow.
+        if (
+            not is_youtube
+            and not asset['skip_asset_check']
+            and url_fails(asset['uri'])
+        ):
             raise AssetCreationError(
                 'Could not retrieve file. Check the asset URL.'
             )

--- a/src/anthias_server/api/serializers/v1_1.py
+++ b/src/anthias_server/api/serializers/v1_1.py
@@ -13,10 +13,10 @@ from rest_framework.serializers import (
 )
 
 from anthias_common.utils import (
-    download_video_from_youtube,
     get_video_duration,
     url_fails,
 )
+from anthias_common.youtube import youtube_destination_path
 from anthias_server.settings import settings
 
 from . import (
@@ -26,6 +26,12 @@ from . import (
 
 
 class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
+    # Source URL of an in-flight YouTube asset, set by prepare_asset
+    # when ``mimetype == 'youtube_asset'``. The view dispatches the
+    # download_youtube_asset task with this value after the row is
+    # persisted. None means "not a YouTube asset" → skip dispatch.
+    _pending_youtube_uri: str | None = None
+
     def __init__(
         self,
         *args: Any,
@@ -72,16 +78,25 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
                 rename(uri, path.join(settings['assetdir'], asset['asset_id']))
                 uri = path.join(settings['assetdir'], asset['asset_id'])
 
-        if 'youtube_asset' in asset['mimetype']:
-            (uri, asset['name'], asset['duration']) = (
-                download_video_from_youtube(uri, asset['asset_id'])
-            )
+        # Exact match — substring `'youtube_asset' in mimetype`
+        # would also fire on `not_youtube_asset` and crash on a
+        # missing/None mimetype. Both bugs predate the celery refactor.
+        is_youtube = asset['mimetype'] == 'youtube_asset'
+        if is_youtube:
+            # Defer the download to download_youtube_asset (Celery).
+            # The row is persisted with mimetype='video',
+            # is_processing=1, uri at the eventual local path, and
+            # duration=0 placeholder. The task overwrites name +
+            # duration once yt-dlp completes.
             asset['mimetype'] = 'video'
             asset['is_processing'] = 1
+            asset['duration'] = 0
+            self._pending_youtube_uri = uri
+            uri = youtube_destination_path(asset['asset_id'], settings)
 
         asset['uri'] = uri
 
-        if 'video' in asset['mimetype']:
+        if 'video' in asset['mimetype'] and not is_youtube:
             duration_raw = data.get('duration')
             try:
                 duration_int = (
@@ -109,7 +124,7 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
                 asset['duration'] = int(video_duration.total_seconds())
             else:
                 asset['duration'] = duration_int
-        else:
+        elif not is_youtube:
             duration_raw = data.get('duration')
             if duration_raw is None:
                 raise ValidationError(
@@ -138,7 +153,13 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
         else:
             asset['end_date'] = ''
 
-        if not asset['skip_asset_check'] and url_fails(asset['uri']):
+        # Skip url_fails for in-flight YouTube assets — the local
+        # mp4 destination doesn't exist until the Celery task lands.
+        if (
+            not is_youtube
+            and not asset['skip_asset_check']
+            and url_fails(asset['uri'])
+        ):
             raise Exception('Could not retrieve file. Check the asset URL.')
 
         return asset

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -272,3 +272,80 @@ def test_v2_create_with_play_days_round_trips(
     assert response.data['play_days'] == [1, 3, 5]
     assert response.data['play_time_from'] == '09:00:00'
     assert response.data['play_time_to'] == '17:00:00'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+def test_create_youtube_asset_dispatches_celery_task(
+    api_client: APIClient, version: str
+) -> None:
+    """Every API version that accepts ``mimetype='youtube_asset'``
+    must dispatch ``download_youtube_asset`` after persisting the
+    row. v1.2 was previously missing this hop, so the row landed
+    with ``is_processing=1`` and never finalized. Parametrize across
+    every version so a future create-view regression for any of
+    them fails this test instead of leaking into prod silently.
+    """
+    youtube_url = 'https://www.youtube.com/watch?v=jNQXAC9IVRw'
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': youtube_url,
+        'mimetype': 'youtube_asset',
+        # Required for YouTube: the serializer sets duration=0 itself,
+        # but the v1.1 serializer's input validation still needs a
+        # 0/None to avoid the "explicit override" branch.
+        'duration': 0,
+    }
+
+    asset_list_url = reverse(f'api:asset_list_{version}')
+    with (
+        mock.patch(
+            'anthias_server.api.views.v1.dispatch_download'
+        ) as v1_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v1_1.dispatch_download'
+        ) as v1_1_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v1_2.dispatch_download'
+        ) as v1_2_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v2.dispatch_download'
+        ) as v2_dispatch,
+        # Skip the network probe — url_fails would be invoked on the
+        # local mp4 destination, which is a no-op in practice but
+        # avoids any future url_fails behaviour change leaking into
+        # this test.
+        mock.patch(
+            'anthias_server.api.serializers.mixins.url_fails',
+            return_value=False,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.url_fails',
+            return_value=False,
+        ),
+    ):
+        response = api_client.post(
+            asset_list_url, data=get_request_data(payload, version)
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    asset_id = response.data['asset_id']
+
+    dispatch_for_version = {
+        'v1': v1_dispatch,
+        'v1_1': v1_1_dispatch,
+        'v1_2': v1_2_dispatch,
+        'v2': v2_dispatch,
+    }[version]
+    dispatch_for_version.assert_called_once_with(asset_id, youtube_url)
+
+    # The other versions' dispatchers must stay untouched — proves
+    # we routed through the right view, not just any of them.
+    for v, m in {
+        'v1': v1_dispatch,
+        'v1_1': v1_1_dispatch,
+        'v1_2': v1_2_dispatch,
+        'v2': v2_dispatch,
+    }.items():
+        if v != version:
+            m.assert_not_called()

--- a/src/anthias_server/api/views/v1.py
+++ b/src/anthias_server/api/views/v1.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from anthias_server.app.models import Asset
+from anthias_common.youtube import dispatch_download
 from anthias_server.api.helpers import (
     AssetCreationError,
     parse_request,
@@ -151,6 +152,13 @@ class AssetListViewV1(APIView):
             return Response(error.errors, status=status.HTTP_400_BAD_REQUEST)
 
         asset = Asset.objects.create(**serializer.data)
+
+        # Kick off the YouTube download out of band when the
+        # serializer flagged a youtube_asset. The row is already
+        # persisted with is_processing=True; the task fills in the
+        # title + duration once yt-dlp finishes.
+        if serializer._pending_youtube_uri:
+            dispatch_download(asset.asset_id, serializer._pending_youtube_uri)
 
         return Response(
             AssetSerializer(asset).data, status=status.HTTP_201_CREATED

--- a/src/anthias_server/api/views/v1_1.py
+++ b/src/anthias_server/api/views/v1_1.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from anthias_server.app.models import Asset
+from anthias_common.youtube import dispatch_download
 from anthias_server.api.helpers import AssetCreationError, parse_request
 from anthias_server.api.serializers import (
     AssetSerializer,
@@ -43,6 +44,12 @@ class AssetListViewV1_1(APIView):
             return Response(error.errors, status=status.HTTP_400_BAD_REQUEST)
 
         asset = Asset.objects.create(**serializer.data)
+
+        # Kick off the YouTube download out of band when the
+        # serializer flagged a youtube_asset. See the v1 view for
+        # the full rationale.
+        if serializer._pending_youtube_uri:
+            dispatch_download(asset.asset_id, serializer._pending_youtube_uri)
 
         return Response(
             AssetSerializer(asset).data, status=status.HTTP_201_CREATED

--- a/src/anthias_server/api/views/v1_2.py
+++ b/src/anthias_server/api/views/v1_2.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from anthias_server.app.models import Asset
+from anthias_common.youtube import dispatch_download
 from anthias_server.api.helpers import (
     AssetCreationError,
     get_active_asset_ids,
@@ -50,6 +51,15 @@ class AssetListViewV1_2(APIView):
 
         active_asset_ids = get_active_asset_ids()
         asset = Asset.objects.create(**serializer.data)
+
+        # Kick off the YouTube download out of band when the
+        # serializer flagged a youtube_asset. Without this dispatch
+        # a v1.2 youtube_asset create would leave the row stuck at
+        # is_processing=1 forever — the prior serializer just
+        # blocked the request on yt-dlp shellouts, so the dispatch
+        # site didn't exist.
+        if serializer._pending_youtube_uri:
+            dispatch_download(asset.asset_id, serializer._pending_youtube_uri)
 
         if asset.is_active():
             active_asset_ids.insert(asset.play_order, asset.asset_id)

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -28,6 +28,7 @@ from anthias_server.api.helpers import (
 )
 from anthias_server.lib.auth import hash_password
 from anthias_common.internal_auth import is_internal_request
+from anthias_common.youtube import dispatch_download
 from anthias_server.api.serializers.v2 import (
     AssetSerializerV2,
     CreateAssetSerializerV2,
@@ -340,6 +341,13 @@ class AssetListViewV2(APIView):
         active_asset_ids = get_active_asset_ids()
         asset = Asset.objects.create(**serializer.data)
         asset.refresh_from_db()
+
+        # Kick off the YouTube download out of band when the
+        # serializer flagged a youtube_asset. The row is already
+        # persisted with is_processing=True; the task fills in the
+        # title + duration once yt-dlp finishes.
+        if serializer._pending_youtube_uri:
+            dispatch_download(asset.asset_id, serializer._pending_youtube_uri)
 
         if asset.is_active():
             active_asset_ids.insert(asset.play_order, asset.asset_id)

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -136,8 +136,21 @@ def assets_table_partial(request: HttpRequest) -> HttpResponse:
 def assets_create(request: HttpRequest) -> HttpResponse:
     """URI-based asset add (the Add modal's URI tab). Mirrors the
     minimum field-set the React modal sent: uri, derived mimetype,
-    default duration window."""
+    default duration window.
+
+    YouTube URLs are special-cased: rather than persisting the URL as
+    a webpage (which YouTube's referrer policy renders as a broken
+    embed), the row is created as ``mimetype='video'`` pointing at a
+    yet-to-be-downloaded local mp4, and ``download_youtube_asset`` is
+    queued to fetch the file. The "Processing" pill on the table row
+    clears once the worker completes.
+    """
     from anthias_common.utils import validate_url
+    from anthias_common.youtube import (
+        dispatch_download,
+        is_youtube_url,
+        youtube_destination_path,
+    )
     from anthias_server.app.models import Asset
     from datetime import timedelta
 
@@ -147,12 +160,21 @@ def assets_create(request: HttpRequest) -> HttpResponse:
         return _asset_table_response(request)
 
     # Best-effort mimetype guess from extension; default to webpage.
-    mimetype = 'webpage'
-    lower = uri.lower()
-    if lower.endswith(('.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg')):
-        mimetype = 'image'
-    elif lower.endswith(('.mp4', '.mov', '.mkv', '.webm', '.avi', '.flv')):
+    # YouTube takes priority — its watch URLs end in `?v=…` not a
+    # video extension, so the file-extension heuristic below would
+    # otherwise classify them as a webpage.
+    is_youtube = is_youtube_url(uri)
+    if is_youtube:
         mimetype = 'video'
+    else:
+        mimetype = 'webpage'
+        lower = uri.lower()
+        if lower.endswith(('.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg')):
+            mimetype = 'image'
+        elif lower.endswith(
+            ('.mp4', '.mov', '.mkv', '.webm', '.avi', '.flv')
+        ):
+            mimetype = 'video'
 
     now = timezone.now()
     # New assets land at the end of the active playlist instead of
@@ -166,6 +188,32 @@ def assets_create(request: HttpRequest) -> HttpResponse:
     play_order = Asset.objects.filter(
         is_enabled=True, is_processing=False
     ).count()
+
+    if is_youtube:
+        # Generate the asset_id up front so the row's URI can point
+        # at the destination path the Celery task will write to.
+        # Title + duration land on the row when the task completes;
+        # the placeholder name is the URL the operator pasted, which
+        # is at least recognisable in the table while processing.
+        asset_id = uuid.uuid4().hex
+        asset = Asset.objects.create(
+            asset_id=asset_id,
+            name=uri,
+            uri=youtube_destination_path(asset_id, settings),
+            mimetype='video',
+            duration=0,
+            is_enabled=True,
+            is_processing=True,
+            play_order=play_order,
+            start_date=now,
+            end_date=now + timedelta(days=30),
+        )
+        dispatch_download(asset.asset_id, uri)
+        return _asset_table_response(
+            request,
+            toast=('info', 'Downloading YouTube video…'),
+        )
+
     Asset.objects.create(
         name=uri,
         uri=uri,

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -171,9 +171,7 @@ def assets_create(request: HttpRequest) -> HttpResponse:
         lower = uri.lower()
         if lower.endswith(('.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg')):
             mimetype = 'image'
-        elif lower.endswith(
-            ('.mp4', '.mov', '.mkv', '.webm', '.avi', '.flv')
-        ):
+        elif lower.endswith(('.mp4', '.mov', '.mkv', '.webm', '.avi', '.flv')):
             mimetype = 'video'
 
     now = timezone.now()

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -417,7 +417,16 @@ def download_youtube_asset(asset_id: str, uri: str) -> None:
         # operator-edited. Don't re-download or clobber its state.
         return
 
-    location = youtube_destination_path(asset_id, settings)
+    # Trust the path the upstream caller persisted on the row rather
+    # than recomputing from settings['assetdir']: if assetdir was
+    # changed between create and task pickup (operator edited
+    # ~/.anthias/anthias.conf, settings reloaded), recomputing here
+    # would write the file to the new path while the row still
+    # points at the old, and the viewer would see a missing file.
+    # Falling back to the recomputed path covers the (defensive)
+    # case where uri is empty for some reason — same destination as
+    # the serializer / frontend create would have produced.
+    location = asset.uri or youtube_destination_path(asset_id, settings)
 
     # Lazy import: yt_dlp pulls in hundreds of extractors at import
     # time. Keeping it inside the task body avoids the cost on

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -26,6 +26,7 @@ from anthias_common.utils import (  # noqa: E402
     shutdown_via_balena_supervisor,
     url_fails,
 )
+from anthias_common.youtube import youtube_destination_path  # noqa: E402
 from anthias_server.settings import settings  # noqa: E402
 
 
@@ -314,6 +315,192 @@ def probe_video_duration(asset_id: str) -> None:
     # Push a refresh nudge over the browser-facing WebSocket so the
     # operator sees the row stop "Processing" and pick up its real
     # duration without waiting for the next 5s table poll.
+    from anthias_server.app.consumers import notify_asset_update
+
+    notify_asset_update(asset_id)
+
+
+class _DownloadYoutubeTask(Task):  # type: ignore[type-arg]
+    """Custom Task subclass so ``on_failure`` clears ``is_processing``
+    when the download fails, mirroring ``_ProbeVideoTask``.
+
+    The previous in-process daemon thread swallowed yt-dlp's exit
+    code, so a failed download silently left the row stuck at
+    "Processing" with an empty .mp4 — the operator had no way to
+    unblock it without editing the database. Now any uncaught
+    exception (DownloadError, ExtractorError, ...) bubbles to celery
+    and lands here once retries are exhausted.
+    """
+
+    def on_failure(
+        self,
+        exc: BaseException,
+        task_id: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        einfo: Any,
+    ) -> None:
+        asset_id = args[0] if args else kwargs.get('asset_id')
+        if not asset_id:
+            return
+        try:
+            Asset.objects.filter(asset_id=asset_id).update(is_processing=False)
+            from anthias_server.app.consumers import notify_asset_update
+
+            notify_asset_update(asset_id)
+        except Exception:
+            logging.exception(
+                'download_youtube_asset on_failure cleanup failed for %s',
+                asset_id,
+            )
+
+
+# Bound the wall-clock cost of a single download attempt. 1080p videos
+# on a slow connection / Pi 1 can run several minutes; 15 min is a
+# generous ceiling that still fails fast enough for the operator to
+# notice via the "Processing" pill not clearing.
+YOUTUBE_DOWNLOAD_TIME_LIMIT_S = 60 * 15
+
+
+@celery.task(
+    base=_DownloadYoutubeTask,
+    time_limit=YOUTUBE_DOWNLOAD_TIME_LIMIT_S,
+    # Transient OSError covers IO-level hiccups (disk pressure,
+    # connection reset surfacing as ConnectionResetError which is an
+    # OSError). yt-dlp's own DownloadError is *not* retried: its
+    # common causes (404, 403, age-gate, geo-block, deleted video,
+    # signature extraction breakage) are permanent and re-running
+    # just burns the worker. Let on_failure clean up.
+    autoretry_for=(OSError,),
+    retry_backoff=15,
+    retry_backoff_max=300,
+    retry_jitter=True,
+    max_retries=2,
+)
+def download_youtube_asset(asset_id: str, uri: str) -> None:
+    """Download a YouTube video out of band and finalize the row.
+
+    Replaces the previous ``YoutubeDownloadThread`` (a daemon thread
+    in the anthias-server process) which:
+      - lost the download on uvicorn restart, leaving rows stuck at
+        ``is_processing=True`` indefinitely,
+      - ignored yt-dlp's exit code, so failures advertised the asset
+        as ready while pointing at an empty file,
+      - blocked the API request for two upfront yt-dlp shellouts
+        (``-O title`` and ``-j``) before returning.
+
+    The row is created upstream with ``mimetype='video'``,
+    ``is_processing=True``, and ``uri`` already pointing at the
+    eventual ``<assetdir>/<asset_id>.mp4``. This task overwrites
+    ``name`` (with the resolved title) and ``duration``, then clears
+    ``is_processing`` and nudges the viewer + browser the same way
+    ``probe_video_duration`` does.
+
+    Uses yt-dlp as a Python library rather than a CLI shellout: a
+    single ``extract_info(uri, download=True)`` call returns title +
+    duration as Python values, eliminating the previous three-
+    shellouts-per-asset pattern (``-O title``, ``-j``, then download)
+    plus the brittle ``\\t``-separated ``--print`` parser (YouTube
+    titles can contain literal tabs).
+    """
+    try:
+        asset = Asset.objects.get(asset_id=asset_id)
+    except Asset.DoesNotExist:
+        # Row was deleted between dispatch and pickup. Any partial
+        # files left behind get swept by cleanup() after the 1h
+        # freshness window — same behaviour as a row deleted
+        # mid-download in the old thread path.
+        return
+
+    if not asset.is_processing:
+        # Row already finalized (e.g. by an earlier invocation) or
+        # operator-edited. Don't re-download or clobber its state.
+        return
+
+    location = youtube_destination_path(asset_id, settings)
+
+    # Lazy import: yt_dlp pulls in hundreds of extractors at import
+    # time. Keeping it inside the task body avoids the cost on
+    # worker startup for jobs that don't touch YouTube.
+    from yt_dlp import YoutubeDL
+    from yt_dlp.utils import DownloadError
+
+    ydl_opts = {
+        # ``format_sort`` mirrors the previous CLI's `-S
+        # vcodec:h264,fps,res:1080,acodec:m4a` — bias toward h264
+        # video and m4a audio, keep resolution at 1080p, prefer
+        # higher fps. yt-dlp still picks the *best matching* format,
+        # falling back to whatever is available if no exact match
+        # exists. Strict `format=` filters would reject videos that
+        # happen to have only vp9, which we don't want.
+        'format_sort': ['vcodec:h264', 'fps', 'res:1080', 'acodec:m4a'],
+        # Final filename — yt-dlp writes <location>.part during the
+        # download and renames on success. cleanup() recognises
+        # .part / .info.json sidecars and skips them inside the 1h
+        # freshness window.
+        'outtmpl': location,
+        # Quiet the worker log: yt-dlp's progress bars and "info"
+        # noise drown out everything else under load. Errors still
+        # raise DownloadError, which we surface via celery.
+        'noprogress': True,
+        'quiet': True,
+        'no_warnings': True,
+        # Don't pull a playlist if the URL happens to be one — we
+        # only want a single-file asset row per request. The viewer
+        # has no concept of "this row expands into N files".
+        'noplaylist': True,
+    }
+
+    try:
+        with YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(uri, download=True)
+    except DownloadError:
+        # Permanent failure surface — let it bubble to on_failure.
+        # autoretry_for excludes DownloadError specifically.
+        raise
+
+    if info is None:
+        # Should not happen with a successful extract_info, but
+        # guard so a future yt-dlp behaviour change doesn't write a
+        # row with a stale name and stale duration. on_failure path
+        # via the explicit raise gives the operator the same
+        # clear-flag-and-stop signal as a download error.
+        raise DownloadError(f'yt-dlp returned no info for {uri!r}')
+
+    # ``noplaylist=True`` collapses single-video extractions; for
+    # the playlist edge cases yt-dlp falls through to, the first
+    # entry is the one we downloaded.
+    if info.get('_type') == 'playlist':
+        entries = info.get('entries') or []
+        info = entries[0] if entries else info
+
+    title = info.get('title') or asset.name
+    raw_duration = info.get('duration')
+    duration: int | None
+    if raw_duration is None:
+        duration = None
+    else:
+        try:
+            # Floor to 1 so a sub-second clip can't slot a 0s entry
+            # into the viewer rotation.
+            duration = max(1, int(float(raw_duration)))
+        except (TypeError, ValueError):
+            duration = None
+
+    update: dict[str, Any] = {
+        'is_processing': False,
+        'name': title,
+    }
+    if duration is not None:
+        update['duration'] = duration
+    Asset.objects.filter(asset_id=asset_id).update(**update)
+
+    # Tell the viewer to reload its playlist now that the file
+    # exists and the row is fully materialised.
+    r.publish('anthias.viewer', 'reload')
+
+    # Browser-side nudge so the table drops "Processing" and picks
+    # up the resolved title/duration without waiting for the 5s poll.
     from anthias_server.app.consumers import notify_asset_update
 
     notify_asset_update(asset_id)

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -502,6 +502,14 @@ def download_youtube_asset(asset_id: str, uri: str) -> None:
     }
     if duration is not None:
         update['duration'] = duration
+    # Backfill the row's uri when we used the defensive fallback
+    # above. Without this the file lands at ``location`` but
+    # Asset.uri stays empty, so the viewer's filesystem check and
+    # the API's serialised uri both come back missing. Only writes
+    # when uri was falsy on entry — leaves an operator-set uri
+    # alone in the normal path.
+    if not asset.uri:
+        update['uri'] = location
     Asset.objects.filter(asset_id=asset_id).update(**update)
 
     # Tell the viewer to reload its playlist now that the file

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -14,6 +14,7 @@ from anthias_server.celery_tasks import (
     ASSET_REVALIDATION_LOCK_KEY,
     asset_recheck_lock_key,
     cleanup,
+    download_youtube_asset,
     get_display_power,
     probe_video_duration,
     reboot_anthias,
@@ -654,3 +655,196 @@ def test_probe_video_duration_no_op_for_unknown_asset() -> None:
     """Stale asset_id (deleted between enqueue and run) — task must not
     crash. Nothing to assert beyond a clean return."""
     probe_video_duration('does-not-exist')
+
+
+# ---------------------------------------------------------------------------
+# download_youtube_asset
+# ---------------------------------------------------------------------------
+
+
+def _make_youtube_asset(asset_id: str = 'yt-1') -> Asset:
+    """A row in the state the serializer / frontend create leaves
+    behind: mimetype=video, is_processing=True, uri pointing at the
+    local destination path, duration=0 placeholder."""
+    return Asset.objects.create(
+        asset_id=asset_id,
+        name='https://www.youtube.com/watch?v=abc',
+        uri=path.join(settings['assetdir'], f'{asset_id}.mp4'),
+        mimetype='video',
+        duration=0,
+        is_enabled=True,
+        is_processing=True,
+        play_order=0,
+    )
+
+
+@pytest.fixture
+def fake_youtube_dl() -> Iterator[mock.MagicMock]:
+    """Patch ``yt_dlp.YoutubeDL`` with a context-manager-shaped mock.
+
+    The task does ``with YoutubeDL(opts) as ydl: ydl.extract_info(...)``,
+    so the fake has to support both __enter__ / __exit__ and
+    extract_info. Tests configure the return value (or side_effect) of
+    extract_info per case.
+    """
+    fake_cls = mock.MagicMock(name='YoutubeDL')
+    fake_inst = mock.MagicMock(name='YoutubeDL_inst')
+    fake_cls.return_value.__enter__.return_value = fake_inst
+    fake_cls.return_value.__exit__.return_value = False
+    with mock.patch.dict('sys.modules'):
+        # yt_dlp is lazy-imported inside the task; mock at module load.
+        import sys
+        import types
+
+        fake_module = types.ModuleType('yt_dlp')
+        fake_module.YoutubeDL = fake_cls
+        utils_mod = types.ModuleType('yt_dlp.utils')
+
+        class FakeDownloadError(Exception):
+            pass
+
+        utils_mod.DownloadError = FakeDownloadError
+        sys.modules['yt_dlp'] = fake_module
+        sys.modules['yt_dlp.utils'] = utils_mod
+        # Exposing the inst lets the test reach `.extract_info` to set
+        # return_value / side_effect; the class itself is also handy
+        # for assertions about ydl_opts.
+        fake_inst._download_error = FakeDownloadError
+        fake_inst._cls = fake_cls
+        yield fake_inst
+
+
+@pytest.mark.django_db
+def test_download_youtube_asset_success_writes_title_and_duration(
+    fake_youtube_dl: mock.MagicMock,
+) -> None:
+    """Happy path: extract_info returns a populated info dict;
+    is_processing clears, name + duration are persisted, viewer +
+    browser get a refresh nudge."""
+    _make_youtube_asset()
+    fake_youtube_dl.extract_info.return_value = {
+        'title': 'Never Gonna Give You Up',
+        'duration': 213,
+    }
+    fake_redis = mock.MagicMock()
+    with (
+        mock.patch.object(celery_tasks_module, 'r', fake_redis),
+        mock.patch(
+            'anthias_server.app.consumers.notify_asset_update'
+        ) as mock_notify,
+    ):
+        download_youtube_asset('yt-1', 'https://www.youtube.com/watch?v=abc')
+
+    a = Asset.objects.get(asset_id='yt-1')
+    assert a.name == 'Never Gonna Give You Up'
+    assert a.duration == 213
+    assert a.is_processing is False
+
+    # Same notifications as probe_video_duration on success.
+    fake_redis.publish.assert_any_call('anthias.viewer', 'reload')
+    mock_notify.assert_called_once_with('yt-1')
+
+
+@pytest.mark.django_db
+def test_download_youtube_asset_floors_subsecond_duration_to_one(
+    fake_youtube_dl: mock.MagicMock,
+) -> None:
+    """A sub-second clip must not slot a 0s rotation entry."""
+    _make_youtube_asset()
+    fake_youtube_dl.extract_info.return_value = {
+        'title': 't',
+        'duration': 0.4,
+    }
+    with mock.patch('anthias_server.app.consumers.notify_asset_update'):
+        download_youtube_asset('yt-1', 'https://youtu.be/abc')
+    assert Asset.objects.get(asset_id='yt-1').duration == 1
+
+
+@pytest.mark.django_db
+def test_download_youtube_asset_handles_missing_duration(
+    fake_youtube_dl: mock.MagicMock,
+) -> None:
+    """Live streams / radio uploads omit duration. Persist what we
+    have (title) without overwriting the placeholder duration."""
+    _make_youtube_asset()
+    fake_youtube_dl.extract_info.return_value = {
+        'title': 'Live now',
+        'duration': None,
+    }
+    with mock.patch('anthias_server.app.consumers.notify_asset_update'):
+        download_youtube_asset('yt-1', 'https://www.youtube.com/watch?v=abc')
+    a = Asset.objects.get(asset_id='yt-1')
+    assert a.name == 'Live now'
+    # Placeholder seeded by the serializer; not overwritten.
+    assert a.duration == 0
+    assert a.is_processing is False
+
+
+@pytest.mark.django_db
+def test_download_youtube_asset_no_op_for_missing_row(
+    fake_youtube_dl: mock.MagicMock,
+) -> None:
+    """Row deleted between dispatch and pickup — task returns cleanly
+    without invoking yt-dlp at all."""
+    download_youtube_asset(
+        'does-not-exist', 'https://www.youtube.com/watch?v=abc'
+    )
+    fake_youtube_dl.extract_info.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_download_youtube_asset_no_op_when_row_already_finalized(
+    fake_youtube_dl: mock.MagicMock,
+) -> None:
+    """A duplicate task firing for a row whose first invocation
+    already cleared is_processing must not re-download or stomp on
+    operator-edited state."""
+    Asset.objects.create(
+        asset_id='yt-2',
+        name='Some title',
+        uri=path.join(settings['assetdir'], 'yt-2.mp4'),
+        mimetype='video',
+        duration=120,
+        is_enabled=True,
+        is_processing=False,
+        play_order=0,
+    )
+    download_youtube_asset('yt-2', 'https://youtu.be/abc')
+    fake_youtube_dl.extract_info.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_download_youtube_asset_failure_propagates_for_on_failure(
+    fake_youtube_dl: mock.MagicMock,
+) -> None:
+    """yt-dlp DownloadError is permanent — the task re-raises so
+    Celery's on_failure path runs (which clears is_processing)."""
+    _make_youtube_asset()
+    DownloadError = fake_youtube_dl._download_error  # noqa: N806
+    fake_youtube_dl.extract_info.side_effect = DownloadError('404')
+    with pytest.raises(DownloadError):
+        download_youtube_asset('yt-1', 'https://youtu.be/dead')
+
+
+@pytest.mark.django_db
+def test_download_youtube_asset_on_failure_clears_processing() -> None:
+    """When Celery declares the task failed, is_processing must
+    flip back to False so the operator can interact with the row.
+    Otherwise the "Processing" pill sticks forever."""
+    _make_youtube_asset()
+    fake_redis = mock.MagicMock()
+    with (
+        mock.patch.object(celery_tasks_module, 'r', fake_redis),
+        mock.patch(
+            'anthias_server.app.consumers.notify_asset_update'
+        ) as mock_notify,
+    ):
+        download_youtube_asset.on_failure(
+            RuntimeError('boom'),
+            task_id='t-1',
+            args=('yt-1',),
+            kwargs={},
+            einfo=None,
+        )
+    assert Asset.objects.get(asset_id='yt-1').is_processing is False
+    mock_notify.assert_called_once_with('yt-1')

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -778,6 +778,42 @@ def test_download_youtube_asset_writes_to_persisted_uri(
     fake_cls.assert_called_once()
     ydl_opts = fake_cls.call_args.args[0]
     assert ydl_opts['outtmpl'] == '/custom/assetdir/yt-uri.mp4'
+    # The row already had a uri; the task must not stomp on it.
+    assert Asset.objects.get(asset_id='yt-uri').uri == (
+        '/custom/assetdir/yt-uri.mp4'
+    )
+
+
+@pytest.mark.django_db
+def test_download_youtube_asset_backfills_uri_when_row_uri_missing(
+    fake_youtube_dl: mock.MagicMock,
+) -> None:
+    """Defensive: if the row landed without a uri (e.g. a custom
+    caller skipped the serializer's path-stamping), the task uses
+    the recomputed destination to download AND backfills the row
+    so the viewer + API can find the file. Without the backfill
+    the file would land at the fallback path while Asset.uri stays
+    empty, leaving the asset orphaned from the operator's view."""
+    Asset.objects.create(
+        asset_id='yt-empty',
+        name='https://youtu.be/abc',
+        uri='',
+        mimetype='video',
+        duration=0,
+        is_enabled=True,
+        is_processing=True,
+        play_order=0,
+    )
+    fake_youtube_dl.extract_info.return_value = {'title': 't', 'duration': 5}
+    with mock.patch('anthias_server.app.consumers.notify_asset_update'):
+        download_youtube_asset('yt-empty', 'https://youtu.be/abc')
+
+    a = Asset.objects.get(asset_id='yt-empty')
+    expected = path.join(settings['assetdir'], 'yt-empty.mp4')
+    assert a.uri == expected
+    # And the actual yt-dlp invocation matched that same path.
+    fake_cls = fake_youtube_dl._cls
+    assert fake_cls.call_args.args[0]['outtmpl'] == expected
 
 
 @pytest.mark.django_db

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -697,13 +697,16 @@ def fake_youtube_dl() -> Iterator[mock.MagicMock]:
         import types
 
         fake_module = types.ModuleType('yt_dlp')
-        fake_module.YoutubeDL = fake_cls
+        # setattr keeps mypy happy on a dynamically-created ModuleType
+        # (a static `module.attr = ...` assignment is `attr-defined`
+        # under --strict).
+        setattr(fake_module, 'YoutubeDL', fake_cls)
         utils_mod = types.ModuleType('yt_dlp.utils')
 
         class FakeDownloadError(Exception):
             pass
 
-        utils_mod.DownloadError = FakeDownloadError
+        setattr(utils_mod, 'DownloadError', FakeDownloadError)
         sys.modules['yt_dlp'] = fake_module
         sys.modules['yt_dlp.utils'] = utils_mod
         # Exposing the inst lets the test reach `.extract_info` to set

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -749,6 +749,38 @@ def test_download_youtube_asset_success_writes_title_and_duration(
 
 
 @pytest.mark.django_db
+def test_download_youtube_asset_writes_to_persisted_uri(
+    fake_youtube_dl: mock.MagicMock,
+) -> None:
+    """The output path passed to yt-dlp must be the row's persisted
+    uri, not a fresh recomputation from settings['assetdir']. If
+    assetdir was changed between the create call and task pickup
+    (operator edited ~/.anthias/anthias.conf), recomputing here
+    would write the file to the new path while the row still
+    points at the old, and the viewer would see a missing file."""
+    Asset.objects.create(
+        asset_id='yt-uri',
+        name='https://youtu.be/abc',
+        # Pin the row to a non-default path: the task must trust this
+        # value rather than rebuilding it from settings.
+        uri='/custom/assetdir/yt-uri.mp4',
+        mimetype='video',
+        duration=0,
+        is_enabled=True,
+        is_processing=True,
+        play_order=0,
+    )
+    fake_youtube_dl.extract_info.return_value = {'title': 't', 'duration': 5}
+    with mock.patch('anthias_server.app.consumers.notify_asset_update'):
+        download_youtube_asset('yt-uri', 'https://youtu.be/abc')
+    # ydl_opts is the first positional arg to the YoutubeDL ctor.
+    fake_cls = fake_youtube_dl._cls
+    fake_cls.assert_called_once()
+    ydl_opts = fake_cls.call_args.args[0]
+    assert ydl_opts['outtmpl'] == '/custom/assetdir/yt-uri.mp4'
+
+
+@pytest.mark.django_db
 def test_download_youtube_asset_floors_subsecond_duration_to_one(
     fake_youtube_dl: mock.MagicMock,
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -203,6 +203,64 @@ def test_assets_create_rejects_invalid_url(client: Client) -> None:
 
 
 @pytest.mark.django_db
+def test_assets_create_routes_youtube_to_celery(client: Client) -> None:
+    """Pasting a YouTube URL into the Add modal must NOT classify it
+    as a webpage (the iframe embed is blocked by YouTube). The row
+    is created as is_processing=True with mimetype=video and a local
+    mp4 destination, and download_youtube_asset is queued."""
+    youtube_url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+    with (
+        mock.patch(
+            'anthias_server.settings.ViewerPublisher.send_to_viewer',
+            return_value=None,
+        ),
+        mock.patch(
+            'anthias_common.youtube.dispatch_download'
+        ) as mock_dispatch,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': youtube_url},
+        )
+    assert response.status_code in (200, 302)
+
+    # The persisted row points at the local mp4 destination, not the
+    # YouTube URL. The placeholder name carries the URL so the
+    # operator can identify the row in the table while it processes.
+    rows = Asset.objects.filter(name=youtube_url)
+    assert rows.count() == 1
+    row = rows.first()
+    assert row is not None
+    assert row.mimetype == 'video'
+    assert row.is_processing is True
+    assert row.uri.endswith(f'{row.asset_id}.mp4')
+    assert row.duration == 0
+
+    mock_dispatch.assert_called_once_with(row.asset_id, youtube_url)
+
+
+@pytest.mark.django_db
+def test_assets_create_youtube_short_form(client: Client) -> None:
+    """youtu.be short URLs are recognised the same as full URLs."""
+    short_url = 'https://youtu.be/dQw4w9WgXcQ'
+    with (
+        mock.patch(
+            'anthias_server.settings.ViewerPublisher.send_to_viewer',
+            return_value=None,
+        ),
+        mock.patch(
+            'anthias_common.youtube.dispatch_download'
+        ) as mock_dispatch,
+    ):
+        client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': short_url},
+        )
+    assert Asset.objects.filter(name=short_url, mimetype='video').exists()
+    mock_dispatch.assert_called_once()
+
+
+@pytest.mark.django_db
 def test_assets_toggle_flips_is_enabled(client: Client, asset: Asset) -> None:
     initial = asset.is_enabled
     with mock.patch(

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -233,6 +233,7 @@ def test_assets_create_routes_youtube_to_celery(client: Client) -> None:
     assert row is not None
     assert row.mimetype == 'video'
     assert row.is_processing is True
+    assert row.uri is not None
     assert row.uri.endswith(f'{row.asset_id}.mp4')
     assert row.duration == 0
 

--- a/tests/test_youtube_helper.py
+++ b/tests/test_youtube_helper.py
@@ -1,0 +1,49 @@
+"""Unit tests for the URL-classification helper that gates the
+YouTube download path. Substring-sniffing variants of this helper
+were rejected during review because they either miss the short
+``youtu.be`` form or false-positive on decoy hosts; these tests
+encode both edges so a future regression to ``'youtube' in uri`` is
+caught."""
+
+import pytest
+
+from anthias_common.youtube import is_youtube_url
+
+
+@pytest.mark.parametrize(
+    'uri',
+    [
+        'https://www.youtube.com/watch?v=abc',
+        'https://youtube.com/watch?v=abc',
+        'https://m.youtube.com/watch?v=abc',
+        'https://music.youtube.com/watch?v=abc',
+        'https://youtu.be/abc',
+        'http://www.youtube.com/watch?v=abc',
+        'HTTPS://YouTube.com/watch?v=abc',
+    ],
+)
+def test_is_youtube_url_recognises_canonical_forms(uri: str) -> None:
+    assert is_youtube_url(uri) is True
+
+
+@pytest.mark.parametrize(
+    'uri',
+    [
+        '',
+        'not a url',
+        'http://example.com',
+        'https://evil.com/?youtube',
+        'ftp://youtube.com/foo',
+        'https://attacker.youtube.com.evil.com/x',
+        # Schemeless local paths must never trigger a download attempt.
+        '/anthias_assets/abc.mp4',
+    ],
+)
+def test_is_youtube_url_rejects_other_inputs(uri: str) -> None:
+    assert is_youtube_url(uri) is False
+
+
+def test_is_youtube_url_handles_whitespace() -> None:
+    """Operators paste from clipboard; trailing whitespace shouldn't
+    flip the classification."""
+    assert is_youtube_url('  https://youtu.be/abc  ') is True

--- a/tests/test_youtube_helper.py
+++ b/tests/test_youtube_helper.py
@@ -10,6 +10,14 @@ import pytest
 from anthias_common.youtube import is_youtube_url
 
 
+# Sonar's S5332 (cleartext protocol) flags the http:// and ftp://
+# fixtures below as security hotspots. They are intentional test
+# data: the http://youtube.com/... case verifies the parser accepts
+# legacy http YouTube URLs operators may have cached, and the
+# ftp:// + plain-http negative cases assert the parser rejects
+# unsupported schemes. None of these strings are dereferenced as
+# URLs at test time. Same NOSONAR(S5332) suppression convention used
+# elsewhere in the repo (see app/views._safe_redirect_uri).
 @pytest.mark.parametrize(
     'uri',
     [
@@ -18,7 +26,7 @@ from anthias_common.youtube import is_youtube_url
         'https://m.youtube.com/watch?v=abc',
         'https://music.youtube.com/watch?v=abc',
         'https://youtu.be/abc',
-        'http://www.youtube.com/watch?v=abc',
+        'http://www.youtube.com/watch?v=abc',  # NOSONAR(S5332)
         'HTTPS://YouTube.com/watch?v=abc',
     ],
 )
@@ -31,9 +39,9 @@ def test_is_youtube_url_recognises_canonical_forms(uri: str) -> None:
     [
         '',
         'not a url',
-        'http://example.com',
+        'http://example.com',  # NOSONAR(S5332)
         'https://evil.com/?youtube',
-        'ftp://youtube.com/foo',
+        'ftp://youtube.com/foo',  # NOSONAR(S5332)
         'https://attacker.youtube.com.evil.com/x',
         # Schemeless local paths must never trigger a download attempt.
         '/anthias_assets/abc.mp4',


### PR DESCRIPTION
## Summary

YouTube assets had two compounding bugs. The frontend Add‑modal silently classified YouTube URLs as `webpage` (the file‑extension heuristic in `assets_create` had no YouTube branch), so the viewer loaded them in an iframe that YouTube refused to embed. The API path that *did* know about `youtube_asset` ran the download in a daemon `Thread` inside uvicorn — lost on restart, blocked the request on two upfront `yt-dlp` shellouts, and silently swallowed yt-dlp's exit code, so a failed download advertised an empty mp4 as ready.

This PR:

- Adds **`src/anthias_common/youtube.py`** as the single source for `is_youtube_url`, the local mp4 destination path, and the Celery dispatch shim.
- Replaces `YoutubeDownloadThread` with **`download_youtube_asset` Celery task**, using `yt_dlp` as a Python library — one `extract_info` call instead of three shellouts plus tab‑separated stdout parsing that YouTube titles can break. `_DownloadYoutubeTask.on_failure` clears `is_processing` so a permanent yt‑dlp failure no longer strands the row at "Processing" forever.
- Routes the **frontend `assets_create`** through `is_youtube_url` before the extension heuristic, so YouTube URLs land as a video asset with `is_processing=True` and the task dispatched.
- Switches both API serializers to **exact‑match** `mimetype == 'youtube_asset'` (substring match also fired on `not_youtube_asset` and crashed on a missing mimetype). The source URI is stashed on `_pending_youtube_uri` for the view to dispatch after `Asset.objects.create`. `url_fails` is skipped for in‑flight YouTube rows whose local mp4 doesn't exist yet.
- Removes `download_video_from_youtube` and `YoutubeDownloadThread` from `anthias_common/utils.py`, plus the unused `Thread` / `subprocess` / `os.path` imports.
- Tests: `tests/test_youtube_helper.py` for URL classification edges, 7 cases in `tests/test_celery_tasks.py` for the task (success, sub‑second floor, missing‑duration, missing/finalized rows, DownloadError propagation, on_failure cleanup), 2 cases in `tests/test_template_views.py` for the frontend create routing.

## Test plan

Verified end‑to‑end through the full compose stack (anthias‑server + anthias‑celery + redis on the dev compose, bind‑mounted to this branch):

- [x] `pytest -m "not integration"` — 544 pass, 0 fail
- [x] `ruff check .` — clean
- [x] API v2 POST with `?v=jNQXAC9IVRw` ("Me at the zoo", 19s) → finalized in 1.8s, name + duration + 614 KiB mp4
- [x] API v2 POST with `?v=aqz-KE-bpKQ` (Big Buck Bunny, 10:35) → finalized in 16.7s, 288 MB mp4
- [x] API v2 POST with `?v=dQw4w9WgXcQ` (Rickroll, 3:33) → finalized in 5.7s, 84 MB mp4
- [x] API v2 POST with bogus video id → `DownloadError` raised, `on_failure` cleared `is_processing`, no orphan files
- [x] Frontend `/assets/new/` POST with a YouTube URL → row created with `mimetype=video`, `is_processing=true`, task dispatched, finalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)