### PR TITLE
fix(compose): route container logs to journald to bound disk usage

### DIFF
--- a/bin/enable_ssl.sh
+++ b/bin/enable_ssl.sh
@@ -201,6 +201,10 @@ EOF
     cat <<'EOF'
       - anthias-caddy-data:/data
       - anthias-caddy-config:/config
+    logging:
+      driver: journald
+      options:
+        tag: anthias-caddy
 
 volumes:
   anthias-caddy-data:

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -29,6 +29,10 @@ services:
       - /etc/localtime:/etc/localtime:ro
     labels:
       io.balena.features.supervisor-api: '1'
+    logging:
+      driver: journald
+      options:
+        tag: anthias-server
 
   anthias-viewer:
     image: ghcr.io/screenly/anthias-viewer:${DOCKER_TAG}-${DEVICE_TYPE}
@@ -55,6 +59,10 @@ services:
       - /etc/localtime:/etc/localtime:ro
     labels:
       io.balena.features.supervisor-api: '1'
+    logging:
+      driver: journald
+      options:
+        tag: anthias-viewer
 
   anthias-celery:
     # Runs on the same image as anthias-server with a CMD override.
@@ -94,6 +102,10 @@ services:
       - /etc/localtime:/etc/localtime:ro
     labels:
       io.balena.features.supervisor-api: '1'
+    logging:
+      driver: journald
+      options:
+        tag: anthias-celery
 
   redis:
     image: ghcr.io/screenly/anthias-redis:${DOCKER_TAG}-${DEVICE_TYPE}
@@ -105,6 +117,10 @@ services:
     restart: always
     volumes:
       - redis-data:/var/lib/redis
+    logging:
+      driver: journald
+      options:
+        tag: anthias-redis
 
 volumes:
   resin-data:

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -21,6 +21,19 @@ driver, so they don't write the unbounded `*-json.log` files under
 installs. You can read the logs three ways: `docker logs`,
 `docker compose logs`, or `journalctl` directly.
 
+> **Note**
+>
+> Switching the driver only affects future writes. Devices that were
+> on the old `json-file` driver will still have the existing log files
+> on disk after upgrading. To reclaim that space, truncate the leftover
+> files in place (Docker keeps them open, so deleting can confuse the
+> daemon — `truncate -s 0` is safe):
+>
+> ```bash
+> $ sudo find /var/lib/docker/containers/ -name "*-json.log" \
+>     -exec truncate -s 0 {} +
+> ```
+
 ### Using `docker logs`
 
 For instance, the command below will show you the logs from the server container:

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -12,9 +12,11 @@ and `raspberrypi` for the hostname, then run:
 $ ssh pi@raspberrypi
 ```
 
-Anthias makes use of Docker for containerization. To get the logs from the
-containers, you can either make use of the `docker logs` command or you can
-use the `docker compose logs` command.
+Anthias ships its container logs through the host's `systemd-journald`,
+so the system handles rotation and retention for you and there is no
+unbounded `*-json.log` file under `/var/lib/docker/containers/` to fill
+the SD card. You can read the logs three ways: `docker logs`,
+`docker compose logs`, or `journalctl` directly.
 
 ### Using `docker logs`
 
@@ -58,6 +60,30 @@ $ docker compose logs -f ${SERVICE_NAME}
 ```
 
 Check out [this section](/docs/development/#understanding-the-components-that-make-up-anthias) of the Developer documentation page for the list of available services.
+
+### Using `journalctl`
+
+Each service is tagged in the journal so you can pull logs without
+docker. Useful when you want to grep across a long time range or
+combine container logs with system logs:
+
+```bash
+$ journalctl -f CONTAINER_TAG=anthias-server
+$ journalctl --since "1 hour ago" CONTAINER_TAG=anthias-viewer
+```
+
+The available tags are `anthias-server`, `anthias-viewer`,
+`anthias-celery`, and `anthias-redis`.
+
+Journal retention is controlled by `systemd-journald` (see
+`/etc/systemd/journald.conf` — `SystemMaxUse` caps total disk usage,
+defaulting to 10% of the filesystem). If you want to free space
+immediately:
+
+```bash
+$ sudo journalctl --vacuum-time=2d   # drop entries older than 2 days
+$ sudo journalctl --vacuum-size=200M # cap journal at 200 MB
+```
 
 ## Enabling SSH
 

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -13,9 +13,12 @@ $ ssh pi@raspberrypi
 ```
 
 Anthias ships its container logs through the host's `systemd-journald`,
-so the system handles rotation and retention for you and there is no
-unbounded `*-json.log` file under `/var/lib/docker/containers/` to fill
-the SD card. You can read the logs three ways: `docker logs`,
+so the system handles rotation and retention for you. The four core
+services (`anthias-server`, `anthias-viewer`, `anthias-celery`, `redis`)
+plus the optional `anthias-caddy` TLS sidecar all use the journald
+driver, so they don't write the unbounded `*-json.log` files under
+`/var/lib/docker/containers/` that can fill an SD card on long-running
+installs. You can read the logs three ways: `docker logs`,
 `docker compose logs`, or `journalctl` directly.
 
 ### Using `docker logs`
@@ -68,12 +71,21 @@ docker. Useful when you want to grep across a long time range or
 combine container logs with system logs:
 
 ```bash
-$ journalctl -f CONTAINER_TAG=anthias-server
-$ journalctl --since "1 hour ago" CONTAINER_TAG=anthias-viewer
+$ sudo journalctl -f CONTAINER_TAG=anthias-server
+$ sudo journalctl --since "1 hour ago" CONTAINER_TAG=anthias-viewer
 ```
 
 The available tags are `anthias-server`, `anthias-viewer`,
-`anthias-celery`, and `anthias-redis`.
+`anthias-celery`, `anthias-redis`, and (when TLS is enabled)
+`anthias-caddy`.
+
+> **Note**
+>
+> The Anthias installer adds your user to the `adm` group, which on
+> Debian/Raspberry Pi OS grants read access to the journal once you've
+> logged out and back in (and provided the journal is persistent —
+> i.e. `/var/log/journal/` exists). On systems where that's set up you
+> can drop the `sudo` from the commands above.
 
 Journal retention is controlled by `systemd-journald` (see
 `/etc/systemd/journald.conf` — `SystemMaxUse` caps total disk usage,


### PR DESCRIPTION
### Issues Fixed

Fixes #2304.

### Description

Switches the four services in `docker-compose.yml.tmpl` (`anthias-server`, `anthias-viewer`, `anthias-celery`, `redis`) to the `journald` log driver with per-service tags. Previously the default `json-file` driver wrote unbounded `*-json.log` files under `/var/lib/docker/containers/` — issue #2304 reported a 19 GB `anthias-viewer` log filling an SD card. With `journald`, the host's `systemd-journald` handles rotation/retention via `SystemMaxUse` (defaults to 10% of the filesystem).

`docker logs` and `docker compose logs` continue to work unchanged because they read through the journald API. Existing installs pick up the change on the next `bin/upgrade_containers.sh` run, which re-renders the template and recreates the containers.

Updated `website/content/docs/_index.md` to explain the bounded behavior and document `journalctl -f CONTAINER_TAG=anthias-server` access plus `journalctl --vacuum-*` for one-shot cleanup.

Note: pre-existing fat `*-json.log` files on already-deployed devices are not reclaimed automatically — users will need to truncate or remove them once after upgrading. Happy to bolt a one-shot cleanup into `upgrade_containers.sh` in a follow-up if desired.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).