### PR TITLE
chore: drop MY_IP env-var IP injection (#2869)

### DIFF
--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -12,7 +12,6 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 "${SCRIPT_DIR}/migrate_legacy_paths.sh"
 
 # Export various environment variables
-export MY_IP=$(ip -4 route get 8.8.8.8 | awk {'print $7'} | tr -d '\n')
 TOTAL_MEMORY_KB=$(grep MemTotal /proc/meminfo | awk {'print $2'})
 export VIEWER_MEMORY_LIMIT_KB=$(echo "$TOTAL_MEMORY_KB" \* 0.8 | bc)
 export SHM_SIZE_KB="$(echo "$TOTAL_MEMORY_KB" \* 0.3 | bc | cut -d'.' -f1)"

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -9,7 +9,6 @@ services:
     ports:
       - 80:8080
     environment:
-      - MY_IP=${MY_IP}
       - MAC_ADDRESS=${MAC_ADDRESS}
       - HOST_USER=${USER}
       - HOME=/data

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -136,11 +136,19 @@ def get_balena_supervisor_version() -> str:
 
 def get_node_ip() -> str:
     """
-    Returns the node's IP address.
-    We're using an API call to the supervisor for this on Balena
-    and an environment variable set by `install.sh` for other environments.
-    The reason for this is because we can't retrieve the host IP from
-    within Docker.
+    Returns the node's IP address(es) as a whitespace-separated string,
+    or ``'Unable to retrieve IP.'`` / ``'Unknown'`` on failure.
+
+    The container can't see the host's real interfaces (just its veth on
+    the docker bridge), so the actual IP lookup happens out-of-process:
+
+    * **Balena:** one API call to the local supervisor.
+    * **Bare metal:** the ``anthias-host-agent`` systemd unit runs on the
+      host, enumerates real interfaces with netifaces, and writes the
+      results to Redis. This function publishes ``hostcmd:
+      set_ip_addresses`` to trigger a refresh, waits up to ~80s
+      (60s ``host_agent_ready`` + 20s ``ip_addresses_ready``) for
+      host_agent to populate the cache, then reads ``ip_addresses``.
     """
 
     if is_balena_app():

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -199,8 +199,6 @@ def get_node_ip() -> str:
 
         if ip_addresses:
             return ' '.join(json.loads(ip_addresses))
-        elif os.getenv('MY_IP'):
-            return os.getenv('MY_IP') or 'Unable to retrieve IP.'
 
     return 'Unable to retrieve IP.'
 

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -134,10 +134,9 @@ def _resolve_node_ip() -> str:
         raw = r.get('ip_addresses')
     except redis.RedisError:
         # Redis is the cache backing this whole codepath; if it's
-        # flaking (early boot, transient broker hiccup), fall through
-        # to the MY_IP fallback below instead of 500-ing the splash
-        # poll. The JS keeps polling and recovers as soon as Redis
-        # comes back.
+        # flaking (early boot, transient broker hiccup), return ''
+        # instead of 500-ing the splash poll. The JS keeps polling
+        # and recovers as soon as Redis comes back.
         raw = None
     if raw:
         try:
@@ -174,17 +173,11 @@ def _resolve_node_ip() -> str:
 
     # Cache miss / empty list / malformed / Redis flake: ask
     # host_agent to populate. The next poll picks it up — we don't
-    # block waiting for completion.
+    # block waiting for completion. The JS keeps polling and the
+    # splash shows "Detecting network…" until host_agent fills the
+    # cache.
     _publish_refresh()
-
-    # Mirror ``anthias_common.utils.get_node_ip()``'s ``MY_IP`` fallback.
-    # ``bin/upgrade_containers.sh`` exports the host's outbound IP
-    # into the server container via ``docker-compose.yml.tmpl``, so
-    # the splash can show *something* useful even when host_agent
-    # isn't running (custom deploys, late host_agent start, crashed
-    # host_agent). Without this fallback, those installs would be
-    # stuck on "Detecting network…" forever.
-    return getenv('MY_IP', '') or ''
+    return ''
 
 
 def _publish_refresh() -> None:

--- a/tests/test_splash_page.py
+++ b/tests/test_splash_page.py
@@ -96,21 +96,9 @@ def test_format_drops_garbage_tokens() -> None:
 
 
 @pytest.fixture
-def bare_metal_no_pending(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Each test starts with a clean Redis fake (no debounce key set)
-    and an unset ``MY_IP`` env var.
-
-    ``_resolve_node_ip()`` falls back to ``MY_IP`` on the cache-miss
-    path (mirroring ``anthias_common.utils.get_node_ip()``); leaving the env var
-    in whatever state the dev shell or CI runner picked up would let
-    that fallback bleed into tests that mean to assert on the
-    no-cache-no-fallback case. Tests that exercise the MY_IP
-    fallback set the env var explicitly via ``monkeypatch.setenv``.
-    """
+def bare_metal_no_pending() -> None:
+    """Each test starts with a clean Redis fake (no debounce key set)."""
     v2_views.r.delete(v2_views._IP_REFRESH_PENDING_KEY)
-    monkeypatch.delenv('MY_IP', raising=False)
 
 
 def test_resolve_reads_from_redis_cache(bare_metal_no_pending: None) -> None:
@@ -299,65 +287,6 @@ def test_resolve_setnx_failure_returns_empty(
         mock.patch.object(
             v2_views.r, 'set', side_effect=redis.RedisError('synthetic')
         ),
-    ):
-        assert v2_views._resolve_node_ip() == ''
-
-
-def test_resolve_cache_miss_falls_back_to_my_ip(
-    bare_metal_no_pending: None,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``bin/upgrade_containers.sh`` exports the host's outbound IP
-    into the server container as ``MY_IP``. ``anthias_common.utils.get_node_ip()``
-    falls back to it when ``ip_addresses`` is empty in Redis. The
-    polling resolver mirrors that — without the fallback, any setup
-    where host_agent isn't running (custom deploys, late-starting
-    host_agent, crashed host_agent) would freeze the splash on
-    'Detecting network…' forever."""
-    monkeypatch.setenv('MY_IP', _FIXTURE_IPV4)
-    with (
-        mock.patch(
-            'anthias_server.api.views.v2.is_balena_app', return_value=False
-        ),
-        mock.patch.object(v2_views.r, 'get', return_value=None),
-        mock.patch.object(v2_views.r, 'publish'),
-    ):
-        assert v2_views._resolve_node_ip() == _FIXTURE_IPV4
-
-
-def test_resolve_redis_get_failure_falls_back_to_my_ip(
-    bare_metal_no_pending: None,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If Redis is fully down (early boot, broker crash), the cache
-    read raises before we can decide cache miss vs hit. The MY_IP
-    fallback must still apply — that's exactly the scenario it's
-    there to cover."""
-    monkeypatch.setenv('MY_IP', _FIXTURE_IPV4)
-    with (
-        mock.patch(
-            'anthias_server.api.views.v2.is_balena_app', return_value=False
-        ),
-        mock.patch.object(
-            v2_views.r, 'get', side_effect=redis.RedisError('synthetic')
-        ),
-    ):
-        assert v2_views._resolve_node_ip() == _FIXTURE_IPV4
-
-
-def test_resolve_cache_miss_with_unset_my_ip_returns_empty(
-    bare_metal_no_pending: None,
-) -> None:
-    """The fixture clears MY_IP. With no cache and no env fallback,
-    we return '' so the JS keeps polling (and the splash continues
-    to show 'Detecting network…' until something populates either
-    side)."""
-    with (
-        mock.patch(
-            'anthias_server.api.views.v2.is_balena_app', return_value=False
-        ),
-        mock.patch.object(v2_views.r, 'get', return_value=None),
-        mock.patch.object(v2_views.r, 'publish'),
     ):
         assert v2_views._resolve_node_ip() == ''
 


### PR DESCRIPTION
## Summary

Closes #2869.

`MY_IP` was a stale-by-construction snapshot of the host's outbound IP, captured once at install/upgrade time and injected into the server/celery containers. host_agent already owns IP detection at runtime and writes the current addresses to Redis — `MY_IP` was a parallel source of truth that went stale on DHCP renewals, cable swaps, or subnet changes until the next `upgrade_containers.sh` run.

- Drop the `ip route get 8.8.8.8` capture in `bin/upgrade_containers.sh` and the `MY_IP=${MY_IP}` env entry in `docker-compose.yml.tmpl`.
- Remove the `MY_IP` fallback branches in `anthias_common.utils.get_node_ip` and the splash polling resolver `_resolve_node_ip` in `api/views/v2.py`. On cache miss the resolver now just returns empty and lets the JS keep polling host_agent — the splash shows "Detecting network…" until the cache populates (typically within a few seconds).
- Update the splash-page test suite: drop the two MY_IP-fallback cases and the now-redundant "unset MY_IP returns empty" case, simplify the `bare_metal_no_pending` fixture (no more env-var sanitisation), and refresh the surrounding docstrings.
- The MAC-address injection in the same install step is left in place per the issue's scope note — the container only sees its veth on the docker bridge, so the host has to resolve that one.

## Test plan

- [x] `uv run ruff check` on touched files passes
- [x] `pytest tests/test_splash_page.py -m "not integration"` — 25 passed (run inside `docker-compose.test.yml`)
- [x] Full non-integration suite — 698 passed
- [ ] CI green