### PR TITLE
ci(docker): pull bun from ghcr.io/screenly mirror

### DIFF
--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -19,7 +19,7 @@
    requirement we'd need to either drop bun (e.g. back to Node, which
    still ships armv7 binaries) or check `static/dist/` into the
    image / a cache and skip this stage entirely. #}
-FROM --platform=$BUILDPLATFORM oven/bun:1.3.13-slim AS bun-builder
+FROM --platform=$BUILDPLATFORM ghcr.io/screenly/bun:1.3.13-slim AS bun-builder
 
 RUN mkdir -p /app
 WORKDIR /app
@@ -62,7 +62,7 @@ COPY --from=bun-builder \
     /app/src/anthias_server/app/static/dist/ \
     /usr/src/app/src/anthias_server/app/static/dist/
 {% else %}
-COPY --from=oven/bun:1.3.13-slim /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=ghcr.io/screenly/bun:1.3.13-slim /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -sf bun /usr/local/bin/bunx
 {% endif %}
 

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     {% endfor %}
 {% endif %}
 
-COPY --from=oven/bun:1.3.13-slim /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=ghcr.io/screenly/bun:1.3.13-slim /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -sf bun /usr/local/bin/bunx
 
 # @TODO: Uncomment the lines below when test_add_asset_streaming is fixed.


### PR DESCRIPTION
### Issues Fixed

Follow-up to #2847 — switches CI builds off the Docker Hub `oven/bun` pull, eliminating the last source of Docker Hub anonymous-pull rate limits.

### Description

Swaps the three remaining `oven/bun:1.3.13-slim` references in `docker/Dockerfile.server.j2` and `docker/Dockerfile.test.j2` to `ghcr.io/screenly/bun:1.3.13-slim`, populated daily by the mirror workflow added in #2847.

The GHCR tag has been verified — both `linux/amd64` and `linux/arm64` manifests are present (matches the platforms bun ships; the existing 32-bit-ARM caveat in `Dockerfile.server.j2` is unchanged).

When bumping the bun tag in the future, also bump `BUN_TAG` in `.github/workflows/mirror-bun-image.yaml` and trigger that workflow before merging.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)