### PR TITLE
feat(webview): per-asset auto-refresh interval for webpage assets

### DIFF
--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -110,12 +110,12 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
         # on GET; the field is itself written from UpdateAssetSerializerV2
         # back into metadata. Default 0 = no auto-refresh, mirroring the
         # viewer's handling for assets without the key set. Clamp both
-        # bounds on read (per Copilot): the serializer's write path
-        # rejects out-of-range values, but a hand-edited row or a legacy
-        # import could leave a junk value in there. Surfacing it as-is
-        # would contradict the documented 0..REFRESH_INTERVAL_S_MAX
-        # contract and could let a client UI display / accept a value
-        # the next PATCH would 400 on.
+        # bounds on read: the serializer's write path rejects out-of-
+        # range values, but a hand-edited row or a legacy import could
+        # leave a junk value in there. Surfacing it as-is would
+        # contradict the documented 0..REFRESH_INTERVAL_S_MAX contract
+        # and could let a client UI display / accept a value the next
+        # PATCH would 400 on.
         value = (obj.metadata or {}).get('refresh_interval_s', 0)
         try:
             interval = int(value)

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -50,6 +50,15 @@ def _normalise_play_days(value: list[int]) -> list[int]:
     return deduped
 
 
+# Per-asset webpage auto-refresh cadence is stored inside ``Asset.metadata``
+# but exposed as a top-level field on the v2 serializers so ``metadata``
+# can stay read-only (the upload pipeline owns those keys). 24h cap is a
+# UI / typo guard — anything beyond that is almost certainly a "tried to
+# enter milliseconds" mistake — and matches the assets_update form
+# handler, which mirrors this validation server-side.
+REFRESH_INTERVAL_S_MAX = 86400
+
+
 def _validate_time_window(
     attrs: dict[str, Any],
     instance: Asset | None = None,
@@ -85,6 +94,7 @@ def _validate_time_window(
 class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
     is_active = SerializerMethodField()
     play_days = SerializerMethodField()
+    refresh_interval_s = SerializerMethodField()
 
     @extend_schema_field(OpenApiTypes.BOOL)
     def get_is_active(self, obj: Asset) -> bool:
@@ -93,6 +103,18 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
     @extend_schema_field({'type': 'array', 'items': {'type': 'integer'}})
     def get_play_days(self, obj: Asset) -> list[int]:
         return obj.get_play_days()
+
+    @extend_schema_field(OpenApiTypes.INT)
+    def get_refresh_interval_s(self, obj: Asset) -> int:
+        # Pulled out of metadata so it shows up as a first-class column
+        # on GET; the field is itself written from UpdateAssetSerializerV2
+        # back into metadata. Default 0 = no auto-refresh, mirroring the
+        # viewer's handling for assets without the key set.
+        value = (obj.metadata or {}).get('refresh_interval_s', 0)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
 
     class Meta:
         model = Asset
@@ -116,6 +138,7 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
             'is_reachable',
             'last_reachability_check',
             'metadata',
+            'refresh_interval_s',
         ]
         read_only_fields = [
             'is_reachable',
@@ -126,7 +149,10 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
             # bookkeeping but can't overwrite it from the API — letting
             # them stomp on it would invite "transcoded=true but the
             # file is the original" desync. Same posture as
-            # is_reachable / last_reachability_check above.
+            # is_reachable / last_reachability_check above. The webpage
+            # auto-refresh interval is surfaced as its own writable
+            # field (refresh_interval_s) so operators can edit just
+            # that one key without opening the whole bag.
             'metadata',
         ]
 
@@ -162,13 +188,41 @@ class CreateAssetSerializerV2(
     )
     play_time_from = TimeField(required=False, allow_null=True)
     play_time_to = TimeField(required=False, allow_null=True)
+    # write_only because ``Asset`` has no ``refresh_interval_s`` column
+    # — the value lives inside ``metadata``. Keeping it out of
+    # ``serializer.data`` avoids ``Asset.objects.create(**serializer.data)``
+    # crashing on an unknown kwarg in the v2 POST view; the field is
+    # surfaced back on the response via ``AssetSerializerV2``'s
+    # SerializerMethodField. The view applies ``validated_data['metadata']``
+    # (set in ``validate()`` below) to the persisted row after create().
+    refresh_interval_s = IntegerField(
+        required=False,
+        write_only=True,
+        min_value=0,
+        max_value=REFRESH_INTERVAL_S_MAX,
+    )
 
     def validate_play_days(self, value: Any) -> list[int]:
         return _normalise_play_days(value)
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         _validate_time_window(data)
-        return self.prepare_asset(data, version='v2')
+        prepared = self.prepare_asset(data, version='v2')
+        # POST round-trip for the webpage auto-refresh interval. Land it
+        # in ``metadata`` so a fresh row that gets created with a
+        # refresh interval doesn't need a follow-up PATCH to take
+        # effect. Skipping the key entirely (rather than storing 0)
+        # keeps ``metadata`` a clean ``{}`` for assets that didn't ask
+        # for auto-refresh, matching what the upload pipeline expects.
+        # ``metadata`` is not a declared field on this serializer, so
+        # it appears in ``validated_data`` but not in ``serializer.data``
+        # — the v2 POST view reads it from ``validated_data`` and
+        # applies it to the asset after Asset.objects.create().
+        if 'refresh_interval_s' in data:
+            metadata = dict(prepared.get('metadata') or {})
+            metadata['refresh_interval_s'] = int(data['refresh_interval_s'])
+            prepared['metadata'] = metadata
+        return prepared
 
 
 class UpdateAssetSerializerV2(UpdateAssetSerializer):
@@ -183,6 +237,11 @@ class UpdateAssetSerializerV2(UpdateAssetSerializer):
     )
     play_time_from = TimeField(required=False, allow_null=True)
     play_time_to = TimeField(required=False, allow_null=True)
+    refresh_interval_s = IntegerField(
+        required=False,
+        min_value=0,
+        max_value=REFRESH_INTERVAL_S_MAX,
+    )
 
     def validate_play_days(self, value: Any) -> list[int]:
         return _normalise_play_days(value)
@@ -196,6 +255,20 @@ class UpdateAssetSerializerV2(UpdateAssetSerializer):
         for field in ('play_days', 'play_time_from', 'play_time_to'):
             if field in validated_data:
                 setattr(instance, field, validated_data[field])
+        if 'refresh_interval_s' in validated_data:
+            # Merge into metadata so pipeline-owned keys (original_ext,
+            # transcoded, error_message) survive the update — clobbering
+            # them via dict assignment would resurrect the
+            # "transcoded=true but file is original" desync we made
+            # ``metadata`` read-only to prevent. For non-webpage assets
+            # we accept and persist the value but it's a no-op at
+            # playback time (viewer only branches on refresh_interval_s
+            # for ``mimetype contains 'web'``).
+            metadata = dict(instance.metadata or {})
+            metadata['refresh_interval_s'] = int(
+                validated_data['refresh_interval_s']
+            )
+            instance.metadata = metadata
         return super().update(instance, validated_data)
 
 

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -109,12 +109,17 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
         # Pulled out of metadata so it shows up as a first-class column
         # on GET; the field is itself written from UpdateAssetSerializerV2
         # back into metadata. Default 0 = no auto-refresh, mirroring the
-        # viewer's handling for assets without the key set.
+        # viewer's handling for assets without the key set. Clamp the
+        # read to ``>= 0`` (per Copilot): the serializer's write path
+        # rejects negatives, but a hand-edited row or a legacy import
+        # could leave a junk value in there, and surfacing it on GET
+        # would contradict the API's documented contract.
         value = (obj.metadata or {}).get('refresh_interval_s', 0)
         try:
-            return int(value)
+            interval = int(value)
         except (TypeError, ValueError):
             return 0
+        return max(0, interval)
 
     class Meta:
         model = Asset

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -90,10 +90,30 @@ def _validate_time_window(
     return attrs
 
 
+def _clamp_refresh_interval(value: Any) -> int:
+    """Clamp ``metadata['refresh_interval_s']`` to ``[0, MAX]``.
+
+    The serializer's write path rejects out-of-range values, but a
+    hand-edited row or a legacy import could leave a junk value in
+    there. Surfacing it as-is would contradict the documented
+    0..REFRESH_INTERVAL_S_MAX contract and could let a client UI
+    display / accept a value the next PATCH would 400 on. Used by
+    both the top-level ``refresh_interval_s`` field and the
+    sanitised ``metadata`` dict so the two halves of the response
+    can't disagree.
+    """
+    try:
+        interval = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(interval, REFRESH_INTERVAL_S_MAX))
+
+
 class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
     is_active = SerializerMethodField()
     play_days = SerializerMethodField()
     refresh_interval_s = SerializerMethodField()
+    metadata = SerializerMethodField()
 
     @extend_schema_field(OpenApiTypes.BOOL)
     def get_is_active(self, obj: Asset) -> bool:
@@ -108,19 +128,25 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
         # Pulled out of metadata so it shows up as a first-class column
         # on GET; the field is itself written from UpdateAssetSerializerV2
         # back into metadata. Default 0 = no auto-refresh, mirroring the
-        # viewer's handling for assets without the key set. Clamp both
-        # bounds on read: the serializer's write path rejects out-of-
-        # range values, but a hand-edited row or a legacy import could
-        # leave a junk value in there. Surfacing it as-is would
-        # contradict the documented 0..REFRESH_INTERVAL_S_MAX contract
-        # and could let a client UI display / accept a value the next
-        # PATCH would 400 on.
-        value = (obj.metadata or {}).get('refresh_interval_s', 0)
-        try:
-            interval = int(value)
-        except (TypeError, ValueError):
-            return 0
-        return max(0, min(interval, REFRESH_INTERVAL_S_MAX))
+        # viewer's handling for assets without the key set.
+        return _clamp_refresh_interval(
+            (obj.metadata or {}).get('refresh_interval_s', 0)
+        )
+
+    @extend_schema_field({'type': 'object', 'additionalProperties': True})
+    def get_metadata(self, obj: Asset) -> dict[str, Any]:
+        # Sanitise ``refresh_interval_s`` in the embedded metadata too,
+        # so a legacy/hand-edited row can't return a top-level
+        # ``refresh_interval_s: 0`` while the ``metadata`` field still
+        # echoes the raw out-of-range value. Other keys (the upload-
+        # pipeline's original_ext / transcoded / error_message) pass
+        # through untouched.
+        raw = dict(obj.metadata or {})
+        if 'refresh_interval_s' in raw:
+            raw['refresh_interval_s'] = _clamp_refresh_interval(
+                raw['refresh_interval_s']
+            )
+        return raw
 
     class Meta:
         model = Asset

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -109,17 +109,19 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
         # Pulled out of metadata so it shows up as a first-class column
         # on GET; the field is itself written from UpdateAssetSerializerV2
         # back into metadata. Default 0 = no auto-refresh, mirroring the
-        # viewer's handling for assets without the key set. Clamp the
-        # read to ``>= 0`` (per Copilot): the serializer's write path
-        # rejects negatives, but a hand-edited row or a legacy import
-        # could leave a junk value in there, and surfacing it on GET
-        # would contradict the API's documented contract.
+        # viewer's handling for assets without the key set. Clamp both
+        # bounds on read (per Copilot): the serializer's write path
+        # rejects out-of-range values, but a hand-edited row or a legacy
+        # import could leave a junk value in there. Surfacing it as-is
+        # would contradict the documented 0..REFRESH_INTERVAL_S_MAX
+        # contract and could let a client UI display / accept a value
+        # the next PATCH would 400 on.
         value = (obj.metadata or {}).get('refresh_interval_s', 0)
         try:
             interval = int(value)
         except (TypeError, ValueError):
             return 0
-        return max(0, interval)
+        return max(0, min(interval, REFRESH_INTERVAL_S_MAX))
 
     class Meta:
         model = Asset

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -17,7 +17,11 @@ from rest_framework.serializers import (
     TimeField,
 )
 
-from anthias_server.app.models import Asset, REFRESH_INTERVAL_S_MAX
+from anthias_server.app.models import (
+    Asset,
+    REFRESH_INTERVAL_S_MAX,
+    clamp_refresh_interval,
+)
 from anthias_server.api.serializers import UpdateAssetSerializer
 from anthias_server.api.serializers.mixins import CreateAssetSerializerMixin
 
