### PR TITLE
docs(compat): clean up supported hardware references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,20 +40,7 @@ See [this](https://anthias.screenly.io/docs/install/) page for options on how to
 
 ### Raspberry Pi OS
 
-* Raspberry Pi 5 Model B - 64-bit Trixie, 64-bit Bookworm
-* Raspberry Pi 4 Model B - 64-bit Trixie, 64-bit Bookworm
-* Raspberry Pi 3 Model B+ - 64-bit Trixie, 64-bit Bookworm
-* Raspberry Pi 3 Model B - 64-bit Trixie, 64-bit Bookworm
-* Raspberry Pi 2 Model B - 32-bit Trixie, 32-bit Bookworm
-* PC (x86) - 64-bit Trixie, 64-bit Bookworm
-  * Any 64-bit PC works (Intel NUCs, mini-PCs, old laptops).
-  * See the [PC installation guide](https://anthias.screenly.io/docs/pc/) for the Debian setup steps,
-    then run the standard [installation script](https://anthias.screenly.io/docs/install/#installing-on-raspberry-pi-os-lite-or-debian).
-
-> [!NOTE]
-> We're still fixing the Raspberry Pi OS installer so that it'll work with Raspberry Pi Zero and Raspberry Pi 1.
-> Should you encounter any issues, please file an issue either in this repository or in the
-[forums](https://forums.screenly.io).
+See the [supported hardware](https://anthias.screenly.io/get-started/#supported-hardware) section on the website for the full list of supported devices.
 
 ## :star: Star History
 

--- a/website/content/docs/installation-options.md
+++ b/website/content/docs/installation-options.md
@@ -37,7 +37,6 @@ here are the links to the images:
 * [Raspberry Pi 4](https://hub.balena.io/fleets-for-good/1971389/anthias-pi4)
 * [Raspberry Pi 3](https://hub.balena.io/fleets-for-good/1971388/anthias-pi3)
 * [Raspberry Pi 2](https://hub.balena.io/fleets-for-good/1971385/anthias-pi2)
-* [Raspberry Pi 1](https://hub.balena.io/fleets-for-good/1971378/anthias-pi1)
 
 Go to one of the links above and click the *Join* button, then select either *Ethernet only* or *Wifi + Ethernet* for Network options.
 You can either click the *Flash* button to open balenaEtcher (make sure that it's installed) or download the image file and flash it using your preferred imager.
@@ -111,7 +110,7 @@ installation.
 
 > **Note**
 >
-> During ideal conditions (Raspberry Pi 3 Model B+, class 10 SD card and fast internet connection), the installation normally takes 15-30 minutes. On a Raspberry Pi Zero or Raspberry Pi Model B with a class 4 SD card, the installation will take hours.
+> During ideal conditions (Raspberry Pi 3 Model B+, class 10 SD card and fast internet connection), the installation normally takes 15-30 minutes.
 
 #### Prompt: Network Management
 

--- a/website/layouts/_default/get-started.html
+++ b/website/layouts/_default/get-started.html
@@ -70,7 +70,7 @@
 
 <section class="bg-white py-16 lg:py-24 px-6 md:px-12 lg:px-20">
     <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl font-bold">Supported hardware</h2>
+        <h2 id="supported-hardware" class="text-2xl font-bold">Supported hardware</h2>
         <p class="text-zinc-500 mt-2">Anthias runs on Raspberry Pi single-board computers and 64-bit x86 PCs running Raspberry Pi OS or Debian (Trixie or Bookworm).</p>
 
         <div class="mt-6 overflow-x-auto">


### PR DESCRIPTION
### Issues Fixed

N/A

### Description

- Replace inline Pi OS compatibility list in README with a link to the supported hardware section on the website
- Remove outdated Pi 1 / Pi Zero notes and balenaHub link
- Add `id="supported-hardware"` to the heading in `get-started.html` to support the anchor link

### Checklist

- [ ] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).