### PR TITLE
fix(ui): use {% comment %} for multi-line upload-accept note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,9 @@ docker compose exec anthias-server python manage.py createsuperuser
 ### Qt/C++ (WebView)
 - Use macros for Qt5/Qt6 cross-version compatibility
 
+### Django templates
+- `{# … #}` only comments out a single line. Anything that wraps to the next line renders verbatim in the page. Use `{% comment %}…{% endcomment %}` for any comment that does not fit on one line.
+
 ## API Versions
 
 The REST API has multiple versions at `/api/v1/`, `/api/v1.1/`, `/api/v1.2/`, and `/api/v2/`. The v2 API (in `api/views/v2.py`) is the current primary API using DRF with drf-spectacular for OpenAPI schema generation.

--- a/src/anthias_server/app/templates/_asset_modal.html
+++ b/src/anthias_server/app/templates/_asset_modal.html
@@ -90,15 +90,17 @@
             <i class="ti ti-cloud-upload" style="font-size: 2.25rem; opacity: 0.55"></i>
             <p class="mb-1 font-semibold mt-2">Click to choose a file</p>
             <p class="muted-label mb-0">Image or video. Upload starts immediately.</p>
-            {# Browser MIME globs cover JPEG/PNG/WebP/GIF/MP4/WebM/MKV out of
-               the box. iOS HEIC and TIFF still slip through `image/*` on
-               some browsers, and macOS QuickTime .mov / .m4v likewise on
-               `video/*` — listing extensions explicitly keeps the file
-               picker showing them as selectable rather than greyed out.
-               The server-side normalisation pipeline (exotic image
-               formats → WebP, exotic video codecs → board-appropriate
-               H.264/HEVC MP4) makes the wider accept range safe to
-               surface here. #}
+            {% comment %}
+              Browser MIME globs cover JPEG/PNG/WebP/GIF/MP4/WebM/MKV out of
+              the box. iOS HEIC and TIFF still slip through `image/*` on
+              some browsers, and macOS QuickTime .mov / .m4v likewise on
+              `video/*` — listing extensions explicitly keeps the file
+              picker showing them as selectable rather than greyed out.
+              The server-side normalisation pipeline (exotic image
+              formats → WebP, exotic video codecs → board-appropriate
+              H.264/HEVC MP4) makes the wider accept range safe to
+              surface here.
+            {% endcomment %}
             <input type="file" class="hidden" id="add-file" name="file_upload"
               accept="image/*,video/*,.heic,.heif,.tif,.tiff,.bmp,.ico,.tga,.jp2,.j2k,.jpx,.jpc,.jpf,.avif,.mov,.m4v,.mkv,.webm,.avi,.mpg,.mpeg,.ts,.flv"
               @change="if ($event.target.files.length) { uploadFileName = $event.target.files[0].name; $event.target.form.requestSubmit() }">


### PR DESCRIPTION
### Issues Fixed

No linked issue — fixing a bug introduced in #2832 where a multi-line `{# … #}` Django comment in the asset upload modal leaks as visible text above the file picker.

### Description

Django only treats `{# … #}` as a comment when it stays on a single line; anything that wraps renders verbatim. Replaced the multi-line `{# … #}` block in `_asset_modal.html` with `{% comment %}…{% endcomment %}` so the explanation about the wider `accept` attribute stays out of the rendered DOM.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)