@@ -90,25 +94,6 @@ def _validate_time_window(
     return attrs
 
 
-def _clamp_refresh_interval(value: Any) -> int:
-    """Clamp ``metadata['refresh_interval_s']`` to ``[0, MAX]``.
-
-    The serializer's write path rejects out-of-range values, but a
-    hand-edited row or a legacy import could leave a junk value in
-    there. Surfacing it as-is would contradict the documented
-    0..REFRESH_INTERVAL_S_MAX contract and could let a client UI
-    display / accept a value the next PATCH would 400 on. Used by
-    both the top-level ``refresh_interval_s`` field and the
-    sanitised ``metadata`` dict so the two halves of the response
-    can't disagree.
-    """
-    try:
-        interval = int(value)
-    except (TypeError, ValueError):
-        return 0
-    return max(0, min(interval, REFRESH_INTERVAL_S_MAX))
-
-
 class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
     is_active = SerializerMethodField()
     play_days = SerializerMethodField()
@@ -129,7 +114,7 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
         # on GET; the field is itself written from UpdateAssetSerializerV2
         # back into metadata. Default 0 = no auto-refresh, mirroring the
         # viewer's handling for assets without the key set.
-        return _clamp_refresh_interval(
+        return clamp_refresh_interval(
             (obj.metadata or {}).get('refresh_interval_s', 0)
         )
 
@@ -143,7 +128,7 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
         # through untouched.
         raw = dict(obj.metadata or {})
         if 'refresh_interval_s' in raw:
-            raw['refresh_interval_s'] = _clamp_refresh_interval(
+            raw['refresh_interval_s'] = clamp_refresh_interval(
                 raw['refresh_interval_s']
             )
         return raw

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -17,7 +17,7 @@ from rest_framework.serializers import (
     TimeField,
 )
 
-from anthias_server.app.models import Asset
+from anthias_server.app.models import Asset, REFRESH_INTERVAL_S_MAX
 from anthias_server.api.serializers import UpdateAssetSerializer
 from anthias_server.api.serializers.mixins import CreateAssetSerializerMixin
 
@@ -52,11 +52,10 @@ def _normalise_play_days(value: list[int]) -> list[int]:
 
 # Per-asset webpage auto-refresh cadence is stored inside ``Asset.metadata``
 # but exposed as a top-level field on the v2 serializers so ``metadata``
-# can stay read-only (the upload pipeline owns those keys). 24h cap is a
-# UI / typo guard — anything beyond that is almost certainly a "tried to
-# enter milliseconds" mistake — and matches the assets_update form
-# handler, which mirrors this validation server-side.
-REFRESH_INTERVAL_S_MAX = 86400
+# can stay read-only (the upload pipeline owns those keys). The cap
+# itself lives on the model (REFRESH_INTERVAL_S_MAX, imported above) so
+# the form handler in app/views.py and the v2 API agree on the same
+# value without drift.
 
 
 def _validate_time_window(

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -275,6 +275,152 @@ def test_v2_create_with_play_days_round_trips(
 
 
 @pytest.mark.django_db
+def test_v2_post_with_refresh_interval_round_trips(
+    api_client: APIClient,
+) -> None:
+    """POST round-trip for the webpage auto-refresh interval.
+
+    The interval lives inside ``Asset.metadata`` (so the upload
+    pipeline's read-only stance on metadata is preserved) but is
+    surfaced as a top-level ``refresh_interval_s`` field on the v2
+    response via SerializerMethodField, and accepted as a write_only
+    field on the create serializer. Verifies the value lands on the
+    persisted row, not just on the response.
+    """
+    response = api_client.post(
+        reverse('api:asset_list_v2'),
+        data={**ASSET_CREATION_DATA, 'refresh_interval_s': 30},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data['refresh_interval_s'] == 30
+    assert response.data['metadata'] == {'refresh_interval_s': 30}
+
+    # GET the freshly created row through the read serializer to make
+    # sure the response above isn't echoing the request — round-trip
+    # through the DB confirms the post-create metadata save fired.
+    asset_id = response.data['asset_id']
+    detail = api_client.get(reverse('api:asset_detail_v2', args=[asset_id]))
+    assert detail.status_code == status.HTTP_200_OK
+    assert detail.data['refresh_interval_s'] == 30
+
+
+@pytest.mark.django_db
+def test_v2_post_without_refresh_interval_defaults_to_zero(
+    api_client: APIClient,
+) -> None:
+    """A create without ``refresh_interval_s`` reads back as 0 (the
+    "no auto-refresh" default), and ``metadata`` is left as an empty
+    dict so the upload pipeline's other keys aren't shadowed by a
+    stub entry."""
+    response = api_client.post(
+        reverse('api:asset_list_v2'),
+        data=ASSET_CREATION_DATA,
+        format='json',
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data['refresh_interval_s'] == 0
+    assert response.data['metadata'] == {}
+
+
+@pytest.mark.django_db
+def test_v2_patch_refresh_interval_round_trips(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """PATCH a single ``refresh_interval_s`` (partial update) onto an
+    existing webpage asset and read the new value back."""
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'refresh_interval_s': 45},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['refresh_interval_s'] == 45
+    assert response.data['metadata'] == {'refresh_interval_s': 45}
+
+
+@pytest.mark.django_db
+def test_v2_patch_negative_refresh_interval_rejected(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'refresh_interval_s': -1},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'refresh_interval_s' in response.data
+
+
+@pytest.mark.django_db
+def test_v2_patch_refresh_interval_over_cap_rejected(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """24h cap (REFRESH_INTERVAL_S_MAX = 86400) — anything above is a
+    typo (operator entered milliseconds, etc.) and should fail
+    validation rather than persist a value the viewer would honour."""
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'refresh_interval_s': 86401},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'refresh_interval_s' in response.data
+
+
+@pytest.mark.django_db
+def test_v2_patch_refresh_interval_preserves_pipeline_metadata(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """Operator-driven refresh_interval_s edits must not stomp on the
+    upload pipeline's metadata keys (original_ext, transcoded,
+    error_message). Pre-seeding the row with a pipeline payload and
+    then PATCHing the interval is the canonical regression for the
+    "transcoded=true but file is original" desync that motivated
+    making metadata read-only on the create/update serializers."""
+    from anthias_server.app.models import Asset
+
+    asset_id = v2_asset_detail_url.rstrip('/').rsplit('/', 1)[-1]
+    asset = Asset.objects.get(asset_id=asset_id)
+    asset.metadata = {'original_ext': '.heic', 'transcoded': False}
+    asset.save(update_fields=['metadata'])
+
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'refresh_interval_s': 60},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['metadata'] == {
+        'original_ext': '.heic',
+        'transcoded': False,
+        'refresh_interval_s': 60,
+    }
+
+
+@pytest.mark.django_db
+def test_v2_patch_refresh_interval_zero_disables(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """0 stores explicitly; the viewer treats 0 the same as a missing
+    key (no auto-refresh). Operators clearing the field from the edit
+    modal POST 0 to disable rather than DELETE the metadata key, so
+    the round-trip should accept 0 and surface 0 on read."""
+    api_client.patch(
+        v2_asset_detail_url,
+        data={'refresh_interval_s': 30},
+        format='json',
+    )
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'refresh_interval_s': 0},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['refresh_interval_s'] == 0
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
 def test_create_youtube_asset_dispatches_celery_task(
     api_client: APIClient, version: str

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -417,7 +417,7 @@ def test_v2_get_clamps_out_of_range_refresh_interval(
     metadata. GET should clamp to the documented 0..86400 contract
     rather than echo whatever's in the column — a UI that round-tripped
     the raw value would let the operator save a value the next PATCH
-    would 400 on. Per Copilot review (rounds 1 and 2)."""
+    would 400 on."""
     from anthias_server.app.models import Asset
 
     asset_id = v2_asset_detail_url.rstrip('/').rsplit('/', 1)[-1]

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -399,6 +399,37 @@ def test_v2_patch_refresh_interval_preserves_pipeline_metadata(
 
 
 @pytest.mark.django_db
+def test_v2_get_normalises_refresh_interval_in_metadata_too(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """The top-level ``refresh_interval_s`` and the embedded
+    ``metadata['refresh_interval_s']`` must agree on the response —
+    a row with an out-of-range stored value would otherwise produce
+    contradictory JSON (top-level clamped to 0, metadata still echoing
+    -42), and a client reading metadata could re-submit the bad
+    value. Other metadata keys (upload-pipeline state) pass
+    through untouched."""
+    from anthias_server.app.models import Asset
+
+    asset_id = v2_asset_detail_url.rstrip('/').rsplit('/', 1)[-1]
+    asset = Asset.objects.get(asset_id=asset_id)
+    asset.metadata = {
+        'refresh_interval_s': 999999,
+        'original_ext': '.heic',
+        'transcoded': True,
+    }
+    asset.save(update_fields=['metadata'])
+
+    response = api_client.get(v2_asset_detail_url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['refresh_interval_s'] == 86400
+    assert response.data['metadata']['refresh_interval_s'] == 86400
+    # Pipeline-owned keys must pass through unchanged.
+    assert response.data['metadata']['original_ext'] == '.heic'
+    assert response.data['metadata']['transcoded'] is True
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     'stored,expected',
     [

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -340,28 +340,21 @@ def test_v2_patch_refresh_interval_round_trips(
 
 
 @pytest.mark.django_db
-def test_v2_patch_negative_refresh_interval_rejected(
-    api_client: APIClient, v2_asset_detail_url: str
+@pytest.mark.parametrize(
+    'value',
+    [-1, 86401],
+    ids=['negative', 'over-24h-cap'],
+)
+def test_v2_patch_refresh_interval_out_of_range_rejected(
+    api_client: APIClient, v2_asset_detail_url: str, value: int
 ) -> None:
+    """Both bounds of the documented 0..REFRESH_INTERVAL_S_MAX range
+    must 400 on write. ``-1`` is the just-below-zero case; ``86401``
+    catches the typo (operator entered milliseconds, etc.) that the
+    24h cap exists to prevent."""
     response = api_client.patch(
         v2_asset_detail_url,
-        data={'refresh_interval_s': -1},
-        format='json',
-    )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert 'refresh_interval_s' in response.data
-
-
-@pytest.mark.django_db
-def test_v2_patch_refresh_interval_over_cap_rejected(
-    api_client: APIClient, v2_asset_detail_url: str
-) -> None:
-    """24h cap (REFRESH_INTERVAL_S_MAX = 86400) — anything above is a
-    typo (operator entered milliseconds, etc.) and should fail
-    validation rather than persist a value the viewer would honour."""
-    response = api_client.patch(
-        v2_asset_detail_url,
-        data={'refresh_interval_s': 86401},
+        data={'refresh_interval_s': value},
         format='json',
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -399,6 +399,26 @@ def test_v2_patch_refresh_interval_preserves_pipeline_metadata(
 
 
 @pytest.mark.django_db
+def test_v2_get_clamps_negative_refresh_interval(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """The serializer's write path rejects negatives, but a hand-edited
+    row or a legacy import could leave a junk value in metadata.
+    GET should clamp to 0 rather than echo a negative value (which
+    would contradict the documented contract). Per Copilot review."""
+    from anthias_server.app.models import Asset
+
+    asset_id = v2_asset_detail_url.rstrip('/').rsplit('/', 1)[-1]
+    asset = Asset.objects.get(asset_id=asset_id)
+    asset.metadata = {'refresh_interval_s': -42}
+    asset.save(update_fields=['metadata'])
+
+    response = api_client.get(v2_asset_detail_url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['refresh_interval_s'] == 0
+
+
+@pytest.mark.django_db
 def test_v2_patch_refresh_interval_zero_disables(
     api_client: APIClient, v2_asset_detail_url: str
 ) -> None:

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -399,23 +399,35 @@ def test_v2_patch_refresh_interval_preserves_pipeline_metadata(
 
 
 @pytest.mark.django_db
-def test_v2_get_clamps_negative_refresh_interval(
-    api_client: APIClient, v2_asset_detail_url: str
+@pytest.mark.parametrize(
+    'stored,expected',
+    [
+        (-42, 0),  # negative clamped up to 0
+        (999999, 86400),  # huge value clamped down to 24h cap
+    ],
+)
+def test_v2_get_clamps_out_of_range_refresh_interval(
+    api_client: APIClient,
+    v2_asset_detail_url: str,
+    stored: int,
+    expected: int,
 ) -> None:
-    """The serializer's write path rejects negatives, but a hand-edited
-    row or a legacy import could leave a junk value in metadata.
-    GET should clamp to 0 rather than echo a negative value (which
-    would contradict the documented contract). Per Copilot review."""
+    """The serializer's write path rejects out-of-range values, but a
+    hand-edited row or a legacy import could leave a junk value in
+    metadata. GET should clamp to the documented 0..86400 contract
+    rather than echo whatever's in the column — a UI that round-tripped
+    the raw value would let the operator save a value the next PATCH
+    would 400 on. Per Copilot review (rounds 1 and 2)."""
     from anthias_server.app.models import Asset
 
     asset_id = v2_asset_detail_url.rstrip('/').rsplit('/', 1)[-1]
     asset = Asset.objects.get(asset_id=asset_id)
-    asset.metadata = {'refresh_interval_s': -42}
+    asset.metadata = {'refresh_interval_s': stored}
     asset.save(update_fields=['metadata'])
 
     response = api_client.get(v2_asset_detail_url)
     assert response.status_code == status.HTTP_200_OK
-    assert response.data['refresh_interval_s'] == 0
+    assert response.data['refresh_interval_s'] == expected
 
 
 @pytest.mark.django_db

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -347,6 +347,22 @@ class AssetListViewV2(APIView):
 
         active_asset_ids = get_active_asset_ids()
         asset = Asset.objects.create(**serializer.data)
+        # Apply ``metadata`` (set by CreateAssetSerializerV2.validate()
+        # when the operator passes ``refresh_interval_s``). It lives in
+        # ``validated_data`` rather than ``serializer.data`` because
+        # ``metadata`` isn't a declared field on the create serializer
+        # — surfacing it as one would open the upload-pipeline-owned
+        # bag (original_ext, transcoded, error_message) for arbitrary
+        # client writes. Pulling it from validated_data and applying
+        # post-create keeps the read-only stance on metadata while
+        # still letting the dedicated refresh_interval_s knob round-
+        # trip on POST.
+        post_create_metadata = serializer.validated_data.get('metadata')
+        if post_create_metadata:
+            existing = dict(asset.metadata or {})
+            existing.update(post_create_metadata)
+            asset.metadata = existing
+            asset.save(update_fields=['metadata'])
         asset.refresh_from_db()
 
         # Kick off the YouTube download out of band when the

--- a/src/anthias_server/app/models.py
+++ b/src/anthias_server/app/models.py
@@ -18,6 +18,24 @@ ALL_DAYS = [1, 2, 3, 4, 5, 6, 7]
 REFRESH_INTERVAL_S_MAX = 86400
 
 
+def clamp_refresh_interval(value: object) -> int:
+    """Coerce an arbitrary ``metadata['refresh_interval_s']`` value to
+    a safe int in ``[0, REFRESH_INTERVAL_S_MAX]``.
+
+    The serializer's write path rejects out-of-range values, but a
+    hand-edited row, a legacy import, or a non-int JSON value could
+    leave junk in the column. Every read site (v2 serializer, edit-
+    modal ``to_json`` filter, viewer ``asset_loop``, page-form
+    handler) funnels through this so the clamp can't drift between
+    them.
+    """
+    try:
+        interval = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(interval, REFRESH_INTERVAL_S_MAX))
+
+
 def generate_asset_id() -> str:
     return uuid.uuid4().hex
 

--- a/src/anthias_server/app/models.py
+++ b/src/anthias_server/app/models.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from datetime import datetime
+from typing import Any
 
 from django.db import models
 from django.utils import timezone
@@ -18,7 +19,7 @@ ALL_DAYS = [1, 2, 3, 4, 5, 6, 7]
 REFRESH_INTERVAL_S_MAX = 86400
 
 
-def clamp_refresh_interval(value: object) -> int:
+def clamp_refresh_interval(value: Any) -> int:
     """Coerce an arbitrary ``metadata['refresh_interval_s']`` value to
     a safe int in ``[0, REFRESH_INTERVAL_S_MAX]``.
 
@@ -27,10 +28,12 @@ def clamp_refresh_interval(value: object) -> int:
     leave junk in the column. Every read site (v2 serializer, edit-
     modal ``to_json`` filter, viewer ``asset_loop``, page-form
     handler) funnels through this so the clamp can't drift between
-    them.
+    them. ``Any`` rather than ``object`` because callers pass dict /
+    list / unknown JSON values and we want ``int(value)`` to attempt
+    coercion regardless — TypeError / ValueError gets caught.
     """
     try:
-        interval = int(value)  # type: ignore[arg-type]
+        interval = int(value)
     except (TypeError, ValueError):
         return 0
     return max(0, min(interval, REFRESH_INTERVAL_S_MAX))

--- a/src/anthias_server/app/models.py
+++ b/src/anthias_server/app/models.py
@@ -8,6 +8,15 @@ from django.utils import timezone
 
 ALL_DAYS = [1, 2, 3, 4, 5, 6, 7]
 
+# Upper bound for ``Asset.metadata['refresh_interval_s']`` (seconds).
+# 24h cap acts as a typo guard — anything beyond is almost certainly
+# a units mistake — and is a hostile-input guard for the int math
+# in the C++ webview's setReloadInterval (``seconds * 1000`` would
+# otherwise overflow). Imported by the v2 serializer (write
+# validation), the form handler (clamping), and mirrored by
+# kMaxReloadIntervalS in webview/src/view.cpp.
+REFRESH_INTERVAL_S_MAX = 86400
+
 
 def generate_asset_id() -> str:
     return uuid.uuid4().hex

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -254,9 +254,15 @@ def assets() -> dict[str, Any]:
             inactive.append(asset)
     active.sort(key=lambda a: a.play_order)
     inactive.sort(key=lambda a: a.play_order)
+    from anthias_server.app.models import REFRESH_INTERVAL_S_MAX
+
     return {
         'active_assets': active,
         'inactive_assets': inactive,
+        # Render the auto-refresh input's ``max`` attribute from the
+        # same constant the v2 serializer / form handler use, so the
+        # client-side and server-side caps can't drift.
+        'refresh_interval_s_max': REFRESH_INTERVAL_S_MAX,
     }
 
 

--- a/src/anthias_server/app/templates/_asset_modal.html
+++ b/src/anthias_server/app/templates/_asset_modal.html
@@ -280,7 +280,7 @@
                   <div class="app-floating">
                     <input type="number" class="app-input" id="edit-refresh-interval"
                       name="refresh_interval_s"
-                      min="0" max="86400" step="1"
+                      min="0" max="{{ refresh_interval_s_max }}" step="1"
                       :value="(editAsset.metadata && editAsset.metadata.refresh_interval_s) || ''"
                       placeholder="0">
                     <label for="edit-refresh-interval">Auto-refresh interval (seconds)</label>

--- a/src/anthias_server/app/templates/_asset_modal.html
+++ b/src/anthias_server/app/templates/_asset_modal.html
@@ -155,11 +155,13 @@
           },
           get hasAdvancedDefaults() {
             const days = editAsset.play_days_list || [];
+            const refresh = editAsset.metadata && editAsset.metadata.refresh_interval_s;
             return days.length === 7 &&
                    !editAsset.play_time_from &&
                    !editAsset.play_time_to &&
                    !editAsset.nocache &&
-                   !editAsset.skip_asset_check;
+                   !editAsset.skip_asset_check &&
+                   !refresh;
           },
           advancedOpen: false,
         }"
@@ -260,6 +262,34 @@
                   <label class="app-check-label ml-2" for="edit-skip">Skip asset check</label>
                 </div>
               </div>
+
+              {% comment %} Per-asset auto-refresh interval (feature #2813).
+                 Only meaningful for webpage assets — the viewer reads
+                 metadata.refresh_interval_s in view_webpage and arms a
+                 setReloadInterval D-Bus call to the QtWebEngine
+                 process. 0 / empty disables; max 86400 (24h) matches
+                 the v2 serializer's REFRESH_INTERVAL_S_MAX cap. The
+                 input lives inside the existing Advanced disclosure
+                 (rather than a top-level webpage-only section) to
+                 keep the Edit modal's primary surface consistent
+                 across mimetypes.
+              {% endcomment %}
+              <template x-if="editAsset.mimetype === 'webpage'">
+                <div>
+                  <div class="modal-section__divider"></div>
+                  <div class="app-floating">
+                    <input type="number" class="app-input" id="edit-refresh-interval"
+                      name="refresh_interval_s"
+                      min="0" max="86400" step="1"
+                      :value="(editAsset.metadata && editAsset.metadata.refresh_interval_s) || ''"
+                      placeholder="0">
+                    <label for="edit-refresh-interval">Auto-refresh interval (seconds)</label>
+                  </div>
+                  <p class="modal-section__hint mt-2 mb-0">
+                    Reload the page on this cadence so dashboards stay current. Empty or 0 disables.
+                  </p>
+                </div>
+              </template>
             </div>
           </section>
         </div>

--- a/src/anthias_server/app/templatetags/asset_filters.py
+++ b/src/anthias_server/app/templatetags/asset_filters.py
@@ -147,18 +147,14 @@ def _to_dict(obj: Any) -> Any:
         # value would otherwise put the <input type="number" max="...">
         # in :invalid state and block form submission entirely (the
         # operator couldn't save *any* changes). Mirrors the v2 API's
-        # response normalisation in AssetSerializerV2.get_metadata.
+        # response normalisation via the shared clamp helper.
         meta = out.get('metadata')
         if isinstance(meta, dict) and 'refresh_interval_s' in meta:
-            from anthias_server.app.models import REFRESH_INTERVAL_S_MAX
+            from anthias_server.app.models import clamp_refresh_interval
 
-            try:
-                v = int(meta['refresh_interval_s'])
-            except (TypeError, ValueError):
-                v = 0
             meta = dict(meta)
-            meta['refresh_interval_s'] = max(
-                0, min(v, REFRESH_INTERVAL_S_MAX)
+            meta['refresh_interval_s'] = clamp_refresh_interval(
+                meta['refresh_interval_s']
             )
             out['metadata'] = meta
         return out

--- a/src/anthias_server/app/templatetags/asset_filters.py
+++ b/src/anthias_server/app/templatetags/asset_filters.py
@@ -142,6 +142,25 @@ def _to_dict(obj: Any) -> Any:
             v = out.get(key)
             if isinstance(v, str) and len(v) >= 5:
                 out[key] = v[:5]
+        # Sanitise metadata['refresh_interval_s'] before it reaches the
+        # edit modal: a legacy / hand-edited row with an out-of-range
+        # value would otherwise put the <input type="number" max="...">
+        # in :invalid state and block form submission entirely (the
+        # operator couldn't save *any* changes). Mirrors the v2 API's
+        # response normalisation in AssetSerializerV2.get_metadata.
+        meta = out.get('metadata')
+        if isinstance(meta, dict) and 'refresh_interval_s' in meta:
+            from anthias_server.app.models import REFRESH_INTERVAL_S_MAX
+
+            try:
+                v = int(meta['refresh_interval_s'])
+            except (TypeError, ValueError):
+                v = 0
+            meta = dict(meta)
+            meta['refresh_interval_s'] = max(
+                0, min(v, REFRESH_INTERVAL_S_MAX)
+            )
+            out['metadata'] = meta
         return out
     return _coerce(obj)
 

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -18,6 +18,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_http_methods
 
 from anthias_server.app import page_context
+from anthias_server.app.models import REFRESH_INTERVAL_S_MAX
 from anthias_server.celery_tasks import reboot_anthias, shutdown_anthias
 from anthias_server.lib import backup_helper, diagnostics
 from anthias_server.lib.auth import (
@@ -533,15 +534,16 @@ def assets_update(request: HttpRequest, asset_id: str) -> HttpResponse:
     # cleared the field, disable auto-refresh" (stored as 0, the
     # viewer treats it the same as a missing key). Out-of-range /
     # non-int values are clamped instead of 400'd because this is a
-    # server-rendered form (the v2 API does the strict 400). Range
-    # mirrors v2's REFRESH_INTERVAL_S_MAX (24h).
+    # server-rendered form (the v2 API does the strict 400). The cap
+    # is shared with the v2 serializer via REFRESH_INTERVAL_S_MAX so
+    # the two paths can't drift.
     raw_interval = request.POST.get('refresh_interval_s')
     if raw_interval is not None:
         try:
             interval = int(raw_interval.strip() or 0)
         except ValueError:
             interval = 0
-        interval = max(0, min(interval, 86400))
+        interval = max(0, min(interval, REFRESH_INTERVAL_S_MAX))
         metadata = dict(asset.metadata or {})
         metadata['refresh_interval_s'] = interval
         asset.metadata = metadata

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -525,6 +525,27 @@ def assets_update(request: HttpRequest, asset_id: str) -> HttpResponse:
         asset.play_time_from = None
         asset.play_time_to = None
 
+    # Webpage auto-refresh — feature #2813. Persisted inside
+    # ``metadata`` so the upload pipeline's read-only posture on that
+    # field is preserved. The edit modal only renders the input for
+    # webpage assets, so a missing key here means "non-webpage edit,
+    # leave the metadata alone"; an empty string means "operator
+    # cleared the field, disable auto-refresh" (stored as 0, the
+    # viewer treats it the same as a missing key). Out-of-range /
+    # non-int values are clamped instead of 400'd because this is a
+    # server-rendered form (the v2 API does the strict 400). Range
+    # mirrors v2's REFRESH_INTERVAL_S_MAX (24h).
+    raw_interval = request.POST.get('refresh_interval_s')
+    if raw_interval is not None:
+        try:
+            interval = int(raw_interval.strip() or 0)
+        except ValueError:
+            interval = 0
+        interval = max(0, min(interval, 86400))
+        metadata = dict(asset.metadata or {})
+        metadata['refresh_interval_s'] = interval
+        asset.metadata = metadata
+
     asset.save()
     ViewerPublisher.get_instance().send_to_viewer('reload')
     return _asset_table_response(request, toast=('success', 'Changes saved'))

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -18,7 +18,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_http_methods
 
 from anthias_server.app import page_context
-from anthias_server.app.models import REFRESH_INTERVAL_S_MAX
+from anthias_server.app.models import clamp_refresh_interval
 from anthias_server.celery_tasks import reboot_anthias, shutdown_anthias
 from anthias_server.lib import backup_helper, diagnostics
 from anthias_server.lib.auth import (
@@ -539,13 +539,10 @@ def assets_update(request: HttpRequest, asset_id: str) -> HttpResponse:
     # the two paths can't drift.
     raw_interval = request.POST.get('refresh_interval_s')
     if raw_interval is not None:
-        try:
-            interval = int(raw_interval.strip() or 0)
-        except ValueError:
-            interval = 0
-        interval = max(0, min(interval, REFRESH_INTERVAL_S_MAX))
         metadata = dict(asset.metadata or {})
-        metadata['refresh_interval_s'] = interval
+        metadata['refresh_interval_s'] = clamp_refresh_interval(
+            raw_interval.strip() or 0
+        )
         asset.metadata = metadata
 
     asset.save()

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -54,6 +54,14 @@ __license__ = 'Dual License: GPLv2 and Commercial License'
 
 
 current_browser_url: str | None = None
+# Latched True->False on the first failure of ``setReloadInterval`` —
+# version skew between the running viewer and the AnthiasWebview
+# binary persists for the lifetime of the viewer process, so once we
+# know the slot isn't there we don't need to keep paying the D-Bus
+# round-trip or flooding journald with warnings every rotation.
+# An operator who upgrades the webview package should restart the
+# viewer anyway; that resets the cache.
+_webview_supports_set_reload_interval: bool = True
 browser: Any = None
 loop_is_stopped: bool = False
 browser_bus: Any = None
@@ -167,16 +175,21 @@ def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
     # against an older AnthiasWebview (version skew during rollout, or
     # a WEBVIEW_VERSION override pinning a pre-2026.05 tarball) would
     # raise here and abort the asset loop, taking the screen down.
-    # Catch broadly: log a warning and keep playing the page without
-    # auto-refresh, which matches the old webview's behaviour.
-    try:
-        browser_bus.setReloadInterval(int(reload_interval_s))
-    except Exception as exc:
-        logging.warning(
-            'setReloadInterval not supported by webview '
-            '(version skew?); auto-refresh disabled for this asset: %s',
-            exc,
-        )
+    # Catch broadly on the first call, log once, and latch the
+    # capability flag so subsequent rotations skip the D-Bus hop and
+    # don't refill journald with the same warning every cycle.
+    global _webview_supports_set_reload_interval
+    if _webview_supports_set_reload_interval:
+        try:
+            browser_bus.setReloadInterval(int(reload_interval_s))
+        except Exception as exc:
+            _webview_supports_set_reload_interval = False
+            logging.warning(
+                'setReloadInterval not supported by webview '
+                '(version skew?); auto-refresh disabled until viewer '
+                'restart: %s',
+                exc,
+            )
     logging.info('Current url is {0}'.format(current_browser_url))
 
 

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -175,21 +175,39 @@ def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
     # against an older AnthiasWebview (version skew during rollout, or
     # a WEBVIEW_VERSION override pinning a pre-2026.05 tarball) would
     # raise here and abort the asset loop, taking the screen down.
-    # Catch broadly on the first call, log once, and latch the
-    # capability flag so subsequent rotations skip the D-Bus hop and
-    # don't refill journald with the same warning every cycle.
+    # Latch the capability flag *only* for "the method doesn't exist"
+    # — transient D-Bus failures (bus disconnect, timeout, race during
+    # a webview restart) are logged at debug and retried next rotation
+    # so they don't permanently disable auto-refresh on a webview
+    # that actually supports it.
     global _webview_supports_set_reload_interval
     if _webview_supports_set_reload_interval:
         try:
             browser_bus.setReloadInterval(int(reload_interval_s))
         except Exception as exc:
-            _webview_supports_set_reload_interval = False
-            logging.warning(
-                'setReloadInterval not supported by webview '
-                '(version skew?); auto-refresh disabled until viewer '
-                'restart: %s',
-                exc,
+            message = str(exc)
+            # pydbus surfaces missing-slot errors with the D-Bus error
+            # code 'org.freedesktop.DBus.Error.UnknownMethod' in the
+            # exception message. Match either the code or the human
+            # phrasing so we don't miss it across pydbus versions.
+            method_missing = (
+                'UnknownMethod' in message
+                or 'no such method' in message.lower()
             )
+            if method_missing:
+                _webview_supports_set_reload_interval = False
+                logging.warning(
+                    'setReloadInterval not supported by webview '
+                    '(version skew?); auto-refresh disabled until '
+                    'viewer restart: %s',
+                    exc,
+                )
+            else:
+                logging.debug(
+                    'Transient setReloadInterval failure (will retry '
+                    'next rotation): %s',
+                    exc,
+                )
     logging.info('Current url is {0}'.format(current_browser_url))
 
 

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -140,7 +140,18 @@ def load_browser() -> None:
     )
 
 
-def view_webpage(uri: str) -> None:
+def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
+    """Display a webpage and arm its per-asset auto-refresh timer.
+
+    ``reload_interval_s`` mirrors ``Asset.metadata['refresh_interval_s']``:
+    0 (the default, and the value used for splash / fallback URLs)
+    leaves the existing webview without a reload timer; a positive value
+    reloads the visible page on that cadence so dashboards / status
+    pages stay current. We always re-send setReloadInterval — even
+    when the URL is unchanged from the previous tick — so an edit that
+    only flips the interval (no URI change) takes effect on the next
+    asset_loop iteration.
+    """
     global current_browser_url
 
     if browser is None or not browser.is_alive():
@@ -148,6 +159,7 @@ def view_webpage(uri: str) -> None:
     if current_browser_url is not uri:
         browser_bus.loadPage(uri)
         current_browser_url = uri
+    browser_bus.setReloadInterval(int(reload_interval_s))
     logging.info('Current url is {0}'.format(current_browser_url))
 
 
@@ -311,7 +323,21 @@ def asset_loop(scheduler: Any) -> None:
         if 'image' in mime:
             view_image(uri)
         elif 'web' in mime:
-            view_webpage(uri)
+            # Per-asset auto-refresh — feature #2813. ``metadata`` is a
+            # JSONField (defaults to {}); the column was historically
+            # nullable so be defensive. Anything non-int / negative is
+            # rejected on write by the v2 serializer + the page-form
+            # handler, but a hand-crafted DB row could still slip a
+            # garbage value through, so coerce-or-zero here rather
+            # than trust the read.
+            metadata = asset.get('metadata') or {}
+            try:
+                interval = int(metadata.get('refresh_interval_s') or 0)
+            except (TypeError, ValueError):
+                interval = 0
+            if interval < 0:
+                interval = 0
+            view_webpage(uri, reload_interval_s=interval)
         elif 'video' or 'streaming' in mime:
             view_video(uri, asset['duration'])
         else:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -12,7 +12,7 @@ import pydbus
 import requests
 import sh as sh
 
-from anthias_server.app.models import REFRESH_INTERVAL_S_MAX
+from anthias_server.app.models import clamp_refresh_interval
 from anthias_server.settings import LISTEN, PORT, ReplySender, settings
 from anthias_viewer.constants import EMPTY_PL_DELAY as EMPTY_PL_DELAY
 from anthias_viewer.constants import SERVER_WAIT_TIMEOUT as SERVER_WAIT_TIMEOUT
@@ -390,16 +390,14 @@ def asset_loop(scheduler: Any) -> None:
             # nullable so be defensive. Anything non-int / out-of-range
             # is rejected on write by the v2 serializer + the page-form
             # handler, but a hand-crafted DB row could still slip a
-            # garbage value through, so clamp on the read side too —
-            # the C++ webview's setReloadInterval also clamps, but
-            # doing it here means we don't pay the D-Bus round-trip
-            # for an obviously bogus value.
+            # garbage value through, so clamp on read here too via the
+            # shared helper. The C++ webview's setReloadInterval also
+            # clamps, but doing it here means we don't pay the D-Bus
+            # round-trip for an obviously bogus value.
             metadata = asset.get('metadata') or {}
-            try:
-                interval = int(metadata.get('refresh_interval_s') or 0)
-            except (TypeError, ValueError):
-                interval = 0
-            interval = max(0, min(interval, REFRESH_INTERVAL_S_MAX))
+            interval = clamp_refresh_interval(
+                metadata.get('refresh_interval_s')
+            )
             view_webpage(uri, reload_interval_s=interval)
         elif 'video' in mime or 'streaming' in mime:
             # ``'video' or 'streaming' in mime`` parses as ``'video'

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -163,7 +163,21 @@ def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
     if current_browser_url != uri:
         browser_bus.loadPage(uri)
         current_browser_url = uri
-    browser_bus.setReloadInterval(int(reload_interval_s))
+    # ``setReloadInterval`` is a new D-Bus method (added with this
+    # feature). A viewer running against an older AnthiasWebview build
+    # — version skew during rollout, or a WEBVIEW_VERSION override that
+    # pins to a pre-2026.05 tarball — would raise here and abort the
+    # asset loop, taking the screen down. Catch broadly: log a warning
+    # and keep playing the page without auto-refresh, which is exactly
+    # the behaviour the old webview already gave us. Per Copilot review.
+    try:
+        browser_bus.setReloadInterval(int(reload_interval_s))
+    except Exception as exc:
+        logging.warning(
+            'setReloadInterval not supported by webview '
+            '(version skew?); auto-refresh disabled for this asset: %s',
+            exc,
+        )
     logging.info('Current url is {0}'.format(current_browser_url))
 
 

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -12,7 +12,6 @@ import pydbus
 import requests
 import sh as sh
 
-from anthias_server.app.models import clamp_refresh_interval
 from anthias_server.settings import LISTEN, PORT, ReplySender, settings
 from anthias_viewer.constants import EMPTY_PL_DELAY as EMPTY_PL_DELAY
 from anthias_viewer.constants import SERVER_WAIT_TIMEOUT as SERVER_WAIT_TIMEOUT
@@ -45,6 +44,7 @@ from anthias_common.utils import (  # noqa: E402
     detect_screen_resolution,
     string_to_bool,
 )
+from anthias_server.app.models import clamp_refresh_interval  # noqa: E402
 from anthias_viewer.messaging import ViewerSubscriber  # noqa: E402
 from anthias_viewer.scheduling import Scheduler  # noqa: E402
 

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -12,6 +12,7 @@ import pydbus
 import requests
 import sh as sh
 
+from anthias_server.app.models import REFRESH_INTERVAL_S_MAX
 from anthias_server.settings import LISTEN, PORT, ReplySender, settings
 from anthias_viewer.constants import EMPTY_PL_DELAY as EMPTY_PL_DELAY
 from anthias_viewer.constants import SERVER_WAIT_TIMEOUT as SERVER_WAIT_TIMEOUT
@@ -386,18 +387,19 @@ def asset_loop(scheduler: Any) -> None:
         elif 'web' in mime:
             # Per-asset auto-refresh — feature #2813. ``metadata`` is a
             # JSONField (defaults to {}); the column was historically
-            # nullable so be defensive. Anything non-int / negative is
-            # rejected on write by the v2 serializer + the page-form
+            # nullable so be defensive. Anything non-int / out-of-range
+            # is rejected on write by the v2 serializer + the page-form
             # handler, but a hand-crafted DB row could still slip a
-            # garbage value through, so coerce-or-zero here rather
-            # than trust the read.
+            # garbage value through, so clamp on the read side too —
+            # the C++ webview's setReloadInterval also clamps, but
+            # doing it here means we don't pay the D-Bus round-trip
+            # for an obviously bogus value.
             metadata = asset.get('metadata') or {}
             try:
                 interval = int(metadata.get('refresh_interval_s') or 0)
             except (TypeError, ValueError):
                 interval = 0
-            if interval < 0:
-                interval = 0
+            interval = max(0, min(interval, REFRESH_INTERVAL_S_MAX))
             view_webpage(uri, reload_interval_s=interval)
         elif 'video' in mime or 'streaming' in mime:
             # ``'video' or 'streaming' in mime`` parses as ``'video'

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -156,20 +156,19 @@ def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
 
     if browser is None or not browser.is_alive():
         load_browser()
-    # ``!=`` (value comparison) — using ``is not`` here was an identity
-    # check that worked only because the asset_loop happened to pass the
-    # same str object on consecutive ticks; any loop that reconstructs
-    # the URL from JSON each tick would defeat the dedup. Per-Copilot.
+    # ``!=`` (value comparison): an ``is not`` identity check would
+    # only short-circuit when the asset_loop happens to pass the same
+    # str object on consecutive ticks, which a JSON-reconstructed URL
+    # would defeat.
     if current_browser_url != uri:
         browser_bus.loadPage(uri)
         current_browser_url = uri
-    # ``setReloadInterval`` is a new D-Bus method (added with this
-    # feature). A viewer running against an older AnthiasWebview build
-    # — version skew during rollout, or a WEBVIEW_VERSION override that
-    # pins to a pre-2026.05 tarball — would raise here and abort the
-    # asset loop, taking the screen down. Catch broadly: log a warning
-    # and keep playing the page without auto-refresh, which is exactly
-    # the behaviour the old webview already gave us. Per Copilot review.
+    # ``setReloadInterval`` is a new D-Bus method. A viewer running
+    # against an older AnthiasWebview (version skew during rollout, or
+    # a WEBVIEW_VERSION override pinning a pre-2026.05 tarball) would
+    # raise here and abort the asset loop, taking the screen down.
+    # Catch broadly: log a warning and keep playing the page without
+    # auto-refresh, which matches the old webview's behaviour.
     try:
         browser_bus.setReloadInterval(int(reload_interval_s))
     except Exception as exc:
@@ -357,12 +356,10 @@ def asset_loop(scheduler: Any) -> None:
                 interval = 0
             view_webpage(uri, reload_interval_s=interval)
         elif 'video' in mime or 'streaming' in mime:
-            # Operator-precedence fix per Copilot: the prior
-            # ``'video' or 'streaming' in mime`` evaluated as
-            # ``'video' or ('streaming' in mime)`` — i.e. the truthy
-            # literal short-circuited and the branch ran for every
-            # mimetype, which made the ``else: Unknown MimeType`` arm
-            # below unreachable.
+            # ``'video' or 'streaming' in mime`` parses as ``'video'
+            # or ('streaming' in mime)`` — the truthy literal short-
+            # circuits and the branch runs for every mimetype, making
+            # the ``else: Unknown MimeType`` arm below unreachable.
             view_video(uri, asset['duration'])
         else:
             logging.error('Unknown MimeType %s', mime)

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -121,8 +121,17 @@ BROWSER_HANDSHAKE_LINE = 'Anthias service start'
 
 
 def load_browser() -> None:
-    global browser
+    global browser, _webview_supports_set_reload_interval
     logging.info('Loading browser...')
+
+    # Re-probe the setReloadInterval capability against the freshly
+    # launched binary. The flag latches OFF on UnknownMethod, but a
+    # webview crash + restart (or an in-place upgrade then process
+    # bounce) might bring up a binary that *does* support the slot —
+    # we don't want to leave auto-refresh disabled forever in that
+    # case. Resetting on every launch keeps the latch tied to the
+    # actual running process, not the viewer's lifetime.
+    _webview_supports_set_reload_interval = True
 
     browser = sh.Command('AnthiasWebview')(_bg=True, _err_to_out=True)
 
@@ -216,7 +225,11 @@ def view_image(uri: str) -> None:
 
     if browser is None or not browser.is_alive():
         load_browser()
-    if current_browser_url is not uri:
+    # Value comparison (matches view_webpage): an ``is not`` identity
+    # check would only short-circuit when the asset_loop happens to
+    # pass the same str object on consecutive ticks, which a JSON-
+    # reconstructed URL would defeat.
+    if current_browser_url != uri:
         browser_bus.loadImage(uri)
         current_browser_url = uri
     logging.info('Current url is {0}'.format(current_browser_url))

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -156,7 +156,11 @@ def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
 
     if browser is None or not browser.is_alive():
         load_browser()
-    if current_browser_url is not uri:
+    # ``!=`` (value comparison) — using ``is not`` here was an identity
+    # check that worked only because the asset_loop happened to pass the
+    # same str object on consecutive ticks; any loop that reconstructs
+    # the URL from JSON each tick would defeat the dedup. Per-Copilot.
+    if current_browser_url != uri:
         browser_bus.loadPage(uri)
         current_browser_url = uri
     browser_bus.setReloadInterval(int(reload_interval_s))
@@ -338,7 +342,13 @@ def asset_loop(scheduler: Any) -> None:
             if interval < 0:
                 interval = 0
             view_webpage(uri, reload_interval_s=interval)
-        elif 'video' or 'streaming' in mime:
+        elif 'video' in mime or 'streaming' in mime:
+            # Operator-precedence fix per Copilot: the prior
+            # ``'video' or 'streaming' in mime`` evaluated as
+            # ``'video' or ('streaming' in mime)`` — i.e. the truthy
+            # literal short-circuited and the branch ran for every
+            # mimetype, which made the ``else: Unknown MimeType`` arm
+            # below unreachable.
             view_video(uri, asset['duration'])
         else:
             logging.error('Unknown MimeType %s', mime)

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -464,6 +464,100 @@ def test_assets_update_via_post(client: Client, asset: Asset) -> None:
 
 
 @pytest.mark.django_db
+def test_assets_update_writes_refresh_interval_to_metadata(
+    client: Client, asset: Asset
+) -> None:
+    """The webpage auto-refresh field on the edit modal — feature #2813
+    — POSTs ``refresh_interval_s`` alongside the rest of the form.
+    The handler must merge it into ``Asset.metadata`` rather than
+    overwriting the dict, so any pipeline-owned keys
+    (original_ext / transcoded / error_message) survive an operator
+    edit."""
+    asset.metadata = {'original_ext': '.heic', 'transcoded': True}
+    asset.save(update_fields=['metadata'])
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_update', args=[asset.asset_id]),
+            data={
+                'name': asset.name,
+                'mimetype': 'webpage',
+                'duration': '20',
+                'start_date': '2026-01-01T00:00',
+                'end_date': '2027-01-01T00:00',
+                'refresh_interval_s': '45',
+            },
+        )
+
+    asset.refresh_from_db()
+    assert asset.metadata == {
+        'original_ext': '.heic',
+        'transcoded': True,
+        'refresh_interval_s': 45,
+    }
+
+
+@pytest.mark.django_db
+def test_assets_update_clears_refresh_interval_on_empty_input(
+    client: Client, asset: Asset
+) -> None:
+    """An empty ``refresh_interval_s`` from the edit form means the
+    operator cleared the field, which the AC for #2813 specifies must
+    disable auto-refresh — recorded as 0 (the viewer treats 0 the
+    same as a missing key)."""
+    asset.metadata = {'refresh_interval_s': 60}
+    asset.save(update_fields=['metadata'])
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_update', args=[asset.asset_id]),
+            data={
+                'name': asset.name,
+                'mimetype': 'webpage',
+                'duration': '20',
+                'start_date': '2026-01-01T00:00',
+                'end_date': '2027-01-01T00:00',
+                'refresh_interval_s': '',
+            },
+        )
+
+    asset.refresh_from_db()
+    assert asset.metadata.get('refresh_interval_s') == 0
+
+
+@pytest.mark.django_db
+def test_assets_update_clamps_oversize_refresh_interval(
+    client: Client, asset: Asset
+) -> None:
+    """The form-level handler clamps (rather than 400s) for friendlier
+    UX — the strict validation lives on the v2 API. 86400 (24h) is
+    the cap shared with REFRESH_INTERVAL_S_MAX in the v2 serializer."""
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_update', args=[asset.asset_id]),
+            data={
+                'name': asset.name,
+                'mimetype': 'webpage',
+                'duration': '20',
+                'start_date': '2026-01-01T00:00',
+                'end_date': '2027-01-01T00:00',
+                'refresh_interval_s': '999999',
+            },
+        )
+    asset.refresh_from_db()
+    assert asset.metadata.get('refresh_interval_s') == 86400
+
+
+@pytest.mark.django_db
 def test_assets_update_missing_id_is_no_op(client: Client) -> None:
     with mock.patch(
         'anthias_server.settings.ViewerPublisher.send_to_viewer',

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -228,20 +228,17 @@ def test_view_webpage_default_zero_interval(
     fake_bus.setReloadInterval.assert_called_once_with(0)
 
 
-def test_view_webpage_falls_back_when_setreloadinterval_unsupported(
+def test_view_webpage_latches_off_on_unknown_method(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:
-    """An older AnthiasWebview build (or a WEBVIEW_VERSION pin to a
-    pre-2026.05 tarball) doesn't expose the ``setReloadInterval``
-    D-Bus slot — calling it raises and would otherwise abort the
-    asset_loop, taking the screen down. The viewer must catch and
-    keep playing the page without auto-refresh, matching the old
-    no-auto-refresh behaviour, AND latch the capability flag so the
-    next rotation doesn't pay the D-Bus round-trip again or refill
-    journald with a duplicate warning."""
+    """An older AnthiasWebview without ``setReloadInterval`` raises
+    a UnknownMethod D-Bus error. The viewer must catch it, keep
+    playing the page, AND latch the capability flag so the next
+    rotation skips the D-Bus hop instead of refilling journald."""
     fake_bus = mock.Mock()
     fake_bus.setReloadInterval.side_effect = RuntimeError(
-        'no such D-Bus method'
+        "GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: "
+        "No such method 'setReloadInterval'"
     )
     fake_browser = mock.Mock()
     fake_browser.is_alive.return_value = True
@@ -256,15 +253,43 @@ def test_view_webpage_falls_back_when_setreloadinterval_unsupported(
             True,
         ),
     ):
-        # First call: must not raise; should attempt setReloadInterval.
         viewer_fixtures.u.view_webpage('https://example.com', 30)
-        # Second call (same URL: no loadPage hop, but the unsupported
-        # path still ran on the first call) must NOT call
-        # setReloadInterval again — capability is latched off.
         viewer_fixtures.u.view_webpage('https://example.com', 60)
 
-    fake_bus.loadPage.assert_called_once_with('https://example.com')
     assert fake_bus.setReloadInterval.call_count == 1
+
+
+def test_view_webpage_does_not_latch_off_on_transient_dbus_error(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """A transient D-Bus error (bus disconnect, timeout, race during
+    webview restart) must NOT permanently disable auto-refresh: the
+    method exists, the call just failed once. Next rotation should
+    retry, and the warning lands at debug level so journald isn't
+    flooded."""
+    fake_bus = mock.Mock()
+    fake_bus.setReloadInterval.side_effect = RuntimeError(
+        'Connection closed by peer'
+    )
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(
+            viewer_fixtures.u,
+            '_webview_supports_set_reload_interval',
+            True,
+        ),
+    ):
+        viewer_fixtures.u.view_webpage('https://example.com', 30)
+        viewer_fixtures.u.view_webpage('https://example.com', 60)
+
+    # Both rotations attempted setReloadInterval — capability NOT
+    # latched off.
+    assert fake_bus.setReloadInterval.call_count == 2
 
 
 def test_view_webpage_resets_interval_on_unchanged_url(

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -236,7 +236,7 @@ def test_view_webpage_falls_back_when_setreloadinterval_unsupported(
     D-Bus slot — calling it raises and would otherwise abort the
     asset_loop, taking the screen down. The viewer must catch and
     keep playing the page without auto-refresh, matching the old
-    no-auto-refresh behaviour. Per Copilot review (round 2)."""
+    no-auto-refresh behaviour."""
     fake_bus = mock.Mock()
     fake_bus.setReloadInterval.side_effect = RuntimeError(
         'no such D-Bus method'

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -228,18 +228,34 @@ def test_view_webpage_default_zero_interval(
     fake_bus.setReloadInterval.assert_called_once_with(0)
 
 
-def test_view_webpage_latches_off_on_unknown_method(
+@pytest.mark.parametrize(
+    'error_message,expected_call_count',
+    [
+        # An older AnthiasWebview without setReloadInterval raises
+        # UnknownMethod — viewer must latch the capability flag off
+        # so the next rotation skips the D-Bus hop instead of
+        # refilling journald.
+        (
+            'GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: '
+            "No such method 'setReloadInterval'",
+            1,
+        ),
+        # Transient D-Bus error (bus disconnect, timeout, race during
+        # webview restart) must NOT permanently disable auto-refresh:
+        # the method exists, the call just failed once. Next rotation
+        # retries and the warning is debug-level so journald isn't
+        # flooded.
+        ('Connection closed by peer', 2),
+    ],
+    ids=['unknown-method-latches', 'transient-error-retries'],
+)
+def test_view_webpage_setreloadinterval_failure_modes(
     viewer_fixtures: _ViewerFixtures,
+    error_message: str,
+    expected_call_count: int,
 ) -> None:
-    """An older AnthiasWebview without ``setReloadInterval`` raises
-    a UnknownMethod D-Bus error. The viewer must catch it, keep
-    playing the page, AND latch the capability flag so the next
-    rotation skips the D-Bus hop instead of refilling journald."""
     fake_bus = mock.Mock()
-    fake_bus.setReloadInterval.side_effect = RuntimeError(
-        'GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: '
-        "No such method 'setReloadInterval'"
-    )
+    fake_bus.setReloadInterval.side_effect = RuntimeError(error_message)
     fake_browser = mock.Mock()
     fake_browser.is_alive.return_value = True
 
@@ -256,7 +272,7 @@ def test_view_webpage_latches_off_on_unknown_method(
         viewer_fixtures.u.view_webpage('https://example.com', 30)
         viewer_fixtures.u.view_webpage('https://example.com', 60)
 
-    assert fake_bus.setReloadInterval.call_count == 1
+    assert fake_bus.setReloadInterval.call_count == expected_call_count
 
 
 def test_load_browser_resets_set_reload_interval_capability(
@@ -288,39 +304,6 @@ def test_load_browser_resets_set_reload_interval_capability(
     finally:
         viewer_fixtures.p_sleep.stop()
         viewer_fixtures.p_cmd.stop()
-
-
-def test_view_webpage_does_not_latch_off_on_transient_dbus_error(
-    viewer_fixtures: _ViewerFixtures,
-) -> None:
-    """A transient D-Bus error (bus disconnect, timeout, race during
-    webview restart) must NOT permanently disable auto-refresh: the
-    method exists, the call just failed once. Next rotation should
-    retry, and the warning lands at debug level so journald isn't
-    flooded."""
-    fake_bus = mock.Mock()
-    fake_bus.setReloadInterval.side_effect = RuntimeError(
-        'Connection closed by peer'
-    )
-    fake_browser = mock.Mock()
-    fake_browser.is_alive.return_value = True
-
-    with (
-        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
-        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
-        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
-        mock.patch.object(
-            viewer_fixtures.u,
-            '_webview_supports_set_reload_interval',
-            True,
-        ),
-    ):
-        viewer_fixtures.u.view_webpage('https://example.com', 30)
-        viewer_fixtures.u.view_webpage('https://example.com', 60)
-
-    # Both rotations attempted setReloadInterval — capability NOT
-    # latched off.
-    assert fake_bus.setReloadInterval.call_count == 2
 
 
 def test_view_webpage_resets_interval_on_unchanged_url(

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -236,7 +236,9 @@ def test_view_webpage_falls_back_when_setreloadinterval_unsupported(
     D-Bus slot — calling it raises and would otherwise abort the
     asset_loop, taking the screen down. The viewer must catch and
     keep playing the page without auto-refresh, matching the old
-    no-auto-refresh behaviour."""
+    no-auto-refresh behaviour, AND latch the capability flag so the
+    next rotation doesn't pay the D-Bus round-trip again or refill
+    journald with a duplicate warning."""
     fake_bus = mock.Mock()
     fake_bus.setReloadInterval.side_effect = RuntimeError(
         'no such D-Bus method'
@@ -248,11 +250,21 @@ def test_view_webpage_falls_back_when_setreloadinterval_unsupported(
         mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
         mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
         mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(
+            viewer_fixtures.u,
+            '_webview_supports_set_reload_interval',
+            True,
+        ),
     ):
-        # Must not raise.
+        # First call: must not raise; should attempt setReloadInterval.
         viewer_fixtures.u.view_webpage('https://example.com', 30)
+        # Second call (same URL: no loadPage hop, but the unsupported
+        # path still ran on the first call) must NOT call
+        # setReloadInterval again — capability is latched off.
+        viewer_fixtures.u.view_webpage('https://example.com', 60)
 
     fake_bus.loadPage.assert_called_once_with('https://example.com')
+    assert fake_bus.setReloadInterval.call_count == 1
 
 
 def test_view_webpage_resets_interval_on_unchanged_url(

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -237,7 +237,7 @@ def test_view_webpage_latches_off_on_unknown_method(
     rotation skips the D-Bus hop instead of refilling journald."""
     fake_bus = mock.Mock()
     fake_bus.setReloadInterval.side_effect = RuntimeError(
-        "GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: "
+        'GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: '
         "No such method 'setReloadInterval'"
     )
     fake_browser = mock.Mock()
@@ -283,8 +283,7 @@ def test_load_browser_resets_set_reload_interval_capability(
         ):
             viewer_fixtures.u.load_browser()
             assert (
-                viewer_fixtures.u._webview_supports_set_reload_interval
-                is True
+                viewer_fixtures.u._webview_supports_set_reload_interval is True
             )
     finally:
         viewer_fixtures.p_sleep.stop()

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -228,6 +228,33 @@ def test_view_webpage_default_zero_interval(
     fake_bus.setReloadInterval.assert_called_once_with(0)
 
 
+def test_view_webpage_falls_back_when_setreloadinterval_unsupported(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """An older AnthiasWebview build (or a WEBVIEW_VERSION pin to a
+    pre-2026.05 tarball) doesn't expose the ``setReloadInterval``
+    D-Bus slot — calling it raises and would otherwise abort the
+    asset_loop, taking the screen down. The viewer must catch and
+    keep playing the page without auto-refresh, matching the old
+    no-auto-refresh behaviour. Per Copilot review (round 2)."""
+    fake_bus = mock.Mock()
+    fake_bus.setReloadInterval.side_effect = RuntimeError(
+        'no such D-Bus method'
+    )
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+    ):
+        # Must not raise.
+        viewer_fixtures.u.view_webpage('https://example.com', 30)
+
+    fake_bus.loadPage.assert_called_once_with('https://example.com')
+
+
 def test_view_webpage_resets_interval_on_unchanged_url(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -259,6 +259,38 @@ def test_view_webpage_latches_off_on_unknown_method(
     assert fake_bus.setReloadInterval.call_count == 1
 
 
+def test_load_browser_resets_set_reload_interval_capability(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """If the webview process crashed and we latched off, the next
+    ``load_browser()`` should re-enable capability detection — the
+    fresh process might be a newer build that supports the slot,
+    and we shouldn't leave auto-refresh permanently disabled because
+    the *old* process didn't have it."""
+    browser_proc = viewer_fixtures.m_cmd.return_value.return_value
+    _stub_browser_stdout_chunks(
+        browser_proc,
+        [b'Anthias service start\n'],
+    )
+    browser_proc.is_alive.return_value = True
+    viewer_fixtures.p_cmd.start()
+    viewer_fixtures.p_sleep.start()
+    try:
+        with mock.patch.object(
+            viewer_fixtures.u,
+            '_webview_supports_set_reload_interval',
+            False,
+        ):
+            viewer_fixtures.u.load_browser()
+            assert (
+                viewer_fixtures.u._webview_supports_set_reload_interval
+                is True
+            )
+    finally:
+        viewer_fixtures.p_sleep.stop()
+        viewer_fixtures.p_cmd.stop()
+
+
 def test_view_webpage_does_not_latch_off_on_transient_dbus_error(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -200,9 +200,7 @@ def test_view_webpage_arms_reload_interval(
     with (
         mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
         mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
-        mock.patch.object(
-            viewer_fixtures.u, 'current_browser_url', None
-        ),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
     ):
         viewer_fixtures.u.view_webpage('https://example.com', 30)
 
@@ -223,9 +221,7 @@ def test_view_webpage_default_zero_interval(
     with (
         mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
         mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
-        mock.patch.object(
-            viewer_fixtures.u, 'current_browser_url', None
-        ),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
     ):
         viewer_fixtures.u.view_webpage('https://example.com')
 

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -185,6 +185,76 @@ def test_load_browser_times_out_when_handshake_never_arrives(
         viewer_fixtures.p_cmd.stop()
 
 
+def test_view_webpage_arms_reload_interval(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """``view_webpage`` must always call ``setReloadInterval`` after
+    ``loadPage`` — even when the URI is unchanged from the previous
+    tick, since an asset edit that flips only the interval (no URI
+    change) needs the new value to take effect on the next rotation.
+    Feature #2813."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(
+            viewer_fixtures.u, 'current_browser_url', None
+        ),
+    ):
+        viewer_fixtures.u.view_webpage('https://example.com', 30)
+
+    fake_bus.loadPage.assert_called_once_with('https://example.com')
+    fake_bus.setReloadInterval.assert_called_once_with(30)
+
+
+def test_view_webpage_default_zero_interval(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """Splash / fallback callers pass no interval, which becomes 0 —
+    the C++ side treats that as "disable the timer", so this is the
+    no-auto-refresh contract for legacy code paths."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(
+            viewer_fixtures.u, 'current_browser_url', None
+        ),
+    ):
+        viewer_fixtures.u.view_webpage('https://example.com')
+
+    fake_bus.setReloadInterval.assert_called_once_with(0)
+
+
+def test_view_webpage_resets_interval_on_unchanged_url(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """When the URI matches ``current_browser_url`` we skip the
+    ``loadPage`` D-Bus call (cheap no-op), but ``setReloadInterval``
+    still has to fire so an interval-only edit takes effect without
+    a URI change."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+    uri = 'https://example.com'
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', uri),
+    ):
+        viewer_fixtures.u.view_webpage(uri, 90)
+
+    fake_bus.loadPage.assert_not_called()
+    fake_bus.setReloadInterval.assert_called_once_with(90)
+
+
 def test_watchdog_should_create_file_if_not_exists(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -152,7 +152,7 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
     # while the new WebView-v* tag is still being cut, since
     # Dockerfile.viewer.j2 will otherwise 404 when fetching the
     # not-yet-published artifact.
-    webview_version = os.environ.get('WEBVIEW_VERSION', '2026.04.1')
+    webview_version = os.environ.get('WEBVIEW_VERSION', '2026.05.0')
     webview_base_url = f'{releases_url}/WebView-v{webview_version}'
 
     is_qt6 = board in ['pi5', 'pi4-64', 'x86']

--- a/website/layouts/_default/features.html
+++ b/website/layouts/_default/features.html
@@ -2,76 +2,61 @@
 <header class="bg-brand-dark py-16 md:py-20 px-6 md:px-12 lg:px-20">
     <div class="max-w-7xl mx-auto">
         <h1 class="text-white text-4xl md:text-5xl font-extrabold tracking-tight">Features</h1>
-        <p class="text-white/60 text-lg mt-4 max-w-xl">Everything you need to run digital signage on your own hardware.</p>
+        <p class="text-white/60 text-lg mt-4 max-w-xl">Everything Anthias does, in plain language &mdash; what you can show, when it plays, and how you manage it all.</p>
     </div>
 </header>
 
 <section class="bg-white py-16 lg:py-24 px-6 md:px-12 lg:px-20">
     <div class="max-w-7xl mx-auto">
-        <h2 class="text-2xl font-bold">Content &amp; display</h2>
+        <h2 class="text-2xl font-bold">What you can show</h2>
+        <p class="text-zinc-500 mt-2 max-w-xl">Photos, videos, web pages, YouTube, live streams &mdash; if it goes on a screen, Anthias plays it.</p>
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
                     <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="12" rx="2"/><path d="M7 20h10M9 16v4M15 16v4"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Drop in almost anything</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Upload photos and videos straight from your phone or camera, or point to any web page. iPhone photos, screenshots, and most common video files all play without you having to convert anything first.</p>
+                <h3 class="text-lg font-bold">Anything that goes on a screen</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Photos, videos, web pages, and live video feeds, all in one playlist. Drag a file in or paste a link &mdash; that's the whole workflow.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 5h16v14H4z"/><path d="M9 9l6 3-6 3z" fill="currentColor"/></svg>
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="20" rx="2"/><path d="M11 18h2"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Plays smoothly on any device</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">When a file isn't quite right for your screen's hardware, Anthias quietly prepares it in the background. Your existing playback keeps running &mdash; uploads never interrupt what's on screen.</p>
+                <h3 class="text-lg font-bold">Phone photos just work</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">iPhone photos, screenshots, and pictures straight off a camera all upload and play without anyone having to convert them first.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 5h16v14H4z"/><path d="M9 9l6 3-6 3z" fill="currentColor"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">YouTube on your screen</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Paste a YouTube link into the dashboard. Anthias downloads it and gets it ready to play locally, so your screen never buffers and never shows ads or recommended videos.</p>
+                <h3 class="text-lg font-bold">Uploads never interrupt the screen</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">If a file isn't quite right for your hardware, Anthias quietly prepares it in the background while whatever's already on screen keeps playing.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M10 8l6 4-6 4z" fill="currentColor"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Content scheduling</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Set start and end dates for each asset. Control per-asset display duration. Assets activate and deactivate on schedule without manual intervention.</p>
+                <h3 class="text-lg font-bold">YouTube without ads or buffering</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Paste a YouTube link. Anthias downloads the video and plays it locally, so your screen never buffers and never shows ads or recommended videos.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 6h16M4 10h16M4 14h10M4 18h7"/></svg>
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2c2.5 3 4 6.5 4 10s-1.5 7-4 10c-2.5-3-4-6.5-4-10s1.5-7 4-10z"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Playlist management</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Drag-and-drop ordering, shuffle mode, active/inactive states. Skip forward, back, or jump to a specific asset.</p>
+                <h3 class="text-lg font-bold">Live web pages and dashboards</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Point Anthias at any web page &mdash; a status board, a weather widget, a live feed, an internal report &mdash; and set an auto-refresh interval so the page reloads on its own and stays current.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
                     <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Full HD output</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">1920&times;1080 native resolution with hardware-accelerated video playback on Raspberry Pi. HDMI audio output supported.</p>
-            </div>
-
-            <div class="feature-card">
-                <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-                </div>
-                <h3 class="text-lg font-bold">Real-time updates</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">WebSocket-powered live sync between the web dashboard and the display. Changes reflect immediately without a page refresh.</p>
-            </div>
-
-            <div class="feature-card">
-                <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-                </div>
-                <h3 class="text-lg font-bold">Display state detection</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Anthias polls the connected TV over HDMI-CEC and reports whether it's currently on or off. Visible on the System Info page so you can spot dark screens at a glance.</p>
+                <h3 class="text-lg font-bold">Sharp full-HD picture and sound</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">1080p output with smooth, hardware-accelerated video. Sound goes out through HDMI or the headphone jack &mdash; your choice.</p>
             </div>
         </div>
     </div>
@@ -79,54 +64,55 @@
 
 <section class="bg-bg-light py-16 lg:py-24 px-6 md:px-12 lg:px-20">
     <div class="max-w-7xl mx-auto">
-        <h2 class="text-2xl font-bold">Management &amp; integration</h2>
+        <h2 class="text-2xl font-bold">When things play</h2>
+        <p class="text-zinc-500 mt-2 max-w-xl">Schedule by date, day of the week, or time of day. Anthias takes care of switching things on and off for you.</p>
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/><path d="M2 12h20M12 2c2.5 3 4 6.5 4 10s-1.5 7-4 10c-2.5-3-4-6.5-4-10s1.5-7 4-10z"/></svg>
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 10h18M8 3v4M16 3v4"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Web dashboard</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Manage assets, view system health, and configure settings from any browser on your local network. No app to install.</p>
+                <h3 class="text-lg font-bold">Schedule by date range</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Set a start and end date so an asset appears for a campaign and disappears on its own when it's over &mdash; no reminders, no manual cleanup.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 18l2-2-2-2M8 6L6 8l2 2"/><path d="M14.5 4l-5 16"/></svg>
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 7h16M4 12h16M4 17h10"/><circle cx="6" cy="7" r="1" fill="currentColor"/><circle cx="10" cy="7" r="1" fill="currentColor"/><circle cx="6" cy="12" r="1" fill="currentColor"/><circle cx="14" cy="12" r="1" fill="currentColor"/><circle cx="6" cy="17" r="1" fill="currentColor"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">REST API</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Full API with OpenAPI documentation. Create, update, and delete assets. Control playback. Manage settings. Automate everything.</p>
+                <h3 class="text-lg font-bold">Pick the days of the week</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Run one playlist on weekdays, another on weekends, or something special only on Fridays. Each item picks its own days.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg>
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Docker containers</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Runs as a set of Docker containers: web server, task queue, viewer, and Redis. Clean isolation, easy updates.</p>
+                <h3 class="text-lg font-bold">Pick the time of day</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Show "we're open" content from 9 to 5, then switch to something else overnight. Schedules that cross midnight work too.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></svg>
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 7v5l3 2"/><circle cx="12" cy="12" r="9"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Backup &amp; restore</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Export settings and assets as a single compressed archive. Restore to the same device or migrate to a new one.</p>
+                <h3 class="text-lg font-bold">Set how long each item plays</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Tell each photo or web page exactly how long to stay on screen. Videos figure out their own length automatically.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 6h16M4 10h16M4 14h10M4 18h7"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">Authentication</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Optional HTTP basic authentication protects the dashboard and API from unauthorized access on your network.</p>
+                <h3 class="text-lg font-bold">Drag to reorder, or shuffle</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Arrange your playlist by dragging items into place, or turn on shuffle to mix things up on every loop.</p>
             </div>
 
             <div class="feature-card">
                 <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
-                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M5 4l8 8-8 8M14 4v16"/></svg>
                 </div>
-                <h3 class="text-lg font-bold">System monitoring</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">View disk space, CPU load, uptime, and software version from the System Info page. Reboot or shut down remotely.</p>
+                <h3 class="text-lg font-bold">Skip ahead, skip back, pause an item</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Jump forward, jump back, or temporarily turn an item off without deleting it &mdash; all from the dashboard.</p>
             </div>
         </div>
     </div>
@@ -134,30 +120,150 @@
 
 <section class="bg-white py-16 lg:py-24 px-6 md:px-12 lg:px-20">
     <div class="max-w-7xl mx-auto">
+        <h2 class="text-2xl font-bold">Run it from your browser</h2>
+        <p class="text-zinc-500 mt-2 max-w-xl">A clean dashboard for managing your screen, with a clear view of how the device is doing.</p>
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2c2.5 3 4 6.5 4 10s-1.5 7-4 10c-2.5-3-4-6.5-4-10s1.5-7 4-10z"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">No app to install</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Open the dashboard from your laptop, phone, or tablet. There's no cloud account &mdash; Anthias runs on the device itself, on your own network.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="6"/><path d="M21 21l-5-5"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Preview before you publish</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Click any photo, video, or web page to see exactly what your screen will show, right inside the dashboard.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Know when your screen is dark</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Anthias can tell whether the connected TV is actually powered on, so you can spot a dark display at a glance instead of walking over to check.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">System info at a glance</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">See how long the device has been running, how much storage and memory is in use, the software version, and the device's address on your network.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 4v8M12 16h.01"/><circle cx="12" cy="12" r="10"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Tells you when there's an update</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">When a newer version of Anthias is released, the dashboard quietly says so. No mailing lists, no checking the website.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 2v10"/><path d="M5 6a8 8 0 1 0 14 0"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Restart and shut down remotely</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Reboot or power off the player from the dashboard, without walking over to the screen. Useful when your displays are scattered around a building.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="bg-bg-light py-16 lg:py-24 px-6 md:px-12 lg:px-20">
+    <div class="max-w-7xl mx-auto">
+        <h2 class="text-2xl font-bold">First-boot and access</h2>
+        <p class="text-zinc-500 mt-2 max-w-xl">Set up a new screen in minutes, then lock it down to whoever should have the keys.</p>
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 14h3v3h-3zM18 14h3M14 18h3v3h-3zM18 18h3v3"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Onboarding right on the screen</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">On first boot, your TV shows the device's network address and a QR code. Scan it with your phone and you land straight on the dashboard.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Optional password protection</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Turn on a username and password so only the people you trust can change what's playing. Off by default for quick setup, on whenever you want it.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Easy HTTPS encryption</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Encrypt the dashboard with one command. Pick a self-signed certificate for a private setup, a free auto-renewing one for your own domain, or bring your own certificate.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="bg-white py-16 lg:py-24 px-6 md:px-12 lg:px-20">
+    <div class="max-w-7xl mx-auto">
+        <h2 class="text-2xl font-bold">Backups and integrations</h2>
+        <p class="text-zinc-500 mt-2 max-w-xl">Move things around, plug Anthias into your tools, or manage many screens at once.</p>
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Backup and restore in one file</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Download a single file with your settings and asset list. Upload it later to put everything back, or move it to a brand-new device.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-purple/10 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-purple" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 18l2-2-2-2M8 6L6 8l2 2"/><path d="M14.5 4l-5 16"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Plays well with your tools</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Push content and control playback from your own scripts. The programmable interface is fully documented and stays compatible with older integrations.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="w-10 h-10 rounded-lg bg-brand-yellow/20 flex items-center justify-center mb-4">
+                    <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><path d="M3.3 7L12 12l8.7-5M12 22V12"/></svg>
+                </div>
+                <h3 class="text-lg font-bold">Manage many screens with Balena</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Deploy and update Anthias across a fleet of devices through Balena, with over-the-air updates handled for you.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="bg-bg-light py-16 lg:py-24 px-6 md:px-12 lg:px-20">
+    <div class="max-w-7xl mx-auto">
         <h2 class="text-2xl font-bold">Supported hardware</h2>
         <p class="text-zinc-500 mt-2 max-w-xl">Anthias runs on Raspberry Pi single-board computers and 64-bit x86 PCs.</p>
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mt-8">
-            <div class="bg-bg-light rounded-lg p-4 text-center">
+            <div class="bg-white rounded-lg p-4 text-center">
                 <p class="font-bold text-sm">Pi 5</p>
                 <p class="text-zinc-500 text-xs mt-1">64-bit</p>
             </div>
-            <div class="bg-bg-light rounded-lg p-4 text-center">
+            <div class="bg-white rounded-lg p-4 text-center">
                 <p class="font-bold text-sm">Pi 4</p>
                 <p class="text-zinc-500 text-xs mt-1">64-bit</p>
             </div>
-            <div class="bg-bg-light rounded-lg p-4 text-center">
+            <div class="bg-white rounded-lg p-4 text-center">
                 <p class="font-bold text-sm">Pi 3 B+</p>
                 <p class="text-zinc-500 text-xs mt-1">64-bit</p>
             </div>
-            <div class="bg-bg-light rounded-lg p-4 text-center">
+            <div class="bg-white rounded-lg p-4 text-center">
                 <p class="font-bold text-sm">Pi 3 B</p>
                 <p class="text-zinc-500 text-xs mt-1">64-bit</p>
             </div>
-            <div class="bg-bg-light rounded-lg p-4 text-center">
+            <div class="bg-white rounded-lg p-4 text-center">
                 <p class="font-bold text-sm">Pi 2 B</p>
                 <p class="text-zinc-500 text-xs mt-1">32-bit</p>
             </div>
-            <div class="bg-bg-light rounded-lg p-4 text-center">
+            <div class="bg-white rounded-lg p-4 text-center">
                 <p class="font-bold text-sm">x86 PC</p>
                 <p class="text-zinc-500 text-xs mt-1">64-bit</p>
             </div>

--- a/webview/README.md
+++ b/webview/README.md
@@ -115,7 +115,7 @@ from pydbus import SessionBus
 bus = SessionBus()
 browser_bus = bus.get('anthias.webview', '/Anthias')
 
-browser_bus.loadPage("www.example.com")
+browser_bus.loadPage("https://www.example.com")
 browser_bus.setReloadInterval(30)  # reload every 30s; 0 disables
 ```
 

--- a/webview/README.md
+++ b/webview/README.md
@@ -98,7 +98,14 @@ The resulting files will be placed in `~/tmp-pi5/build/release`.
 DBus is used for communication.
 Webview registers `anthias.webview` object at `/Anthias` address on the session bus.
 
-Webview provides 2 methods:`loadPage` and `loadImage`.
+Webview provides 3 methods: `loadPage`, `loadImage`, and
+`setReloadInterval`.
+
+`setReloadInterval(seconds)` arms a per-asset auto-refresh timer that
+reloads the visible web page every `seconds` seconds (`0` disables it).
+The timer is cleared automatically on the next `loadPage`/`loadImage`,
+so the caller arms it once after each `loadPage` and the webview
+forgets it on the next rotation.
 
 Example of interaction (python):
 
@@ -109,6 +116,7 @@ bus = SessionBus()
 browser_bus = bus.get('anthias.webview', '/Anthias')
 
 browser_bus.loadPage("www.example.com")
+browser_bus.setReloadInterval(30)  # reload every 30s; 0 disables
 ```
 
 Supported protocols: `http://`, `https://`

--- a/webview/src/mainwindow.cpp
+++ b/webview/src/mainwindow.cpp
@@ -22,3 +22,8 @@ void MainWindow::loadImage(const QString &uri)
 {
     view->loadImage(uri);
 }
+
+void MainWindow::setReloadInterval(int seconds)
+{
+    view->setReloadInterval(seconds);
+}

--- a/webview/src/mainwindow.h
+++ b/webview/src/mainwindow.h
@@ -15,6 +15,7 @@ class MainWindow : public QMainWindow
     public slots:
         void loadPage(const QString &uri);
         void loadImage(const QString &uri);
+        void setReloadInterval(int seconds);
 
     private:
         View *view = nullptr;

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -79,6 +79,7 @@ View::View(QWidget* parent) : QWidget(parent)
     isAnimatedImage = false;
     loadGenerationId = 0;
     reloadTimer = nullptr;
+    pendingReloadIntervalS = 0;
 }
 
 View::~View()
@@ -118,9 +119,12 @@ void View::loadPage(const QString &uri)
     currentImage = QImage();
     stopAnimation();
     // Drop any per-asset reload timer left over from the previous
-    // webpage. setReloadInterval re-arms it after the new page load
-    // commits if the next asset still wants auto-refresh.
+    // webpage AND the prior asset's pending interval — the viewer
+    // calls setReloadInterval right after this with the new asset's
+    // value, so any old pending value would be wrong if it leaked
+    // into the swap that's about to happen.
     stopReloadTimer();
+    pendingReloadIntervalS = 0;
     nextWebViewReady = false;
 
     // Drop any prior loadFinished handler before stop() — a synchronous
@@ -182,9 +186,11 @@ void View::loadImage(const QString &preUri)
         pageLoadConnection = QMetaObject::Connection{};
     }
     // Webpage auto-refresh only applies while a webpage is on screen;
-    // killing the timer here keeps a stale reload from firing into the
-    // (now hidden) QWebEngineView after the viewer rotates to an image.
+    // killing the timer (and clearing the pending interval) here keeps
+    // a stale reload from firing into the (now hidden) QWebEngineView
+    // after the viewer rotates to an image.
     stopReloadTimer();
+    pendingReloadIntervalS = 0;
     webView1->stop();
     webView2->stop();
 
@@ -372,19 +378,36 @@ void View::setReloadInterval(int seconds)
 {
     // Per-asset auto-refresh. The viewer calls this right after each
     // loadPage() with the asset's metadata.refresh_interval_s value
-    // (0 when the field is absent or explicitly disabled). 0 stops the
-    // timer; a positive value (re)arms it. The timer reloads the
-    // visible web view in place via reload() — no buffer swap, since
-    // this is a refresh of the page already on screen, not a transition
-    // to a new URL.
+    // (0 when the field is absent or explicitly disabled). Stash the
+    // requested cadence and only arm the QTimer once the new page is
+    // actually visible — a load is in flight when ``pageLoadConnection``
+    // is set, in which case currentWebView is still the *previous*
+    // page and arming now would race the swap and reload the wrong
+    // page (Copilot review, PR #2841). When no load is pending — the
+    // common URL-unchanged-since-last-tick case where the viewer
+    // skips loadPage() — arm immediately.
+    pendingReloadIntervalS = (seconds > 0) ? seconds : 0;
     stopReloadTimer();
 
-    if (seconds <= 0) {
+    if (!pageLoadConnection) {
+        armReloadTimer();
+    }
+}
+
+void View::armReloadTimer()
+{
+    // Idempotent: callers may invoke this multiple times around a
+    // single load (setReloadInterval, then switchToNextWebView), and
+    // we always want a single live timer attached to the now-visible
+    // currentWebView.
+    stopReloadTimer();
+
+    if (pendingReloadIntervalS <= 0 || !currentWebView) {
         return;
     }
 
     reloadTimer = new QTimer(this);
-    reloadTimer->setInterval(seconds * 1000);
+    reloadTimer->setInterval(pendingReloadIntervalS * 1000);
     connect(reloadTimer, &QTimer::timeout, this, [this]() {
         if (currentWebView) {
             qDebug() << "Auto-refreshing web page";
@@ -423,4 +446,11 @@ void View::switchToNextWebView()
     nextWebViewReady = false;
 
     qDebug() << "Successfully switched to next web view";
+
+    // The new page is now visible — safe to arm the auto-refresh
+    // timer against it. setReloadInterval may have been called while
+    // the load was in flight; it stashed the cadence in
+    // pendingReloadIntervalS and deferred to here. No-op if the asset
+    // didn't request auto-refresh.
+    armReloadTimer();
 }

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -78,6 +78,7 @@ View::View(QWidget* parent) : QWidget(parent)
     movie = nullptr;
     isAnimatedImage = false;
     loadGenerationId = 0;
+    reloadTimer = nullptr;
 }
 
 View::~View()
@@ -85,6 +86,7 @@ View::~View()
     if (pageLoadConnection) {
         QObject::disconnect(pageLoadConnection);
     }
+    stopReloadTimer();
     stopAnimation();
 }
 
@@ -115,6 +117,10 @@ void View::loadPage(const QString &uri)
     const quint64 requestId = ++loadGenerationId;
     currentImage = QImage();
     stopAnimation();
+    // Drop any per-asset reload timer left over from the previous
+    // webpage. setReloadInterval re-arms it after the new page load
+    // commits if the next asset still wants auto-refresh.
+    stopReloadTimer();
     nextWebViewReady = false;
 
     // Drop any prior loadFinished handler before stop() — a synchronous
@@ -175,6 +181,10 @@ void View::loadImage(const QString &preUri)
         QObject::disconnect(pageLoadConnection);
         pageLoadConnection = QMetaObject::Connection{};
     }
+    // Webpage auto-refresh only applies while a webpage is on screen;
+    // killing the timer here keeps a stale reload from firing into the
+    // (now hidden) QWebEngineView after the viewer rotates to an image.
+    stopReloadTimer();
     webView1->stop();
     webView2->stop();
 
@@ -356,6 +366,41 @@ void View::setupAnimation()
     movie->jumpToFrame(0);
     currentImage = movie->currentImage();
     update();
+}
+
+void View::setReloadInterval(int seconds)
+{
+    // Per-asset auto-refresh. The viewer calls this right after each
+    // loadPage() with the asset's metadata.refresh_interval_s value
+    // (0 when the field is absent or explicitly disabled). 0 stops the
+    // timer; a positive value (re)arms it. The timer reloads the
+    // visible web view in place via reload() — no buffer swap, since
+    // this is a refresh of the page already on screen, not a transition
+    // to a new URL.
+    stopReloadTimer();
+
+    if (seconds <= 0) {
+        return;
+    }
+
+    reloadTimer = new QTimer(this);
+    reloadTimer->setInterval(seconds * 1000);
+    connect(reloadTimer, &QTimer::timeout, this, [this]() {
+        if (currentWebView) {
+            qDebug() << "Auto-refreshing web page";
+            currentWebView->reload();
+        }
+    });
+    reloadTimer->start();
+}
+
+void View::stopReloadTimer()
+{
+    if (reloadTimer) {
+        reloadTimer->stop();
+        reloadTimer->deleteLater();
+        reloadTimer = nullptr;
+    }
 }
 
 void View::switchToNextWebView()

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -374,6 +374,14 @@ void View::setupAnimation()
     update();
 }
 
+// Mirrors the v2 serializer's REFRESH_INTERVAL_S_MAX. Caps a hostile
+// or buggy D-Bus caller — the multiplication ``seconds * 1000`` later
+// in armReloadTimer would otherwise overflow ``int`` for values north
+// of ~2.1M and produce a wraparound cadence (small or negative). The
+// server side validates the range on write but the D-Bus contract is
+// trust-no-one (anything on the session bus could call this).
+static constexpr int kMaxReloadIntervalS = 86400;
+
 void View::setReloadInterval(int seconds)
 {
     // Per-asset auto-refresh. The viewer calls this right after each
@@ -385,8 +393,16 @@ void View::setReloadInterval(int seconds)
     // page and arming now would race the swap and reload the wrong
     // page (Copilot review, PR #2841). When no load is pending — the
     // common URL-unchanged-since-last-tick case where the viewer
-    // skips loadPage() — arm immediately.
-    pendingReloadIntervalS = (seconds > 0) ? seconds : 0;
+    // skips loadPage() — arm immediately. ``seconds`` is clamped to
+    // [0, kMaxReloadIntervalS] to defend against int-overflow on the
+    // millisecond multiplication done at arm time.
+    if (seconds <= 0) {
+        pendingReloadIntervalS = 0;
+    } else if (seconds > kMaxReloadIntervalS) {
+        pendingReloadIntervalS = kMaxReloadIntervalS;
+    } else {
+        pendingReloadIntervalS = seconds;
+    }
     stopReloadTimer();
 
     if (!pageLoadConnection) {
@@ -408,9 +424,13 @@ void View::armReloadTimer()
 
     reloadTimer = new QTimer(this);
     reloadTimer->setInterval(pendingReloadIntervalS * 1000);
+    // Don't qDebug() the reload itself — short intervals (5–10s) would
+    // flood journald to the point of unusability for very little
+    // diagnostic value. A failure to load shows up via the existing
+    // pageLoadConnection / loadFinished path; reload() succeeding is
+    // the boring case.
     connect(reloadTimer, &QTimer::timeout, this, [this]() {
         if (currentWebView) {
-            qDebug() << "Auto-refreshing web page";
             currentWebView->reload();
         }
     });

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -391,9 +391,9 @@ void View::setReloadInterval(int seconds)
     // actually visible — a load is in flight when ``pageLoadConnection``
     // is set, in which case currentWebView is still the *previous*
     // page and arming now would race the swap and reload the wrong
-    // page (Copilot review, PR #2841). When no load is pending — the
-    // common URL-unchanged-since-last-tick case where the viewer
-    // skips loadPage() — arm immediately. ``seconds`` is clamped to
+    // page. When no load is pending — the common
+    // URL-unchanged-since-last-tick case where the viewer skips
+    // loadPage() — arm immediately. ``seconds`` is clamped to
     // [0, kMaxReloadIntervalS] to defend against int-overflow on the
     // millisecond multiplication done at arm time.
     if (seconds <= 0) {

--- a/webview/src/view.h
+++ b/webview/src/view.h
@@ -6,6 +6,7 @@
 #include <QNetworkAccessManager>
 #include <QImage>
 #include <QMovie>
+#include <QTimer>
 #include <QUrl>
 
 class View : public QWidget
@@ -18,6 +19,7 @@ public:
 
     void loadPage(const QString &uri);
     void loadImage(const QString &uri);
+    void setReloadInterval(int seconds);
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -52,4 +54,11 @@ private:
     // we can drop it before issuing stop() on the next loadPage and
     // avoid a synchronous loadFinished(false) racing into a stale slot.
     QMetaObject::Connection pageLoadConnection;
+
+    // Per-asset auto-refresh timer. When non-null and active, fires
+    // currentWebView->reload() every N seconds. Cleared on every
+    // loadPage / loadImage so a fresh asset starts from a clean slate;
+    // setReloadInterval re-arms it. Owned by the View (parent=this).
+    QTimer* reloadTimer;
+    void stopReloadTimer();
 };

--- a/webview/src/view.h
+++ b/webview/src/view.h
@@ -69,7 +69,7 @@ private:
     // immediately would target the still-visible *previous* page via
     // currentWebView->reload(). We instead remember the value here and
     // arm the timer in switchToNextWebView() once the new page is
-    // actually visible. Per Copilot review on PR #2841.
+    // actually visible.
     int pendingReloadIntervalS;
     void stopReloadTimer();
     void armReloadTimer();

--- a/webview/src/view.h
+++ b/webview/src/view.h
@@ -56,9 +56,21 @@ private:
     QMetaObject::Connection pageLoadConnection;
 
     // Per-asset auto-refresh timer. When non-null and active, fires
-    // currentWebView->reload() every N seconds. Cleared on every
-    // loadPage / loadImage so a fresh asset starts from a clean slate;
-    // setReloadInterval re-arms it. Owned by the View (parent=this).
+    // currentWebView->reload() every ``pendingReloadIntervalS`` seconds.
+    // Cleared on every loadPage / loadImage so a fresh asset starts
+    // from a clean slate. Owned by the View (parent=this).
     QTimer* reloadTimer;
+
+    // Most recently requested auto-refresh cadence, in seconds. 0 = no
+    // auto-refresh. Held separately from the timer because
+    // setReloadInterval can land *while a page load is still in flight*
+    // (loadPage queues a load into nextWebView, then the viewer calls
+    // setReloadInterval before the swap completes); arming a QTimer
+    // immediately would target the still-visible *previous* page via
+    // currentWebView->reload(). We instead remember the value here and
+    // arm the timer in switchToNextWebView() once the new page is
+    // actually visible. Per Copilot review on PR #2841.
+    int pendingReloadIntervalS;
     void stopReloadTimer();
+    void armReloadTimer();
 };


### PR DESCRIPTION
### Issues Fixed

Closes #2813.

### Description

Adds a per-asset auto-refresh interval for webpage assets so dashboards / news feeds / status pages stay current without operator intervention. Stored inside `Asset.metadata['refresh_interval_s']`; default 0 = no auto-refresh (current behaviour).

Touches both server and webview:

- **API (v2)**: `refresh_interval_s` is read+write on the v2 serializers (validated 0..86400). `metadata` itself stays read-only — the upload pipeline keeps owning `original_ext` / `transcoded` / `error_message`. PATCH merges into existing metadata so pipeline keys survive operator edits. The cap (`REFRESH_INTERVAL_S_MAX`) lives on the Asset model so the v2 serializer, the form handler, and the edit-modal `<input max>` all share one constant.
- **Form handler**: `assets_update` merges the value into `metadata`, clamping to [0, `REFRESH_INTERVAL_S_MAX`].
- **Edit modal**: new "Auto-refresh interval (seconds)" input inside the existing Advanced section, only rendered when `mimetype === 'webpage'`. Auto-expands Advanced when an interval is set.
- **Viewer**: `view_webpage(uri, reload_interval_s)` always calls the new `browser_bus.setReloadInterval` slot, so an interval-only edit takes effect even when the URI is unchanged. Wrapped in a try/except so version skew against an older AnthiasWebview fails soft (warning + no auto-refresh) instead of crashing the asset loop.
- **Webview (Qt5/Qt6)**: `QTimer`-driven `currentWebView->reload()`; new D-Bus slot `MainWindow::setReloadInterval(int)`; timer cleared on every `loadPage` / `loadImage` and only armed once the new page is visible (via `switchToNextWebView`) so it can't fire on the prior page during a swap.
- **Build**: bumped `WEBVIEW_VERSION` default to `2026.05.0` (the D-Bus contract grew a slot).

**Bundled (not strictly the feature)**:
- **Marketing site** (`website/layouts/_default/features.html`): a copy rewrite that was already in flight on disk before this PR was opened. Folded in here so the new "set an auto-refresh interval" capability is described in the same change as the implementation, rather than landing as a docs-only follow-up. Mentioned in commit `21956f1` and discussed in the PR thread.

x86 webview built locally via `webview/docker-compose.yml` (`builder-x86` profile, Qt6 trixie); produced `webview-2026.05.0-dev-trixie-x86.tar.gz` with no warnings.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).