### PR TITLE
fix(csrf): accept same-host Origin regardless of scheme (#2867)

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -111,20 +111,23 @@ if getenv('ANTHIAS_SERVICE') != 'viewer':
         'dbbackup',
     ]
 
+# Sonar's S4502 ("disabling CSRF protection") fires on the MIDDLEWARE
+# list because it pattern-matches the literal ``CsrfViewMiddleware``
+# class name and doesn't see one. SameHostOriginCsrfMiddleware (see
+# src/anthias_server/lib/csrf.py) is a subclass of
+# ``django.middleware.csrf.CsrfViewMiddleware``, so CSRF protection
+# is still wired in — the rule's a false positive. NOSONAR on the
+# closing bracket where S4502 actually raises its issue.
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    # SameHostOriginCsrfMiddleware subclasses Django's
-    # ``CsrfViewMiddleware`` (see src/anthias_server/lib/csrf.py) — CSRF
-    # protection is still in place. Sonar's S4502 pattern-matches the
-    # bare class name though, so flag this site as reviewed.
-    'anthias_server.lib.csrf.SameHostOriginCsrfMiddleware',  # NOSONAR
+    'anthias_server.lib.csrf.SameHostOriginCsrfMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-]
+]  # NOSONAR
 
 ROOT_URLCONF = 'anthias_server.django_project.urls'
 

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -74,8 +74,10 @@ ALLOWED_HOSTS = [
 # CSRF_TRUSTED_ORIGINS is intentionally not set. Django only honours
 # subdomain wildcards there (e.g. https://*.example.com), so a leading
 # 'http://*' / 'https://*' would be a no-op rather than the broad
-# allowlist it appears to be. Same-origin POSTs pass without it via
-# Django's built-in Host/Origin equality check.
+# allowlist it appears to be. Same-host POSTs still pass through the
+# custom SameHostOriginCsrfMiddleware below, which also tolerates
+# scheme drift caused by a TLS-terminating proxy in front of
+# anthias-server (issue #2867).
 
 
 # Application definition
@@ -114,7 +116,7 @@ MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    'anthias_server.lib.csrf.SameHostOriginCsrfMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -116,7 +116,11 @@ MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'anthias_server.lib.csrf.SameHostOriginCsrfMiddleware',
+    # SameHostOriginCsrfMiddleware subclasses Django's
+    # ``CsrfViewMiddleware`` (see src/anthias_server/lib/csrf.py) — CSRF
+    # protection is still in place. Sonar's S4502 pattern-matches the
+    # bare class name though, so flag this site as reviewed.
+    'anthias_server.lib.csrf.SameHostOriginCsrfMiddleware',  # NOSONAR
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/src/anthias_server/lib/csrf.py
+++ b/src/anthias_server/lib/csrf.py
@@ -21,12 +21,17 @@ same reason — Anthias is a LAN signage device reached by IP, mDNS,
 or whatever DNS entry the operator wires up.
 
 So: accept an Origin whose **host** matches ``request.get_host()``
-even when the schemes disagree. A real cross-site forgery still
-fails — the browser sets ``Origin`` from the attacker's page, and
-attacker.example doesn't match the device's host. The masked-token
-check still runs on top, so a same-host Origin alone isn't enough;
-the POST must also carry a token that hashes against the cookie
-secret, which only a page Anthias actually rendered can produce.
+even when the schemes disagree, and tolerate port drift *only* when
+at least one side's port is the default for its scheme (so
+``Host: device.example:443`` + ``Origin: https://device.example``
+passes, but ``Origin: http://device:8080`` posting to
+``Host: device:8000`` — two distinct web origins — still 403s). A
+real cross-site forgery still fails: the browser sets ``Origin``
+from the attacker's page, and attacker.example doesn't match the
+device's host. The masked-token check still runs on top, so a
+same-host Origin alone isn't enough; the POST must also carry a
+token that hashes against the cookie secret, which only a page
+Anthias actually rendered can produce.
 """
 
 from __future__ import annotations
@@ -41,26 +46,51 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
 
 
-def _hostname(value: str) -> str | None:
-    """Lowercased hostname from either a full URL or a bare ``Host``
-    header value, ignoring port and IPv6 brackets. Returns ``None``
-    when the input doesn't parse to a hostname.
+_DEFAULT_PORTS = {'http': 80, 'https': 443}
 
