### PR TITLE
feat(x86): support balenaOS x86 fleets via Wayland

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -113,7 +113,7 @@ jobs:
         run: |
           set -euo pipefail
           missing=()
-          for board in pi2 pi3 pi4-64 pi5; do
+          for board in pi2 pi3 pi4-64 pi5 x86; do
             for service in server viewer redis; do
               ref="ghcr.io/screenly/anthias-${service}:${SHORT_HASH}-${board}"
               if ! docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        board: ['pi2', 'pi3', 'pi4-64', 'pi5']
+        board: ['pi2', 'pi3', 'pi4-64', 'pi5', 'x86']
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout at tag
@@ -180,6 +180,7 @@ jobs:
             pi3)    FLEET=anthias-pi3 ;;
             pi4-64) FLEET=anthias-pi4 ;;
             pi5)    FLEET=anthias-pi5 ;;
+            x86)    FLEET=anthias-x86 ;;
           esac
           {
             echo "FLEET_SLUG=$FLEET"
@@ -194,11 +195,13 @@ jobs:
           cp balena.yml balena-deploy/
           envsubst < docker-compose.balena.yml.tmpl > balena-deploy/docker-compose.yml
 
-          # Pi 5 doesn't expose /dev/vchiq; strip the bind mount.
-          if [ "${{ matrix.board }}" == "pi5" ]; then
-            sed -i '/devices:/ {N; /\n.*\/dev\/vchiq:\/dev\/vchiq/d}' \
-              balena-deploy/docker-compose.yml
-          fi
+          # Pi 5 and x86 don't expose /dev/vchiq; strip the bind mount.
+          case "${{ matrix.board }}" in
+            pi5|x86)
+              sed -i '/devices:/ {N; /\n.*\/dev\/vchiq:\/dev\/vchiq/d}' \
+                balena-deploy/docker-compose.yml
+              ;;
+          esac
 
       # `balena deploy` (vs `balena push`) takes the rendered compose
       # file and points the fleet at the existing GHCR images — no
@@ -226,7 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        board: ['pi2', 'pi3', 'pi4-64', 'pi5']
+        board: ['pi2', 'pi3', 'pi4-64', 'pi5', 'x86']
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -272,6 +275,14 @@ jobs:
             pi5)
               echo "BALENA_IMAGE=raspberrypi5" >> "$GITHUB_ENV"
               echo "FLEET_SLUG=anthias-pi5" >> "$GITHUB_ENV"
+              ;;
+            x86)
+              # genericx86-64-ext is balena's UEFI-boot generic
+              # x86_64 device type — works on most modern PCs / NUCs.
+              # Users without UEFI need a different image; intel-nuc
+              # is the legacy alternative.
+              echo "BALENA_IMAGE=genericx86-64-ext" >> "$GITHUB_ENV"
+              echo "FLEET_SLUG=anthias-x86" >> "$GITHUB_ENV"
               ;;
           esac
 

--- a/bin/deploy_to_balena.sh
+++ b/bin/deploy_to_balena.sh
@@ -6,7 +6,7 @@ print_help() {
     echo "Usage: deploy_to_balena.sh [options]"
     echo "Options:"
     echo "  -h, --help            show this help message and exit"
-    echo "  -b, --board BOARD     specify the board to build for (pi2, pi3, pi4-64, pi5)"
+    echo "  -b, --board BOARD     specify the board to build for (pi2, pi3, pi4-64, pi5, x86)"
     echo "  -f, --fleet FLEET     specify the fleet name to deploy to"
     echo "  -s, --short-hash HASH specify the short hash to use for the image tag"
     echo "  -d, --dev             run in dev mode"
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
         -b|--board)
             export BOARD="$2"
 
-            if [[ $BOARD =~ ^(pi2|pi3|pi4-64|pi5)$ ]]; then
+            if [[ $BOARD =~ ^(pi2|pi3|pi4-64|pi5|x86)$ ]]; then
                 echo "Building for $BOARD"
             else
                 echo "Invalid board $BOARD"
