### PR TITLE
docs(website): link Screenly in footer and add tagline

### DIFF
--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -12,7 +12,7 @@
                     <img class="md:hidden h-7" src="{{ $logoMobile.RelPermalink }}" alt="Anthias" />
                     <img class="hidden md:block h-7" src="{{ $logoDesk.RelPermalink }}" alt="Anthias" />
                 </a>
-                <p class="text-white/40 text-sm mt-3 max-w-xs">Open source digital signage for Raspberry Pi and PC. Built by Screenly.</p>
+                <p class="text-white/40 text-sm mt-3 max-w-xs">Open source digital signage for Raspberry Pi and PC. Built by <a class="text-white/70 no-underline hover:text-white transition-colors" href="https://screenly.io" target="_blank" rel="noopener">Screenly</a> &mdash; the secure digital signage company.</p>
             </div>
 
             <div class="flex flex-wrap gap-12 lg:gap-16">


### PR DESCRIPTION
### Issues Fixed

N/A — minor footer copy update.

### Description

Updates the website footer so the "Screenly" mention links to https://screenly.io and appends the tagline "the secure digital signage company".

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)