### PR TITLE
fix(ui): publish bare next/previous to viewer for skip buttons (#2821)

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -87,7 +87,7 @@ jobs:
 
       # ANTHIAS_INTEGRATION_TEST=1 tells src/anthias_server/django_project/settings.py to
       # pin DATABASES.default.TEST.NAME to the same SQLite path the
-      # anthias-server container reads. Selenium tests assert on
+      # anthias-server container reads. Playwright tests assert on
       # `Asset.objects.all()` after the server persists an upload, so
       # both ends must share one file. Unit tests must NOT set this
       # — they run under xdist and need pytest-django's default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,9 @@ uv sync --group test
 uv run pytest -m "not integration"
 ```
 
-Integration tests (`-m integration`) drive Selenium/Chrome and still
-require the Docker stack; use the recipe below.
+Integration tests (`-m integration`) drive Playwright (sync API)
+against Chromium and still require the Docker stack; use the recipe
+below.
 
 #### Docker-based runs (CI parity, integration suite)
 
@@ -102,7 +103,7 @@ docker compose -f docker-compose.test.yml up -d --build
 docker compose -f docker-compose.test.yml exec anthias-test bash ./bin/prepare_test_environment.sh -s
 docker compose -f docker-compose.test.yml exec anthias-test pytest -n auto -m "not integration"
 # ANTHIAS_INTEGRATION_TEST=1 pins TEST.NAME to the same SQLite file the
-# anthias-server container writes — required for Selenium tests that
+# anthias-server container writes — required for Playwright tests that
 # assert on Asset.objects after a browser-driven upload.
 # --reuse-db skips pytest-django's destroy-and-recreate cycle so
 # uvicorn's open handle stays valid; prepare_test_environment.sh has

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -32,7 +32,7 @@ services:
 
   anthias-celery:
     # Same image as anthias-test (test image is a superset of server:
-    # same base apt + venv + bun + chrome for selenium); only the CMD
+    # same base apt + venv + bun + chromium for playwright); only the CMD
     # differs. Sharing the ``build:`` anchor lets compose route this
     # service through the ghcr layer cache too instead of attempting
     # a Docker Hub pull on the local-only ``anthias-test:dev`` tag.

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -562,7 +562,7 @@ def assets_control(request: HttpRequest, command: str) -> HttpResponse:
     """Previous / Next playback. Dispatches the same Redis pub/sub
     command the API mixin sends."""
     if command in ('previous', 'next'):
-        ViewerPublisher.get_instance().send_to_viewer(f'asset_{command}')
+        ViewerPublisher.get_instance().send_to_viewer(command)
     return redirect(reverse('anthias_app:home'))
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -785,27 +785,81 @@ def test_system_info_page_renders(reset_assets: None, page: Page) -> None:
 
 @pytest.mark.integration
 @pytest.mark.django_db(transaction=True)
-def test_skip_next_button_present(reset_assets: None, page: Page) -> None:
-    """The Next/Previous controls fire a viewer Redis publish — we
-    can't observe the side effect without a viewer process, so the
-    test just confirms the controls exist and submit cleanly (no 5xx
-    on the action endpoint)."""
-    Asset.objects.create(**asset_active)
-    page.goto(BASE_URL)
-    expect(
-        page.get_by_role('heading', name='Schedule Overview')
-    ).to_be_visible()
-    _disable_asset_poll(page)
+@pytest.mark.parametrize(
+    ('selector', 'expected_command'),
+    [
+        ('form[action*="control/next"] button[type="submit"]', 'next'),
+        ('form[action*="control/previous"] button[type="submit"]', 'previous'),
+    ],
+)
+def test_skip_buttons_publish_correct_command(
+    reset_assets: None,
+    page: Page,
+    selector: str,
+    expected_command: str,
+) -> None:
+    """Regression for #2821: clicking Next / Previous on the home page
+    must publish the bare ``next`` / ``previous`` token on the
+    ``anthias.viewer`` Redis channel — that's what the viewer's
+    command dispatch table (src/anthias_viewer/__init__.py — ``commands``)
+    keys on. A previous revision sent ``asset_<command>`` instead,
+    which fell through to the ``unknown`` handler so the buttons
+    silently no-op'd in production despite returning a clean 302."""
+    import redis as _redis
 
-    next_btn = page.locator(
-        'form[action*="control/next"] button[type="submit"]'
-    )
-    prev_btn = page.locator(
-        'form[action*="control/previous"] button[type="submit"]'
-    )
-    expect(next_btn).to_be_visible()
-    expect(prev_btn).to_be_visible()
-    next_btn.click()
-    expect(
-        page.get_by_role('heading', name='Schedule Overview')
-    ).to_be_visible()
+    Asset.objects.create(**asset_active)
+
+    # Subscribe to the viewer channel BEFORE clicking. Using a
+    # directly-constructed client (not connect_to_redis) bypasses the
+    # autouse fake in conftest.py — uvicorn is a separate process and
+    # publishes against the real broker either way.
+    sub = _redis.Redis(
+        host='redis', port=6379, db=0, decode_responses=True
+    ).pubsub()
+    try:
+        sub.subscribe('anthias.viewer')
+        # Drain the subscribe-confirmation frame so the next get_message
+        # call returns the actual publish.
+        deadline = monotonic() + 2.0
+        while monotonic() < deadline:
+            msg = sub.get_message(timeout=0.1)
+            if msg is None:
+                break
+            if msg.get('type') == 'subscribe':
+                break
+
+        page.goto(BASE_URL)
+        expect(
+            page.get_by_role('heading', name='Schedule Overview')
+        ).to_be_visible()
+        _disable_asset_poll(page)
+
+        btn = page.locator(selector)
+        expect(btn).to_be_visible()
+        btn.click()
+        expect(
+            page.get_by_role('heading', name='Schedule Overview')
+        ).to_be_visible()
+
+        published: str | None = None
+        deadline = monotonic() + 5.0
+        while monotonic() < deadline:
+            msg = sub.get_message(timeout=0.5)
+            if msg is None:
+                continue
+            if msg.get('type') != 'message':
+                continue
+            data = msg.get('data')
+            if isinstance(data, str) and data.startswith('viewer '):
+                published = data[len('viewer ') :]
+                break
+        assert published == expected_command, (
+            f'expected viewer publish {expected_command!r}, '
+            f'got {published!r}'
+        )
+    finally:
+        try:
+            sub.unsubscribe()
+            sub.close()
+        except Exception:
+            pass

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -822,15 +822,22 @@ def test_skip_buttons_publish_correct_command(
     sub: Any = client.pubsub()
     try:
         sub.subscribe('anthias.viewer')
-        # Drain the subscribe-confirmation frame so the next get_message
-        # call returns the actual publish.
-        deadline = monotonic() + 2.0
+        # Wait for the SUBSCRIBE ack frame before clicking — otherwise
+        # uvicorn can publish faster than the broker registers the
+        # subscription, and the test races. ``get_message`` returning
+        # ``None`` just means no frame arrived in this poll window;
+        # keep polling until the deadline rather than breaking out
+        # early.
+        subscribed = False
+        deadline = monotonic() + 5.0
         while monotonic() < deadline:
-            msg = sub.get_message(timeout=0.1)
+            msg = sub.get_message(timeout=0.2)
             if msg is None:
-                break
+                continue
             if msg.get('type') == 'subscribe':
+                subscribed = True
                 break
+        assert subscribed, 'redis SUBSCRIBE ack never arrived'
 
         page.goto(BASE_URL)
         expect(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -813,9 +813,13 @@ def test_skip_buttons_publish_correct_command(
     # directly-constructed client (not connect_to_redis) bypasses the
     # autouse fake in conftest.py — uvicorn is a separate process and
     # publishes against the real broker either way.
-    sub = _redis.Redis(
+    # ``pubsub`` typed as Any because redis-py's stubs don't expose
+    # get_message / unsubscribe on the PubSub class (matches the
+    # workaround in src/anthias_viewer/messaging.py).
+    client: Any = _redis.Redis(
         host='redis', port=6379, db=0, decode_responses=True
-    ).pubsub()
+    )
+    sub: Any = client.pubsub()
     try:
         sub.subscribe('anthias.viewer')
         # Drain the subscribe-confirmation frame so the next get_message
@@ -854,8 +858,7 @@ def test_skip_buttons_publish_correct_command(
                 published = data[len('viewer ') :]
                 break
         assert published == expected_command, (
-            f'expected viewer publish {expected_command!r}, '
-            f'got {published!r}'
+            f'expected viewer publish {expected_command!r}, got {published!r}'
         )
     finally:
         try:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2,10 +2,10 @@
 
 Each view in src/anthias_server/app/views.py beyond the legacy ``react``,
 ``login`` and ``splash_page`` is exercised here through Django's test
-client — fast, deterministic, no Selenium overhead. The integration
-suite (tests/test_app.py) still drives the full stack via Chrome, but
-that suite hits a parallel uvicorn process and doesn't accumulate
-coverage. These tests do.
+client — fast, deterministic, no browser overhead. The integration
+suite (tests/test_app.py) still drives the full stack via Playwright +
+Chromium, but that suite hits a parallel uvicorn process and doesn't
+accumulate coverage. These tests do.
 """
 
 from __future__ import annotations
@@ -320,16 +320,22 @@ def test_assets_order_persists_play_order(client: Client) -> None:
 
 
 @pytest.mark.django_db
-def test_assets_control_dispatches(client: Client) -> None:
+@pytest.mark.parametrize('command', ['next', 'previous'])
+def test_assets_control_dispatches(client: Client, command: str) -> None:
+    """Regression for #2821: the form-post view must publish the same
+    bare ``next``/``previous`` token the viewer's command dispatch
+    table keys on (src/anthias_viewer/__init__.py — ``commands``).
+    A previous revision sent ``asset_<command>``, which fell through
+    to the ``unknown`` handler and silently no-op'd."""
     with mock.patch(
         'anthias_server.settings.ViewerPublisher.send_to_viewer',
         return_value=None,
     ) as send:
         response = client.post(
-            reverse('anthias_app:assets_control', args=['next'])
+            reverse('anthias_app:assets_control', args=[command])
         )
     assert response.status_code in (200, 302)
-    assert send.called
+    send.assert_called_once_with(command)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Fixes #2821 — the home-page **Next** / **Previous** buttons returned a clean 302 but silently no-op'd in the browser, while `GET /api/v2/assets/control/{next,previous}` continued to work.

- **Root cause** (`src/anthias_server/app/views.py:565`): the form-post handler published `asset_next` / `asset_previous` on the `anthias.viewer` Redis channel, but the viewer's command dispatch table (`src/anthias_viewer/__init__.py:95-108`) only keys on the bare `next` / `previous` tokens — so messages fell through to the `unknown` handler. The v2 API endpoint uses a different code path (`api/views/mixins.py:328`) that already sends the bare token, which is why the API kept working.
- **Fix**: send `command` instead of `f'asset_{command}'`.

## Tests

- `tests/test_template_views.py::test_assets_control_dispatches` — tightened to parametrize over both commands and `assert_called_once_with(command)`. Confirmed it fails against the buggy code (`'asset_next' != 'next'`) and passes against the fix.
- `tests/test_app.py::test_skip_buttons_publish_correct_command` — Playwright integration test that subscribes to `anthias.viewer` before clicking and verifies the published payload is `viewer next` / `viewer previous`.

## Drive-by docs cleanup

The integration suite migrated from Selenium to Playwright a while back; updated stale references in `CLAUDE.md`, `.github/workflows/test-runner.yml`, `docker-compose.test.yml`, and the `tests/test_template_views.py` docstring.

## Test plan

- [x] `uv run --group test pytest tests/test_template_views.py` — 70 passed
- [x] `uv run ruff check` — clean on changed files
- [x] Manual reproduction via `client.post(reverse('anthias_app:assets_control', args=['next']))` → confirmed `send_to_viewer` called with `'asset_next'` before fix, `'next'` after
- [ ] Playwright integration test (`-m integration`) — requires the Docker test stack; CI will run it

🤖 Generated with [Claude Code](https://claude.com/claude-code)