-    The comparison this is feeding is intentionally port-agnostic — a
-    common proxy shape sends ``Host: device.example:443`` upstream
-    while the browser's ``Origin`` is ``https://device.example`` with
-    no port; same site from the user's perspective, but the raw
-    netloc/get_host() strings disagree.
+
+def _split_origin(
+    value: str, *, default_scheme: str
+) -> tuple[str, int] | None:
+    """Return ``(hostname, port)`` for a URL or bare ``Host`` value.
+
+    ``default_scheme`` is the scheme to fall back to when ``value`` is
+    a bare ``Host`` header (no scheme of its own) — typically
+    ``request.scheme``. Port is resolved to the scheme's default when
+    the value omits it, so ``Origin: https://device.example`` and
+    ``Origin: https://device.example:443`` collapse to the same
+    ``(host, 443)`` pair. ``None`` means the input didn't parse.
     """
-    # Protocol-relative prefix (``//host[:port]``) is enough for
-    # ``urlsplit`` to recognise a bare ``Host`` value as a netloc
-    # without baking a literal scheme into this file.
-    candidate = value if '://' in value else f'//{value}'
+    scheme: str
+    if '://' in value:
+        try:
+            parts = urlsplit(value)
+        except ValueError:
+            return None
+        scheme = parts.scheme.lower() or default_scheme
+        netloc = parts
+    else:
+        scheme = default_scheme
+        try:
+            netloc = urlsplit(f'//{value}')
+        except ValueError:
+            return None
+
+    hostname = netloc.hostname
+    if not hostname:
+        return None
     try:
-        host = urlsplit(candidate).hostname
+        explicit_port = netloc.port
     except ValueError:
         return None
-    return host.lower() if host else None
+    port = (
+        explicit_port
+        if explicit_port is not None
+        else _DEFAULT_PORTS.get(scheme)
+    )
+    if port is None:
+        return None
+    return hostname.lower(), port
 
 
 class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
@@ -92,9 +122,25 @@ class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
         except DisallowedHost:
             return False
 
-        origin_hostname = _hostname(request_origin)
-        request_hostname = _hostname(request_host)
-        if not origin_hostname or not request_hostname:
+        request_scheme = (request.scheme or 'http').lower()
+        origin = _split_origin(request_origin, default_scheme=request_scheme)
+        target = _split_origin(request_host, default_scheme=request_scheme)
+        if origin is None or target is None:
             return False
 
-        return bool(origin_hostname == request_hostname)
+        origin_host, origin_port = origin
+        target_host, target_port = target
+        if origin_host != target_host:
+            return False
+
+        if origin_port == target_port:
+            return True
+
+        # Different ports are accepted only when at least one side is
+        # already at the scheme's default — that's the proxy/HSTS
+        # shape (``Host: device:443`` + ``Origin: https://device``)
+        # the fallback exists for. Two explicit non-default ports
+        # mean genuinely different web origins and stay rejected.
+        return origin_port in _DEFAULT_PORTS.values() or (
+            target_port in _DEFAULT_PORTS.values()
+        )

--- a/src/anthias_server/lib/csrf.py
+++ b/src/anthias_server/lib/csrf.py
@@ -105,10 +105,9 @@ class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
 
     # ``_origin_verified`` is a private hook on ``CsrfViewMiddleware``
     # that django-stubs doesn't model, so the ``super()`` call needs a
-    # ``type: ignore`` and the final comparison needs ``bool(...)`` to
-    # satisfy ``--strict``'s ``no-any-return``. The runtime override
-    # itself is well-defined — Django's CSRF middleware has called
-    # this hook since 4.0.
+    # ``type: ignore`` at the call site. The runtime override itself
+    # is well-defined — Django's CSRF middleware has called this hook
+    # since 4.0.
     def _origin_verified(self, request: 'HttpRequest') -> bool:
         if super()._origin_verified(request):  # type: ignore[misc]
             return True

--- a/src/anthias_server/lib/csrf.py
+++ b/src/anthias_server/lib/csrf.py
@@ -136,11 +136,10 @@ class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
         if origin_port == target_port:
             return True
 
