### PR TITLE
fix(ui): make dashboard responsive on mobile (#2826)

### DIFF
--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -428,7 +428,22 @@ label { text-align: left; }
   // duration/toggle/actions strip below the schedule window.
   @media (max-width: 640px) {
     table-layout: auto;
-    thead { display: none; }
+    // Visually hide thead instead of `display: none` so screen
+    // readers still pick up the column headers — `display: none`
+    // would drop them from the accessibility tree along with the
+    // <th scope="col"> associations. The clip/absolute technique is
+    // the WAI-ARIA visually-hidden recipe.
+    thead {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
 
     tbody tr {
       display: block;

--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -171,6 +171,11 @@ label { text-align: left; }
   letter-spacing: -0.02em;
   margin: 0;
   color: var(--color-text-on-dark);
+  // 30px swallows two lines of vertical space on a narrow phone for
+  // a single-word title. Drop to 24px below the sm breakpoint so the
+  // header bar (title + lede + actions) fits the same vertical
+  // footprint as one asset card underneath.
+  @media (max-width: 640px) { font-size: 1.5rem; }
 }
 
 .page-header-bar {
@@ -414,6 +419,76 @@ label { text-align: left; }
   tbody tr:last-child td { border-bottom: none; }
   tbody tr:hover td { background: var(--surface-scrim-2); }
   tbody tr.is-dragging td { background: var(--surface-scrim-5); opacity: 0.85; }
+
+  // Below 640px (covers iPhone 13 at 390px and smaller phones),
+  // the 5-column layout with table-layout: fixed crushes the
+  // schedule-window text and the action-icons row. Switch to a
+  // stacked card per row: thead hidden, each cell labelled inline
+  // via attr(data-label), home rows use a 2-col grid for the
+  // duration/toggle/actions strip below the schedule window.
+  @media (max-width: 640px) {
+    table-layout: auto;
+    thead { display: none; }
+
+    tbody tr {
+      display: block;
+      padding: var(--space-3) 0;
+      border-bottom: 1px solid var(--surface-divider);
+    }
+    tbody tr:last-child { border-bottom: none; }
+
+    tbody td,
+    tbody th {
+      display: block;
+      padding: var(--space-1) 0;
+      border: 0;
+      text-align: left;
+
+      &::before {
+        content: attr(data-label);
+        display: block;
+        font-size: 0.65rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--surface-text-muted);
+        margin-bottom: 2px;
+      }
+      // Hide the synthetic label on cells that don't carry one
+      // (integrations table uses <th scope="row"> instead) and on
+      // the home page's Name cell where the title doubles as the
+      // visible label.
+      &:not([data-label])::before,
+      &[data-label="Name"]::before { display: none; }
+    }
+
+    // Home rows: 2-column grid. Name spans both, schedule + duration
+    // share row 2, toggle + actions share row 3. Right-aligned cells
+    // align their labels to match.
+    tbody tr[data-asset-id] {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: var(--space-2) var(--space-3);
+
+      td:nth-child(1) { grid-column: 1 / -1; }
+      td:nth-child(2) { grid-column: 1 / 2; }
+      td:nth-child(3) {
+        grid-column: 2 / 3;
+        text-align: right;
+        &::before { text-align: right; }
+      }
+      td:nth-child(4) { grid-column: 1 / 2; align-self: center; }
+      td:nth-child(5) {
+        grid-column: 2 / 3;
+        align-self: center;
+        &::before { text-align: right; }
+      }
+
+      .action-group { justify-content: flex-end; }
+    }
+
+    tbody tr:hover td { background: transparent; }
+  }
 }
 
 .asset-cell-name {
@@ -705,7 +780,9 @@ label { text-align: left; }
   padding: var(--space-5) var(--space-6);
   border-bottom: 1px solid var(--color-border);
   display: flex;
-  align-items: center;
+  // Align top so a long asset name (preview modal) wraps to multiple
+  // lines without dragging the close button down with it.
+  align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-3);
 
@@ -714,10 +791,14 @@ label { text-align: left; }
     font-size: 1.125rem;
     font-weight: 700;
     letter-spacing: -0.01em;
+    flex: 1 1 auto;
+    min-width: 0;
+    word-break: break-word;
   }
 }
 
 .modal-card__close {
+  flex: none;
   width: 2rem;
   height: 2rem;
   border-radius: var(--radius-md);
@@ -774,6 +855,11 @@ label { text-align: left; }
   align-items: center;
   justify-content: flex-end;
   gap: var(--space-2);
+  // Preview modal's footer carries an "Open in new tab" link plus a
+  // help blurb plus the Done button — at narrow widths these can't
+  // share a single row without the link wrapping mid-text. Allow the
+  // row to break so each control gets full horizontal space.
+  flex-wrap: wrap;
 }
 
 // Edit-asset form sections. Two semantic blocks share the same
