### PR TITLE
fix: e2e-test findings (host-agent venv, celery beat, asset GET 404)

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -334,7 +334,12 @@ function install_ansible() {
     # every subsequent `uv sync` (Fixes #2842). Letting `.python-version`
     # be the single source of truth keeps both invocations aligned.
     INSTALLER_VENV=$(mktemp -d -t anthias-installer-venv.XXXXXX)
+    # UV_LINK_MODE=copy: ~/.cache/uv and /tmp are on different
+    # filesystems on most Pi/Debian installs (tmpfs vs the SD card),
+    # so uv's default hardlink fails and falls back to copy with a
+    # warning. Force copy mode to match what we actually want.
     UV_PROJECT_ENVIRONMENT="${INSTALLER_VENV}" \
+    UV_LINK_MODE=copy \
         uv sync \
             --project "${ANTHIAS_REPO_DIR}" \
             --no-default-groups \

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -16,14 +16,15 @@ ARCHITECTURE=$(uname -m)
 # Pin uv to match docker/uv-builder.j2 so host and image use the same binary.
 UV_PIN_VERSION="0.9.17"
 
-# Ephemeral install-time venv for ansible-core + the host-group deps.
-# Created in install_ansible(), torn down by the EXIT trap below — the
-# venv has no runtime role, so there's no reason to leave 100+ MB of
-# Python state in $HOME after the playbook finishes. Earlier releases
-# kept it at /home/$USER/installer_venv, which deserved a heuristic to
-# detect and replace pre-uv layouts; with the venv ephemeral, that's no
-# longer needed.
+# Ephemeral install-time venv for ansible-core. Created in
+# install_ansible(), torn down by the EXIT trap below. A separate
+# *persistent* venv at HOST_AGENT_VENV (see provision_host_agent_venv
+# below) is what the anthias-host-agent.service systemd unit
+# ExecStart actually executes — keeping the two venvs distinct lets
+# the installer-only Python state (~100 MB) come and go with each
+# install without taking the host-agent down.
 INSTALLER_VENV=""
+HOST_AGENT_VENV="/home/${USER}/installer_venv"
 
 cleanup_installer_venv() {
     if [ -n "${INSTALLER_VENV}" ] && [ -d "${INSTALLER_VENV}" ]; then
@@ -249,6 +250,42 @@ function install_ansible() {
             --no-default-groups \
             --group host \
             --no-install-project
+}
+
+function provision_host_agent_venv() {
+    display_section "Provision Host Agent Python Environment"
+
+    # Permanent venv consumed by anthias-host-agent.service. The unit
+    # template (ansible/roles/anthias/templates/anthias-host-agent.service)
+    # hardcodes this path so a Trixie/Python-3.13 cutover that retires
+    # the system interpreter the host-agent was launched with leaves a
+    # 203/EXEC loop until reinstall — recreating the venv unconditionally
+    # on every install + upgrade is what keeps the service self-healing.
+    if [ -d "${HOST_AGENT_VENV}" ]; then
+        # Same sudo-with-fallback pattern as cleanup_installer_venv:
+        # earlier runs may have left root-owned __pycache__ entries.
+        sudo -n rm -rf "${HOST_AGENT_VENV}" 2>/dev/null \
+            || rm -rf "${HOST_AGENT_VENV}" 2>/dev/null
+    fi
+    UV_PROJECT_ENVIRONMENT="${HOST_AGENT_VENV}" \
+        uv sync \
+            --project "${ANTHIAS_REPO_DIR}" \
+            --no-default-groups \
+            --group host \
+            --no-install-project
+
+    # On upgrade the unit is already loaded and running with the
+    # *previous* venv's interpreter (Python keeps its image even after
+    # the venv directory is unlinked), so the ansible task's
+    # `state: started` is a no-op and the new deps never get picked
+    # up. Restart explicitly when the unit is present. On a fresh
+    # install the unit doesn't exist yet, so the check is a no-op and
+    # ansible's `state: started` does the first start.
+    if systemctl list-unit-files anthias-host-agent.service \
+        >/dev/null 2>&1 \
+        && systemctl is-active --quiet anthias-host-agent.service; then
+        sudo systemctl restart anthias-host-agent.service
+    fi
 }
 
 function set_device_type() {
@@ -489,6 +526,7 @@ function main() {
     clone_repo
     post_clone_migrate_legacy_paths
     install_ansible
+    provision_host_agent_venv
     run_ansible_playbook
 
     upgrade_docker_containers

--- a/bin/start_development_server.sh
+++ b/bin/start_development_server.sh
@@ -8,5 +8,5 @@ COMPOSE_ARGS=(
 
 bin/generate_dev_mode_dockerfiles.sh
 
-docker compose "${COMPOSE_ARGS[@]}" down
-docker compose "${COMPOSE_ARGS[@]}" up -d --build
+docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans
+docker compose "${COMPOSE_ARGS[@]}" up -d --build --remove-orphans

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -124,4 +124,9 @@ if [ -f /var/run/reboot-required ]; then
     exit 0
 fi
 
-sudo -E docker compose "${COMPOSE_FILES[@]}" up -d
+# --remove-orphans sweeps containers that linger after a service is
+# renamed or removed from the compose file (e.g. legacy run-NNN sidecar
+# instances left over from earlier `docker compose run` invocations).
+# Without it `up -d` only logs a warning and leaves the orphans running,
+# which is confusing on a `docker ps` audit later.
+sudo -E docker compose "${COMPOSE_FILES[@]}" up -d --remove-orphans

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
         condition: service_started
     command: >
       celery -A anthias_server.celery_tasks.celery worker -B -n worker@anthias
-      --loglevel=info --schedule /tmp/celerybeat-schedule
+      --loglevel=info --scheduler celery.beat.Scheduler
     environment:
       - HOME=/data
       - CELERY_BROKER_URL=redis://redis:6379/0

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -40,7 +40,7 @@ services:
     build: *test_build
     command: >
       celery -A anthias_server.celery_tasks.celery worker -B -n worker@anthias
-      --loglevel=info --schedule /tmp/celerybeat-schedule
+      --loglevel=info --scheduler celery.beat.Scheduler
     depends_on:
       anthias-test:
         condition: service_started

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -82,7 +82,7 @@ services:
     command: >
       nice -n 19 ionice -c 3
       celery -A anthias_server.celery_tasks.celery worker -B -n worker@anthias
-      --loglevel=info --schedule /tmp/celerybeat-schedule
+      --loglevel=info --scheduler celery.beat.Scheduler
     depends_on:
       - anthias-server
       - redis

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -193,6 +193,21 @@ def test_delete_asset_should_return_204(
     assert len(assets) == 0
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+def test_unknown_asset_id_returns_404(
+    api_client: APIClient, version: str
+) -> None:
+    # Asset.objects.get(asset_id=...) used to bubble DoesNotExist as a
+    # 500 here; views now use get_object_or_404 so a deleted or
+    # mistyped id maps cleanly to 404 across every API version.
+    detail_url = reverse(f'api:asset_detail_{version}', args=['nonexistent'])
+    assert api_client.get(detail_url).status_code == status.HTTP_404_NOT_FOUND
+    assert (
+        api_client.delete(detail_url).status_code == status.HTTP_404_NOT_FOUND
+    )
+
+
 @pytest.fixture
 def v2_asset_detail_url(api_client: APIClient) -> str:
     asset = api_client.post(

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -7,6 +7,7 @@ from mimetypes import guess_extension, guess_type
 from os import path, remove, statvfs
 from typing import Any
 
+from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import filesizeformat
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -40,7 +41,7 @@ class DeleteAssetViewMixin:
     @extend_schema(summary='Delete asset')
     @authorized
     def delete(self, request: Request, asset_id: str) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
 
         try:
             if asset.uri and asset.uri.startswith(settings['assetdir']):
@@ -263,7 +264,7 @@ class AssetContentViewMixin(APIView):
         asset_id: str,
         format: str | None = None,
     ) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
         if asset.uri is None:
             raise NotFound('Asset has no content URI.')
 

--- a/src/anthias_server/api/views/v1.py
+++ b/src/anthias_server/api/views/v1.py
@@ -233,5 +233,5 @@ class ViewerCurrentAssetViewV1(APIView):
         if not current_asset_id:
             return Response([])
 
-        queryset = get_object_or_404(Asset, asset_id=current_asset_id)
-        return Response(AssetSerializer(queryset).data)
+        asset = get_object_or_404(Asset, asset_id=current_asset_id)
+        return Response(AssetSerializer(asset).data)

--- a/src/anthias_server/api/views/v1.py
+++ b/src/anthias_server/api/views/v1.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiRequest,
@@ -89,7 +90,7 @@ class AssetViewV1(APIView, DeleteAssetViewMixin):
         asset_id: str,
         format: str | None = None,
     ) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
         return Response(AssetSerializer(asset).data)
 
     @extend_schema(
@@ -104,7 +105,7 @@ class AssetViewV1(APIView, DeleteAssetViewMixin):
         asset_id: str,
         format: str | None = None,
     ) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
 
         data = parse_request(request)
         serializer = UpdateAssetSerializer(asset, data=data, partial=False)
@@ -232,5 +233,5 @@ class ViewerCurrentAssetViewV1(APIView):
         if not current_asset_id:
             return Response([])
 
-        queryset = Asset.objects.get(asset_id=current_asset_id)
+        queryset = get_object_or_404(Asset, asset_id=current_asset_id)
         return Response(AssetSerializer(queryset).data)

--- a/src/anthias_server/api/views/v1_1.py
+++ b/src/anthias_server/api/views/v1_1.py
@@ -1,3 +1,4 @@
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.request import Request
@@ -73,7 +74,7 @@ class AssetViewV1_1(APIView, DeleteAssetViewMixin):
     )
     @authorized
     def get(self, request: Request, asset_id: str) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
         return Response(AssetSerializer(asset).data)
 
     @extend_schema(
@@ -83,7 +84,7 @@ class AssetViewV1_1(APIView, DeleteAssetViewMixin):
     )
     @authorized
     def put(self, request: Request, asset_id: str) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
 
         data = parse_request(request)
         serializer = UpdateAssetSerializer(asset, data=data, partial=False)

--- a/src/anthias_server/api/views/v1_2.py
+++ b/src/anthias_server/api/views/v1_2.py
@@ -1,3 +1,4 @@
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.request import Request
@@ -88,7 +89,7 @@ class AssetViewV1_2(APIView, DeleteAssetViewMixin):
     @extend_schema(summary='Get asset')
     @authorized
     def get(self, request: Request, asset_id: str) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
         serializer = self.serializer_class(asset)
         return Response(serializer.data)
 
@@ -98,7 +99,7 @@ class AssetViewV1_2(APIView, DeleteAssetViewMixin):
         asset_id: str,
         partial: bool = False,
     ) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
         serializer = UpdateAssetSerializer(
             asset, data=request.data, partial=partial
         )

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -9,6 +9,7 @@ from typing import Any
 import psutil
 import redis
 import requests
+from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import filesizeformat
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -412,7 +413,7 @@ class AssetViewV2(APIView, DeleteAssetViewMixin):
     @extend_schema(summary='Get asset')
     @authorized
     def get(self, request: Request, asset_id: str) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
         serializer = self.serializer_class(asset)
         return Response(serializer.data)
 
@@ -422,7 +423,7 @@ class AssetViewV2(APIView, DeleteAssetViewMixin):
         asset_id: str,
         partial: bool = False,
     ) -> Response:
-        asset = Asset.objects.get(asset_id=asset_id)
+        asset = get_object_or_404(Asset, asset_id=asset_id)
         serializer = UpdateAssetSerializerV2(
             asset, data=request.data, partial=partial
         )

--- a/src/anthias_server/lib/telemetry.py
+++ b/src/anthias_server/lib/telemetry.py
@@ -19,8 +19,8 @@ ANALYTICS_API_SECRET = 'G8NcBpRIS9qBsOj3ODK8gw'
 ANALYTICS_URL = 'https://www.google-analytics.com/mp/collect'
 ANALYTICS_TIMEOUT = 5
 
-# Anthias's celerybeat schedule lives in /tmp (`--schedule
-# /tmp/celerybeat-schedule` in docker-compose.yml.tmpl), so the daily
+# celery-beat runs with the in-memory scheduler (--scheduler
+# celery.beat.Scheduler in docker-compose.yml.tmpl), so the daily
 # interval resets on every container restart. The cooldown lives in
 # the persisted Redis volume so devices that reboot frequently still
 # emit at most one telemetry event per 24h.


### PR DESCRIPTION
## Summary

Three independent fixes found by running an end-to-end test of master against an x86 device and a Pi 4B side-by-side.

### 1. Persistent host-agent venv (`bin/install.sh`)
The installer venv was made ephemeral (mktemp tmpdir, cleaned on EXIT) without updating `anthias-host-agent.service`'s ExecStart, which still hardcodes `/home/${USER}/installer_venv/bin/python`. Result on every fresh install since: 203/EXEC restart loop, no IP cache, `/api/v2/info` blocks ~80s in `get_node_ip()` waiting for `host_agent_ready` that never lands. Now split into two venvs — ephemeral for ansible-core, persistent for the host-agent — and restart the unit explicitly on upgrade since the in-memory interpreter survives the venv removal.

### 2. Celery beat in-memory scheduler
`celery -B` with the default PersistentScheduler stores its schedule via shelve. On Python 3.13, shelve defaults to `dbm.sqlite3`, which intermittently raises `dbm.sqlite3.error: locking protocol` — observed in this build matrix on x86 only. When Beat stalls, `reconcile_stuck_processing` and the other periodic tasks stop, so `is_processing=true` rows never get re-dispatched. `setup_periodic_tasks` defines every periodic task statically, so a non-persistent scheduler is sufficient — switch to `celery.beat.Scheduler` in all three compose files.

### 3. 404 (not 500) for unknown asset_id
`AssetView{V1,V1_1,V1_2,V2}.get/put/patch/update`, `DeleteAssetViewMixin`, `AssetContentViewMixin`, and `ViewerCurrentAssetViewV1` all called `Asset.objects.get(asset_id=...)` bare. The `DoesNotExist` had no DRF handler registered → 500 + traceback for what is structurally a missing resource. Route the lookup through `django.shortcuts.get_object_or_404` (DRF's exception handler converts the `Http404` to a clean 404 Response). New parametrised test guards every API version.

## Test plan
- [x] `ruff check` + `ruff format --check` clean on all changed files
- [x] Host-side: recreated `/home/mvip/installer_venv/` on the x86 test rig with the same uv command the new function emits, restarted `anthias-host-agent.service` — service active, `host_agent_ready=true` in Redis, `/api/v2/info` returns in 1s (down from 79s)
- [x] Host-side: `celery -A anthias_server.celery_tasks.celery beat --scheduler celery.beat.Scheduler` smoke-tested inside `anthias-anthias-celery-1` — beat starts cleanly, schedule loads, no shelve/dbm files written
- [x] Stuck `Sample Mpeg` asset deleted manually from x86 (root cause #2)
- [ ] CI green on this PR (pytest covers the new 404 test across all four versions)
- [ ] Post-merge: pull on the x86 rig + sanity-check the asset GET-after-delete returns 404