-        # Different ports are accepted only when at least one side is
-        # already at the scheme's default — that's the proxy/HSTS
-        # shape (``Host: device:443`` + ``Origin: https://device``)
-        # the fallback exists for. Two explicit non-default ports
-        # mean genuinely different web origins and stay rejected.
-        return origin_port in _DEFAULT_PORTS.values() or (
-            target_port in _DEFAULT_PORTS.values()
-        )
+        # Port mismatch is accepted only for the specific 80↔443
+        # scheme-drift pair (``Host: device`` + ``Origin: https://device``,
+        # or vice versa) — that's the proxy/HSTS shape the fallback
+        # exists for. Anything else (e.g. ``Origin: https://device``
+        # → 443 vs ``Host: device:8000``) is a genuinely different
+        # web origin and must stay rejected.
+        return {origin_port, target_port} == set(_DEFAULT_PORTS.values())

--- a/src/anthias_server/lib/csrf.py
+++ b/src/anthias_server/lib/csrf.py
@@ -52,7 +52,10 @@ def _hostname(value: str) -> str | None:
     no port; same site from the user's perspective, but the raw
     netloc/get_host() strings disagree.
     """
-    candidate = value if '://' in value else f'http://{value}'
+    # The ``http://`` here is a synthetic scheme so ``urlsplit`` will
+    # parse a bare ``Host`` header value into a hostname+port; nothing
+    # is ever sent over the wire on this scheme, so S5332 doesn't apply.
+    candidate = value if '://' in value else f'http://{value}'  # NOSONAR
     try:
         host = urlsplit(candidate).hostname
     except ValueError:

--- a/src/anthias_server/lib/csrf.py
+++ b/src/anthias_server/lib/csrf.py
@@ -51,8 +51,14 @@ class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
     and pass on that basis.
     """
 
+    # ``_origin_verified`` is a private hook on ``CsrfViewMiddleware``
+    # that django-stubs doesn't model, so the ``super()`` call needs a
+    # ``type: ignore`` and the final comparison needs ``bool(...)`` to
+    # satisfy ``--strict``'s ``no-any-return``. The runtime override
+    # itself is well-defined — Django's CSRF middleware has called
+    # this hook since 4.0.
     def _origin_verified(self, request: 'HttpRequest') -> bool:
-        if super()._origin_verified(request):
+        if super()._origin_verified(request):  # type: ignore[misc]
             return True
 
         request_origin = request.META.get('HTTP_ORIGIN')
@@ -71,4 +77,4 @@ class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
         except DisallowedHost:
             return False
 
-        return origin_netloc.lower() == request_host.lower()
+        return bool(origin_netloc.lower() == request_host.lower())

--- a/src/anthias_server/lib/csrf.py
+++ b/src/anthias_server/lib/csrf.py
@@ -1,0 +1,74 @@
+"""CSRF middleware that ignores Origin scheme on same-host POSTs.
+
+Django 4.x+ rejects an unsafe request when its ``Origin`` header
+disagrees with the request's own scheme://host. That breaks Anthias
+deployments where a TLS-terminating proxy (a Caddy sidecar, a
+Cloudflare Tunnel, Tailscale Serve, a home-router HTTPS rewrite, …)
+hands plain HTTP to anthias-server without us also setting
+``FORWARDED_ALLOW_IPS`` so uvicorn would honour ``X-Forwarded-Proto``.
+The browser sees ``https://device.example``, the server sees plain
+HTTP, and the default check compares ``http://device.example``
+against ``https://device.example`` and 403s every form submit. The
+same shape shows up after the operator disables a previously enabled
+TLS proxy: the browser's HSTS / HTTPS-First cache keeps sending
+``Origin: https://…`` for a while.
+
+We don't know the operator's hostname or scheme at build time
+(``CSRF_TRUSTED_ORIGINS`` only supports subdomain wildcards like
+``https://*.example.com``, not the bare-scheme ``https://*`` that
+would cover this), and ``ALLOWED_HOSTS`` defaults to ``*`` for the
+same reason — Anthias is a LAN signage device reached by IP, mDNS,
+or whatever DNS entry the operator wires up.
+
+So: accept an Origin whose **host** matches ``request.get_host()``
+even when the schemes disagree. A real cross-site forgery still
+fails — the browser sets ``Origin`` from the attacker's page, and
+attacker.example doesn't match the device's host. The masked-token
+check still runs on top, so a same-host Origin alone isn't enough;
+the POST must also carry a token that hashes against the cookie
+secret, which only a page Anthias actually rendered can produce.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from django.core.exceptions import DisallowedHost
+from django.middleware.csrf import CsrfViewMiddleware
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+
+class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
+    """``CsrfViewMiddleware`` with a scheme-agnostic same-host fallback.
+
+    Defers to the stock check first so wildcards in
+    ``CSRF_TRUSTED_ORIGINS`` and the stock scheme-strict equality
+    keep working unchanged. Only when the stock check would 403 do
+    we look at whether the Origin's host equals ``request.get_host()``
+    and pass on that basis.
+    """
+
+    def _origin_verified(self, request: 'HttpRequest') -> bool:
+        if super()._origin_verified(request):
+            return True
+
+        request_origin = request.META.get('HTTP_ORIGIN')
+        if not request_origin:
+            return False
+
+        try:
+            origin_netloc = urlparse(request_origin).netloc
+        except ValueError:
+            return False
+        if not origin_netloc:
+            return False
+
+        try:
+            request_host = request.get_host()
+        except DisallowedHost:
+            return False
+
+        return origin_netloc.lower() == request_host.lower()

--- a/src/anthias_server/lib/csrf.py
+++ b/src/anthias_server/lib/csrf.py
@@ -52,10 +52,10 @@ def _hostname(value: str) -> str | None:
     no port; same site from the user's perspective, but the raw
     netloc/get_host() strings disagree.
     """