@@ -1439,6 +1525,36 @@ label { text-align: left; }
   backdrop-filter: blur(10px) saturate(140%);
   -webkit-backdrop-filter: blur(10px) saturate(140%);
   border-bottom: 1px solid var(--scrim-on-dark-6);
+  position: relative;
+
+  // Below the lg breakpoint (1024px, matching Tailwind's `lg:`) the
+  // menu is gated by the hamburger toggle. Without intervention the
+  // open menu spills past the 4.5rem navbar bg and overlays the
+  // page-header text — see issue #2826. Anchor the open menu as an
+  // absolute dropdown panel below the brand row so it carries its
+  // own background and the body's padding-top reservation stays
+  // accurate.
+  @media (max-width: 1023px) {
+    #navbarNav {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      padding: var(--space-2) var(--space-4) var(--space-3);
+      background: rgba(15, 0, 25, 0.97);
+      backdrop-filter: blur(10px) saturate(140%);
+      -webkit-backdrop-filter: blur(10px) saturate(140%);
+      border-bottom: 1px solid var(--scrim-on-dark-6);
+      box-shadow: var(--shadow-md);
+    }
+    .app-nav-items {
+      gap: 0;
+    }
+    .app-tab-link {
+      width: 100%;
+      padding: 0.65rem 0.75rem !important;
+    }
+  }
 
   .app-nav-brand {
     padding: 0;
@@ -2042,7 +2158,10 @@ body.auth-body {
   border-radius: var(--radius-md);
   font-size: 1.1rem;
   line-height: 1;
-  @media (min-width: 992px) { display: none; }
+  // 1024px matches Tailwind's `lg:hidden` on the toggler markup —
+  // keeping both in sync avoids a dead-zone (992–1023px) where the
+  // toggler hides but the menu's lg:block hasn't kicked in yet.
+  @media (min-width: 1024px) { display: none; }
 }
 .app-nav-items {
   display: flex;
@@ -2050,7 +2169,7 @@ body.auth-body {
   list-style: none;
   margin: 0;
   padding: 0;
-  @media (min-width: 992px) { flex-direction: row; }
+  @media (min-width: 1024px) { flex-direction: row; }
 }
 .app-nav-brand {
   display: inline-flex;

--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -456,10 +456,10 @@ label { text-align: left; }
       }
       // Hide the synthetic label on cells that don't carry one
       // (integrations table uses <th scope="row"> instead) and on
-      // the home page's Name cell where the title doubles as the
-      // visible label.
+      // cells flagged with data-no-label, e.g. the home asset name
+      // cell where the title is its own visible label.
       &:not([data-label])::before,
-      &[data-label="Name"]::before { display: none; }
+      &[data-no-label]::before { display: none; }
     }
 
     // Home rows: 2-column grid. Name spans both, schedule + duration
@@ -780,8 +780,12 @@ label { text-align: left; }
   padding: var(--space-5) var(--space-6);
   border-bottom: 1px solid var(--color-border);
   display: flex;
-  // Align top so a long asset name (preview modal) wraps to multiple
-  // lines without dragging the close button down with it.
+  // Top-aligned across every modal: only the preview modal can carry
+  // a long title (the asset name), but `flex-start` is also fine for
+  // the short titles used by Add / Edit / Delete / Reboot / Shutdown
+  // since each fits one line. With `flex: 1` + `min-width: 0` the
+  // title wraps inside its column instead of dragging the close
+  // button down.
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-3);
@@ -855,10 +859,10 @@ label { text-align: left; }
   align-items: center;
   justify-content: flex-end;
   gap: var(--space-2);
