### PR TITLE
fix(viewer): skip deleted/deactivated asset immediately

### DIFF
--- a/src/anthias_server/api/helpers.py
+++ b/src/anthias_server/api/helpers.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
 from anthias_server.app.models import Asset
+from anthias_server.settings import ViewerPublisher
 
 
 class AssetCreationError(Exception):
@@ -68,6 +69,32 @@ def get_active_asset_ids() -> list[str]:
 def save_active_assets_ordering(active_asset_ids: list[str]) -> None:
     for i, asset_id in enumerate(active_asset_ids):
         Asset.objects.filter(asset_id=asset_id).update(play_order=i)
+
+
+def finalize_asset_update(asset: Asset) -> None:
+    """Post-save housekeeping shared by v1_2/v2 ``AssetView.update``.
+
+    Reorders the active-asset list around the just-saved row's new
+    activeness (an edit can flip is_enabled, push the row out of its
+    date range, or trip its play_days / play_time window) and wakes
+    the viewer so it can skip past the asset if it's still on screen
+    but no longer active (issue #2430).
+    """
+    active_asset_ids = get_active_asset_ids()
+    asset.refresh_from_db()
+
+    try:
+        active_asset_ids.remove(asset.asset_id)
+    except ValueError:
+        pass
+
+    if asset.is_active():
+        active_asset_ids.insert(asset.play_order, asset.asset_id)
+
+    save_active_assets_ordering(active_asset_ids)
+    asset.refresh_from_db()
+
+    ViewerPublisher.get_instance().send_to_viewer('reload')
 
 
 def parse_request(request: Any) -> Any:

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -582,50 +582,30 @@ def test_delete_asset_publishes_reload(
 
 
 @pytest.mark.django_db
-@mock.patch('anthias_server.api.views.v2.ViewerPublisher')
-def test_v2_update_asset_publishes_reload(
-    publisher_mock: Any, api_client: APIClient
+@pytest.mark.parametrize(
+    'version,publisher_target',
+    [
+        ('v1', 'anthias_server.api.views.v1.ViewerPublisher'),
+        ('v1_2', 'anthias_server.api.helpers.ViewerPublisher'),
+        ('v2', 'anthias_server.api.helpers.ViewerPublisher'),
+    ],
+)
+def test_update_asset_publishes_reload(
+    api_client: APIClient, version: str, publisher_target: str
 ) -> None:
-    publisher_instance = mock.MagicMock()
-    publisher_mock.get_instance.return_value = publisher_instance
+    """v1.put writes its own publish; v1_2/v2 share the helper."""
+    with mock.patch(publisher_target) as publisher_mock:
+        publisher_instance = mock.MagicMock()
+        publisher_mock.get_instance.return_value = publisher_instance
 
-    asset = _create_asset(api_client, ASSET_CREATION_DATA, 'v2')
+        asset = _create_asset(api_client, ASSET_CREATION_DATA, version)
+        data = (
+            ASSET_UPDATE_DATA_V2 if version == 'v2' else ASSET_UPDATE_DATA_V1_2
+        )
 
-    _update_asset(api_client, asset['asset_id'], ASSET_UPDATE_DATA_V2, 'v2')
+        _update_asset(api_client, asset['asset_id'], data, version)
 
-    publisher_instance.send_to_viewer.assert_called_once_with('reload')
-
-
-@pytest.mark.django_db
-@mock.patch('anthias_server.api.views.v1.ViewerPublisher')
-def test_v1_update_asset_publishes_reload(
-    publisher_mock: Any, api_client: APIClient
-) -> None:
-    publisher_instance = mock.MagicMock()
-    publisher_mock.get_instance.return_value = publisher_instance
-
-    asset = _create_asset(api_client, ASSET_CREATION_DATA, 'v1')
-
-    _update_asset(api_client, asset['asset_id'], ASSET_UPDATE_DATA_V1_2, 'v1')
-
-    publisher_instance.send_to_viewer.assert_called_once_with('reload')
-
-
-@pytest.mark.django_db
-@mock.patch('anthias_server.api.views.v1_2.ViewerPublisher')
-def test_v1_2_update_asset_publishes_reload(
-    publisher_mock: Any, api_client: APIClient
-) -> None:
-    publisher_instance = mock.MagicMock()
-    publisher_mock.get_instance.return_value = publisher_instance
-
-    asset = _create_asset(api_client, ASSET_CREATION_DATA, 'v1_2')
-
-    _update_asset(
-        api_client, asset['asset_id'], ASSET_UPDATE_DATA_V1_2, 'v1_2'
-    )
-
-    publisher_instance.send_to_viewer.assert_called_once_with('reload')
+        publisher_instance.send_to_viewer.assert_called_once_with('reload')
 
 
 @pytest.mark.django_db

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -551,3 +551,99 @@ def test_create_youtube_asset_dispatches_celery_task(
     }.items():
         if v != version:
             m.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Viewer wake-ups on mutation — issue #2430
+# ---------------------------------------------------------------------------
+#
+# Delete / update / reorder must publish ``reload`` so the viewer can
+# advance past the just-modified asset instead of finishing its
+# originally-scheduled duration on screen. The viewer-side decision of
+# whether to actually skip lives in _skip_if_current_asset_inactive
+# (tested in tests/test_viewer.py); here we just assert the wake-up
+# is sent.
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+@mock.patch('anthias_server.api.views.mixins.ViewerPublisher')
+def test_delete_asset_publishes_reload(
+    publisher_mock: Any, api_client: APIClient, version: str
+) -> None:
+    publisher_instance = mock.MagicMock()
+    publisher_mock.get_instance.return_value = publisher_instance
+
+    asset = _create_asset(api_client, ASSET_CREATION_DATA, version)
+    response = _delete_asset(api_client, asset['asset_id'], version)
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    publisher_instance.send_to_viewer.assert_called_once_with('reload')
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v2.ViewerPublisher')
+def test_v2_update_asset_publishes_reload(
+    publisher_mock: Any, api_client: APIClient
+) -> None:
+    publisher_instance = mock.MagicMock()
+    publisher_mock.get_instance.return_value = publisher_instance
+
+    asset = _create_asset(api_client, ASSET_CREATION_DATA, 'v2')
+
+    _update_asset(api_client, asset['asset_id'], ASSET_UPDATE_DATA_V2, 'v2')
+
+    publisher_instance.send_to_viewer.assert_called_once_with('reload')
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v1.ViewerPublisher')
+def test_v1_update_asset_publishes_reload(
+    publisher_mock: Any, api_client: APIClient
+) -> None:
+    publisher_instance = mock.MagicMock()
+    publisher_mock.get_instance.return_value = publisher_instance
+
+    asset = _create_asset(api_client, ASSET_CREATION_DATA, 'v1')
+
+    _update_asset(api_client, asset['asset_id'], ASSET_UPDATE_DATA_V1_2, 'v1')
+
+    publisher_instance.send_to_viewer.assert_called_once_with('reload')
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v1_2.ViewerPublisher')
+def test_v1_2_update_asset_publishes_reload(
+    publisher_mock: Any, api_client: APIClient
+) -> None:
+    publisher_instance = mock.MagicMock()
+    publisher_mock.get_instance.return_value = publisher_instance
+
+    asset = _create_asset(api_client, ASSET_CREATION_DATA, 'v1_2')
+
+    _update_asset(
+        api_client, asset['asset_id'], ASSET_UPDATE_DATA_V1_2, 'v1_2'
+    )
+
+    publisher_instance.send_to_viewer.assert_called_once_with('reload')
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url_name', ['api:playlist_order_v1', 'api:playlist_order_v2']
+)
+@mock.patch('anthias_server.api.views.mixins.ViewerPublisher')
+def test_playlist_order_publishes_reload(
+    publisher_mock: Any, api_client: APIClient, url_name: str
+) -> None:
+    publisher_instance = mock.MagicMock()
+    publisher_mock.get_instance.return_value = publisher_instance
+
+    asset = _create_asset(api_client, ASSET_CREATION_DATA, 'v2')
+
+    response = api_client.post(
+        reverse(url_name), data={'ids': asset['asset_id']}
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    publisher_instance.send_to_viewer.assert_called_once_with('reload')

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -557,12 +557,11 @@ def test_create_youtube_asset_dispatches_celery_task(
 # Viewer wake-ups on mutation — issue #2430
 # ---------------------------------------------------------------------------
 #
-# Delete / update / reorder must publish ``reload`` so the viewer can
-# advance past the just-modified asset instead of finishing its
-# originally-scheduled duration on screen. The viewer-side decision of
-# whether to actually skip lives in _skip_if_current_asset_inactive
-# (tested in tests/test_viewer.py); here we just assert the wake-up
-# is sent.
+# Delete / update must publish ``reload`` so the viewer can advance
+# past the just-modified asset instead of finishing its originally-
+# scheduled duration on screen. The viewer-side decision of whether to
+# actually skip lives in _skip_if_current_asset_inactive (tested in
+# tests/test_viewer.py); here we just assert the wake-up is sent.
 
 
 @pytest.mark.django_db
@@ -586,6 +585,7 @@ def test_delete_asset_publishes_reload(
     'version,publisher_target',
     [
         ('v1', 'anthias_server.api.views.v1.ViewerPublisher'),
+        ('v1_1', 'anthias_server.api.views.v1_1.ViewerPublisher'),
         ('v1_2', 'anthias_server.api.helpers.ViewerPublisher'),
         ('v2', 'anthias_server.api.helpers.ViewerPublisher'),
     ],
@@ -593,7 +593,7 @@ def test_delete_asset_publishes_reload(
 def test_update_asset_publishes_reload(
     api_client: APIClient, version: str, publisher_target: str
 ) -> None:
-    """v1.put writes its own publish; v1_2/v2 share the helper."""
+    """v1.x put writes its own publish; v1_2/v2 share the helper."""
     with mock.patch(publisher_target) as publisher_mock:
         publisher_instance = mock.MagicMock()
         publisher_mock.get_instance.return_value = publisher_instance
@@ -606,24 +606,3 @@ def test_update_asset_publishes_reload(
         _update_asset(api_client, asset['asset_id'], data, version)
 
         publisher_instance.send_to_viewer.assert_called_once_with('reload')
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    'url_name', ['api:playlist_order_v1', 'api:playlist_order_v2']
-)
-@mock.patch('anthias_server.api.views.mixins.ViewerPublisher')
-def test_playlist_order_publishes_reload(
-    publisher_mock: Any, api_client: APIClient, url_name: str
-) -> None:
-    publisher_instance = mock.MagicMock()
-    publisher_mock.get_instance.return_value = publisher_instance
-
-    asset = _create_asset(api_client, ASSET_CREATION_DATA, 'v2')
-
-    response = api_client.post(
-        reverse(url_name), data={'ids': asset['asset_id']}
-    )
-
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-    publisher_instance.send_to_viewer.assert_called_once_with('reload')

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -301,11 +301,6 @@ class PlaylistOrderViewMixin(APIView):
         asset_ids = request.data.get('ids', '').split(',')
         save_active_assets_ordering(asset_ids)
 
-        # Reordering can drop an asset from the active set (it's now
-        # absent from the ids list). Notify the viewer so it can skip
-        # past the displayed asset if that happened (issue #2430).
-        ViewerPublisher.get_instance().send_to_viewer('reload')
-
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -50,6 +50,12 @@ class DeleteAssetViewMixin:
 
         asset.delete()
 
+        # Wake the viewer so it can advance past the just-deleted asset
+        # instead of finishing its remaining ``duration`` on screen
+        # (issue #2430). The viewer's reload handler checks whether the
+        # currently-displayed asset is still active and skips if not.
+        ViewerPublisher.get_instance().send_to_viewer('reload')
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -294,6 +300,11 @@ class PlaylistOrderViewMixin(APIView):
     def post(self, request: Request) -> Response:
         asset_ids = request.data.get('ids', '').split(',')
         save_active_assets_ordering(asset_ids)
+
+        # Reordering can drop an asset from the active set (it's now
+        # absent from the ids list). Notify the viewer so it can skip
+        # past the displayed asset if that happened (issue #2430).
+        ViewerPublisher.get_instance().send_to_viewer('reload')
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/src/anthias_server/api/views/v1.py
+++ b/src/anthias_server/api/views/v1.py
@@ -116,6 +116,12 @@ class AssetViewV1(APIView, DeleteAssetViewMixin):
             )
 
         asset.refresh_from_db()
+
+        # See AssetViewV2.update — wake the viewer so a just-edited
+        # asset that's still on screen but no longer active gets
+        # skipped (issue #2430).
+        ViewerPublisher.get_instance().send_to_viewer('reload')
+
         return Response(AssetSerializer(asset).data)
 
 

--- a/src/anthias_server/api/views/v1_1.py
+++ b/src/anthias_server/api/views/v1_1.py
@@ -15,6 +15,7 @@ from anthias_server.api.serializers.v1_1 import CreateAssetSerializerV1_1
 from anthias_server.api.views.mixins import DeleteAssetViewMixin
 from anthias_server.api.views.v1 import V1_ASSET_REQUEST
 from anthias_server.lib.auth import authorized
+from anthias_server.settings import ViewerPublisher
 
 
 class AssetListViewV1_1(APIView):
@@ -88,4 +89,10 @@ class AssetViewV1_1(APIView, DeleteAssetViewMixin):
             )
 
         asset.refresh_from_db()
+
+        # See AssetViewV2.update — wake the viewer so a just-edited
+        # asset that's still on screen but no longer active gets
+        # skipped (issue #2430).
+        ViewerPublisher.get_instance().send_to_viewer('reload')
+
         return Response(AssetSerializer(asset).data)

--- a/src/anthias_server/api/views/v1_2.py
+++ b/src/anthias_server/api/views/v1_2.py
@@ -12,6 +12,7 @@ from anthias_server.processing import (
 )
 from anthias_server.api.helpers import (
     AssetCreationError,
+    finalize_asset_update,
     get_active_asset_ids,
     save_active_assets_ordering,
 )
@@ -22,7 +23,6 @@ from anthias_server.api.serializers import (
 from anthias_server.api.serializers.v1_2 import CreateAssetSerializerV1_2
 from anthias_server.api.views.mixins import DeleteAssetViewMixin
 from anthias_server.lib.auth import authorized
-from anthias_server.settings import ViewerPublisher
 
 
 class AssetListViewV1_2(APIView):
@@ -114,25 +114,7 @@ class AssetViewV1_2(APIView, DeleteAssetViewMixin):
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
 
-        active_asset_ids = get_active_asset_ids()
-
-        asset.refresh_from_db()
-
-        try:
-            active_asset_ids.remove(asset.asset_id)
-        except ValueError:
-            pass
-
-        if asset.is_active():
-            active_asset_ids.insert(asset.play_order, asset.asset_id)
-
-        save_active_assets_ordering(active_asset_ids)
-        asset.refresh_from_db()
-
-        # See AssetViewV2.update — wake the viewer so a just-edited
-        # asset that's still on screen but no longer active gets
-        # skipped (issue #2430).
-        ViewerPublisher.get_instance().send_to_viewer('reload')
+        finalize_asset_update(asset)
 
         return Response(AssetSerializer(asset).data)
 

--- a/src/anthias_server/api/views/v1_2.py
+++ b/src/anthias_server/api/views/v1_2.py
@@ -22,6 +22,7 @@ from anthias_server.api.serializers import (
 from anthias_server.api.serializers.v1_2 import CreateAssetSerializerV1_2
 from anthias_server.api.views.mixins import DeleteAssetViewMixin
 from anthias_server.lib.auth import authorized
+from anthias_server.settings import ViewerPublisher
 
 
 class AssetListViewV1_2(APIView):
@@ -127,6 +128,11 @@ class AssetViewV1_2(APIView, DeleteAssetViewMixin):
 
         save_active_assets_ordering(active_asset_ids)
         asset.refresh_from_db()
+
+        # See AssetViewV2.update — wake the viewer so a just-edited
+        # asset that's still on screen but no longer active gets
+        # skipped (issue #2430).
+        ViewerPublisher.get_instance().send_to_viewer('reload')
 
         return Response(AssetSerializer(asset).data)
 

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -431,6 +431,13 @@ class AssetViewV2(APIView, DeleteAssetViewMixin):
         save_active_assets_ordering(active_asset_ids)
         asset.refresh_from_db()
 
+        # An edit can flip is_enabled or push the asset out of its
+        # date / play_days / play_time window — both effectively
+        # deactivate it. Tell the viewer so it can skip past the row
+        # immediately instead of finishing the originally scheduled
+        # duration (issue #2430).
+        ViewerPublisher.get_instance().send_to_viewer('reload')
+
         return Response(AssetSerializerV2(asset).data)
 
     @extend_schema(

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -23,6 +23,7 @@ from anthias_server.app.helpers import (
 from anthias_server.app.models import Asset
 from anthias_server.api.helpers import (
     AssetCreationError,
+    finalize_asset_update,
     get_active_asset_ids,
     save_active_assets_ordering,
 )
@@ -416,27 +417,7 @@ class AssetViewV2(APIView, DeleteAssetViewMixin):
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
 
-        active_asset_ids = get_active_asset_ids()
-
-        asset.refresh_from_db()
-
-        try:
-            active_asset_ids.remove(asset.asset_id)
-        except ValueError:
-            pass
-
-        if asset.is_active():
-            active_asset_ids.insert(asset.play_order, asset.asset_id)
-
-        save_active_assets_ordering(active_asset_ids)
-        asset.refresh_from_db()
-
-        # An edit can flip is_enabled or push the asset out of its
-        # date / play_days / play_time window — both effectively
-        # deactivate it. Tell the viewer so it can skip past the row
-        # immediately instead of finishing the originally scheduled
-        # duration (issue #2430).
-        ViewerPublisher.get_instance().send_to_viewer('reload')
+        finalize_asset_update(asset)
 
         return Response(AssetSerializerV2(asset).data)
 

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -44,6 +44,7 @@ from anthias_common.utils import (  # noqa: E402
     detect_screen_resolution,
     string_to_bool,
 )
+from anthias_server.app.models import Asset  # noqa: E402
 from anthias_server.app.models import clamp_refresh_interval  # noqa: E402
 from anthias_viewer.messaging import ViewerSubscriber  # noqa: E402
 from anthias_viewer.scheduling import Scheduler  # noqa: E402
@@ -105,7 +106,7 @@ commands = {
     'next': lambda _: skip_asset(scheduler),
     'previous': lambda _: skip_asset(scheduler, back=True),
     'asset': lambda asset_id: navigate_to_asset(scheduler, asset_id),
-    'reload': lambda _: load_settings(),
+    'reload': lambda _: _handle_reload(),
     'stop': lambda _: setattr(
         __import__('__main__'), 'loop_is_stopped', stop_loop(scheduler)
     ),
@@ -274,6 +275,51 @@ def load_settings() -> None:
     logging.getLogger().setLevel(
         logging.DEBUG if settings['debug_logging'] else logging.INFO
     )
+
+
+def _handle_reload() -> None:
+    """Process a ``reload`` message from the server.
+
+    Reloads settings (so a settings.patch() change takes effect
+    immediately) and then signals a skip when the currently-displayed
+    asset has been deleted or deactivated — issue #2430.
+    """
+    load_settings()
+    _skip_if_current_asset_inactive()
+
+
+def _skip_if_current_asset_inactive() -> None:
+    """Cut short the current rotation if the displayed asset is gone.
+
+    Issue #2430: deleting or deactivating an asset that's currently on
+    screen would only take effect after its full ``duration`` elapsed —
+    a 1-hour image kept showing for the rest of the hour. The server
+    publishes ``reload`` on every mutation; here we check whether the
+    asset we're displaying is still active, and pop the ``skip_event``
+    if not so ``asset_loop`` advances on the next tick. Playlist
+    refresh itself happens inside ``get_next_asset`` via the existing
+    ``get_db_mtime`` short-circuit, so we don't touch ``scheduler``
+    state from the subscriber thread — we only signal.
+    """
+    if scheduler is None:
+        return
+    current_id = scheduler.current_asset_id
+    if not current_id:
+        return
+    try:
+        asset = Asset.objects.filter(asset_id=current_id).first()
+    except Exception:
+        logging.exception(
+            'reload: failed to check current asset %s; skipping skip-decision',
+            current_id,
+        )
+        return
+    if asset is None or not asset.is_active():
+        logging.info(
+            'Current asset %s is no longer active; signalling skip',
+            current_id,
+        )
+        get_skip_event().set()
 
 
 def _asset_is_displayable(asset: dict[str, Any]) -> bool:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -564,7 +564,7 @@ def test_skip_when_current_asset_deleted() -> None:
     with (
         mock.patch.object(viewer, 'scheduler', scheduler),
         mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
-        mock.patch.object(viewer.Asset.objects, 'filter') as objects_filter,
+        mock.patch('anthias_viewer.Asset.objects.filter') as objects_filter,
     ):
         # ``filter().first()`` returns None for a deleted row.
         objects_filter.return_value.first.return_value = None
@@ -582,7 +582,7 @@ def test_skip_when_current_asset_deactivated() -> None:
     with (
         mock.patch.object(viewer, 'scheduler', scheduler),
         mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
-        mock.patch.object(viewer.Asset.objects, 'filter') as objects_filter,
+        mock.patch('anthias_viewer.Asset.objects.filter') as objects_filter,
     ):
         objects_filter.return_value.first.return_value = inactive_asset
         viewer._skip_if_current_asset_inactive()
@@ -600,7 +600,7 @@ def test_no_skip_when_current_asset_still_active() -> None:
     with (
         mock.patch.object(viewer, 'scheduler', scheduler),
         mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
-        mock.patch.object(viewer.Asset.objects, 'filter') as objects_filter,
+        mock.patch('anthias_viewer.Asset.objects.filter') as objects_filter,
     ):
         objects_filter.return_value.first.return_value = active_asset
         viewer._skip_if_current_asset_inactive()
@@ -615,7 +615,7 @@ def test_skip_noop_when_no_current_asset() -> None:
     with (
         mock.patch.object(viewer, 'scheduler', scheduler),
         mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
-        mock.patch.object(viewer.Asset.objects, 'filter') as objects_filter,
+        mock.patch('anthias_viewer.Asset.objects.filter') as objects_filter,
     ):
         viewer._skip_if_current_asset_inactive()
     objects_filter.assert_not_called()
@@ -644,8 +644,9 @@ def test_skip_swallows_db_errors() -> None:
     with (
         mock.patch.object(viewer, 'scheduler', scheduler),
         mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
-        mock.patch.object(
-            viewer.Asset.objects, 'filter', side_effect=RuntimeError('boom')
+        mock.patch(
+            'anthias_viewer.Asset.objects.filter',
+            side_effect=RuntimeError('boom'),
         ),
     ):
         # Must not raise.

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -531,3 +531,123 @@ def test_asset_loop_rechecks_unreachable_remote_asset() -> None:
     ):
         viewer.asset_loop(scheduler)
     trigger.assert_called_once_with('remote')
+
+
+# ---------------------------------------------------------------------------
+# _handle_reload / _skip_if_current_asset_inactive — issue #2430
+# ---------------------------------------------------------------------------
+#
+# The viewer used to ignore playlist mutations while an asset was on
+# screen — a 1-hour image kept showing for the rest of the hour even
+# after delete/deactivate. The ``reload`` command now also signals a
+# skip when the displayed asset is no longer active.
+
+
+def test_handle_reload_runs_load_settings() -> None:
+    """``reload`` must still reload settings — that path is exercised
+    by the settings.patch() endpoint and predates the skip behaviour."""
+    scheduler = mock.Mock()
+    scheduler.current_asset_id = None
+    with (
+        mock.patch.object(viewer, 'scheduler', scheduler),
+        mock.patch.object(viewer, 'load_settings') as load,
+    ):
+        viewer._handle_reload()
+    load.assert_called_once()
+
+
+def test_skip_when_current_asset_deleted() -> None:
+    """Deleting the currently-displayed asset must set the skip event."""
+    scheduler = mock.Mock()
+    scheduler.current_asset_id = 'gone'
+    skip_event = mock.Mock()
+    with (
+        mock.patch.object(viewer, 'scheduler', scheduler),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
+        mock.patch.object(viewer.Asset.objects, 'filter') as objects_filter,
+    ):
+        # ``filter().first()`` returns None for a deleted row.
+        objects_filter.return_value.first.return_value = None
+        viewer._skip_if_current_asset_inactive()
+    skip_event.set.assert_called_once()
+
+
+def test_skip_when_current_asset_deactivated() -> None:
+    """Toggling is_enabled off on the displayed asset must skip."""
+    scheduler = mock.Mock()
+    scheduler.current_asset_id = 'asset-1'
+    skip_event = mock.Mock()
+    inactive_asset = mock.Mock()
+    inactive_asset.is_active.return_value = False
+    with (
+        mock.patch.object(viewer, 'scheduler', scheduler),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
+        mock.patch.object(viewer.Asset.objects, 'filter') as objects_filter,
+    ):
+        objects_filter.return_value.first.return_value = inactive_asset
+        viewer._skip_if_current_asset_inactive()
+    skip_event.set.assert_called_once()
+
+
+def test_no_skip_when_current_asset_still_active() -> None:
+    """Unrelated edits (e.g. duration on a different asset) shouldn't
+    interrupt the displayed asset."""
+    scheduler = mock.Mock()
+    scheduler.current_asset_id = 'asset-1'
+    skip_event = mock.Mock()
+    active_asset = mock.Mock()
+    active_asset.is_active.return_value = True
+    with (
+        mock.patch.object(viewer, 'scheduler', scheduler),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
+        mock.patch.object(viewer.Asset.objects, 'filter') as objects_filter,
+    ):
+        objects_filter.return_value.first.return_value = active_asset
+        viewer._skip_if_current_asset_inactive()
+    skip_event.set.assert_not_called()
+
+
+def test_skip_noop_when_no_current_asset() -> None:
+    """Empty playlist → no displayed asset → no DB hit, no skip."""
+    scheduler = mock.Mock()
+    scheduler.current_asset_id = None
+    skip_event = mock.Mock()
+    with (
+        mock.patch.object(viewer, 'scheduler', scheduler),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
+        mock.patch.object(viewer.Asset.objects, 'filter') as objects_filter,
+    ):
+        viewer._skip_if_current_asset_inactive()
+    objects_filter.assert_not_called()
+    skip_event.set.assert_not_called()
+
+
+def test_skip_noop_before_scheduler_initialised() -> None:
+    """A ``reload`` can arrive during the pre-Scheduler wait window
+    (``wait_for_server`` etc.) — must not AttributeError."""
+    skip_event = mock.Mock()
+    with (
+        mock.patch.object(viewer, 'scheduler', None),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
+    ):
+        # Must not raise.
+        viewer._skip_if_current_asset_inactive()
+    skip_event.set.assert_not_called()
+
+
+def test_skip_swallows_db_errors() -> None:
+    """A transient DB failure must not interrupt the asset loop — we
+    just leave the rotation alone for this tick."""
+    scheduler = mock.Mock()
+    scheduler.current_asset_id = 'asset-1'
+    skip_event = mock.Mock()
+    with (
+        mock.patch.object(viewer, 'scheduler', scheduler),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
+        mock.patch.object(
+            viewer.Asset.objects, 'filter', side_effect=RuntimeError('boom')
+        ),
+    ):
+        # Must not raise.
+        viewer._skip_if_current_asset_inactive()
+    skip_event.set.assert_not_called()


### PR DESCRIPTION
### Issues Fixed

Fixes #2430

### Description

Previously, deleting or deactivating an asset while it was on screen had no effect until the originally-scheduled `duration` elapsed — a 1-hour image kept showing for the rest of the hour even after the operator removed it.

**Viewer** (`src/anthias_viewer/__init__.py`): the `reload` handler now also checks whether the currently-displayed asset is still in the active set. If not, it sets `skip_event` so `asset_loop`'s `wait()` returns early and the loop rotates on the next tick. Playlist refresh itself still flows through the existing `get_db_mtime` short-circuit inside `get_next_asset` on the main thread; the subscriber thread only signals.

**Server**: API endpoints that mutate an asset's active state now publish `reload` alongside the Django page views that already did:
- `DeleteAssetViewMixin.delete` (shared across all API versions)
- `AssetViewV1.put`, `AssetViewV1_1.put`, `AssetViewV1_2.update`, `AssetViewV2.update`

The shared post-save bookkeeping for v1_2/v2 (active-asset repositioning + viewer publish) was extracted into `api.helpers.finalize_asset_update` to keep the view bodies short. Playlist reordering is **not** wired to publish `reload` — `save_active_assets_ordering` only updates `play_order`, it can't deactivate an asset, so there's no scenario where the currently-displayed asset becomes inactive from a reorder alone.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).