### PR TITLE
fix(viewer): send Accept-Language from system locale

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -33,6 +33,21 @@ mkdir -p "${XDG_RUNTIME_DIR}"
 chown viewer:video "${XDG_RUNTIME_DIR}"
 chmod 700 "${XDG_RUNTIME_DIR}"
 
+# Drop empty locale env vars so they don't override defaults that the
+# container image (or downstream consumers like Python's `locale`
+# module) would otherwise inherit. docker-compose.yml.tmpl wires
+# LANG/LANGUAGE/LC_ALL through envsubst, which produces an empty string
+# (`LANG=`) when the host has no locale configured; an empty value is
+# semantically different from "unset" — it explicitly clobbers anything
+# the image set. Unsetting here means QLocale::system() falls back to
+# its built-in default and the C++ webview leaves Accept-Language
+# unsent (rather than sending an empty / "C" header).
+for var in LANG LANGUAGE LC_ALL; do
+    if [ -z "${!var-}" ]; then
+        unset "$var"
+    fi
+done
+
 # Temporary workaround for watchdog
 touch /tmp/anthias.watchdog
 chown viewer /tmp/anthias.watchdog

--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -33,22 +33,6 @@ mkdir -p "${XDG_RUNTIME_DIR}"
 chown viewer:video "${XDG_RUNTIME_DIR}"
 chmod 700 "${XDG_RUNTIME_DIR}"
 
-# Pick up the host's system locale (issue #480). The Pi user configures
-# their preferred language with `raspi-config` / `update-locale`, which
-# writes LANG/LANGUAGE into /etc/default/locale. We bind-mount that file
-# into the container (see docker-compose.yml.tmpl) and source it here so
-# the env vars are exported into the viewer + child AnthiasWebview
-# processes; the C++ webview then reads QLocale::system() to build an
-# Accept-Language header so multi-language URL assets serve content in
-# the operator's language instead of always defaulting to English.
-# No-op if the file is missing (balena hosts, dev containers) — the
-# webview falls back to its built-in default in that case.
-if [ -f /etc/default/locale ]; then
-    set -a
-    . /etc/default/locale
-    set +a
-fi
-
 # Temporary workaround for watchdog
 touch /tmp/anthias.watchdog
 chown viewer /tmp/anthias.watchdog

--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -33,6 +33,22 @@ mkdir -p "${XDG_RUNTIME_DIR}"
 chown viewer:video "${XDG_RUNTIME_DIR}"
 chmod 700 "${XDG_RUNTIME_DIR}"
 
+# Pick up the host's system locale (issue #480). The Pi user configures
+# their preferred language with `raspi-config` / `update-locale`, which
+# writes LANG/LANGUAGE into /etc/default/locale. We bind-mount that file
+# into the container (see docker-compose.yml.tmpl) and source it here so
+# the env vars are exported into the viewer + child AnthiasWebview
+# processes; the C++ webview then reads QLocale::system() to build an
+# Accept-Language header so multi-language URL assets serve content in
+# the operator's language instead of always defaulting to English.
+# No-op if the file is missing (balena hosts, dev containers) — the
+# webview falls back to its built-in default in that case.
+if [ -f /etc/default/locale ]; then
+    set -a
+    . /etc/default/locale
+    set +a
+fi
+
 # Temporary workaround for watchdog
 touch /tmp/anthias.watchdog
 chown viewer /tmp/anthias.watchdog
@@ -149,12 +165,12 @@ if [ "$DEVICE_TYPE" = "x86" ]; then
     cage -- bash -c '
         chown viewer "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" 2>/dev/null || true
         exec sudo \
-            --preserve-env=XDG_RUNTIME_DIR,QT_SCALE_FACTOR,PYTHONPATH,WAYLAND_DISPLAY \
+            --preserve-env=XDG_RUNTIME_DIR,QT_SCALE_FACTOR,PYTHONPATH,WAYLAND_DISPLAY,LANG,LANGUAGE,LC_ALL \
             -E -u viewer \
             dbus-run-session /venv/bin/python -m anthias_viewer
     ' &
 else
