### PR TITLE
fix(api): v1/v1.1 normalize dispatch + stuck-row reconciler (#2870)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.05.0",
+  "version": "2026.05.1",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.05.0"
+version = "2026.05.1"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"
@@ -52,7 +52,6 @@ server = [
     "django-dbbackup==5.3.0",
     "django-stubs-ext==6.0.3",
     "drf-spectacular==0.29.0",
-    "hurry.filesize==0.9",
     "Jinja2==3.1.6",
     "netifaces==0.11.0",
     "packaging==26.1",
@@ -238,7 +237,6 @@ exclude = [
 module = [
     "cec",
     "channels_redis.*",
-    "hurry.filesize",
     "pillow_heif",
     "pydbus",
     "sh",

--- a/src/anthias_common/youtube.py
+++ b/src/anthias_common/youtube.py
@@ -75,7 +75,17 @@ def dispatch_download(asset_id: str, source_uri: str) -> None:
 
     Lazy import keeps the celery_tasks module out of import paths
     that don't need it (e.g. the viewer or anthias_common itself).
+
+    Stamps ``metadata.processing_started_at`` so the periodic
+    reconciler can recover a row whose download task was lost
+    (worker SIGKILL between enqueue and pickup, redis flake during
+    dispatch). Lives in ``anthias_server.processing`` because that's
+    where the reconciler reads the field; importing it here is
+    safe — the module is already loaded by the same celery worker
+    that runs this task.
     """
     from anthias_server.celery_tasks import download_youtube_asset
+    from anthias_server.processing import _stamp_processing_start
 
+    _stamp_processing_start(asset_id)
     download_youtube_asset.delay(asset_id, source_uri)

--- a/src/anthias_common/youtube.py
+++ b/src/anthias_common/youtube.py
@@ -77,12 +77,27 @@ def dispatch_download(asset_id: str, source_uri: str) -> None:
     that don't need it (e.g. the viewer or anthias_common itself).
 
     Stamps ``metadata.processing_started_at`` so the periodic
-    reconciler can recover a row whose download task was lost
-    (worker SIGKILL between enqueue and pickup, redis flake during
-    dispatch). Lives in ``anthias_server.processing`` because that's
-    where the reconciler reads the field; importing it here is
-    safe — the module is already loaded by the same celery worker
-    that runs this task.
+    ``reconcile_stuck_processing`` task can recover a YouTube row
+    whose download went missing (worker SIGKILL between enqueue and
+    pickup, redis flake during dispatch). Recovery is *not* a
+    re-download — the reconciler doesn't have the original watch URL
+    to hand to yt-dlp, and ``metadata.source_url`` is only written
+    *after* the download task completes (see
+    ``download_youtube_asset``). Instead, the row's
+    ``mimetype='video'`` routes it through the same
+    ``normalize_video_asset`` re-dispatch path as a stuck local-file
+    upload. That task's first guard is ``path.isfile(src_uri)``; for
+    a never-downloaded YouTube row this fails immediately with
+    ``FileNotFoundError`` and the ``_NormalizeAssetTask.on_failure``
+    hook clears ``is_processing`` and writes
+    ``metadata.error_message`` — giving the operator an explicit
+    "Failed" pill (with the diagnostic on hover) and a re-upload
+    affordance rather than a row stuck on "Processing" forever.
+
+    The stamp helper lives in ``anthias_server.processing`` because
+    that's where the reconciler reads the field; importing it here
+    is safe — the same celery worker that runs this task already has
+    that module loaded.
     """
     from anthias_server.celery_tasks import download_youtube_asset
     from anthias_server.processing import _stamp_processing_start

--- a/src/anthias_common/youtube.py
+++ b/src/anthias_common/youtube.py
@@ -100,7 +100,7 @@ def dispatch_download(asset_id: str, source_uri: str) -> None:
     that module loaded.
     """
     from anthias_server.celery_tasks import download_youtube_asset
-    from anthias_server.processing import _stamp_processing_start
+    from anthias_server.processing import stamp_processing_start
 
-    _stamp_processing_start(asset_id)
+    stamp_processing_start(asset_id)
     download_youtube_asset.delay(asset_id, source_uri)

--- a/src/anthias_server/api/serializers/v1_1.py
+++ b/src/anthias_server/api/serializers/v1_1.py
@@ -32,6 +32,21 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
     # persisted. None means "not a YouTube asset" → skip dispatch.
     _pending_youtube_uri: str | None = None
 
+    # Set to ``'video'`` by ``prepare_asset`` when the freshly persisted
+    # row needs the video-normalisation pipeline to run before the
+    # viewer can play it (e.g. an MPEG-1 sample that lands on a board
+    # whose player only handles H.264 / HEVC). The view then dispatches
+    # ``normalize_video_asset`` via the shared ``dispatch_pending_normalize``
+    # helper. ``None`` means "no normalisation needed".
+    #
+    # Image normalisation is deliberately *not* wired here — v1 / v1.1
+    # never converted HEIC / HEIF / TIFF on upload, and changing that
+    # would shift response-time and asset-state semantics for legacy
+    # clients that depend on synchronous availability. The video gap
+    # is the GH #2870 regression; image normalisation stays a v1.2 / v2
+    # opt-in.
+    _pending_normalize: str | None = None
+
     def __init__(
         self,
         *args: Any,
@@ -72,11 +87,19 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
 
         validate_uri(uri)
 
+        # Record whether this row came from a local upload (the
+        # /api/v1/file_asset companion endpoint dropped the file at a
+        # local path before the create POST). ``is_local_upload``
+        # gates the normalize dispatch below: a remote HTTP / RTSP
+        # video URL should never go through the on-device transcode
+        # pipeline, only the locally-staged ``.tmp`` uploads do.
+        is_local_upload = False
         if not asset['asset_id']:
             asset['asset_id'] = uuid.uuid4().hex
             if uri.startswith('/'):
                 rename(uri, path.join(settings['assetdir'], asset['asset_id']))
                 uri = path.join(settings['assetdir'], asset['asset_id'])
+                is_local_upload = True
 
         # Exact match — substring `'youtube_asset' in mimetype`
         # would also fire on `not_youtube_asset` and crash on a
@@ -161,6 +184,23 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
             and url_fails(asset['uri'])
         ):
             raise Exception('Could not retrieve file. Check the asset URL.')
+
+        # Flag the freshly-uploaded local video for the normalisation
+        # pipeline. Fixes GH #2870: pre-fix, v1 / v1.1 left the file
+        # in whatever codec the operator uploaded (e.g. MPEG-1 on an
+        # x86 board with passthrough_video_codecs={'h264','hevc'}),
+        # and the viewer silently skipped it forever. Set
+        # ``is_processing=1`` so the viewer drops the in-flight row
+        # from rotation until ``normalize_video_asset`` finalises it.
+        # Image normalisation deliberately stays opt-in via v1.2 / v2
+        # — see the class-level ``_pending_normalize`` docstring.
+        if (
+            is_local_upload
+            and not is_youtube
+            and 'video' in (asset['mimetype'] or '')
+        ):
+            self._pending_normalize = 'video'
+            asset['is_processing'] = 1
 
         return asset
 

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -551,3 +551,162 @@ def test_create_youtube_asset_dispatches_celery_task(
     }.items():
         if v != version:
             m.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+def test_create_video_asset_dispatches_normalize_task(
+    api_client: APIClient,
+    version: str,
+) -> None:
+    """Every API version that accepts a local video upload must
+    dispatch ``normalize_video_asset`` after persisting the row.
+
+    Regression test for GH #2870: v1 and v1.1 originally skipped this
+    dispatch, leaving the row in whatever codec the operator uploaded
+    (e.g. MPEG-1) — the viewer's per-board passthrough set then
+    silently dropped it from rotation forever. Parametrized so a
+    future create-view regression for any version fails this test
+    instead of leaking into production silently.
+    """
+    # ``stack`` lets the same test cover both serializer surfaces
+    # (v1/v1.1 use ``serializers.v1_1.*`` symbols; v1.2/v2 use the
+    # shared ``serializers.mixins.*`` symbols) without duplicating
+    # the test body. Each version's serializer renames the staged
+    # ``.tmp`` file into assetdir before persistence — for a test
+    # without a real on-disk file we patch the rename out; same for
+    # the url_fails reachability probe.
+    local_video_uri = '/data/anthias_assets/test-video.mp4'
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': local_video_uri,
+        'mimetype': 'video',
+        # v1.2 / v2 mixin requires duration=0 for video uploads (it
+        # defers ffprobe to the normalize task). v1.1 also accepts
+        # 0; we mock get_video_duration so its synchronous probe
+        # doesn't try to ffprobe a non-existent path.
+        'duration': 0,
+    }
+    asset_list_url = reverse(f'api:asset_list_{version}')
+
+    with (
+        mock.patch(
+            'anthias_server.processing.dispatch_normalize_video'
+        ) as mock_dispatch,
+        mock.patch('anthias_server.processing._stamp_processing_start'),
+        mock.patch('anthias_server.api.serializers.mixins.rename'),
+        mock.patch('anthias_server.api.serializers.v1_1.rename'),
+        mock.patch(
+            'anthias_server.api.serializers.mixins.validate_uri',
+            return_value=True,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.mixins.url_fails',
+            return_value=False,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.url_fails',
+            return_value=False,
+        ),
+        # v1.1's prepare_asset calls get_video_duration synchronously
+        # when duration is 0; return a non-None timedelta so the
+        # validator accepts the row.
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.get_video_duration',
+            return_value=__import__('datetime').timedelta(seconds=10),
+        ),
+    ):
+        response = api_client.post(
+            asset_list_url, data=get_request_data(payload, version)
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED, response.data
+    asset_id = response.data['asset_id']
+    mock_dispatch.assert_called_once_with(asset_id)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1_2', 'v2'])
+def test_create_heic_image_dispatches_normalize_task_on_v1_2_and_v2(
+    api_client: APIClient,
+    version: str,
+) -> None:
+    """HEIC uploads route through ``normalize_image_asset`` on v1.2 / v2
+    only — image normalisation deliberately stays opt-in for the older
+    endpoints (see ``CreateAssetSerializerV1_1._pending_normalize``
+    docstring for the rationale). Same dispatch-gap regression guard as
+    the video test but scoped to the versions where image normalize is
+    wired."""
+    local_heic_uri = '/data/anthias_assets/test-image.heic'
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': local_heic_uri,
+        'mimetype': 'image',
+    }
+    asset_list_url = reverse(f'api:asset_list_{version}')
+
+    with (
+        mock.patch(
+            'anthias_server.processing.dispatch_normalize_image'
+        ) as mock_dispatch,
+        mock.patch('anthias_server.processing._stamp_processing_start'),
+        mock.patch('anthias_server.api.serializers.mixins.rename'),
+        mock.patch(
+            'anthias_server.api.serializers.mixins.validate_uri',
+            return_value=True,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.mixins.url_fails',
+            return_value=False,
+        ),
+    ):
+        response = api_client.post(
+            asset_list_url, data=get_request_data(payload, version)
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED, response.data
+    asset_id = response.data['asset_id']
+    mock_dispatch.assert_called_once_with(asset_id)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1'])
+def test_create_heic_image_does_not_dispatch_on_legacy_endpoints(
+    api_client: APIClient,
+    version: str,
+) -> None:
+    """v1 / v1.1 deliberately do NOT route HEIC uploads through the
+    image-normalize pipeline. Image normalisation is opt-in via v1.2 /
+    v2 — promoting it on the legacy endpoints would change synchronous
+    availability semantics for older clients (see
+    ``CreateAssetSerializerV1_1._pending_normalize`` docstring).
+
+    The flip side of GH #2870: video normalisation IS dispatched on
+    v1 / v1.1 (the bug being fixed), but image normalisation stays
+    where it was. This test guards against a future "consistency"
+    refactor accidentally promoting image dispatch onto the legacy
+    surface."""
+    local_heic_uri = '/data/anthias_assets/test-image.heic'
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': local_heic_uri,
+        'mimetype': 'image',
+    }
+    asset_list_url = reverse(f'api:asset_list_{version}')
+
+    with (
+        mock.patch(
+            'anthias_server.processing.dispatch_normalize_image'
+        ) as mock_dispatch,
+        mock.patch('anthias_server.api.serializers.v1_1.rename'),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.url_fails',
+            return_value=False,
+        ),
+    ):
+        response = api_client.post(
+            asset_list_url, data=get_request_data(payload, version)
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED, response.data
+    mock_dispatch.assert_not_called()

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -586,6 +586,10 @@ def test_create_video_asset_dispatches_normalize_task(
         # 0; we mock get_video_duration so its synchronous probe
         # doesn't try to ffprobe a non-existent path.
         'duration': 0,
+        # v1.2 / v2 mixin's rename preserves ``ext`` on the destination
+        # filename — v1 / v1.1 ignore it. Including it keeps both
+        # branches happy.
+        'ext': '.mp4',
     }
     asset_list_url = reverse(f'api:asset_list_{version}')
 
@@ -596,8 +600,16 @@ def test_create_video_asset_dispatches_normalize_task(
         mock.patch('anthias_server.processing._stamp_processing_start'),
         mock.patch('anthias_server.api.serializers.mixins.rename'),
         mock.patch('anthias_server.api.serializers.v1_1.rename'),
+        # ``validate_uri`` raises ``Exception('Invalid file path…')``
+        # when its target doesn't exist on disk. v1 / v1.1 imports it
+        # from ``serializers.v1_1``; v1.2 / v2 import it via the mixin
+        # — patch both binding sites.
         mock.patch(
             'anthias_server.api.serializers.mixins.validate_uri',
+            return_value=True,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.validate_uri',
             return_value=True,
         ),
         mock.patch(
@@ -642,6 +654,10 @@ def test_create_heic_image_dispatches_normalize_task_on_v1_2_and_v2(
         **ASSET_CREATION_DATA,
         'uri': local_heic_uri,
         'mimetype': 'image',
+        # The mixin's rename uses ``ext`` on the destination filename;
+        # without it, the file lands extensionless and
+        # ``needs_image_normalisation`` returns False → no dispatch.
+        'ext': '.heic',
     }
     asset_list_url = reverse(f'api:asset_list_{version}')
 
@@ -699,6 +715,13 @@ def test_create_heic_image_does_not_dispatch_on_legacy_endpoints(
             'anthias_server.processing.dispatch_normalize_image'
         ) as mock_dispatch,
         mock.patch('anthias_server.api.serializers.v1_1.rename'),
+        # ``validate_uri`` rejects non-existent local paths; this
+        # short-circuits the disk-existence check the same way the
+        # video test above does.
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.validate_uri',
+            return_value=True,
+        ),
         mock.patch(
             'anthias_server.api.serializers.v1_1.url_fails',
             return_value=False,

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -597,7 +597,7 @@ def test_create_video_asset_dispatches_normalize_task(
         mock.patch(
             'anthias_server.processing.dispatch_normalize_video'
         ) as mock_dispatch,
-        mock.patch('anthias_server.processing._stamp_processing_start'),
+        mock.patch('anthias_server.processing.stamp_processing_start'),
         mock.patch('anthias_server.api.serializers.mixins.rename'),
         mock.patch('anthias_server.api.serializers.v1_1.rename'),
         # ``validate_uri`` raises ``Exception('Invalid file path…')``
@@ -665,7 +665,7 @@ def test_create_heic_image_dispatches_normalize_task_on_v1_2_and_v2(
         mock.patch(
             'anthias_server.processing.dispatch_normalize_image'
         ) as mock_dispatch,
-        mock.patch('anthias_server.processing._stamp_processing_start'),
+        mock.patch('anthias_server.processing.stamp_processing_start'),
         mock.patch('anthias_server.api.serializers.mixins.rename'),
         mock.patch(
             'anthias_server.api.serializers.mixins.validate_uri',

--- a/src/anthias_server/api/tests/test_info_endpoints.py
+++ b/src/anthias_server/api/tests/test_info_endpoints.py
@@ -48,12 +48,15 @@ def _assert_response_data(
     'anthias_server.lib.diagnostics.get_load_avg',
     return_value={'15 min': 0.11},
 )
-@mock.patch('anthias_server.api.views.mixins.size', return_value='15G')
+@mock.patch(
+    'anthias_server.api.views.mixins.filesizeformat',
+    return_value='15.0\xa0GB',
+)
 @mock.patch('anthias_server.api.views.mixins.statvfs', mock.MagicMock())
 @mock.patch('anthias_server.api.views.mixins.r.get', return_value='off')
 def test_info_v1_endpoint(
     redis_get_mock: Any,
-    size_mock: Any,
+    filesizeformat_mock: Any,
     get_load_avg_mock: Any,
     is_up_to_date_mock: Any,
     api_client: APIClient,
@@ -67,14 +70,22 @@ def test_info_v1_endpoint(
 
     # Assert mock calls
     _assert_mock_calls(
-        [redis_get_mock, size_mock, get_load_avg_mock, is_up_to_date_mock]
+        [
+            redis_get_mock,
+            filesizeformat_mock,
+            get_load_avg_mock,
+            is_up_to_date_mock,
+        ]
     )
 
-    # Assert response data
+    # Assert response data. ``free_space`` follows Django's
+    # ``filesizeformat`` shape: "15.0\xa0GB" — a non-breaking space
+    # between the number and unit. Replaces the previous "15G" emitted
+    # by hurry.filesize, which was dropped to drop the dep.
     expected_data = {
         'viewlog': 'Not yet implemented',
         'loadavg': 0.11,
-        'free_space': '15G',
+        'free_space': '15.0\xa0GB',
         'display_power': 'off',
         'up_to_date': False,
     }
@@ -87,7 +98,10 @@ def test_info_v1_endpoint(
     'anthias_server.lib.diagnostics.get_load_avg',
     return_value={'15 min': 0.25},
 )
-@mock.patch('anthias_server.api.views.v2.size', return_value='20G')
+@mock.patch(
+    'anthias_server.api.views.v2.filesizeformat',
+    return_value='20.0\xa0GB',
+)
 @mock.patch('anthias_server.api.views.v2.statvfs', mock.MagicMock())
 @mock.patch('anthias_server.api.views.v2.r.get', return_value='on')
 @mock.patch(
@@ -135,7 +149,7 @@ def test_info_v2_endpoint(
     get_git_short_hash_mock: Any,
     get_git_branch_mock: Any,
     redis_get_mock: Any,
-    size_mock: Any,
+    filesizeformat_mock: Any,
     get_load_avg_mock: Any,
     is_up_to_date_mock: Any,
     api_client: APIClient,
@@ -151,7 +165,7 @@ def test_info_v2_endpoint(
     _assert_mock_calls(
         [
             redis_get_mock,
-            size_mock,
+            filesizeformat_mock,
             get_load_avg_mock,
             is_up_to_date_mock,
             get_git_branch_mock,
@@ -169,7 +183,7 @@ def test_info_v2_endpoint(
     expected_data = {
         'viewlog': 'Not yet implemented',
         'loadavg': 0.25,
-        'free_space': '20G',
+        'free_space': '20.0\xa0GB',
         'display_power': 'on',
         'up_to_date': True,
         # Version label format is `v{calver} ({short_hash})` on a

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -345,7 +345,11 @@ class InfoViewMixin(APIView):
                 'example': {
                     'viewlog': 'Not yet implemented',
                     'loadavg': 0.1,
-                    'free_space': '10G',
+                    # Shape matches ``django.template.defaultfilters.filesizeformat``:
+                    # number with one decimal, non-breaking space ( ),
+                    # full unit label (KB / MB / GB / TB). Old hurry.filesize
+                    # output ("10G") was removed in the 2026.05.1 release.
+                    'free_space': '10.0 GB',
                     'display_power': 'on',
                     'up_to_date': True,
                 },

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -7,9 +7,9 @@ from mimetypes import guess_extension, guess_type
 from os import path, remove, statvfs
 from typing import Any
 
+from django.template.defaultfilters import filesizeformat
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
-from hurry.filesize import size
 from rest_framework import status
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.request import Request
@@ -358,7 +358,7 @@ class InfoViewMixin(APIView):
 
         # Calculate disk space
         slash = statvfs('/')
-        free_space = size(slash.f_bavail * slash.f_frsize)
+        free_space = filesizeformat(slash.f_bavail * slash.f_frsize)
         display_power = r.get('display_power')
 
         return Response(

--- a/src/anthias_server/api/views/v1.py
+++ b/src/anthias_server/api/views/v1.py
@@ -13,6 +13,7 @@ from rest_framework.views import APIView
 
 from anthias_server.app.models import Asset
 from anthias_common.youtube import dispatch_download
+from anthias_server.processing import dispatch_pending_normalize
 from anthias_server.api.helpers import (
     AssetCreationError,
     parse_request,
@@ -159,6 +160,14 @@ class AssetListViewV1(APIView):
         # title + duration once yt-dlp finishes.
         if serializer._pending_youtube_uri:
             dispatch_download(asset.asset_id, serializer._pending_youtube_uri)
+
+        # Same hand-off as v1.2 / v2: ``CreateAssetSerializerV1_1``
+        # stamps ``_pending_normalize='video'`` (and is_processing=1)
+        # for local video uploads — without this call the row would
+        # land in whatever codec the operator uploaded (e.g. MPEG-1)
+        # and the on-device player would silently drop it from
+        # rotation forever (GH #2870).
+        dispatch_pending_normalize(serializer, asset.asset_id)
 
         return Response(
             AssetSerializer(asset).data, status=status.HTTP_201_CREATED

--- a/src/anthias_server/api/views/v1_1.py
+++ b/src/anthias_server/api/views/v1_1.py
@@ -6,6 +6,7 @@ from rest_framework.views import APIView
 
 from anthias_server.app.models import Asset
 from anthias_common.youtube import dispatch_download
+from anthias_server.processing import dispatch_pending_normalize
 from anthias_server.api.helpers import AssetCreationError, parse_request
 from anthias_server.api.serializers import (
     AssetSerializer,
@@ -50,6 +51,12 @@ class AssetListViewV1_1(APIView):
         # the full rationale.
         if serializer._pending_youtube_uri:
             dispatch_download(asset.asset_id, serializer._pending_youtube_uri)
+
+        # Same hand-off as v1.2 / v2: ``CreateAssetSerializerV1_1``
+        # stamps ``_pending_normalize='video'`` for local video
+        # uploads. Missing this call was the v1/v1.1 half of
+        # GH #2870 — see the v1 view for the full rationale.
+        dispatch_pending_normalize(serializer, asset.asset_id)
 
         return Response(
             AssetSerializer(asset).data, status=status.HTTP_201_CREATED

--- a/src/anthias_server/api/views/v1_2.py
+++ b/src/anthias_server/api/views/v1_2.py
@@ -6,10 +6,7 @@ from rest_framework.views import APIView
 
 from anthias_server.app.models import Asset
 from anthias_common.youtube import dispatch_download
-from anthias_server.processing import (
-    dispatch_normalize_image,
-    dispatch_normalize_video,
-)
+from anthias_server.processing import dispatch_pending_normalize
 from anthias_server.api.helpers import (
     AssetCreationError,
     get_active_asset_ids,
@@ -67,11 +64,10 @@ class AssetListViewV1_2(APIView):
 
         # Same hand-off as v2: the serializer's prepare_asset stamps
         # is_processing on rows that need normalisation; we dispatch
-        # the matching Celery task after persistence.
-        if serializer._pending_normalize == 'image':
-            dispatch_normalize_image(asset.asset_id)
-        elif serializer._pending_normalize == 'video':
-            dispatch_normalize_video(asset.asset_id)
+        # the matching Celery task after persistence. Shared with
+        # v1/v1.1/v2 via dispatch_pending_normalize so adding a new
+        # API version can't re-open GH #2870.
+        dispatch_pending_normalize(serializer, asset.asset_id)
 
         if asset.is_active():
             active_asset_ids.insert(asset.play_order, asset.asset_id)

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -9,8 +9,8 @@ from typing import Any
 import psutil
 import redis
 import requests
+from django.template.defaultfilters import filesizeformat
 from drf_spectacular.utils import extend_schema
-from hurry.filesize import size
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -32,10 +32,7 @@ from anthias_server.lib.auth import (
 )
 from anthias_common.internal_auth import is_internal_request
 from anthias_common.youtube import dispatch_download
-from anthias_server.processing import (
-    dispatch_normalize_image,
-    dispatch_normalize_video,
-)
+from anthias_server.processing import dispatch_pending_normalize
 from anthias_server.api.serializers.v2 import (
     AssetSerializerV2,
     CreateAssetSerializerV2,
@@ -377,11 +374,10 @@ class AssetListViewV2(APIView):
         # the YouTube hop above) so the row's ``asset_id`` is already
         # written to the DB by the time the worker picks it up. The
         # row was set ``is_processing=True`` by ``prepare_asset``;
-        # the task clears it once the file lands.
-        if serializer._pending_normalize == 'image':
-            dispatch_normalize_image(asset.asset_id)
-        elif serializer._pending_normalize == 'video':
-            dispatch_normalize_video(asset.asset_id)
+        # the task clears it once the file lands. Shared with
+        # v1/v1.1/v1.2 via dispatch_pending_normalize so adding a
+        # new API version can't re-open GH #2870.
+        dispatch_pending_normalize(serializer, asset.asset_id)
 
         if asset.is_active():
             active_asset_ids.insert(asset.play_order, asset.asset_id)
@@ -756,7 +752,7 @@ class InfoViewV2(InfoViewMixin):
 
         # Calculate disk space
         slash = statvfs('/')
-        free_space = size(slash.f_bavail * slash.f_frsize)
+        free_space = filesizeformat(slash.f_bavail * slash.f_frsize)
         display_power = r.get('display_power')
 
         return Response(

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -12,7 +12,7 @@ from os import getenv, statvfs
 from typing import Any
 
 import psutil
-from hurry.filesize import size
+from django.template.defaultfilters import filesizeformat
 
 from anthias_common import device_helper
 from anthias_common.utils import (
@@ -125,11 +125,11 @@ def system_info() -> dict[str, Any]:
                 (_load_bar(load_15m), '15 min'),
             ],
         },
-        'free_space': size(disk_free),
+        'free_space': filesizeformat(disk_free),
         'disk': {
-            'total_human': size(disk_total),
-            'used_human': size(disk_used),
-            'free_human': size(disk_free),
+            'total_human': filesizeformat(disk_total),
+            'used_human': filesizeformat(disk_used),
+            'free_human': filesizeformat(disk_free),
             'used_pct': _pct(disk_used, disk_total),
             'free_pct': _pct(disk_free, disk_total),
         },

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -427,10 +427,15 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
         start_date=now,
         end_date=now + timedelta(days=30),
     )
+    # Route through the shared ``dispatch_normalize_*`` helpers rather
+    # than ``.delay()`` directly so the
+    # ``metadata.processing_started_at`` stamp the periodic reconciler
+    # depends on (see celery_tasks.reconcile_stuck_processing) is
+    # applied on every entry into the pipeline — UI, API, and YouTube.
     if is_video:
-        from anthias_server.celery_tasks import normalize_video_asset
+        from anthias_server.processing import dispatch_normalize_video
 
-        normalize_video_asset.delay(asset.asset_id)
+        dispatch_normalize_video(asset.asset_id)
         return _asset_table_response(
             request,
             toast=(
@@ -439,9 +444,9 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
             ),
         )
     if needs_image_normalize:
-        from anthias_server.celery_tasks import normalize_image_asset
+        from anthias_server.processing import dispatch_normalize_image
 
-        normalize_image_asset.delay(asset.asset_id)
+        dispatch_normalize_image(asset.asset_id)
         return _asset_table_response(
             request,
             toast=(

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -59,15 +59,26 @@ ASSET_REVALIDATION_INTERVAL_S = 60 * 15
 
 # Sweep cadence for the stuck-``is_processing`` reconciler. 10 min is
 # short enough that an operator sees a hung row recover within one
-# UI sit-down, long enough that the sweep cost (one SELECT, one
-# UPDATE per stuck row) is negligible on a fleet device.
+# UI sit-down. The per-tick cost is bounded by the number of stuck
+# rows: one initial SELECT over ``is_processing=True``, then per row
+# either a stamp (SELECT + UPDATE inside ``stamp_processing_start``)
+# or a normalize re-dispatch (which itself stamps). On a healthy
+# fleet the filtered set is usually empty so the tick costs one
+# SELECT total; only a backlog of stuck rows scales the work up.
 RECONCILE_STUCK_INTERVAL_S = 60 * 10
 
 # Age threshold for considering a row stuck. Has to be *longer* than
 # the longest reasonable Celery task: ``NORMALIZE_VIDEO_TIME_LIMIT_S``
 # is 30 min and ``YOUTUBE_DOWNLOAD_TIME_LIMIT_S`` is 15 min, so 60 min
-# is a safe floor — a row past that has had its worker time-limit
-# expire (and on_failure should have already run) at least once.
+# is a safe floor. A row past the threshold either had its worker
+# time-limit expire (in which case ``on_failure`` should already have
+# cleared the flag — and the reconciler only sees rows where it
+# didn't, e.g. SIGKILL before on_failure could run) OR was never
+# picked up at all (Redis flake during ``.delay()``, worker crashed
+# between enqueue and accept, container restart mid-dispatch). The
+# threshold doesn't distinguish the two cases — it just says "if a
+# row has carried ``is_processing=True`` for over an hour, something
+# went wrong, recover it".
 RECONCILE_STUCK_THRESHOLD_S = 60 * 60
 
 # Singleton lock for the stuck-row reconciler — same SETNX +

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -70,6 +70,16 @@ RECONCILE_STUCK_INTERVAL_S = 60 * 10
 # expire (and on_failure should have already run) at least once.
 RECONCILE_STUCK_THRESHOLD_S = 60 * 60
 
+# Singleton lock for the stuck-row reconciler — same SETNX +
+# Lua-compare-and-delete pattern as ``revalidate_asset_urls``. The
+# embedded beat scheduler (``celery worker -B``) fires the periodic
+# task inside the same worker process; if a future deploy ever runs
+# two workers with embedded beat (or a separate ``celery beat``
+# instance) this lock keeps the sweep single-flighted across them and
+# prevents the same stuck row from being re-dispatched twice in a
+# tick.
+RECONCILE_STUCK_LOCK_KEY = 'celery:reconcile_stuck_processing:lock'
+
 # Floor on per-asset re-checks. Independent of the sweep interval —
 # this gates the on-demand recheck path so a viewer that keeps
 # encountering the same unreachable asset can't flood the worker with
@@ -735,15 +745,28 @@ def _parse_processing_started_at(value: Any) -> Any:
     restored from a hand-edited JSON dump might. Treat unparseable
     values as "missing" — the reconciler then stamps the row on first
     sight, the same recovery path the legacy / pre-stamp branch takes.
+
+    Naive datetimes (no ``tzinfo``) are also treated as missing — the
+    dispatch helpers stamp via ``timezone.now()`` which is tz-aware
+    under Django's ``USE_TZ=True``, so a naive value is by definition
+    a hand-edit rather than something we wrote. Comparing a naive
+    ``datetime`` to the tz-aware ``cutoff`` below would raise
+    ``TypeError`` and abort the sweep — returning ``None`` here
+    routes the row through the stamp-on-first-sight branch instead,
+    which is the right behaviour for a malformed value (same as the
+    parse-error branch).
     """
     if not value or not isinstance(value, str):
         return None
     from datetime import datetime
 
     try:
-        return datetime.fromisoformat(value)
+        parsed = datetime.fromisoformat(value)
     except ValueError:
         return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed
 
 
 @celery.task(time_limit=300)
@@ -777,6 +800,14 @@ def reconcile_stuck_processing() -> None:
     as processing) lands on ``_set_processing_error`` — the flag
     clears and the operator sees an explicit "Failed" pill with a
     reconciler-sourced error message.
+
+    Single-flighted via a Redis SETNX lock — mirrors
+    ``revalidate_asset_urls``. The default Anthias deploy runs one
+    celery worker with embedded beat, so this is a defence rather
+    than a correctness requirement today; it bounds blast radius if a
+    future deploy ever runs two workers with ``-B`` (or a separate
+    ``celery beat`` instance) by ensuring only one sweep re-dispatches
+    a given stuck row per tick.
     """
     from datetime import timedelta
 
@@ -789,68 +820,96 @@ def reconcile_stuck_processing() -> None:
         dispatch_normalize_video,
     )
 
-    now = timezone.now()
-    cutoff = now - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S)
-
-    for asset in Asset.objects.filter(is_processing=True):
-        metadata = asset.metadata or {}
-        started_at = _parse_processing_started_at(
-            metadata.get('processing_started_at')
+    # SETNX with TTL and a unique per-sweep token, same pattern as
+    # revalidate_asset_urls. TTL matches the task time_limit so a
+    # hard-killed worker doesn't orphan the lock; the Lua release
+    # below is compare-and-delete so a stale-TTL → fresh-acquisition
+    # → original-finally ordering can't clobber the new holder.
+    token = secrets.token_hex(16)
+    if not r.set(
+        RECONCILE_STUCK_LOCK_KEY,
+        token,
+        nx=True,
+        ex=300,  # matches the task's time_limit
+    ):
+        logging.info(
+            'reconcile_stuck_processing: previous sweep still running, '
+            'skipping'
         )
+        return
 
-        if started_at is None:
-            # Legacy / backup-restored / pre-stamp row. Mark its start
-            # so the next sweep can apply the age threshold uniformly
-            # — a still-in-flight task gets the full grace window
-            # rather than being yanked out from under itself.
-            _stamp_processing_start(asset.asset_id)
-            continue
+    try:
+        now = timezone.now()
+        cutoff = now - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S)
 
-        if started_at > cutoff:
-            # Inside the grace window. Let the (presumed-running)
-            # task complete on its own.
-            continue
+        for asset in Asset.objects.filter(is_processing=True):
+            metadata = asset.metadata or {}
+            started_at = _parse_processing_started_at(
+                metadata.get('processing_started_at')
+            )
 
-        # Stuck past the threshold. Route by mimetype.
-        mimetype = (asset.mimetype or '').lower()
-        if mimetype == 'image':
-            logging.warning(
-                'reconcile_stuck_processing: re-dispatching image '
-                'normalize for %s (stuck since %s)',
-                asset.asset_id,
-                started_at.isoformat(),
-            )
-            dispatch_normalize_image(asset.asset_id)
-        elif mimetype == 'video':
-            logging.warning(
-                'reconcile_stuck_processing: re-dispatching video '
-                'normalize for %s (stuck since %s)',
-                asset.asset_id,
-                started_at.isoformat(),
-            )
-            dispatch_normalize_video(asset.asset_id)
-        else:
-            # No clear task to re-dispatch — clear the flag with a
-            # logged error so the operator can interact with the row.
-            # YouTube rows arrive here as mimetype='video' (the
-            # create path rewrites the row to video at the same time
-            # it enqueues download_youtube_asset), so the YouTube case
-            # is covered by the video branch above — we lose the
-            # original watch URL on a backup-restored YouTube row, but
-            # video-pipeline re-dispatch is the best we can do without
-            # re-querying yt-dlp.
-            logging.warning(
-                'reconcile_stuck_processing: clearing flag on '
-                'unknown-mimetype row %s (mimetype=%r, stuck since %s)',
-                asset.asset_id,
-                asset.mimetype,
-                started_at.isoformat(),
-            )
-            _set_processing_error(
-                asset.asset_id,
-                'Processing stalled past threshold; flag cleared by '
-                'reconciler. Re-upload the asset to retry.',
-            )
+            if started_at is None:
+                # Legacy / backup-restored / pre-stamp row. Mark its
+                # start so the next sweep can apply the age threshold
+                # uniformly — a still-in-flight task gets the full
+                # grace window rather than being yanked out from
+                # under itself.
+                _stamp_processing_start(asset.asset_id)
+                continue
+
+            if started_at > cutoff:
+                # Inside the grace window. Let the (presumed-running)
+                # task complete on its own.
+                continue
+
+            # Stuck past the threshold. Route by mimetype.
+            mimetype = (asset.mimetype or '').lower()
+            if mimetype == 'image':
+                logging.warning(
+                    'reconcile_stuck_processing: re-dispatching image '
+                    'normalize for %s (stuck since %s)',
+                    asset.asset_id,
+                    started_at.isoformat(),
+                )
+                dispatch_normalize_image(asset.asset_id)
+            elif mimetype == 'video':
+                logging.warning(
+                    'reconcile_stuck_processing: re-dispatching video '
+                    'normalize for %s (stuck since %s)',
+                    asset.asset_id,
+                    started_at.isoformat(),
+                )
+                dispatch_normalize_video(asset.asset_id)
+            else:
+                # No clear task to re-dispatch — clear the flag with
+                # a logged error so the operator can interact with
+                # the row. YouTube rows arrive here as
+                # mimetype='video' (the create path rewrites the row
+                # to video at the same time it enqueues
+                # download_youtube_asset), so the YouTube case is
+                # covered by the video branch above — we lose the
+                # original watch URL on a backup-restored YouTube
+                # row, but video-pipeline re-dispatch is the best we
+                # can do without re-querying yt-dlp.
+                logging.warning(
+                    'reconcile_stuck_processing: clearing flag on '
+                    'unknown-mimetype row %s '
+                    '(mimetype=%r, stuck since %s)',
+                    asset.asset_id,
+                    asset.mimetype,
+                    started_at.isoformat(),
+                )
+                _set_processing_error(
+                    asset.asset_id,
+                    'Processing stalled past threshold; flag cleared '
+                    'by reconciler. Re-upload the asset to retry.',
+                )
+    finally:
+        # Compare-and-delete via the shared Lua script: only release
+        # if the lock still holds *our* token. If our TTL expired and
+        # someone else acquired the lock with a fresh token, leave it
+        # alone.
+        r.eval(_LOCK_RELEASE_LUA, 1, RECONCILE_STUCK_LOCK_KEY, token)
 
 
 @celery.task(time_limit=30)

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -2,7 +2,7 @@ import logging
 import os
 import secrets
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 from os import getenv, path
 from typing import Any
 
@@ -737,10 +737,10 @@ def revalidate_asset_urls() -> None:
         r.eval(_LOCK_RELEASE_LUA, 1, ASSET_REVALIDATION_LOCK_KEY, token)
 
 
-def _parse_processing_started_at(value: Any) -> Any:
+def _parse_processing_started_at(value: Any) -> datetime | None:
     """Best-effort ISO-8601 parser for ``metadata.processing_started_at``.
 
-    Returns a ``datetime`` (tz-aware) on success, ``None`` on any failure.
+    Returns a tz-aware ``datetime`` on success, ``None`` on any failure.
     Anthias never writes a non-string value to this key, but a backup
     restored from a hand-edited JSON dump might. Treat unparseable
     values as "missing" — the reconciler then stamps the row on first
@@ -758,8 +758,6 @@ def _parse_processing_started_at(value: Any) -> Any:
     """
     if not value or not isinstance(value, str):
         return None
-    from datetime import datetime
-
     try:
         parsed = datetime.fromisoformat(value)
     except ValueError:
@@ -787,9 +785,14 @@ def reconcile_stuck_processing() -> None:
     (``dispatch_normalize_image`` / ``dispatch_normalize_video`` /
     ``dispatch_download``) stamp this field at dispatch time. Rows
     without the stamp are legacy / backup-restored / pre-stamp; they
-    get stamped on first sweep so the *next* sweep can apply the same
-    age threshold uniformly — gives a 10-min grace window in case the
-    row is actively being worked.
+    get stamped on first sweep with ``timezone.now()``, so the
+    *next* re-dispatch decision waits the full
+    ``RECONCILE_STUCK_THRESHOLD_S`` (60 min) from that stamp — at
+    a 10-min sweep cadence that's six sweeps where the row stays
+    inside the grace window before becoming eligible. The grace is
+    deliberately long enough to cover the worst-case live transcode
+    (``NORMALIZE_VIDEO_TIME_LIMIT_S=30min``) plus margin, so a
+    still-in-flight task never gets yanked out from under itself.
 
     Rows older than ``RECONCILE_STUCK_THRESHOLD_S`` (60 min) get
     re-dispatched via the normalisation path matching their mimetype.
@@ -809,15 +812,13 @@ def reconcile_stuck_processing() -> None:
     ``celery beat`` instance) by ensuring only one sweep re-dispatches
     a given stuck row per tick.
     """
-    from datetime import timedelta
-
     from django.utils import timezone
 
     from anthias_server.processing import (
         _set_processing_error,
-        _stamp_processing_start,
         dispatch_normalize_image,
         dispatch_normalize_video,
+        stamp_processing_start,
     )
 
     # SETNX with TTL and a unique per-sweep token, same pattern as
@@ -854,7 +855,7 @@ def reconcile_stuck_processing() -> None:
                 # uniformly — a still-in-flight task gets the full
                 # grace window rather than being yanked out from
                 # under itself.
-                _stamp_processing_start(asset.asset_id)
+                stamp_processing_start(asset.asset_id)
                 continue
 
             if started_at > cutoff:

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -57,6 +57,19 @@ celery = Celery(
 # per HTTP asset) doesn't compound on a large playlist.
 ASSET_REVALIDATION_INTERVAL_S = 60 * 15
 
+# Sweep cadence for the stuck-``is_processing`` reconciler. 10 min is
+# short enough that an operator sees a hung row recover within one
+# UI sit-down, long enough that the sweep cost (one SELECT, one
+# UPDATE per stuck row) is negligible on a fleet device.
+RECONCILE_STUCK_INTERVAL_S = 60 * 10
+
+# Age threshold for considering a row stuck. Has to be *longer* than
+# the longest reasonable Celery task: ``NORMALIZE_VIDEO_TIME_LIMIT_S``
+# is 30 min and ``YOUTUBE_DOWNLOAD_TIME_LIMIT_S`` is 15 min, so 60 min
+# is a safe floor — a row past that has had its worker time-limit
+# expire (and on_failure should have already run) at least once.
+RECONCILE_STUCK_THRESHOLD_S = 60 * 60
+
 # Floor on per-asset re-checks. Independent of the sweep interval —
 # this gates the on-demand recheck path so a viewer that keeps
 # encountering the same unreachable asset can't flood the worker with
@@ -130,6 +143,11 @@ def setup_periodic_tasks(sender: Any, **kwargs: Any) -> None:
         ASSET_REVALIDATION_INTERVAL_S,
         revalidate_asset_urls.s(),
         name='revalidate_asset_urls',
+    )
+    sender.add_periodic_task(
+        RECONCILE_STUCK_INTERVAL_S,
+        reconcile_stuck_processing.s(),
+        name='reconcile_stuck_processing',
     )
 
 
@@ -707,6 +725,132 @@ def revalidate_asset_urls() -> None:
         # *our* token. If the TTL expired and someone else acquired
         # the lock with a different token, leave it alone.
         r.eval(_LOCK_RELEASE_LUA, 1, ASSET_REVALIDATION_LOCK_KEY, token)
+
+
+def _parse_processing_started_at(value: Any) -> Any:
+    """Best-effort ISO-8601 parser for ``metadata.processing_started_at``.
+
+    Returns a ``datetime`` (tz-aware) on success, ``None`` on any failure.
+    Anthias never writes a non-string value to this key, but a backup
+    restored from a hand-edited JSON dump might. Treat unparseable
+    values as "missing" — the reconciler then stamps the row on first
+    sight, the same recovery path the legacy / pre-stamp branch takes.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    from datetime import datetime
+
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+@celery.task(time_limit=300)
+def reconcile_stuck_processing() -> None:
+    """Recover ``Asset`` rows stuck at ``is_processing=True``.
+
+    Causes (incomplete list):
+      * v1/v1.1 file uploads pre-GH #2870 fix: the create view never
+        dispatched ``normalize_video_asset`` / ``normalize_image_asset``,
+        so the row landed at ``is_processing=True`` and stayed there.
+      * Celery worker killed mid-task (SIGKILL, OOM, container
+        restart) before ``on_failure`` could clear the flag.
+      * Backup restore that re-created rows with ``is_processing=True``.
+      * Redis flake during ``.delay()`` that ate the enqueue.
+
+    Lookup: every ``is_processing=True`` row gets its
+    ``metadata.processing_started_at`` examined. The dispatch helpers
+    (``dispatch_normalize_image`` / ``dispatch_normalize_video`` /
+    ``dispatch_download``) stamp this field at dispatch time. Rows
+    without the stamp are legacy / backup-restored / pre-stamp; they
+    get stamped on first sweep so the *next* sweep can apply the same
+    age threshold uniformly — gives a 10-min grace window in case the
+    row is actively being worked.
+
+    Rows older than ``RECONCILE_STUCK_THRESHOLD_S`` (60 min) get
+    re-dispatched via the normalisation path matching their mimetype.
+    A re-dispatch refreshes ``processing_started_at`` automatically
+    (the helper writes the field), so the next sweep won't ping-pong
+    on the same row. A mimetype the reconciler doesn't know how to
+    re-dispatch (e.g. a corrupted row with mimetype='webpage' marked
+    as processing) lands on ``_set_processing_error`` — the flag
+    clears and the operator sees an explicit "Failed" pill with a
+    reconciler-sourced error message.
+    """
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from anthias_server.processing import (
+        _set_processing_error,
+        _stamp_processing_start,
+        dispatch_normalize_image,
+        dispatch_normalize_video,
+    )
+
+    now = timezone.now()
+    cutoff = now - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S)
+
+    for asset in Asset.objects.filter(is_processing=True):
+        metadata = asset.metadata or {}
+        started_at = _parse_processing_started_at(
+            metadata.get('processing_started_at')
+        )
+
+        if started_at is None:
+            # Legacy / backup-restored / pre-stamp row. Mark its start
+            # so the next sweep can apply the age threshold uniformly
+            # — a still-in-flight task gets the full grace window
+            # rather than being yanked out from under itself.
+            _stamp_processing_start(asset.asset_id)
+            continue
+
+        if started_at > cutoff:
+            # Inside the grace window. Let the (presumed-running)
+            # task complete on its own.
+            continue
+
+        # Stuck past the threshold. Route by mimetype.
+        mimetype = (asset.mimetype or '').lower()
+        if mimetype == 'image':
+            logging.warning(
+                'reconcile_stuck_processing: re-dispatching image '
+                'normalize for %s (stuck since %s)',
+                asset.asset_id,
+                started_at.isoformat(),
+            )
+            dispatch_normalize_image(asset.asset_id)
+        elif mimetype == 'video':
+            logging.warning(
+                'reconcile_stuck_processing: re-dispatching video '
+                'normalize for %s (stuck since %s)',
+                asset.asset_id,
+                started_at.isoformat(),
+            )
+            dispatch_normalize_video(asset.asset_id)
+        else:
+            # No clear task to re-dispatch — clear the flag with a
+            # logged error so the operator can interact with the row.
+            # YouTube rows arrive here as mimetype='video' (the
+            # create path rewrites the row to video at the same time
+            # it enqueues download_youtube_asset), so the YouTube case
+            # is covered by the video branch above — we lose the
+            # original watch URL on a backup-restored YouTube row, but
+            # video-pipeline re-dispatch is the best we can do without
+            # re-querying yt-dlp.
+            logging.warning(
+                'reconcile_stuck_processing: clearing flag on '
+                'unknown-mimetype row %s (mimetype=%r, stuck since %s)',
+                asset.asset_id,
+                asset.mimetype,
+                started_at.isoformat(),
+            )
+            _set_processing_error(
+                asset.asset_id,
+                'Processing stalled past threshold; flag cleared by '
+                'reconciler. Re-upload the asset to retry.',
+            )
 
 
 @celery.task(time_limit=30)

--- a/src/anthias_server/processing.py
+++ b/src/anthias_server/processing.py
@@ -330,25 +330,48 @@ def needs_image_normalisation(uri_or_filename: str) -> bool:
     return _ext(uri_or_filename) in NORMALIZE_IMAGE_EXTS
 
 
-def _stamp_processing_start(asset_id: str) -> None:
+def stamp_processing_start(asset_id: str) -> None:
     """Mark ``metadata['processing_started_at']`` to the current UTC.
 
     Read by the periodic reconciler (``reconcile_stuck_processing``)
     to age rows that have been ``is_processing=True`` longer than the
     longest reasonable transcode. Stored as an ISO-8601 string in the
-    existing JSON metadata bag (no schema migration). Best-effort: a
-    row that disappeared between dispatch enqueue and this update is
-    a no-op via the filter().update() pattern.
+    existing JSON metadata bag (no schema migration).
+
+    Public (no leading underscore): the dispatch entry points for
+    every upload path call this — including from outside this module
+    (``anthias_common.youtube.dispatch_download``,
+    ``anthias_server.celery_tasks.reconcile_stuck_processing``).
+    Treat the symbol as a stable internal API; the reconciler depends
+    on the field being written at every dispatch.
+
+    Concurrency: the read-modify-write below preserves the existing
+    metadata bag — wrapped in ``transaction.atomic()`` so a
+    near-simultaneous metadata write (an operator PATCH, a worker
+    landing ``error_message``) is serialised at the DB layer rather
+    than racing with this SELECT. On SQLite (Anthias's default) the
+    DB is single-writer at the file level anyway, so the wrap is
+    primarily documenting intent; on Postgres / MySQL the atomic
+    block produces an actual transaction boundary.
+
+    No-op for a row that doesn't exist: a row that disappeared
+    between dispatch enqueue and this update is silently dropped via
+    the ``filter().first() is None`` guard. The two-query
+    SELECT-then-UPDATE shape is deliberate — Django doesn't expose a
+    cross-backend "merge into JSONField" primitive, so we read the
+    existing bag, patch one key, and write it back.
     """
+    from django.db import transaction
     from django.utils import timezone
 
     now_iso = timezone.now().isoformat()
-    asset = Asset.objects.filter(asset_id=asset_id).first()
-    if asset is None:
-        return
-    metadata = dict(asset.metadata or {})
-    metadata['processing_started_at'] = now_iso
-    Asset.objects.filter(asset_id=asset_id).update(metadata=metadata)
+    with transaction.atomic():
+        asset = Asset.objects.filter(asset_id=asset_id).first()
+        if asset is None:
+            return
+        metadata = dict(asset.metadata or {})
+        metadata['processing_started_at'] = now_iso
+        Asset.objects.filter(asset_id=asset_id).update(metadata=metadata)
 
 
 def dispatch_normalize_image(asset_id: str) -> None:
@@ -365,7 +388,7 @@ def dispatch_normalize_image(asset_id: str) -> None:
     """
     from anthias_server.celery_tasks import normalize_image_asset
 
-    _stamp_processing_start(asset_id)
+    stamp_processing_start(asset_id)
     normalize_image_asset.delay(asset_id)
 
 
@@ -376,7 +399,7 @@ def dispatch_normalize_video(asset_id: str) -> None:
     """
     from anthias_server.celery_tasks import normalize_video_asset
 
-    _stamp_processing_start(asset_id)
+    stamp_processing_start(asset_id)
     normalize_video_asset.delay(asset_id)
 
 

--- a/src/anthias_server/processing.py
+++ b/src/anthias_server/processing.py
@@ -330,6 +330,27 @@ def needs_image_normalisation(uri_or_filename: str) -> bool:
     return _ext(uri_or_filename) in NORMALIZE_IMAGE_EXTS
 
 
+def _stamp_processing_start(asset_id: str) -> None:
+    """Mark ``metadata['processing_started_at']`` to the current UTC.
+
+    Read by the periodic reconciler (``reconcile_stuck_processing``)
+    to age rows that have been ``is_processing=True`` longer than the
+    longest reasonable transcode. Stored as an ISO-8601 string in the
+    existing JSON metadata bag (no schema migration). Best-effort: a
+    row that disappeared between dispatch enqueue and this update is
+    a no-op via the filter().update() pattern.
+    """
+    from django.utils import timezone
+
+    now_iso = timezone.now().isoformat()
+    asset = Asset.objects.filter(asset_id=asset_id).first()
+    if asset is None:
+        return
+    metadata = dict(asset.metadata or {})
+    metadata['processing_started_at'] = now_iso
+    Asset.objects.filter(asset_id=asset_id).update(metadata=metadata)
+
+
 def dispatch_normalize_image(asset_id: str) -> None:
     """Queue ``normalize_image_asset`` for the just-persisted row.
 
@@ -337,17 +358,57 @@ def dispatch_normalize_image(asset_id: str) -> None:
     importable from contexts (the API serializers, tests) that don't
     want celery's broker connection set up at import time. Mirrors
     ``anthias_common.youtube.dispatch_download``.
+
+    Stamps ``metadata.processing_started_at`` so the reconciler can
+    age a row that the worker never picked up (crashed worker, OOM
+    kill, dispatch enqueue racing a redis flake).
     """
     from anthias_server.celery_tasks import normalize_image_asset
 
+    _stamp_processing_start(asset_id)
     normalize_image_asset.delay(asset_id)
 
 
 def dispatch_normalize_video(asset_id: str) -> None:
-    """Queue ``normalize_video_asset`` for the just-persisted row."""
+    """Queue ``normalize_video_asset`` for the just-persisted row.
+
+    See ``dispatch_normalize_image`` for the metadata stamp rationale.
+    """
     from anthias_server.celery_tasks import normalize_video_asset
 
+    _stamp_processing_start(asset_id)
     normalize_video_asset.delay(asset_id)
+
+
+def dispatch_pending_normalize(serializer: Any, asset_id: str) -> None:
+    """Branch on ``serializer._pending_normalize`` and dispatch.
+
+    Single hand-off point shared by every API version's create view
+    (v1 / v1.1 / v1.2 / v2). ``prepare_asset`` stamps the attribute
+    *and* flips ``is_processing=True`` for image/video uploads that
+    need normalisation; the create view then calls this helper after
+    persistence so the matching Celery task picks the row up. v1 and
+    v1.1 used to skip this dispatch entirely (the per-version create
+    views grew the branching inline as v1.2 / v2 were added, and the
+    legacy endpoints were left behind), which left every video
+    uploaded through those endpoints stuck at ``is_processing=True``
+    forever — see GH #2870. Centralising the branch here means the
+    next added or renamed version inherits the dispatch automatically.
+
+    ``serializer`` is typed as ``Any`` because the four versions use
+    four different serializer classes (``CreateAssetSerializerV1_1``,
+    ``CreateAssetSerializerV1_2``, ``CreateAssetSerializerV2``) which
+    share the ``_pending_normalize`` attribute via the
+    ``CreateAssetSerializerMixin`` but don't share a single declared
+    base for typing. Missing-attribute is treated as "no normalisation
+    needed" so a hypothetical future serializer that doesn't route
+    through the mixin still wouldn't crash this code path.
+    """
+    pending = getattr(serializer, '_pending_normalize', None)
+    if pending == 'image':
+        dispatch_normalize_image(asset_id)
+    elif pending == 'video':
+        dispatch_normalize_video(asset_id)
 
 
 def _row_or_none(asset_id: str) -> Asset | None:

--- a/src/anthias_server/processing.py
+++ b/src/anthias_server/processing.py
@@ -345,14 +345,23 @@ def stamp_processing_start(asset_id: str) -> None:
     Treat the symbol as a stable internal API; the reconciler depends
     on the field being written at every dispatch.
 
-    Concurrency: the read-modify-write below preserves the existing
-    metadata bag — wrapped in ``transaction.atomic()`` so a
-    near-simultaneous metadata write (an operator PATCH, a worker
-    landing ``error_message``) is serialised at the DB layer rather
-    than racing with this SELECT. On SQLite (Anthias's default) the
-    DB is single-writer at the file level anyway, so the wrap is
-    primarily documenting intent; on Postgres / MySQL the atomic
-    block produces an actual transaction boundary.
+    Concurrency: the read-modify-write below is a known race against
+    arbitrary other writers of ``Asset.metadata`` — a worker landing
+    ``error_message`` between our SELECT and UPDATE, an operator
+    PATCH, etc. would be clobbered by our UPDATE. The wider codebase
+    accepts the same race in sibling helpers (see ``_set_processing_error``,
+    the normalize-task success path). We accept it here because the
+    practical window is microscopic: stamps fire at *dispatch* time,
+    *before* the worker picks the task up, and the dispatching code
+    has just created or filter-updated the same row a few statements
+    earlier. ``select_for_update()`` would close it on Postgres /
+    MySQL but is a no-op on SQLite — Anthias's only deployed backend
+    — so we'd be paying complexity for zero practical safety today.
+
+    The ``transaction.atomic()`` wrap gives the SELECT / UPDATE pair
+    a transaction boundary on backends that support it; the savepoint
+    is cheap and survives a future switch to a multi-writer backend
+    without code changes here.
 
     No-op for a row that doesn't exist: a row that disappeared
     between dispatch enqueue and this update is silently dropped via

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -974,6 +974,7 @@ from datetime import timedelta  # noqa: E402
 from django.utils import timezone  # noqa: E402
 
 from anthias_server.celery_tasks import (  # noqa: E402
+    RECONCILE_STUCK_LOCK_KEY,
     RECONCILE_STUCK_THRESHOLD_S,
     reconcile_stuck_processing,
 )
@@ -1200,3 +1201,79 @@ def test_reconcile_skips_rows_not_processing(
         reconcile_stuck_processing.apply()
 
     mock_video.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_reconcile_treats_naive_timestamp_as_unstamped(
+    eager_celery_reconcile: None,
+) -> None:
+    """A naive (no tzinfo) ISO-8601 string in
+    ``metadata.processing_started_at`` could come from a hand-edited
+    backup. Comparing it against the tz-aware ``cutoff`` would raise
+    ``TypeError`` and abort the sweep — handle it the same way as a
+    malformed string: stamp on first sight, re-evaluate on the next
+    sweep. Guards against a single bad row breaking the whole sweep
+    for everyone else."""
+    naive = '2020-01-01T00:00:00'  # well past threshold, but no tz
+    _make_stuck_asset(
+        asset_id='naive-ts',
+        processing_started_at=naive,
+        mimetype='video',
+    )
+
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as mock_video:
+        reconcile_stuck_processing.apply()
+
+    mock_video.assert_not_called()
+    a = Asset.objects.get(asset_id='naive-ts')
+    # The naive value was overwritten with a fresh tz-aware stamp.
+    new_stamp = a.metadata['processing_started_at']
+    assert new_stamp != naive
+    from datetime import datetime
+
+    assert datetime.fromisoformat(new_stamp).tzinfo is not None
+
+
+@pytest.mark.django_db
+def test_reconcile_lock_prevents_overlap(
+    eager_celery_reconcile: None,
+) -> None:
+    """A second beat tick that fires while the reconciler is running
+    must be a no-op. Mirrors ``revalidate_asset_urls`` behaviour: only
+    one sweep at a time re-dispatches a given stuck row, regardless of
+    how many workers run embedded beat."""
+    old = (
+        timezone.now() - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S + 60)
+    ).isoformat()
+    _make_stuck_asset(processing_started_at=old, mimetype='video')
+
+    # Pre-acquire the lock to simulate a sweep already in flight.
+    celery_tasks_module.r.set(RECONCILE_STUCK_LOCK_KEY, 'someone-else')
+
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as mock_video:
+        reconcile_stuck_processing.apply()
+
+    # Saw the lock and exited without re-dispatching.
+    mock_video.assert_not_called()
+    # Critically did NOT clobber the existing holder's token.
+    assert (
+        celery_tasks_module.r.get(RECONCILE_STUCK_LOCK_KEY) == 'someone-else'
+    )
+
+
+@pytest.mark.django_db
+def test_reconcile_lock_released_after_clean_run(
+    eager_celery_reconcile: None,
+) -> None:
+    """The ``finally`` block must release our token so the next beat
+    tick can run."""
+    _make_stuck_asset(processing_started_at=None, mimetype='video')
+
+    with mock.patch('anthias_server.processing.dispatch_normalize_video'):
+        reconcile_stuck_processing.apply()
+
+    assert celery_tasks_module.r.get(RECONCILE_STUCK_LOCK_KEY) is None

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -961,3 +961,242 @@ def test_download_youtube_asset_on_failure_writes_error_metadata() -> None:
     assert 'RuntimeError' in a.metadata['error_message']
     assert '404 Not Found' in a.metadata['error_message']
     mock_notify.assert_called_once_with('yt-1')
+
+
+# ---------------------------------------------------------------------------
+# reconcile_stuck_processing (periodic recovery for is_processing=True
+# rows that never finished — GH #2870 second-line defence)
+# ---------------------------------------------------------------------------
+
+
+from datetime import timedelta  # noqa: E402
+
+from django.utils import timezone  # noqa: E402
+
+from anthias_server.celery_tasks import (  # noqa: E402
+    RECONCILE_STUCK_THRESHOLD_S,
+    reconcile_stuck_processing,
+)
+
+
+def _make_stuck_asset(
+    *,
+    asset_id: str = 'stuck-1',
+    mimetype: str = 'video',
+    is_processing: bool = True,
+    processing_started_at: object = None,
+    extra_metadata: dict[str, object] | None = None,
+) -> Asset:
+    """Build a row in the state the reconciler is meant to find.
+
+    The metadata key is the load-bearing field — every age-based
+    decision the reconciler makes is driven by it.
+    """
+    metadata: dict[str, object] = {}
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    if processing_started_at is not None:
+        metadata['processing_started_at'] = processing_started_at
+    return Asset.objects.create(
+        asset_id=asset_id,
+        name=asset_id,
+        uri=f'/data/anthias_assets/{asset_id}.mp4',
+        mimetype=mimetype,
+        duration=10,
+        is_enabled=True,
+        is_processing=is_processing,
+        metadata=metadata,
+    )
+
+
+@pytest.fixture
+def eager_celery_reconcile() -> None:
+    celeryapp.conf.update(
+        CELERY_ALWAYS_EAGER=True,
+        CELERY_RESULT_BACKEND='',
+        CELERY_BROKER_URL='',
+    )
+    Asset.objects.all().delete()
+
+
+@pytest.mark.django_db
+def test_reconcile_skips_rows_within_grace_window(
+    eager_celery_reconcile: None,
+) -> None:
+    """A row whose ``processing_started_at`` is younger than the
+    threshold belongs to an in-flight task — leave it alone."""
+    young = (
+        timezone.now() - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S - 60)
+    ).isoformat()
+    _make_stuck_asset(processing_started_at=young, mimetype='video')
+
+    with (
+        mock.patch(
+            'anthias_server.processing.dispatch_normalize_video'
+        ) as mock_video,
+        mock.patch(
+            'anthias_server.processing.dispatch_normalize_image'
+        ) as mock_image,
+    ):
+        reconcile_stuck_processing.apply()
+
+    mock_video.assert_not_called()
+    mock_image.assert_not_called()
+    # Row left as-is — still flagged so the actual task can finish.
+    assert Asset.objects.get(asset_id='stuck-1').is_processing is True
+
+
+@pytest.mark.django_db
+def test_reconcile_redispatches_stuck_video(
+    eager_celery_reconcile: None,
+) -> None:
+    """An ``is_processing=True`` video row older than the threshold
+    is re-dispatched through ``dispatch_normalize_video`` — recovers
+    rows whose worker crashed between enqueue and pickup."""
+    old = (
+        timezone.now() - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S + 60)
+    ).isoformat()
+    _make_stuck_asset(processing_started_at=old, mimetype='video')
+
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as mock_video:
+        reconcile_stuck_processing.apply()
+
+    mock_video.assert_called_once_with('stuck-1')
+
+
+@pytest.mark.django_db
+def test_reconcile_redispatches_stuck_image(
+    eager_celery_reconcile: None,
+) -> None:
+    """Same recovery path applies to image-mimetype rows."""
+    old = (
+        timezone.now() - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S + 60)
+    ).isoformat()
+    _make_stuck_asset(
+        asset_id='stuck-img',
+        processing_started_at=old,
+        mimetype='image',
+    )
+
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_image'
+    ) as mock_image:
+        reconcile_stuck_processing.apply()
+
+    mock_image.assert_called_once_with('stuck-img')
+
+
+@pytest.mark.django_db
+def test_reconcile_stamps_unstamped_row_on_first_sweep(
+    eager_celery_reconcile: None,
+) -> None:
+    """Legacy / backup-restored rows have no
+    ``metadata.processing_started_at``. The first sweep stamps it so
+    the next sweep can apply the age threshold uniformly — gives the
+    full grace window in case a task is actually still running.
+    Crucially the first sweep must NOT re-dispatch (otherwise a
+    still-in-flight task gets a duplicate)."""
+    _make_stuck_asset(
+        asset_id='unstamped',
+        processing_started_at=None,
+        mimetype='video',
+    )
+
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as mock_video:
+        reconcile_stuck_processing.apply()
+
+    mock_video.assert_not_called()
+    a = Asset.objects.get(asset_id='unstamped')
+    assert a.is_processing is True
+    assert 'processing_started_at' in a.metadata
+
+
+@pytest.mark.django_db
+def test_reconcile_clears_flag_on_unknown_mimetype(
+    eager_celery_reconcile: None,
+) -> None:
+    """A row with a mimetype neither image nor video that's stuck
+    past the threshold has no clear re-dispatch path. Clear the
+    flag and surface an error so the operator can interact with it."""
+    old = (
+        timezone.now() - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S + 60)
+    ).isoformat()
+    _make_stuck_asset(
+        asset_id='weird',
+        processing_started_at=old,
+        mimetype='webpage',
+    )
+
+    with (
+        mock.patch(
+            'anthias_server.processing.dispatch_normalize_video'
+        ) as mock_video,
+        mock.patch(
+            'anthias_server.processing.dispatch_normalize_image'
+        ) as mock_image,
+        mock.patch('anthias_server.app.consumers.notify_asset_update'),
+    ):
+        reconcile_stuck_processing.apply()
+
+    mock_video.assert_not_called()
+    mock_image.assert_not_called()
+    a = Asset.objects.get(asset_id='weird')
+    assert a.is_processing is False
+    assert 'reconciler' in a.metadata.get('error_message', '').lower()
+
+
+@pytest.mark.django_db
+def test_reconcile_treats_malformed_timestamp_as_unstamped(
+    eager_celery_reconcile: None,
+) -> None:
+    """A non-parseable ``processing_started_at`` (e.g. from a
+    hand-edited backup) must follow the same "stamp on first sight"
+    recovery path — never raise during sweep."""
+    _make_stuck_asset(
+        asset_id='bad-ts',
+        processing_started_at='not a timestamp',
+        mimetype='video',
+    )
+
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as mock_video:
+        reconcile_stuck_processing.apply()
+
+    mock_video.assert_not_called()
+    a = Asset.objects.get(asset_id='bad-ts')
+    # Fresh stamp written; existing extra metadata preserved.
+    parsed = a.metadata['processing_started_at']
+    assert parsed != 'not a timestamp'
+    # The new value is a valid ISO-8601 string.
+    from datetime import datetime
+
+    datetime.fromisoformat(parsed)
+
+
+@pytest.mark.django_db
+def test_reconcile_skips_rows_not_processing(
+    eager_celery_reconcile: None,
+) -> None:
+    """``is_processing=False`` rows aren't the reconciler's business,
+    regardless of any stale ``processing_started_at`` left in metadata
+    from a previous run."""
+    old = (
+        timezone.now() - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S + 60)
+    ).isoformat()
+    _make_stuck_asset(
+        asset_id='not-processing',
+        is_processing=False,
+        processing_started_at=old,
+    )
+
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as mock_video:
+        reconcile_stuck_processing.apply()
+
+    mock_video.assert_not_called()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1785,14 +1785,14 @@ def test_needs_image_normalisation(filename: str, expected: bool) -> None:
 
 
 def test_dispatch_normalize_image_invokes_celery_task() -> None:
-    # ``_stamp_processing_start`` writes ``metadata.processing_started_at``
+    # ``stamp_processing_start`` writes ``metadata.processing_started_at``
     # for the reconciler — irrelevant to this delay-was-called check, so
     # mocked out to keep the test off the DB.
     with (
         mock.patch(
             'anthias_server.celery_tasks.normalize_image_asset.delay'
         ) as delay,
-        mock.patch('anthias_server.processing._stamp_processing_start'),
+        mock.patch('anthias_server.processing.stamp_processing_start'),
     ):
         processing.dispatch_normalize_image('asset-1')
     delay.assert_called_once_with('asset-1')
@@ -1803,7 +1803,7 @@ def test_dispatch_normalize_video_invokes_celery_task() -> None:
         mock.patch(
             'anthias_server.celery_tasks.normalize_video_asset.delay'
         ) as delay,
-        mock.patch('anthias_server.processing._stamp_processing_start'),
+        mock.patch('anthias_server.processing.stamp_processing_start'),
     ):
         processing.dispatch_normalize_video('asset-2')
     delay.assert_called_once_with('asset-2')

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1785,19 +1785,126 @@ def test_needs_image_normalisation(filename: str, expected: bool) -> None:
 
 
 def test_dispatch_normalize_image_invokes_celery_task() -> None:
-    with mock.patch(
-        'anthias_server.celery_tasks.normalize_image_asset.delay'
-    ) as delay:
+    # ``_stamp_processing_start`` writes ``metadata.processing_started_at``
+    # for the reconciler — irrelevant to this delay-was-called check, so
+    # mocked out to keep the test off the DB.
+    with (
+        mock.patch(
+            'anthias_server.celery_tasks.normalize_image_asset.delay'
+        ) as delay,
+        mock.patch('anthias_server.processing._stamp_processing_start'),
+    ):
         processing.dispatch_normalize_image('asset-1')
     delay.assert_called_once_with('asset-1')
 
 
 def test_dispatch_normalize_video_invokes_celery_task() -> None:
-    with mock.patch(
-        'anthias_server.celery_tasks.normalize_video_asset.delay'
-    ) as delay:
+    with (
+        mock.patch(
+            'anthias_server.celery_tasks.normalize_video_asset.delay'
+        ) as delay,
+        mock.patch('anthias_server.processing._stamp_processing_start'),
+    ):
         processing.dispatch_normalize_video('asset-2')
     delay.assert_called_once_with('asset-2')
+
+
+@pytest.mark.django_db
+def test_dispatch_normalize_video_stamps_processing_started_at() -> None:
+    """``dispatch_normalize_video`` writes
+    ``metadata.processing_started_at`` so the periodic reconciler can
+    age the row. Regression guard for GH #2870's second fix line —
+    without the stamp, a stuck row has no signal the reconciler can
+    use to decide whether enough time has elapsed to re-dispatch."""
+    Asset.objects.create(
+        asset_id='stamped-vid',
+        name='Test',
+        uri='/data/anthias_assets/stamped-vid.mp4',
+        mimetype='video',
+        duration=10,
+        is_enabled=True,
+        is_processing=True,
+        metadata={'foo': 'bar'},
+    )
+    with mock.patch('anthias_server.celery_tasks.normalize_video_asset.delay'):
+        processing.dispatch_normalize_video('stamped-vid')
+    a = Asset.objects.get(asset_id='stamped-vid')
+    assert 'processing_started_at' in a.metadata
+    # Existing metadata keys preserved.
+    assert a.metadata['foo'] == 'bar'
+    # The stamp is a valid ISO-8601 string.
+    from datetime import datetime
+
+    datetime.fromisoformat(a.metadata['processing_started_at'])
+
+
+class _FakeSerializer:
+    """Stand-in for the four API serializer classes — the dispatch
+    helper only reads ``_pending_normalize``, so a minimal duck type
+    is enough to test the branch logic without spinning up DRF."""
+
+    def __init__(self, pending: str | None) -> None:
+        self._pending_normalize = pending
+
+
+def test_dispatch_pending_normalize_routes_video() -> None:
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as v, mock.patch(
+        'anthias_server.processing.dispatch_normalize_image'
+    ) as i:
+        processing.dispatch_pending_normalize(
+            _FakeSerializer('video'), 'asset-vid'
+        )
+    v.assert_called_once_with('asset-vid')
+    i.assert_not_called()
+
+
+def test_dispatch_pending_normalize_routes_image() -> None:
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as v, mock.patch(
+        'anthias_server.processing.dispatch_normalize_image'
+    ) as i:
+        processing.dispatch_pending_normalize(
+            _FakeSerializer('image'), 'asset-img'
+        )
+    i.assert_called_once_with('asset-img')
+    v.assert_not_called()
+
+
+def test_dispatch_pending_normalize_noop_when_unset() -> None:
+    """A serializer that didn't flag normalisation (most uploads:
+    JPEG/PNG/H.264) leaves the helper as a no-op — no spurious
+    Celery dispatch."""
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as v, mock.patch(
+        'anthias_server.processing.dispatch_normalize_image'
+    ) as i:
+        processing.dispatch_pending_normalize(
+            _FakeSerializer(None), 'asset-plain'
+        )
+    v.assert_not_called()
+    i.assert_not_called()
+
+
+def test_dispatch_pending_normalize_handles_missing_attribute() -> None:
+    """A serializer class that doesn't carry ``_pending_normalize``
+    at all must not crash — defends against a future serializer
+    that doesn't route through the shared mixin."""
+
+    class _Bare:
+        pass
+
+    with mock.patch(
+        'anthias_server.processing.dispatch_normalize_video'
+    ) as v, mock.patch(
+        'anthias_server.processing.dispatch_normalize_image'
+    ) as i:
+        processing.dispatch_pending_normalize(_Bare(), 'asset-bare')
+    v.assert_not_called()
+    i.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1848,11 +1848,10 @@ class _FakeSerializer:
 
 
 def test_dispatch_pending_normalize_routes_video() -> None:
-    with mock.patch(
-        'anthias_server.processing.dispatch_normalize_video'
-    ) as v, mock.patch(
-        'anthias_server.processing.dispatch_normalize_image'
-    ) as i:
+    with (
+        mock.patch('anthias_server.processing.dispatch_normalize_video') as v,
+        mock.patch('anthias_server.processing.dispatch_normalize_image') as i,
+    ):
         processing.dispatch_pending_normalize(
             _FakeSerializer('video'), 'asset-vid'
         )
@@ -1861,11 +1860,10 @@ def test_dispatch_pending_normalize_routes_video() -> None:
 
 
 def test_dispatch_pending_normalize_routes_image() -> None:
-    with mock.patch(
-        'anthias_server.processing.dispatch_normalize_video'
-    ) as v, mock.patch(
-        'anthias_server.processing.dispatch_normalize_image'
-    ) as i:
+    with (
+        mock.patch('anthias_server.processing.dispatch_normalize_video') as v,
+        mock.patch('anthias_server.processing.dispatch_normalize_image') as i,
+    ):
         processing.dispatch_pending_normalize(
             _FakeSerializer('image'), 'asset-img'
         )
@@ -1877,11 +1875,10 @@ def test_dispatch_pending_normalize_noop_when_unset() -> None:
     """A serializer that didn't flag normalisation (most uploads:
     JPEG/PNG/H.264) leaves the helper as a no-op — no spurious
     Celery dispatch."""
-    with mock.patch(
-        'anthias_server.processing.dispatch_normalize_video'
-    ) as v, mock.patch(
-        'anthias_server.processing.dispatch_normalize_image'
-    ) as i:
+    with (
+        mock.patch('anthias_server.processing.dispatch_normalize_video') as v,
+        mock.patch('anthias_server.processing.dispatch_normalize_image') as i,
+    ):
         processing.dispatch_pending_normalize(
             _FakeSerializer(None), 'asset-plain'
         )
@@ -1897,11 +1894,10 @@ def test_dispatch_pending_normalize_handles_missing_attribute() -> None:
     class _Bare:
         pass
 
-    with mock.patch(
-        'anthias_server.processing.dispatch_normalize_video'
-    ) as v, mock.patch(
-        'anthias_server.processing.dispatch_normalize_image'
-    ) as i:
+    with (
+        mock.patch('anthias_server.processing.dispatch_normalize_video') as v,
+        mock.patch('anthias_server.processing.dispatch_normalize_image') as i,
+    ):
         processing.dispatch_pending_normalize(_Bare(), 'asset-bare')
     v.assert_not_called()
     i.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.5.0"
+version = "2026.5.1"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -178,7 +178,6 @@ server = [
     { name = "django-stubs-ext" },
     { name = "djangorestframework" },
     { name = "drf-spectacular" },
-    { name = "hurry-filesize" },
     { name = "jinja2" },
     { name = "netifaces" },
     { name = "packaging" },
@@ -209,7 +208,6 @@ test = [
     { name = "django-stubs-ext" },
     { name = "djangorestframework" },
     { name = "drf-spectacular" },
-    { name = "hurry-filesize" },
     { name = "jinja2" },
     { name = "netifaces" },
     { name = "packaging" },
@@ -347,7 +345,6 @@ server = [
     { name = "django-stubs-ext", specifier = "==6.0.3" },
     { name = "djangorestframework", specifier = "==3.16.1" },
     { name = "drf-spectacular", specifier = "==0.29.0" },
-    { name = "hurry-filesize", specifier = "==0.9" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "netifaces", specifier = "==0.11.0" },
     { name = "packaging", specifier = "==26.1" },
@@ -378,7 +375,6 @@ test = [
     { name = "django-stubs-ext", specifier = "==6.0.3" },
     { name = "djangorestframework", specifier = "==3.16.1" },
     { name = "drf-spectacular", specifier = "==0.29.0" },
-    { name = "hurry-filesize", specifier = "==0.9" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "netifaces", specifier = "==0.11.0" },
     { name = "packaging", specifier = "==26.1" },
@@ -1035,15 +1031,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
     { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
 ]
-
-[[package]]
-name = "hurry-filesize"
-version = "0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/5e/16e17bedcf54d5b618dc0771690deda77178e5c310402881c3d2d6c5f27c/hurry.filesize-0.9.tar.gz", hash = "sha256:f5368329adbef86accd3bc9490522340bb79260455ae89b1a42c10f63801b9a6", size = 2810, upload-time = "2009-03-11T23:15:40.615Z" }
 
 [[package]]
 name = "idna"
@@ -1973,15 +1960,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
     { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
     { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "79.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/71/b6365e6325b3290e14957b2c3a804a529968c77a049b2ed40c095f749707/setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88", size = 1367909, upload-time = "2025-04-23T22:20:59.241Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/6d/b4752b044bf94cb802d88a888dc7d288baaf77d7910b7dedda74b5ceea0c/setuptools-79.0.1-py3-none-any.whl", hash = "sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51", size = 1256281, upload-time = "2025-04-23T22:20:56.768Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Issues Fixed

Closes #2870.

### Description

Two-line defence against the v1 / v1.1 video-upload normalize gap.

**1. Root cause — v1 / v1.1 never dispatched normalize.**
A shared `dispatch_pending_normalize(serializer, asset_id)` helper now
runs after `Asset.objects.create(...)` in all four `AssetListView.post`
methods, branching on the serializer's `_pending_normalize` flag.
`CreateAssetSerializerV1_1` was also updated to set
`_pending_normalize='video'` and `is_processing=1` on local video
uploads — pre-fix, those rows landed in whatever codec the operator
sent (MPEG-1 in the issue's repro) and the per-board passthrough set
silently dropped them from rotation forever. Image normalisation stays
opt-in via v1.2 / v2 only; promoting it onto the legacy endpoints
would shift synchronous-availability semantics for older clients.

**2. Reconciler safety-net.**
New `reconcile_stuck_processing` celery-beat task (10-min cadence,
60-min threshold — longer than `NORMALIZE_VIDEO_TIME_LIMIT_S=30min`)
recovers rows whose normalize task was lost mid-flight (worker
SIGKILL, OOM, backup restore that bypassed dispatch, Redis flake
during `.delay()`). Ages rows via `metadata.processing_started_at`,
stamped by each dispatch helper. Rows missing the stamp (legacy /
restored) get stamped on first sight for the full grace window; the
next sweep applies the threshold uniformly.

**Bonus: drop `hurry.filesize`.**
Five call sites swapped to `django.template.defaultfilters.filesizeformat`.
Wire-format change on `/api/v*/info.free_space` and home-page disk
fields: `"15G"` → `"15.0 GB"` (NBSP separator, decimal, full unit).
The `hurry.filesize` pin is dropped from `pyproject.toml` (deps +
mypy override) and `uv.lock`.

Version bumped to **2026.05.1** in `pyproject.toml` / `package.json` /
`uv.lock`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added documentation for the changes I have made (when necessary).