-  // Preview modal's footer carries an "Open in new tab" link plus a
-  // help blurb plus the Done button — at narrow widths these can't
-  // share a single row without the link wrapping mid-text. Allow the
-  // row to break so each control gets full horizontal space.
+  // Wrap is set on every modal footer but only kicks in when the row
+  // can't fit. The preview modal is the one that actually exercises
+  // it (link + blurb + Done at 390px); other modals' two-button
+  // footers stay on a single row.
   flex-wrap: wrap;
 }
 
@@ -1525,7 +1529,6 @@ label { text-align: left; }
   backdrop-filter: blur(10px) saturate(140%);
   -webkit-backdrop-filter: blur(10px) saturate(140%);
   border-bottom: 1px solid var(--scrim-on-dark-6);
-  position: relative;
 
   // Below the lg breakpoint (1024px, matching Tailwind's `lg:`) the
   // menu is gated by the hamburger toggle. Without intervention the
@@ -1533,7 +1536,10 @@ label { text-align: left; }
   // page-header text — see issue #2826. Anchor the open menu as an
   // absolute dropdown panel below the brand row so it carries its
   // own background and the body's padding-top reservation stays
-  // accurate.
+  // accurate. The Tailwind `.fixed` utility on the <nav> already
+  // provides the positioned ancestor — don't add a competing
+  // position here, since this rule is non-layered and would beat
+  // `@layer utilities { .fixed }` in the cascade.
   @media (max-width: 1023px) {
     #navbarNav {
       position: absolute;

--- a/src/anthias_server/app/templates/_asset_row.html
+++ b/src/anthias_server/app/templates/_asset_row.html
@@ -1,7 +1,7 @@
 {% load asset_filters %}
 {% with pills=asset|schedule_pills %}
 <tr data-asset-id="{{ asset.asset_id }}" data-processing="{{ asset.is_processing|yesno:'true,false' }}" data-name="{{ asset.name|default:''|escape }}" data-duration="{{ asset.duration|default:0 }}">
-  <td data-label="Name">
+  <td data-label="Name" data-no-label>
     <div class="asset-cell-name">
       {% if is_active %}<i class="ti ti-grip-vertical drag-handle" title="Drag to reorder"></i>{% endif %}
       <span class="asset-cell-name__icon">

--- a/src/anthias_server/app/templates/_asset_row.html
+++ b/src/anthias_server/app/templates/_asset_row.html
@@ -1,7 +1,7 @@
 {% load asset_filters %}
 {% with pills=asset|schedule_pills %}
 <tr data-asset-id="{{ asset.asset_id }}" data-processing="{{ asset.is_processing|yesno:'true,false' }}" data-name="{{ asset.name|default:''|escape }}" data-duration="{{ asset.duration|default:0 }}">
-  <td>
+  <td data-label="Name">
     <div class="asset-cell-name">
       {% if is_active %}<i class="ti ti-grip-vertical drag-handle" title="Drag to reorder"></i>{% endif %}
       <span class="asset-cell-name__icon">
@@ -28,7 +28,7 @@
     </div>
   </td>
   {% with window=asset|schedule_window %}
-  <td>
+  <td data-label="Schedule window">
     <div class="schedule-window schedule-window--{{ window.kind }}">
       <div class="schedule-window__dot" aria-hidden="true"></div>
       <div>
@@ -38,8 +38,8 @@
     </div>
   </td>
   {% endwith %}
-  <td>{{ asset.duration|humanize_duration }}</td>
-  <td>
+  <td data-label="Duration">{{ asset.duration|humanize_duration }}</td>
+  <td data-label="Enabled">
     {% if asset.is_processing %}
     <span class="processing-pill"><i class="ti ti-refresh"></i>Processing</span>
     {% else %}
@@ -57,7 +57,7 @@
     </form>
     {% endif %}
   </td>
-  <td class="text-right">
+  <td class="text-right" data-label="Actions">
     <div class="action-group">
       <button
         type="button"

--- a/src/anthias_server/app/templates/base.html
+++ b/src/anthias_server/app/templates/base.html
@@ -4,6 +4,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link href="{% static 'dist/css/tailwind.css' %}" type="text/css" rel="stylesheet"/>
   <link href="{% static 'dist/css/tabler-icons.css' %}" type="text/css" rel="stylesheet"/>
   <link href="{% static 'dist/css/anthias.css' %}" type="text/css" rel="stylesheet"/>

--- a/src/anthias_server/app/templates/home.html
+++ b/src/anthias_server/app/templates/home.html
@@ -20,13 +20,13 @@
       <form method="post" action="{% url 'anthias_app:assets_control' command='previous' %}" class="inline m-0">
         {% csrf_token %}
         <button type="submit" class="app-btn app-btn-light app-btn-pill" title="Skip to previous asset">
-          <i class="ti ti-player-skip-back-filled"></i><span class="hidden md:inline">Previous</span>
+          <i class="ti ti-player-skip-back"></i><span class="hidden md:inline">Previous</span>
         </button>
       </form>
       <form method="post" action="{% url 'anthias_app:assets_control' command='next' %}" class="inline m-0">
         {% csrf_token %}
         <button type="submit" class="app-btn app-btn-light app-btn-pill" title="Skip to next asset">
-          <i class="ti ti-player-skip-forward-filled"></i><span class="hidden md:inline">Next</span>
+          <i class="ti ti-player-skip-forward"></i><span class="hidden md:inline">Next</span>
         </button>
       </form>
       <button type="button" id="add-asset-button" class="app-btn app-btn-primary app-btn-pill" @click="openAdd()">


### PR DESCRIPTION
### Issues Fixed

Closes #2826

### Description

The dashboard rendered at desktop width on phones because `base.html` was missing `<meta name="viewport">`. Even after that, the asset table crushed at 390px and the open mobile menu overlaid the page header.

**Fixes:**
- `base.html`: add the viewport meta — root cause of iOS rendering at 980px and zooming out.
- `_styles.scss`: stack the asset table into cards under 640px (driven by `data-label` attributes added to `_asset_row.html`); shrink `.page-header` to 1.5rem; reduce `Schedule Overview` button row footprint.
- Mobile navbar: turn the open menu into an absolute dropdown panel below the brand row so it stops overlapping page content (issue's second screenshot).
- Align navbar SCSS breakpoints to Tailwind's `lg:` (1024px) — the prior 992px caused a 992–1023px dead zone where both hamburger and menu were hidden.
- Modal header/footer: title wraps without dragging the close button down; footer wraps so the preview's "Open in new tab" link no longer breaks mid-text.
- `home.html`: drop the `-filled` suffix from `ti-player-skip-back/forward` — those variants aren't in the bundled Tabler webfont, so Previous/Next rendered without glyphs.

Audited at 320 / 360 / 390 / 768 / 1280 px on every page (Schedule Overview, Settings, System Info, Integrations, Login) and every modal (Add URL/Upload, Edit with Advanced, Delete, Reboot, Shutdown, Preview).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)