-    # The ``http://`` here is a synthetic scheme so ``urlsplit`` will
-    # parse a bare ``Host`` header value into a hostname+port; nothing
-    # is ever sent over the wire on this scheme, so S5332 doesn't apply.
-    candidate = value if '://' in value else f'http://{value}'  # NOSONAR
+    # Protocol-relative prefix (``//host[:port]``) is enough for
+    # ``urlsplit`` to recognise a bare ``Host`` value as a netloc
+    # without baking a literal scheme into this file.
+    candidate = value if '://' in value else f'//{value}'
     try:
         host = urlsplit(candidate).hostname
     except ValueError:

--- a/src/anthias_server/lib/csrf.py
+++ b/src/anthias_server/lib/csrf.py
@@ -32,13 +32,32 @@ secret, which only a page Anthias actually rendered can produce.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from django.core.exceptions import DisallowedHost
 from django.middleware.csrf import CsrfViewMiddleware
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
+
+
+def _hostname(value: str) -> str | None:
+    """Lowercased hostname from either a full URL or a bare ``Host``
+    header value, ignoring port and IPv6 brackets. Returns ``None``
+    when the input doesn't parse to a hostname.
+
+    The comparison this is feeding is intentionally port-agnostic — a
+    common proxy shape sends ``Host: device.example:443`` upstream
+    while the browser's ``Origin`` is ``https://device.example`` with
+    no port; same site from the user's perspective, but the raw
+    netloc/get_host() strings disagree.
+    """
+    candidate = value if '://' in value else f'http://{value}'
+    try:
+        host = urlsplit(candidate).hostname
+    except ValueError:
+        return None
+    return host.lower() if host else None
 
 
 class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
@@ -66,15 +85,13 @@ class SameHostOriginCsrfMiddleware(CsrfViewMiddleware):
             return False
 
         try:
-            origin_netloc = urlparse(request_origin).netloc
-        except ValueError:
-            return False
-        if not origin_netloc:
-            return False
-
-        try:
             request_host = request.get_host()
         except DisallowedHost:
             return False
 
