### PR TITLE
chore(server): bake collectstatic into image, drop runtime scratch mount

### DIFF
--- a/bin/start_server.sh
+++ b/bin/start_server.sh
@@ -64,8 +64,9 @@ if [[ "$ENVIRONMENT" == "development" ]]; then
         --reload-include "*.css" \
         "${UVICORN_PROXY_ARGS[@]}"
 else
-    echo "Generating Django static files..."
-    python -m anthias_server.manage collectstatic --clear --noinput
+    # collectstatic ran at image build time (docker/Dockerfile.server.j2)
+    # — STATIC_ROOT is baked into the read-only image layer. No runtime
+    # invocation needed.
     echo "Starting uvicorn..."
     exec uvicorn anthias_server.django_project.asgi:application \
         --host "$UVICORN_BIND_HOST" \

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -25,7 +25,6 @@ services:
       - resin-data:/data
       - /home/${USER}/.anthias:/data/.anthias
       - /home/${USER}/anthias_assets:/data/anthias_assets
-      - /home/${USER}/anthias/staticfiles:/data/anthias/staticfiles
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     labels:

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -75,7 +75,7 @@ ENV PYTHONPATH="/usr/src/app/src"
 
 {% if environment == 'production' %}
 # collectstatic at image build time. Source files (admin static + the
-# bun-built dist/ COPYed in above) are immutable from this point on, so
+# bun-built dist/ copied in above) are immutable from this point on, so
 # there's no reason to repeat the work on every container start. The
 # previous setup ran `collectstatic --clear` from start_server.sh into
 # a host bind-mount on /data/anthias/staticfiles — same data, every

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -73,4 +73,25 @@ ENV DEVICE_TYPE={{ device_type }}
 ENV DJANGO_SETTINGS_MODULE="anthias_server.django_project.settings"
 ENV PYTHONPATH="/usr/src/app/src"
 
+{% if environment == 'production' %}
+# collectstatic at image build time. Source files (admin static + the
+# bun-built dist/ COPYed in above) are immutable from this point on, so
+# there's no reason to repeat the work on every container start. The
+# previous setup ran `collectstatic --clear` from start_server.sh into
+# a host bind-mount on /data/anthias/staticfiles — same data, every
+# restart, into a writable host scratch dir. Baking the result into the
+# image lets us drop the bind-mount, the runtime invocation, and one
+# of the reasons /home/<user>/anthias has to persist after install.
+#
+# `HOME=/tmp/anthias-build` is throwaway: importing the Django settings
+# module instantiates AnthiasSettings(), which writes a default
+# anthias.conf into $HOME/.anthias/ if one isn't there yet. At runtime
+# start_server.sh seeds /data/.anthias from ansible/roles/anthias/files/
+# before this same import happens; at build time we just give it a
+# scratch dir and remove it after collectstatic finishes.
+RUN mkdir -p /tmp/anthias-build/.anthias && \
+    HOME=/tmp/anthias-build python -m anthias_server.manage collectstatic --noinput --clear && \
+    rm -rf /tmp/anthias-build
+{% endif %}
+
 CMD ["bash", "bin/start_server.sh"]

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -242,7 +242,14 @@ except (pytz.exceptions.UnknownTimeZoneError, FileNotFoundError):
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = '/data/anthias/staticfiles'
+# Baked into the production server image at build time
+# (docker/Dockerfile.server.j2 runs `manage.py collectstatic` after
+# the bun-built dist/ is COPYed in). The runtime container treats
+# this path as read-only: admin assets + collected app static is
+# immutable per-image. Dev (DEBUG=True) bypasses STATIC_ROOT
+# entirely via WHITENOISE_USE_FINDERS below, so the path doesn't
+# need to exist in the dev image.
+STATIC_ROOT = '/usr/src/app/staticfiles'
 
 # Dev runs uvicorn (not runserver) and skips collectstatic, so files
 # only exist in STATICFILES_DIRS — let WhiteNoise fall back to the

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -244,8 +244,8 @@ except (pytz.exceptions.UnknownTimeZoneError, FileNotFoundError):
 STATIC_URL = '/static/'
 # Baked into the production server image at build time
 # (docker/Dockerfile.server.j2 runs `manage.py collectstatic` after