-    sudo --preserve-env=XDG_RUNTIME_DIR,QT_SCALE_FACTOR,PYTHONPATH -E -u viewer \
+    sudo --preserve-env=XDG_RUNTIME_DIR,QT_SCALE_FACTOR,PYTHONPATH,LANG,LANGUAGE,LC_ALL -E -u viewer \
         dbus-run-session /venv/bin/python -m anthias_viewer &
 fi
 

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -89,6 +89,20 @@ docker rm -f \
     >/dev/null 2>&1
 set -e
 
+# Pull the host's configured locale into our shell env so envsubst can
+# substitute LANG/LANGUAGE into the viewer service block (issue #480 —
+# AnthiasWebview reads QLocale::system() to set Accept-Language). The
+# `locales` package writes LANG=... into /etc/default/locale when the
+# operator runs `raspi-config` or `update-locale`; sourcing it here is
+# how those settings reach the viewer container. No-op if the file is
+# missing — the compose substitutions then resolve to empty strings,
+# and the webview falls back to QtWebEngine's built-in default.
+if [ -f /etc/default/locale ]; then
+    set -a
+    . /etc/default/locale
+    set +a
+fi
+
 cat /home/${USER}/anthias/docker-compose.yml.tmpl \
     | envsubst \
     > /home/${USER}/anthias/docker-compose.yml

--- a/docker-compose.balena.dev.yml.tmpl
+++ b/docker-compose.balena.dev.yml.tmpl
@@ -31,6 +31,10 @@ services:
       dockerfile: ./docker/Dockerfile.viewer
     depends_on:
       - anthias-server
+    # Issue #480 — see docker-compose.balena.yml.tmpl. balena Device or
+    # Service Variables (e.g. LANG=nl_NL.UTF-8) are injected by the
+    # supervisor at runtime; no compose entry needed for AnthiasWebview
+    # to pick them up.
     environment:
       - HOME=/data
       - PORT=8080

--- a/docker-compose.balena.yml.tmpl
+++ b/docker-compose.balena.yml.tmpl
@@ -25,6 +25,13 @@ services:
     image: ghcr.io/screenly/anthias-viewer:${GIT_SHORT_HASH}-${BOARD}
     depends_on:
       - anthias-server
+    # Issue #480 — to localise URL-asset rendering, set LANG (and
+    # optionally LANGUAGE) as a balena Device or Service Variable in the
+    # dashboard, e.g. LANG=nl_NL.UTF-8. balena's supervisor injects
+    # dashboard variables as env vars into the running container at
+    # boot, so no entry is needed in this `environment:` block —
+    # AnthiasWebview reads QLocale::system() and builds Accept-Language
+    # from whatever LANG/LANGUAGE the supervisor passed in.
     environment:
       - HOME=/data
       - PORT=8080

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -56,6 +56,12 @@ services:
       - /home/${USER}/anthias_assets:/data/anthias_assets
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
+      # Surface the host's system locale (LANG, LANGUAGE) to the viewer
+      # so AnthiasWebview can send an Accept-Language header derived
+      # from it — fixes issue #480 where multi-language URL assets
+      # always rendered in English regardless of the Pi's locale config.
+      # start_viewer.sh sources this file at boot.
+      - /etc/default/locale:/etc/default/locale:ro
     labels:
       io.balena.features.supervisor-api: '1'
     logging:

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -47,15 +47,18 @@ services:
       - NOREFRESH=1
       - LISTEN=anthias-server
       # Forward the host's system locale into the viewer container so
-      # AnthiasWebview can send a matching Accept-Language header (issue
-      # #480 — multi-language URL assets used to render in English
-      # regardless of the Pi's locale). upgrade_containers.sh sources
-      # /etc/default/locale before running envsubst, so these substitute
-      # to whatever update-locale wrote (empty when the host has no
-      # locale configured — the webview then falls back to QtWebEngine's
-      # default rather than to "C").
+      # AnthiasWebview can send a matching Accept-Language header
+      # (issue 480 — multi-language URL assets used to render in
+      # English regardless of the Pi's locale). upgrade_containers.sh
+      # sources /etc/default/locale before running envsubst, so these
+      # substitute to whatever `update-locale` wrote. When the host has
+      # no locale configured these substitute to empty strings; the
+      # viewer's start_viewer.sh treats an empty value as "unset" so
+      # downstream consumers see the container image's defaults rather
+      # than an empty LANG.
       - LANG=${LANG}
       - LANGUAGE=${LANGUAGE}
