### PR TITLE
ci(website): override addopts for rpi-imager pytest run

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -51,7 +51,13 @@ jobs:
           version: ${{ env.UV_VERSION }}
 
       - name: Run rpi-imager tests
-        run: uv run --no-dev --group website -m pytest --confcutdir=tools/raspberry_pi_imager tools/raspberry_pi_imager/tests/ -v
+        # The repo-wide pytest addopts in pyproject.toml include
+        # pytest-playwright flags (--browser, --tracing, --screenshot,
+        # --output) for the integration suite. The website group
+        # doesn't pull pytest-playwright, so we override addopts here
+        # to keep just --strict-markers — otherwise pytest dies with
+        # "unrecognized arguments" before any test runs.
+        run: uv run --no-dev --group website -m pytest --confcutdir=tools/raspberry_pi_imager tools/raspberry_pi_imager/tests/ -v -o "addopts=--strict-markers"
 
   # Build job
   build:


### PR DESCRIPTION
### Issues Fixed

Unblocks the deploy-website workflow which has been failing on master since [#2828 merged on 2026-05-06](https://github.com/Screenly/Anthias/actions/runs/25460337652) — every push that touches `website/`, `tools/raspberry_pi_imager/`, or `deploy-website.yaml` has had its deploy fail at the rpi-imager test step. Most recent failure: https://github.com/Screenly/Anthias/actions/runs/25550275037/job/74996271699 (the run triggered by #2851).

### Description

Root cause: `pyproject.toml` (since #2818) has

```toml
addopts = "--strict-markers --browser chromium --tracing retain-on-failure --screenshot only-on-failure --output test-artifacts"
```

The `--browser`/`--tracing`/`--screenshot`/`--output` flags belong to `pytest-playwright`, which is only present in the `dev` dependency group (used by the integration suite). The deploy-website workflow runs the rpi-imager tests with `uv run --no-dev --group website` — so `pytest-playwright` isn't installed and pytest dies with `unrecognized arguments` before collecting any tests.

Surgical fix: override `addopts` to just `--strict-markers` for that one invocation via `-o "addopts=--strict-markers"`. Verified locally — all 21 rpi-imager tests pass.

Doesn't fatten the `website` group, doesn't disturb how integration tests run.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)