-# the bun-built dist/ is COPYed in). The runtime container treats
-# this path as read-only: admin assets + collected app static is
+# the bun-built dist/ is copied in). The runtime container treats
+# this path as read-only: admin assets and collected app static are
 # immutable per-image. Dev (DEBUG=True) bypasses STATIC_ROOT
 # entirely via WHITENOISE_USE_FINDERS below, so the path doesn't
 # need to exist in the dev image.


### PR DESCRIPTION
### Issues Fixed

- Refs #2845 (sub-task: "Drop the staticfiles/ host bind-mount")

### Description

Static files (admin assets + the bun-built dist/) don't change after image build, but `bin/start_server.sh` was running `collectstatic --clear --noinput` on every container start into a host bind-mount on `~/anthias/staticfiles`. Same data, every restart, into a directory the container itself populated. Pure ceremony.

This PR moves the work to where it belongs — image build time:

- **`docker/Dockerfile.server.j2`** — run `collectstatic --noinput --clear` in the production stage, after the bun-built `dist/` is COPYed in. Wrapped in `HOME=/tmp/anthias-build` because Django's settings import instantiates `AnthiasSettings()` at module load, which writes a default `anthias.conf` into `$HOME/.anthias/` if one isn't there yet. Throwaway HOME, removed after the RUN finishes.
- **`src/anthias_server/django_project/settings.py`** — `STATIC_ROOT` moves from `/data/anthias/staticfiles` to `/usr/src/app/staticfiles`. Inside the container the path is now read-only; admin + collected app static is immutable per-image. Dev (DEBUG=True) bypasses `STATIC_ROOT` via `WHITENOISE_USE_FINDERS`, so the path doesn't need to exist in the dev image.
- **`bin/start_server.sh`** — drop the runtime `collectstatic` invocation.
- **`docker-compose.yml.tmpl`** — drop the `~/anthias/staticfiles → /data/anthias/staticfiles` bind-mount. Host-side directory becomes orphan state after upgrade; operators can `rm -rf ~/anthias/staticfiles` once the new image is pulled.

### Why now

#2845 lays out a broader refactor to make `~/anthias` install-only. The bind-mount on `staticfiles/` is one of the two real reasons `~/anthias` has to persist after install (the other being runtime shell scripts in `~/anthias/bin/`). Removing it is a clean standalone change — independent of the rest of #2845 — and a useful precondition for that work.

### Test plan

Verified locally by building the production server image:

```
$ docker buildx build --file docker/Dockerfile.server --platform linux/amd64 .
...
#32 [stage-2 8/8] RUN ... collectstatic ...
#32 0.412 210 static files copied to '/usr/src/app/staticfiles'.
```

Then run the new image:

```
$ docker run -d --name anthias-server-test ... anthias-server-test:latest
$ docker logs anthias-server-test | grep -i "static\|uvicorn"
Starting uvicorn...
INFO:     Uvicorn running on http://0.0.0.0:8080
$ curl -o /dev/null -w "%{http_code} %{size_download}\n" http://localhost:18080/static/admin/css/base.css
200 22120
$ docker exec anthias-server-test ls /data/anthias 2>&1
ls: cannot access '/data/anthias': No such file or directory
```

- 210 static files baked into `/usr/src/app/staticfiles` at image build.
- Container starts; no "Generating Django static files..." line.
- `/static/admin/css/base.css` serves with HTTP 200, 22120 bytes (matches the baked file).
- `/data/anthias/` does not exist in the running container — no runtime scratch dir.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for x86 devices (production server image build + curl).
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)