+      - LC_ALL=${LC_ALL}
     privileged: true
     restart: always
     shm_size: ${SHM_SIZE_KB}kb

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -46,6 +46,16 @@ services:
       - PORT=8080
       - NOREFRESH=1
       - LISTEN=anthias-server
+      # Forward the host's system locale into the viewer container so
+      # AnthiasWebview can send a matching Accept-Language header (issue
+      # #480 — multi-language URL assets used to render in English
+      # regardless of the Pi's locale). upgrade_containers.sh sources
+      # /etc/default/locale before running envsubst, so these substitute
+      # to whatever update-locale wrote (empty when the host has no
+      # locale configured — the webview then falls back to QtWebEngine's
+      # default rather than to "C").
+      - LANG=${LANG}
+      - LANGUAGE=${LANGUAGE}
     privileged: true
     restart: always
     shm_size: ${SHM_SIZE_KB}kb
@@ -56,12 +66,6 @@ services:
       - /home/${USER}/anthias_assets:/data/anthias_assets
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
-      # Surface the host's system locale (LANG, LANGUAGE) to the viewer
-      # so AnthiasWebview can send an Accept-Language header derived
-      # from it — fixes issue #480 where multi-language URL assets
-      # always rendered in English regardless of the Pi's locale config.
-      # start_viewer.sh sources this file at boot.
-      - /etc/default/locale:/etc/default/locale:ro
     labels:
       io.balena.features.supervisor-api: '1'
     logging:

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -126,6 +126,16 @@
       answer: |
         Not currently. Anthias plays one asset, then immediately switches to the next. Adding crossfades would require composited rendering on the viewer side, which the lightweight Pi WebView pipeline doesn't do. If this matters for your deployment, [Screenly](https://www.screenly.io) supports transitions.
 
+    - question: A multi-language website displays in English instead of my language — how do I fix it?
+      answer: |
+        Anthias sends an HTTP `Accept-Language` header derived from the device's system locale, and sites that ship multiple languages use that header to pick which version to serve. Out of the box the locale is whatever the OS image was built with (usually `en_GB.UTF-8` on the Anthias Raspberry Pi image), so multi-language URL assets default to English. Set the locale to the language you want and the site will follow.
+
+        * **Raspberry Pi OS / Debian:** SSH in and run `sudo raspi-config` → **Localisation Options** → **Locale**, tick the locales you need, then pick one as the default — or, non-interactively, `sudo update-locale LANG=nl_NL.UTF-8` (substitute your locale). Re-run `~/anthias/bin/upgrade_containers.sh` so the new `LANG` is baked into the viewer container.
+
+        * **balena:** open your fleet/device in the [balena dashboard](https://dashboard.balena-cloud.com/), add a **Device Variable** (or Service Variable scoped to `anthias-viewer`) with name `LANG` and value e.g. `nl_NL.UTF-8`. The balena supervisor restarts the viewer container with the new env var; no SSH needed.
+
+        Either way, the change takes effect after the viewer container restarts. Open a multi-language site in the dashboard's **Add Asset** preview to confirm it picks up the new language.
+
 - group: Operations
   items:
     - question: How do I get logs from Anthias?

--- a/webview/src/view.cpp
+++ b/webview/src/view.cpp
@@ -1,7 +1,9 @@
 #include <QDebug>
 #include <QFileInfo>
+#include <QLocale>
 #include <QUrl>
 #include <QStandardPaths>
+#include <QStringList>
 #include <QWebEnginePage>
 #include <QWebEngineProfile>
 #include <QWebEngineSettings>
@@ -41,6 +43,56 @@ int getServerPort()
 
     return value;
 }