@@ -87,7 +87,8 @@ function prepare_balena_file() {
     cat docker-compose.balena.yml.tmpl | \
     envsubst > balena-deploy/docker-compose.yml
 
-    if [[ "$BOARD" == "pi5" ]]; then
+    # Pi 5 and x86 don't expose /dev/vchiq; strip the bind mount.
+    if [[ $BOARD =~ ^(pi5|x86)$ ]]; then
         sed -i '/devices:/ {N; /\n.*\/dev\/vchiq:\/dev\/vchiq/d}' \
             balena-deploy/docker-compose.yml
     fi
@@ -114,7 +115,7 @@ else
     cat docker-compose.balena.dev.yml.tmpl | \
         envsubst > docker-compose.yml
 
-    if [[ "$BOARD" == "pi5" ]]; then
+    if [[ $BOARD =~ ^(pi5|x86)$ ]]; then
         sed -i '/devices:/ {N; /\n.*\/dev\/vchiq:\/dev\/vchiq/d}' \
             docker-compose.yml
     fi

--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -100,8 +100,23 @@ fi
 # --preserve-env=XDG_RUNTIME_DIR forces sudo to forward the runtime dir
 # we just set; -E alone is subject to env_check / env_delete and is not
 # guaranteed for XDG_* on Debian's default sudoers.
-sudo --preserve-env=XDG_RUNTIME_DIR,QT_SCALE_FACTOR,PYTHONPATH -E -u viewer \
-    dbus-run-session /venv/bin/python -m anthias_viewer &
+#
+# x86 boards run under `cage`, a kiosk wlroots compositor, because
+# balenaOS x86 doesn't expose /dev/fb0 (Qt's linuxfb plugin has nothing
+# to draw to) and there's no host display server. cage acquires DRM
+# master as root, exports WAYLAND_DISPLAY for its child, and exits when
+# the child exits — so the existing kill -0 watchdog below still works.
+# The inner sudo drops back to the viewer user; WAYLAND_DISPLAY has to
+# be added to --preserve-env to survive sudo's env scrub.
+if [ "$DEVICE_TYPE" = "x86" ]; then
+    cage -- sudo \
+        --preserve-env=XDG_RUNTIME_DIR,QT_SCALE_FACTOR,PYTHONPATH,WAYLAND_DISPLAY \
+        -E -u viewer \
+        dbus-run-session /venv/bin/python -m anthias_viewer &
+else
+    sudo --preserve-env=XDG_RUNTIME_DIR,QT_SCALE_FACTOR,PYTHONPATH -E -u viewer \
+        dbus-run-session /venv/bin/python -m anthias_viewer &
+fi
 
 # Wait for the viewer
 while true; do

--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -49,7 +49,15 @@ RUN curl "{{webview_base_url}}/webview-{{webview_version}}-{{debian_version}}-{{
     rm "webview-{{webview_version}}-{{debian_version}}-{{artifact_board}}.tar.gz"
 
 ENV QT_QPA_EGLFS_FORCE888=1
+{% if board == 'x86' %}
+# balenaOS x86 doesn't expose /dev/fb0, so the linuxfb plugin has
+# nothing to draw to. Run Qt under Wayland instead; bin/start_viewer.sh
+# wraps the viewer in `cage`, a kiosk Wayland compositor that talks to
+# KMS via wlroots.
+ENV QT_QPA_PLATFORM=wayland
+{% else %}
 ENV QT_QPA_PLATFORM=linuxfb
+{% endif %}
 
 # Turn on debug logging for now
 #ENV QT_LOGGING_RULES=qt.qpa.*=true

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -187,7 +187,10 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
     # configured with `-no-xcb -no-xcb-xlib -qpa eglfs` (see
     # webview/build_qt{5,6}.sh) and runs under QT_QPA_PLATFORM=linuxfb
     # straight on KMS/DRM, so Qt has no X code path to dlopen. mpv
-    # uses --vo=drm. Same reason there's nothing wayland-related here.
+    # uses --vo=drm. Wayland is similarly absent on Pi for the same
+    # reason; the x86 board is the one exception (it has no /dev/fb0,
+    # so the qt6-wayland + cage pair is added to the per-board apt
+    # extension below).
     viewer_extra_apt_dependencies = [
         'ca-certificates',
         'dbus-daemon',

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -263,6 +263,20 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
                 'qt6-image-formats-plugins',
             ]
         )
+
+        if board == 'x86':
+            # balenaOS x86 has no /dev/fb0 for Qt's linuxfb plugin and
+            # no host display server. cage is a kiosk wlroots
+            # compositor that talks straight to KMS; qt6-wayland is
+            # the Qt platform plugin the viewer loads to render into
+            # cage's surface. See docker/Dockerfile.viewer.j2 and
+            # bin/start_viewer.sh for the runtime wiring.
+            viewer_extra_apt_dependencies.extend(
+                [
+                    'cage',
+                    'qt6-wayland',
+                ]
+            )
     else:
         # libraspberrypi0 already comes in via base_apt_dependencies on
         # 32-bit Pi boards (see __main__.py), so it's deliberately not