-        return bool(origin_netloc.lower() == request_host.lower())
+        origin_hostname = _hostname(request_origin)
+        request_hostname = _hostname(request_host)
+        if not origin_hostname or not request_hostname:
+            return False
+
+        return bool(origin_hostname == request_hostname)

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,116 @@
+"""Regression coverage for ``SameHostOriginCsrfMiddleware`` (#2867).
+
+The middleware relaxes Django's strict scheme+host Origin check on a
+same-host fallback so a TLS-terminating proxy in front of Anthias
+(Caddy sidecar, Cloudflare Tunnel, Tailscale Serve, …) doesn't 403
+every form submit. Cross-host POSTs and bad/missing tokens must
+still fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+
+def _seed_form_token(client: Client, host: str) -> str:
+    """Render the home page so the middleware sets ``csrftoken`` on
+    ``client.cookies`` and emits a matching token in the form. Return
+    the form's masked token."""
+    import re
+
+    response = client.get(reverse('anthias_app:home'), HTTP_HOST=host)
+    assert response.status_code == 200
+    match = re.search(
+        r'name="csrfmiddlewaretoken"\s+value="([^"]+)"',
+        response.content.decode(),
+    )
+    assert match is not None, 'no csrf token rendered in home form'
+    return match.group(1)
+
+
+@pytest.mark.django_db
+def test_same_host_http_origin_passes() -> None:
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_form_token(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local',
+        HTTP_ORIGIN='http://anthias.local',
+    )
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_same_host_https_origin_on_http_passes() -> None:
+    """The user-reported case in #2867. Browser advertises an
+    ``https://device`` Origin (TLS terminated at a proxy / HSTS
+    leftover / browser HTTPS-First) while uvicorn sees plain HTTP.
+    Stock Django would 403; the custom middleware must accept."""
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_form_token(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local',
+        HTTP_ORIGIN='https://anthias.local',
+    )
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_cross_host_origin_still_rejected() -> None:
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_form_token(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local',
+        HTTP_ORIGIN='http://attacker.example',
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_missing_token_still_rejected() -> None:
+    """The same-host Origin relaxation must not bypass the token
+    check itself — a POST with a matching Origin but no
+    ``csrfmiddlewaretoken`` body / ``X-CSRFToken`` header still 403s."""
+    client = Client(enforce_csrf_checks=True)
+    _seed_form_token(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        HTTP_HOST='anthias.local',
+        HTTP_ORIGIN='https://anthias.local',
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_bad_token_still_rejected() -> None:
+    client = Client(enforce_csrf_checks=True)
+    _seed_form_token(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': 'not-the-real-token-12345678'},
+        HTTP_HOST='anthias.local',
+        HTTP_ORIGIN='https://anthias.local',
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_no_origin_header_still_works() -> None:
+    """Curl-style clients with no Origin header (legitimate
+    server-to-server callers, scripted operators) must still POST
+    successfully when they carry a matching token + cookie."""
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_form_token(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local',
+    )
+    assert response.status_code == 302

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -13,6 +13,15 @@ import pytest
 from django.test import Client
 from django.urls import reverse
 
+# The whole point of this suite is exercising plain-HTTP Origin headers
+# against an HTTP-served Anthias — that's the deployment shape the bug
+# happens on. Sonar's S5332 would flag every ``HTTP_ORIGIN='http://...'``
+# call site, so funnel through module-level constants with a single
+# NOSONAR per literal.
+_HTTP_SAME_HOST_ORIGIN = 'http://anthias.local'  # NOSONAR
+_HTTP_CROSS_HOST_ORIGIN = 'http://attacker.example'  # NOSONAR
+_HTTPS_SAME_HOST_ORIGIN = 'https://anthias.local'
+
 
 def _seed_form_token(client: Client, host: str) -> str:
     """Render the home page so the middleware sets ``csrftoken`` on
@@ -38,7 +47,7 @@ def test_same_host_http_origin_passes() -> None:
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': token},
         HTTP_HOST='anthias.local',
-        HTTP_ORIGIN='http://anthias.local',
+        HTTP_ORIGIN=_HTTP_SAME_HOST_ORIGIN,
     )
     assert response.status_code == 302
 
@@ -55,7 +64,7 @@ def test_same_host_https_origin_on_http_passes() -> None:
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': token},
         HTTP_HOST='anthias.local',
-        HTTP_ORIGIN='https://anthias.local',
+        HTTP_ORIGIN=_HTTPS_SAME_HOST_ORIGIN,
     )
     assert response.status_code == 302
 
@@ -68,7 +77,7 @@ def test_cross_host_origin_still_rejected() -> None:
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': token},
         HTTP_HOST='anthias.local',
-        HTTP_ORIGIN='http://attacker.example',
+        HTTP_ORIGIN=_HTTP_CROSS_HOST_ORIGIN,
     )
     assert response.status_code == 403
 
@@ -83,7 +92,7 @@ def test_missing_token_still_rejected() -> None:
     response = client.post(
         reverse('anthias_app:assets_control', args=['next']),
         HTTP_HOST='anthias.local',
-        HTTP_ORIGIN='https://anthias.local',
+        HTTP_ORIGIN=_HTTPS_SAME_HOST_ORIGIN,
     )
     assert response.status_code == 403
 
@@ -96,7 +105,7 @@ def test_bad_token_still_rejected() -> None:
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': 'not-the-real-token-12345678'},
         HTTP_HOST='anthias.local',
-        HTTP_ORIGIN='https://anthias.local',
+        HTTP_ORIGIN=_HTTPS_SAME_HOST_ORIGIN,
     )
     assert response.status_code == 403
 

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -3,8 +3,8 @@
 The middleware relaxes Django's strict scheme+host Origin check on a
 same-host fallback so a TLS-terminating proxy in front of Anthias
 (Caddy sidecar, Cloudflare Tunnel, Tailscale Serve, …) doesn't 403
-every form submit. Cross-host POSTs and bad/missing tokens must
-still fail.
+every form submit. Cross-host POSTs, distinct-port web origins, and
+bad / missing tokens must still fail.
 """
 
 from __future__ import annotations
@@ -23,26 +23,22 @@ _HTTP_CROSS_HOST_ORIGIN = 'http://attacker.example'  # NOSONAR
 _HTTPS_SAME_HOST_ORIGIN = 'https://anthias.local'
 
 
-def _seed_form_token(client: Client, host: str) -> str:
-    """Render the home page so the middleware sets ``csrftoken`` on
-    ``client.cookies`` and emits a matching token in the form. Return
-    the form's masked token."""
-    import re
-
+def _seed_csrf_cookie(client: Client, host: str) -> str:
+    """GET the home page so the middleware sets ``csrftoken`` on the
+    client, then return the raw cookie value. Django's CSRF check
+    accepts the unmasked secret directly as ``csrfmiddlewaretoken``,
+    so callers can sidestep parsing the rendered form HTML — keeps
+    these tests focused on Origin handling rather than template markup.
+    """
     response = client.get(reverse('anthias_app:home'), HTTP_HOST=host)
     assert response.status_code == 200
-    match = re.search(
-        r'name="csrfmiddlewaretoken"\s+value="([^"]+)"',
-        response.content.decode(),
-    )
-    assert match is not None, 'no csrf token rendered in home form'
-    return match.group(1)
+    return client.cookies['csrftoken'].value
 
 
 @pytest.mark.django_db
 def test_same_host_http_origin_passes() -> None:
     client = Client(enforce_csrf_checks=True)
-    token = _seed_form_token(client, 'anthias.local')
+    token = _seed_csrf_cookie(client, 'anthias.local')
     response = client.post(
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': token},
@@ -59,7 +55,7 @@ def test_same_host_https_origin_on_http_passes() -> None:
     leftover / browser HTTPS-First) while uvicorn sees plain HTTP.
     Stock Django would 403; the custom middleware must accept."""
     client = Client(enforce_csrf_checks=True)
-    token = _seed_form_token(client, 'anthias.local')
+    token = _seed_csrf_cookie(client, 'anthias.local')
     response = client.post(
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': token},
@@ -75,9 +71,10 @@ def test_host_with_port_origin_without_port_passes() -> None:
     explicit (often default) port — e.g. ``Host: anthias.local:443``
     — while the browser's ``Origin`` is ``https://anthias.local``
     with the default port elided. Same site from the user's view;
-    the fallback must compare hostnames and ignore the port drift."""
+    the fallback must compare hostnames and tolerate the port drift
+    because at least one side is on the scheme's default port."""
     client = Client(enforce_csrf_checks=True)
-    token = _seed_form_token(client, 'anthias.local:443')
+    token = _seed_csrf_cookie(client, 'anthias.local:443')
     response = client.post(
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': token},
@@ -88,9 +85,26 @@ def test_host_with_port_origin_without_port_passes() -> None:
 
 
 @pytest.mark.django_db
+def test_same_host_distinct_non_default_ports_rejected() -> None:
+    """``Origin: http://anthias.local:8080`` posting to a server on
+    ``Host: anthias.local:8000`` is a cross-origin request even
+    though the host matches — different non-default ports are
+    distinct web origins. The fallback must keep rejecting this."""
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_csrf_cookie(client, 'anthias.local:8000')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local:8000',
+        HTTP_ORIGIN='http://anthias.local:8080',  # NOSONAR
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
 def test_cross_host_origin_still_rejected() -> None:
     client = Client(enforce_csrf_checks=True)
-    token = _seed_form_token(client, 'anthias.local')
+    token = _seed_csrf_cookie(client, 'anthias.local')
     response = client.post(
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': token},
@@ -106,7 +120,7 @@ def test_missing_token_still_rejected() -> None:
     check itself — a POST with a matching Origin but no
     ``csrfmiddlewaretoken`` body / ``X-CSRFToken`` header still 403s."""
     client = Client(enforce_csrf_checks=True)
-    _seed_form_token(client, 'anthias.local')
+    _seed_csrf_cookie(client, 'anthias.local')
     response = client.post(
         reverse('anthias_app:assets_control', args=['next']),
         HTTP_HOST='anthias.local',
@@ -118,7 +132,7 @@ def test_missing_token_still_rejected() -> None:
 @pytest.mark.django_db
 def test_bad_token_still_rejected() -> None:
     client = Client(enforce_csrf_checks=True)
-    _seed_form_token(client, 'anthias.local')
+    _seed_csrf_cookie(client, 'anthias.local')
     response = client.post(
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': 'not-the-real-token-12345678'},
@@ -134,7 +148,7 @@ def test_no_origin_header_still_works() -> None:
     server-to-server callers, scripted operators) must still POST
     successfully when they carry a matching token + cookie."""
     client = Client(enforce_csrf_checks=True)
-    token = _seed_form_token(client, 'anthias.local')
+    token = _seed_csrf_cookie(client, 'anthias.local')
     response = client.post(
         reverse('anthias_app:assets_control', args=['next']),
         data={'csrfmiddlewaretoken': token},

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -102,6 +102,24 @@ def test_same_host_distinct_non_default_ports_rejected() -> None:
 
 
 @pytest.mark.django_db
+def test_default_port_origin_vs_non_default_host_port_rejected() -> None:
+    """``Origin: https://anthias.local`` (port 443) posting to a
+    server on ``Host: anthias.local:8000`` is a cross-origin request
+    even though one side is on a scheme default — 443 and 8000 are
+    distinct web origins. The fallback must reject anything outside
+    the 80↔443 scheme-drift pair."""
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_csrf_cookie(client, 'anthias.local:8000')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local:8000',
+        HTTP_ORIGIN=_HTTPS_SAME_HOST_ORIGIN,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
 def test_cross_host_origin_still_rejected() -> None:
     client = Client(enforce_csrf_checks=True)
     token = _seed_csrf_cookie(client, 'anthias.local')

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -70,6 +70,24 @@ def test_same_host_https_origin_on_http_passes() -> None:
 
 
 @pytest.mark.django_db
+def test_host_with_port_origin_without_port_passes() -> None:
+    """Common reverse-proxy shape: the upstream ``Host`` carries an
+    explicit (often default) port — e.g. ``Host: anthias.local:443``
+    — while the browser's ``Origin`` is ``https://anthias.local``
+    with the default port elided. Same site from the user's view;
+    the fallback must compare hostnames and ignore the port drift."""
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_form_token(client, 'anthias.local:443')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local:443',
+        HTTP_ORIGIN=_HTTPS_SAME_HOST_ORIGIN,
+    )
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
 def test_cross_host_origin_still_rejected() -> None:
     client = Client(enforce_csrf_checks=True)
     token = _seed_form_token(client, 'anthias.local')


### PR DESCRIPTION
### Issues Fixed

Closes #2867.

### Description

Django 4.x+ rejects POSTs where the `Origin` header's `scheme://host` doesn't match what uvicorn sees. That 403s every form submit on Anthias when the device sits behind a TLS-terminating proxy (Caddy sidecar, Cloudflare Tunnel, Tailscale Serve, home-router HTTPS rewrite) without `FORWARDED_ALLOW_IPS` also being set, and after disabling a previously-enabled TLS proxy while the browser's HSTS / HTTPS-First cache still sends `https://`. Confirmed in dev: `Origin checking failed - https://localhost:8000 does not match any trusted origins.`

`CSRF_TRUSTED_ORIGINS = ['http://*', 'https://*']` looks like the answer but is a Django no-op (only subdomain wildcards like `https://*.example.com` are honoured).

The fix is a thin `CsrfViewMiddleware` subclass that defers to the stock check first, then falls back to accepting any `Origin` whose host equals `request.get_host()` regardless of scheme. The masked-token check still runs on top, so the relaxation can't bypass CSRF — cross-host `Origin` and missing / bad tokens still 403.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)