+
+// Build an Accept-Language header value from the system locale so
+// multi-language URL assets serve content in the operator's configured
+// language (issue #480). QLocale::system().uiLanguages() reads LANGUAGE
+// (colon-separated) then LC_ALL/LANG on Linux and returns BCP47 tags
+// like "nl-NL", "nl", "en-US", "en" in preference order — exactly what
+// Accept-Language wants. Returns an empty string when the system is on
+// the C/POSIX locale so we leave QtWebEngine's default in place rather
+// than poisoning the header with "C".
+QString detectAcceptLanguage()
+{
+    QStringList tags;
+    const auto append = [&tags](const QString& tag) {
+        if (tag.isEmpty()
+            || tag == QLatin1String("C")
+            || tag == QLatin1String("POSIX")) {
+            return;
+        }
+        if (!tags.contains(tag, Qt::CaseInsensitive)) {
+            tags.append(tag);
+        }
+    };
+
+    for (const QString& lang : QLocale::system().uiLanguages()) {
+        append(lang);
+        // Qt 5.15 sometimes returns only the region-qualified form
+        // (e.g. "nl-NL"); RFC 7231 servers will then miss a "nl"-only
+        // catalog. Append the base language as a softer fallback so a
+        // site that only ships generic Dutch still matches.
+        const int dash = lang.indexOf(QLatin1Char('-'));
+        if (dash > 0) {
+            append(lang.left(dash));
+        }
+    }
+
+    if (tags.isEmpty()) {
+        return QString();
+    }
+
+    QString header = tags.first();
+    for (int i = 1; i < tags.size(); ++i) {
+        double q = 1.0 - i * 0.1;
+        if (q < 0.1) {
+            q = 0.1;
+        }
+        header += QStringLiteral(",") + tags.at(i)
+                + QStringLiteral(";q=") + QString::number(q, 'f', 1);
+    }
+    return header;
+}
 }
 
 
@@ -64,6 +116,12 @@ View::View(QWidget* parent) : QWidget(parent)
     QWebEngineProfile* profile = QWebEngineProfile::defaultProfile();
     profile->setHttpCacheType(QWebEngineProfile::MemoryHttpCache);
     profile->clearHttpCache();
+
+    const QString acceptLanguage = detectAcceptLanguage();
+    if (!acceptLanguage.isEmpty()) {
+        profile->setHttpAcceptLanguage(acceptLanguage);
+        qDebug() << "Accept-Language:" << acceptLanguage;
+    }
 
     currentWebView = webView1;
     nextWebView = webView2;


### PR DESCRIPTION
### Issues Fixed

Closes https://github.com/Screenly/Anthias/issues/480.

### Description

`AnthiasWebview` (the Qt WebEngine binary that renders URL assets) never set an `Accept-Language` HTTP header, so multi-language sites always served their default — typically English — regardless of how the device's locale was configured.

Plumb the host locale through to the viewer container:

- `webview/src/view.cpp` — build an RFC 7231 `Accept-Language` value from `QLocale::system().uiLanguages()` (which honors `LANGUAGE` / `LC_ALL` / `LANG` per the GNU gettext convention) and set it on the shared `QWebEngineProfile`. A Pi with `LANG=nl_NL.UTF-8` now advertises `nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7`. Skips `C` / `POSIX` so a misconfigured device falls back to QtWebEngine's default rather than to "C".
- `bin/upgrade_containers.sh` — source `/etc/default/locale` before `envsubst` runs, so the host's configured `LANG` / `LANGUAGE` end up baked into the generated `docker-compose.yml`.
- `docker-compose.yml.tmpl` — declare `LANG=${LANG}` / `LANGUAGE=${LANGUAGE}` in the viewer service's `environment:` block; envsubst fills them in at compose-generation time. No host bind mount, so there's no risk of Docker silently creating an empty directory at the mount path when `/etc/default/locale` doesn't exist.
- `bin/start_viewer.sh` — add `LANG` / `LANGUAGE` / `LC_ALL` to `sudo --preserve-env` so the env vars survive the drop from root to the `viewer` user on both Pi and x86 (cage) paths.
- `docker-compose.balena.yml.tmpl` / `docker-compose.balena.dev.yml.tmpl` — comment explaining that balena operators set `LANG` as a Device or Service Variable in the dashboard; the balena supervisor injects dashboard variables as container env vars at runtime, so no compose entry is needed.
- `website/data/faq.yaml` — FAQ entry walking the operator through setting the locale on Raspberry Pi OS (`sudo update-locale`) and balena (Device Variable).

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).