### PR DESCRIPTION
## Summary

- Brings x86 to feature parity with Pi for balenaOS deployments. Closes #2075.
- balenaOS x86 doesn't expose `/dev/fb0`, so Qt's `linuxfb` plugin (used on Pi) has nothing to draw to and there's no host display server. The viewer now runs Qt under Wayland via `cage`, a kiosk wlroots compositor that talks straight to KMS — no X server, no `DISPLAY` juggling, single-app by design.
- Pi boards are untouched: `linuxfb` and the existing launch path still apply on every non-x86 board.

## Stacking

> [!IMPORTANT]
> This PR is **stacked on top of #2854** (`refactor/release-flow-issue-2769`) and is targeted at that branch. GitHub will auto-retarget to `master` once #2854 merges. Marked draft until then.

## Changes

| File | What |
| --- | --- |
| `bin/deploy_to_balena.sh` | Accept `-b x86` in the whitelist; strip `/dev/vchiq` from the rendered compose (same conditional that already covers `pi5`); update help text |
| `docker/Dockerfile.viewer.j2` | `QT_QPA_PLATFORM=wayland` on x86; every other board keeps `linuxfb` |
| `tools/image_builder/utils.py` | Add `cage` + `qt6-wayland` to the x86 viewer apt list (transitively pulls in `libwlroots12t64`, `libqt6waylandclient6`, etc.) |
| `bin/start_viewer.sh` | Wrap the viewer launch in `cage --` on x86; `WAYLAND_DISPLAY` added to sudo's `--preserve-env` so cage's exported value survives sudo's env scrub when dropping to the `viewer` user |
| `.github/workflows/build-balena-disk-image.yaml` | Extend `preflight`, `balena-cloud-deploy`, and `balena-build-images` to include x86. Fleet: `screenly_ose/anthias-x86`. Balena device type: `genericx86-64-ext`. `build-rpi-imager-json` deliberately unchanged — its `.img.zst` regex is Pi-only, so x86 ships on the release without polluting the Raspberry Pi Imager JSON |

## Relationship to #2409

Supersedes the ~7-month-stale draft #2409. Master moved past it on multiple fronts (`bin/start_viewer.sh` has new QT scale-factor logic + a different viewer module name; the Dockerfile template variables changed; `viewer/media_player.py` audio paths changed), so this PR was written from scratch against current master rather than being a rebase.

The following changes from #2409 are **intentionally not carried forward**:
- `static/src/components/home.tsx` `dispatch(fetchDeviceModel())` — orphaned; nothing reads the resulting state.
- `viewer/media_player.py` x86 audio device table — hardware-specific and unverifiable here, and master's video path for x86 has moved to `mpv` (see `src/anthias_server/processing.py`), so the FFMPEG/VLC changes don't carry cleanly.
- Silent removal of `sha256sum -c` on the webview tarball in `Dockerfile.viewer.j2` — would disable supply-chain integrity checking on every viewer build.
- All X11 packages and Xorg startup logic — Wayland (cage) replaces them entirely.

## Test plan

Hardware-specific bits can only be fully verified on real balenaOS x86 hardware, but locally:

- [x] `bash -n bin/{deploy_to_balena,start_viewer}.sh`
- [x] `uv run ruff check tools/image_builder/utils.py`
- [x] `actionlint .github/workflows/build-balena-disk-image.yaml`
- [x] `uv run python -m tools.image_builder --dockerfiles-only --service viewer --build-target x86 --disable-cache-mounts` → rendered `docker/Dockerfile.viewer` contains `cage`, `qt6-wayland`, `QT_QPA_PLATFORM=wayland`, and **still keeps** `sha256sum -c` on the webview tarball
- [x] Re-rendered for `--build-target pi5` to confirm pi5 stays on `linuxfb` with no cage/wayland packages
- [x] Simulated `prepare_balena_file` with `BOARD=x86`: rendered compose has no `/dev/vchiq` mount

End-to-end (after #2854 merges):

- [ ] Cut a prerelease tag, `workflow_dispatch` the disk-image workflow, confirm `<date>-anthias-x86.img.zst` and `.json` appear on the release
- [ ] Flash with balenaEtcher onto an x86 device joined to `anthias-x86`; confirm playback for image, video, and web assets
- [ ] Inside the viewer container: `cage` is the parent of the viewer python; `/run/user/<viewer-uid>/wayland-0` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)