### PR TITLE
chore(docker): drop the 2026-05-01 webview cache-bust step

### DIFF
--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -39,9 +39,6 @@ RUN curl "{{webview_base_url}}/qt{{qt_major_version}}-{{qt_version}}-{{debian_ve
     rm "qt{{qt_major_version}}-{{qt_version}}-{{debian_version}}-{{artifact_board}}.tar.gz"
 {% endif %}
 
-# Cache bust 2026-05-01: re-fetch corrected pi4-64/pi5 webview tarballs
-# (per b9509609); revert this once the next viewer image rebuild ships.
-RUN : "webview-cache-bust-2026-05-01"
 RUN curl "{{webview_base_url}}/webview-{{webview_version}}-{{debian_version}}-{{artifact_board}}.tar.gz" \
         -sL -o "/tmp/webview-{{webview_version}}-{{debian_version}}-{{artifact_board}}.tar.gz" && \
     curl "{{webview_base_url}}/webview-{{webview_version}}-{{debian_version}}-{{artifact_board}}.tar.gz.sha256" \


### PR DESCRIPTION
### Issues Fixed

Follow-up cleanup from #2841.

### Description

The ``RUN : "webview-cache-bust-2026-05-01"`` no-op in ``Dockerfile.viewer.j2`` was a one-shot Docker-layer-cache invalidator added when pi4-64/pi5 webview tarballs got reuploaded under the same ``WebView-v2026.04.1`` release URL after b9509609. The comment told a future committer to revert it *once the next viewer image rebuild ships* — that's now: the viewer image is on ``WebView-v2026.05.0``, the URL itself differs, and Docker no longer needs the marker step to bust the layer cache.

Caught in https://github.com/Screenly/Anthias/actions/runs/25540327654/job/74964936691 where the orphan step still showed in the build log even though the actual fetch already targets the new release.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).