### PR TITLE
fix(ui): truncate long asset names with ellipsis and hover tooltip

### DIFF
--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -391,6 +391,7 @@ label { text-align: left; }
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
+  table-layout: fixed;
 
   thead th {
     font-size: 0.7rem;

--- a/src/anthias_server/app/templates/_asset_row.html
+++ b/src/anthias_server/app/templates/_asset_row.html
@@ -11,7 +11,7 @@
         {% endif %}
       </span>
       <span class="asset-cell-name__title">
-        <span class="asset-cell-name__primary">{{ asset.name }}</span>
+        <span class="asset-cell-name__primary" title="{{ asset.name }}">{{ asset.name }}</span>
         {% if pills %}
         <span class="schedule-chips">
           {% for pill in pills %}


### PR DESCRIPTION
## Summary

- Adding an asset whose name is a long URL with no whitespace (e.g. `https://www.google.com/?q=Lorem%20ipsum%20dolor%20sit%20amet,%20consectetur%20adipiscing%20elit,...`) pushed the asset table — and the whole page — past the viewport.
- Root cause: `.asset-table` was using the default `table-layout: auto`, so the cell expanded to fit the unbreakable URL. The existing `text-overflow: ellipsis` on `.asset-cell-name__primary` had nothing to clip against because its parent cell kept growing.
- Switch `.asset-table` to `table-layout: fixed` so the column widths declared on `<th>` actually bind and the existing ellipsis kicks in.
- Add a `title="{{ asset.name }}"` attribute to the primary name span so the full name is visible on hover.

Resolves issue reported by @MarleTangible.

## Test plan
- [ ] In the dev UI, add an asset using the example URL from the bug report and confirm the table no longer overflows the page.
- [ ] Confirm the truncated name shows a tooltip with the full URL on hover.
- [ ] Verify short names still render normally on both Enabled and Inactive tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)