### PR TITLE
feat(viewer): UI-driven screen rotation for portrait/landscape

### DIFF
--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -30,6 +30,29 @@ from anthias_server.settings import settings
 arch = machine()
 
 
+# Issue #2856 — the four cardinal screen-rotation angles the Settings
+# page exposes. Centralised here (rather than re-declared in the v2
+# serializer, the form handler, and the two viewer helpers) so the
+# allowed set can't drift between read and write paths.
+SCREEN_ROTATION_CHOICES: tuple[int, ...] = (0, 90, 180, 270)
+
+
+def clamp_screen_rotation(value: Any) -> int:
+    """Coerce a raw rotation value to one of SCREEN_ROTATION_CHOICES.
+
+    Returns 0 for anything that doesn't parse as an int in the
+    cardinal set — defends every read site (env-var composition,
+    mpv/VLC CLI args, form save) against a hand-edited conf or
+    bypassed serializer that could otherwise inject a hostile string
+    into a subprocess argv or QPA option list.
+    """
+    try:
+        rotation = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return rotation if rotation in SCREEN_ROTATION_CHOICES else 0
+
+
 def string_to_bool(string: Any) -> bool:
     # Direct port of distutils.util.strtobool (removed in Python 3.12)
     # so existing callers keep accepting the same y/yes/t/true/on/1 set.

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -304,7 +304,10 @@ class DeviceSettingsSerializerV2(Serializer[Any]):
     shuffle_playlist = BooleanField()
     use_24_hour_clock = BooleanField()
     debug_logging = BooleanField()
-    screen_rotation = IntegerField()
+    # Mirror the PATCH-side ChoiceField so the OpenAPI schema
+    # advertises the same enum on both directions — clients can rely
+    # on the value being one of {0, 90, 180, 270} when reading too.
+    screen_rotation = ChoiceField(choices=SCREEN_ROTATION_CHOICES)
     username = CharField()
 
 

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -289,6 +289,9 @@ class UpdateAssetSerializerV2(UpdateAssetSerializer):
         return super().update(instance, validated_data)
 
 
+SCREEN_ROTATION_CHOICES = (0, 90, 180, 270)
+
+
 class DeviceSettingsSerializerV2(Serializer[Any]):
     player_name = CharField()
     audio_output = CharField()
@@ -301,6 +304,7 @@ class DeviceSettingsSerializerV2(Serializer[Any]):
     shuffle_playlist = BooleanField()
     use_24_hour_clock = BooleanField()
     debug_logging = BooleanField()
+    screen_rotation = IntegerField()
     username = CharField()
 
 
@@ -315,6 +319,9 @@ class UpdateDeviceSettingsSerializerV2(Serializer[Any]):
     shuffle_playlist = BooleanField(required=False)
     use_24_hour_clock = BooleanField(required=False)
     debug_logging = BooleanField(required=False)
+    screen_rotation = ChoiceField(
+        required=False, choices=SCREEN_ROTATION_CHOICES
+    )
     username = CharField(required=False, allow_blank=True)
     password = CharField(required=False, allow_blank=True)
     password_2 = CharField(required=False, allow_blank=True)

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -17,6 +17,7 @@ from rest_framework.serializers import (
     TimeField,
 )
 
+from anthias_common.utils import SCREEN_ROTATION_CHOICES
 from anthias_server.app.models import (
     Asset,
     REFRESH_INTERVAL_S_MAX,
@@ -287,9 +288,6 @@ class UpdateAssetSerializerV2(UpdateAssetSerializer):
             )
             instance.metadata = metadata
         return super().update(instance, validated_data)
-
-
-SCREEN_ROTATION_CHOICES = (0, 90, 180, 270)
 
 
 class DeviceSettingsSerializerV2(Serializer[Any]):

--- a/src/anthias_server/api/tests/test_v2_endpoints.py
+++ b/src/anthias_server/api/tests/test_v2_endpoints.py
@@ -46,6 +46,7 @@ def test_get_device_settings(
         'shuffle_playlist': False,
         'use_24_hour_clock': True,
         'debug_logging': False,
+        'screen_rotation': 90,
     }[key]
 
     response = api_client.get(device_settings_url)
@@ -64,6 +65,7 @@ def test_get_device_settings(
         'shuffle_playlist': False,
         'use_24_hour_clock': True,
         'debug_logging': False,
+        'screen_rotation': 90,
         'username': '',
     }
 
@@ -276,6 +278,7 @@ def test_disable_basic_auth(
         'shuffle_playlist': False,
         'use_24_hour_clock': True,
         'debug_logging': False,
+        'screen_rotation': 0,
     }[key]
     settings_mock.__setitem__ = mock.MagicMock()
 
@@ -395,6 +398,57 @@ def test_patch_device_settings_default_assets(
     remove_default_assets_mock.assert_called_once()
     add_default_assets_mock.assert_not_called()
     publisher_instance.send_to_viewer.assert_called_once_with('reload')
+
+
+# Issue #2856 — Screen rotation is a UI-driven setting; the v2 patch
+# must accept the four cardinal angles, persist the new value, and
+# publish ``reload`` so the viewer picks the change up live.
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v2.settings')
+@mock.patch('anthias_server.api.views.v2.ViewerPublisher')
+def test_patch_device_settings_screen_rotation(
+    publisher_mock: Any,
+    settings_mock: Any,
+    api_client: APIClient,
+    device_settings_url: str,
+) -> None:
+    settings_mock.load = mock.MagicMock()
+    settings_mock.save = mock.MagicMock()
+    settings_mock.__getitem__.side_effect = lambda key: {
+        'player_name': 'Test Player',
+        'auth_backend': '',
+    }[key]
+    settings_mock.__setitem__ = mock.MagicMock()
+
+    publisher_instance = mock.MagicMock()
+    publisher_mock.get_instance.return_value = publisher_instance
+
+    response = api_client.patch(
+        device_settings_url, data={'screen_rotation': 90}, format='json'
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    settings_mock.__setitem__.assert_any_call('screen_rotation', 90)
+    publisher_instance.send_to_viewer.assert_called_once_with('reload')
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v2.settings')
+def test_patch_device_settings_rotation_rejects_non_cardinal(
+    settings_mock: Any, api_client: APIClient, device_settings_url: str
+) -> None:
+    """45 isn't one of the four supported angles — serializer must 400
+    rather than passing it through to the viewer (where neither the Qt
+    linuxfb plugin nor wlr-randr will honor it)."""
+    response = api_client.patch(
+        device_settings_url, data={'screen_rotation': 45}, format='json'
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'screen_rotation' in response.data
+    settings_mock.load.assert_not_called()
+    settings_mock.save.assert_not_called()
 
 
 @pytest.fixture

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -580,6 +580,7 @@ class DeviceSettingsViewV2(APIView):
                 'shuffle_playlist': settings['shuffle_playlist'],
                 'use_24_hour_clock': settings['use_24_hour_clock'],
                 'debug_logging': settings['debug_logging'],
+                'screen_rotation': int(settings['screen_rotation']),
                 'username': (
                     operator_username()
                     if settings['auth_backend'] == 'auth_basic'
@@ -654,6 +655,8 @@ class DeviceSettingsViewV2(APIView):
                 settings['use_24_hour_clock'] = data['use_24_hour_clock']
             if 'debug_logging' in data:
                 settings['debug_logging'] = data['debug_logging']
+            if 'screen_rotation' in data:
+                settings['screen_rotation'] = int(data['screen_rotation'])
 
             settings.save()
             publisher = ViewerPublisher.get_instance()

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -69,6 +69,7 @@ from anthias_server.lib import diagnostics
 from anthias_server.lib.auth import authorized
 from anthias_server.lib.github import is_up_to_date
 from anthias_common.utils import (
+    clamp_screen_rotation,
     connect_to_redis,
     get_balena_device_info,
     get_node_ip,
@@ -580,7 +581,15 @@ class DeviceSettingsViewV2(APIView):
                 'shuffle_playlist': settings['shuffle_playlist'],
                 'use_24_hour_clock': settings['use_24_hour_clock'],
                 'debug_logging': settings['debug_logging'],
-                'screen_rotation': int(settings['screen_rotation']),
+                # Clamp on read too — the OpenAPI schema advertises
+                # an enum of {0,90,180,270}, but a hand-edited conf
+                # could have a stale 45 or any other int sitting on
+                # disk. Going through the shared helper guarantees
+                # the API never returns a value the client wasn't
+                # told to expect (Copilot review of #2882).
+                'screen_rotation': clamp_screen_rotation(
+                    settings['screen_rotation']
+                ),
                 'username': (
                     operator_username()
                     if settings['auth_backend'] == 'auth_basic'

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -218,6 +218,7 @@ def device_settings() -> dict[str, Any]:
         'shuffle_playlist': settings['shuffle_playlist'],
         'use_24_hour_clock': settings['use_24_hour_clock'],
         'debug_logging': settings['debug_logging'],
+        'screen_rotation': int(settings['screen_rotation']),
         # Auth-form chrome
         'has_saved_basic_auth': has_persisted_operator
         or settings['auth_backend'] == 'auth_basic',

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -16,6 +16,7 @@ from django.template.defaultfilters import filesizeformat
 
 from anthias_common import device_helper
 from anthias_common.utils import (
+    clamp_screen_rotation,
     connect_to_redis,
     get_node_mac_address,
     is_balena_app,
@@ -218,7 +219,12 @@ def device_settings() -> dict[str, Any]:
         'shuffle_playlist': settings['shuffle_playlist'],
         'use_24_hour_clock': settings['use_24_hour_clock'],
         'debug_logging': settings['debug_logging'],
-        'screen_rotation': int(settings['screen_rotation']),
+        # Clamp on the read side so a stale conf value (e.g. an
+        # old 45 from a hand-edit) doesn't leave the dropdown with no
+        # ``selected`` option — the template's {% if screen_rotation
+        # == 0 %} ladder picks 0° in that case, matching the
+        # viewer's runtime clamp (Copilot review of #2882).
+        'screen_rotation': clamp_screen_rotation(settings['screen_rotation']),
         # Auth-form chrome
         'has_saved_basic_auth': has_persisted_operator
         or settings['auth_backend'] == 'auth_basic',

--- a/src/anthias_server/app/templates/settings.html
+++ b/src/anthias_server/app/templates/settings.html
@@ -75,6 +75,16 @@
           </select>
           <label for="date_format">Date format</label>
         </div>
+
+        <div class="app-floating">
+          <select class="app-select" id="screen_rotation" name="screen_rotation">
+            <option value="0" {% if screen_rotation == 0 %}selected{% endif %}>Landscape (0°)</option>
+            <option value="90" {% if screen_rotation == 90 %}selected{% endif %}>Portrait (90°)</option>
+            <option value="180" {% if screen_rotation == 180 %}selected{% endif %}>Landscape, inverted (180°)</option>
+            <option value="270" {% if screen_rotation == 270 %}selected{% endif %}>Portrait, inverted (270°)</option>
+          </select>
+          <label for="screen_rotation">Screen rotation</label>
+        </div>
       </div>
 
       <div>

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -26,6 +26,7 @@ from anthias_server.lib.auth import (
     authorized,
 )
 from anthias_common.utils import (
+    clamp_screen_rotation,
     connect_to_redis,
 )
 from anthias_server.settings import ViewerPublisher, settings
@@ -861,18 +862,16 @@ def settings_save(request: HttpRequest) -> HttpResponse:
         settings['use_24_hour_clock'] = _checkbox(request, 'use_24_hour_clock')
         settings['debug_logging'] = _checkbox(request, 'debug_logging')
 
-        # Restrict to the four cardinal angles. The Qt linuxfb plugin
-        # only honors 0/90/180/270 (anything else is silently treated
-        # as 0); wlr-randr rejects non-cardinal --transform values
-        # outright. Mirror the v2 serializer's choice list so a hand-
-        # crafted form POST can't slip a 45 through.
-        try:
-            rotation = int(request.POST.get('screen_rotation') or 0)
-        except ValueError:
-            rotation = 0
-        if rotation not in (0, 90, 180, 270):
-            rotation = 0
-        settings['screen_rotation'] = rotation
+        # Restrict to the four cardinal angles via the shared
+        # clamp_screen_rotation() helper. The Qt linuxfb plugin only
+        # honors 0/90/180/270 (anything else is silently treated as
+        # 0); wlr-randr rejects non-cardinal --transform values
+        # outright. Going through the helper keeps the HTML form
+        # path, the v2 serializer, and the viewer-side read sites on
+        # exactly the same allowed set.
+        settings['screen_rotation'] = clamp_screen_rotation(
+            request.POST.get('screen_rotation')
+        )
 
         settings.save()
         ViewerPublisher.get_instance().send_to_viewer('reload')

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -861,6 +861,19 @@ def settings_save(request: HttpRequest) -> HttpResponse:
         settings['use_24_hour_clock'] = _checkbox(request, 'use_24_hour_clock')
         settings['debug_logging'] = _checkbox(request, 'debug_logging')
 
+        # Restrict to the four cardinal angles. The Qt linuxfb plugin
+        # only honors 0/90/180/270 (anything else is silently treated
+        # as 0); wlr-randr rejects non-cardinal --transform values
+        # outright. Mirror the v2 serializer's choice list so a hand-
+        # crafted form POST can't slip a 45 through.
+        try:
+            rotation = int(request.POST.get('screen_rotation') or 0)
+        except ValueError:
+            rotation = 0
+        if rotation not in (0, 90, 180, 270):
+            rotation = 0
+        settings['screen_rotation'] = rotation
+
         settings.save()
         ViewerPublisher.get_instance().send_to_viewer('reload')
 

--- a/src/anthias_server/settings.py
+++ b/src/anthias_server/settings.py
@@ -37,6 +37,7 @@ DEFAULTS = {
         'default_streaming_duration': '300',
         'player_name': '',
         'resolution': '1920x1080',
+        'screen_rotation': 0,
         'show_splash': True,
         'shuffle_playlist': False,
         'verify_ssl': True,

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -175,19 +175,35 @@ def _apply_wlr_transform(rotation_deg: int) -> None:
     transform = _wlr_transform_value(rotation_deg)
     for name in _wlr_output_names():
         try:
-            subprocess.run(
+            result = subprocess.run(
                 ['wlr-randr', '--output', name, '--transform', transform],
                 capture_output=True,
                 text=True,
                 timeout=5,
                 check=False,
             )
-            logging.info(
-                'Applied wlroots transform %s to output %s', transform, name
-            )
         except (FileNotFoundError, subprocess.SubprocessError) as exc:
             logging.warning(
                 'wlr-randr --transform failed for %s: %s', name, exc
+            )
+            continue
+        # Don't blanket-log "Applied" on every invocation: cage may not
+        # be ready yet at viewer startup, an EDID-renamed output can
+        # vanish between list and apply, or wlroots can reject the
+        # transform for an output that doesn't support it. Treat
+        # returncode==0 as success and surface stderr on failure so a
+        # silently-broken rotation is debuggable from journald.
+        if result.returncode == 0:
+            logging.info(
+                'Applied wlroots transform %s to output %s', transform, name
+            )
+        else:
+            logging.warning(
+                'wlr-randr --transform %s on %s exited %d: %s',
+                transform,
+                name,
+                result.returncode,
+                (result.stderr or '').strip(),
             )
 
 
@@ -462,6 +478,17 @@ def _maybe_reapply_rotation() -> None:
         return
 
     # linuxfb path — kill the webview so asset_loop respawns it.
+    # Latch _last_applied_rotation NOW (rather than waiting for
+    # load_browser() to overwrite it after the respawn): a second
+    # ``reload`` arriving in the gap between terminate() and the next
+    # asset_loop tick would otherwise compare the unchanged settings
+    # value against the still-stale latch, decide rotation is "again"
+    # changing, and re-fire terminate() / skip_event on an already-
+    # dying webview process — which spams the warning log and could
+    # race the respawn. load_browser() unconditionally re-reads the
+    # setting and re-assigns this variable, so the latch is still
+    # accurate once the new process is up.
+    _last_applied_rotation = rotation
     global browser
     if browser is not None:
         try:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -366,7 +366,9 @@ def load_browser() -> None:
             _last_applied_rotation = rotation
         else:
             # Reset to a sentinel that doesn't match any valid angle
-            # so the next reload retries the apply. -1 is safe because
+            # so the next asset_loop tick (via
+            # _retry_wayland_rotation_if_pending) or the next server
+            # `reload` retries the apply. -1 is safe because
             # _rotation_value() only returns cardinals.
             _last_applied_rotation = -1
     else:
@@ -577,16 +579,18 @@ def _maybe_reapply_rotation() -> None:
         # any state shared with the main thread. Only latch on
         # success so a transient failure (cage not ready, transient
         # wayland-socket hiccup) leaves us in "still needs to retry"
-        # state — the next ``reload`` (asset edit, recheck, etc.) will
-        # see the mismatch and retry. Without this guard a startup
-        # race could latch the unrotated state permanently and only
-        # a user re-toggle would recover.
+        # state — the next asset_loop tick (via
+        # _retry_wayland_rotation_if_pending) or the next ``reload``
+        # (asset edit, recheck, etc.) will see the mismatch and
+        # retry. Without this guard a startup race could latch the
+        # unrotated state permanently and only a user re-toggle
+        # would recover.
         if _apply_wlr_transform(rotation):
             _last_applied_rotation = rotation
         else:
             logging.warning(
                 'wlr-randr could not apply rotation %d on any output; '
-                'will retry on the next reload.',
+                'will retry on the next asset_loop tick.',
                 rotation,
             )
         return

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -84,6 +84,16 @@ scheduler: Any = None
 # operator changed rotation from the UI and we need to re-apply.
 _last_applied_rotation: int = 0
 
+# Cross-thread handoff for the linuxfb rotation-change path. The
+# subscriber thread (ViewerSubscriber) runs _handle_reload when a
+# `reload` arrives on Redis pub/sub, but ``browser`` and
+# ``current_browser_url`` are owned by the main asset_loop thread —
+# touching them from the subscriber would race a concurrent
+# view_image()/view_webpage() mid-D-Bus call. Instead, the subscriber
+# sets this flag and the main thread consumes it at the top of
+# asset_loop via _consume_pending_rotation_bounce().
+_rotation_bounce_pending: bool = False
+
 
 def _rotation_value() -> int:
     """Coerce settings['screen_rotation'] to a known cardinal angle.
@@ -162,18 +172,28 @@ def _wlr_output_names() -> list[str]:
     return names
 
 
-def _apply_wlr_transform(rotation_deg: int) -> None:
+def _apply_wlr_transform(rotation_deg: int) -> bool:
     """Push the requested transform to every wlroots output.
 
-    No-op (and no error) on non-Wayland boards or when cage isn't up
-    yet — the linuxfb path handles rotation through QT_QPA_PLATFORM
-    instead, so the early-startup window before cage's socket exists
-    isn't a problem for Pi.
+    Returns True when at least one output was successfully rotated,
+    False on a non-Wayland board (no-op success — the linuxfb path
+    handles rotation through QT_QPA_PLATFORM instead) cannot happen
+    here, because callers gate on ``_is_wayland_board()``. Callers
+    use the boolean to decide whether to latch
+    ``_last_applied_rotation`` — a transient startup failure (cage
+    not ready yet, wayland socket missing) should leave the latch
+    untouched so the next ``reload`` retries.
     """
     if not _is_wayland_board():
-        return
+        # Treat as success: nothing to do on linuxfb, so the caller
+        # latching is correct.
+        return True
     transform = _wlr_transform_value(rotation_deg)
-    for name in _wlr_output_names():
+    names = _wlr_output_names()
+    if not names:
+        return False
+    any_success = False
+    for name in names:
         try:
             result = subprocess.run(
                 ['wlr-randr', '--output', name, '--transform', transform],
@@ -197,6 +217,7 @@ def _apply_wlr_transform(rotation_deg: int) -> None:
             logging.info(
                 'Applied wlroots transform %s to output %s', transform, name
             )
+            any_success = True
         else:
             logging.warning(
                 'wlr-randr --transform %s on %s exited %d: %s',
@@ -205,6 +226,7 @@ def _apply_wlr_transform(rotation_deg: int) -> None:
                 result.returncode,
                 (result.stderr or '').strip(),
             )
+    return any_success
 
 
 def send_current_asset_id_to_server(correlation_id: str | None) -> None:
@@ -271,10 +293,23 @@ def load_browser() -> None:
     # Apply screen rotation *before* the webview starts so it picks up
     # the rotated geometry on first frame: the wlroots compositor
     # needs the transform set before Qt queries the output size, and
-    # the linuxfb plugin reads ``:rotation=N`` once at QPA init.
+    # the linuxfb plugin reads ``:rotation=N`` once at QPA init. On
+    # linuxfb the env-var path is synchronous (the QPA reads it on
+    # construction) so we can latch unconditionally. On Wayland, only
+    # latch when at least one output rotation actually succeeded —
+    # otherwise an early-boot cage-not-ready failure would silently
+    # stick at the unrotated state until a setting change.
     rotation = _rotation_value()
-    _apply_wlr_transform(rotation)
-    _last_applied_rotation = rotation
+    if _is_wayland_board():
+        if _apply_wlr_transform(rotation):
+            _last_applied_rotation = rotation
+        else:
+            # Reset to a sentinel that doesn't match any valid angle
+            # so the next reload retries the apply. -1 is safe because
+            # _rotation_value() only returns cardinals.
+            _last_applied_rotation = -1
+    else:
+        _last_applied_rotation = rotation
 
     browser = sh.Command('AnthiasWebview')(
         _bg=True, _err_to_out=True, _env=_build_webview_env()
@@ -455,7 +490,7 @@ def _maybe_reapply_rotation() -> None:
     unrelated ``reload`` traffic (asset edits, etc.) doesn't blank
     the screen.
     """
-    global _last_applied_rotation
+    global _last_applied_rotation, _rotation_bounce_pending
     rotation = _rotation_value()
     if rotation == _last_applied_rotation:
         return
@@ -469,27 +504,64 @@ def _maybe_reapply_rotation() -> None:
     # Drop the cached media player either way — VLC bakes the
     # transform filter into the instance at construction, so the new
     # angle only takes effect after we re-init. mpv is unaffected
-    # (rotation is computed per play) but reset() is cheap.
+    # (rotation is computed per play) but reset() is cheap. Safe to
+    # call from the subscriber thread: ``MediaPlayerProxy.INSTANCE``
+    # is only ever read by the main thread at the top of view_video,
+    # and reset() just stops + nulls the cached instance.
     MediaPlayerProxy.reset()
 
     if _is_wayland_board():
-        _apply_wlr_transform(rotation)
-        _last_applied_rotation = rotation
+        # Apply via wlr-randr from the subscriber thread directly:
+        # wlr-randr is an out-of-process IPC call that doesn't touch
+        # any state shared with the main thread. Only latch on
+        # success so a transient failure (cage not ready, transient
+        # wayland-socket hiccup) leaves us in "still needs to retry"
+        # state — the next ``reload`` (asset edit, recheck, etc.) will
+        # see the mismatch and retry. Without this guard a startup
+        # race could latch the unrotated state permanently and only
+        # a user re-toggle would recover.
+        if _apply_wlr_transform(rotation):
+            _last_applied_rotation = rotation
+        else:
+            logging.warning(
+                'wlr-randr could not apply rotation %d on any output; '
+                'will retry on the next reload.',
+                rotation,
+            )
         return
 
-    # linuxfb path — kill the webview so asset_loop respawns it.
-    # Latch _last_applied_rotation NOW (rather than waiting for
-    # load_browser() to overwrite it after the respawn): a second
-    # ``reload`` arriving in the gap between terminate() and the next
-    # asset_loop tick would otherwise compare the unchanged settings
-    # value against the still-stale latch, decide rotation is "again"
-    # changing, and re-fire terminate() / skip_event on an already-
-    # dying webview process — which spams the warning log and could
-    # race the respawn. load_browser() unconditionally re-reads the
-    # setting and re-assigns this variable, so the latch is still
-    # accurate once the new process is up.
+    # linuxfb path — the webview needs to be respawned with the new
+    # QT_QPA_PLATFORM env. browser.terminate() and current_browser_url
+    # are owned by the main asset_loop thread (view_image/view_webpage
+    # mutate them mid-D-Bus call), so we MUST NOT touch them from this
+    # subscriber thread. Instead, latch the new rotation and raise a
+    # ``_rotation_bounce_pending`` flag that the main thread consumes
+    # via _consume_pending_rotation_bounce() at the top of asset_loop.
+    # The skip_event wakes the main thread out of its current sleep so
+    # the bounce happens promptly rather than after the current
+    # asset's full duration elapses.
     _last_applied_rotation = rotation
-    global browser
+    _rotation_bounce_pending = True
+    get_skip_event().set()
+
+
+def _consume_pending_rotation_bounce() -> None:
+    """Main-thread half of the linuxfb rotation handoff.
+
+    Called from ``asset_loop`` at the top of each tick. If the
+    subscriber set ``_rotation_bounce_pending``, terminate the
+    AnthiasWebview process here — on the same thread that owns it —
+    so the next view_image/view_webpage sees ``browser.is_alive()``
+    return false and respawns it via ``load_browser()`` with the
+    updated rotation env. Clearing ``current_browser_url`` defeats
+    the value-comparison short-circuit so the fresh webview actually
+    gets a loadPage/loadImage on its first asset.
+    """
+    global _rotation_bounce_pending, browser, current_browser_url
+    if not _rotation_bounce_pending:
+        return
+    _rotation_bounce_pending = False
+    logging.info('Consuming pending rotation bounce on main thread')
     if browser is not None:
         try:
             browser.terminate()
@@ -498,15 +570,7 @@ def _maybe_reapply_rotation() -> None:
                 'Could not terminate AnthiasWebview for rotation change: %s',
                 exc,
             )
-    # Force the next view_image/view_webpage call to re-issue loadPage
-    # against the freshly spawned webview — without this, the URL
-    # short-circuit ``current_browser_url != uri`` would skip the
-    # reload and the new process would sit on a blank page.
-    global current_browser_url
     current_browser_url = None
-    # Bump the skip event so the loop wakes immediately rather than
-    # sleeping out the current asset's full duration before noticing.
-    get_skip_event().set()
 
 
 def _skip_if_current_asset_inactive() -> None:
@@ -626,6 +690,16 @@ def _trigger_asset_recheck(asset_id: str | None) -> None:
 
 
 def asset_loop(scheduler: Any) -> None:
+    # Issue #2856 — consume any pending rotation bounce queued by the
+    # subscriber thread BEFORE we do anything else this tick. The
+    # subscriber can only set the flag (it doesn't own ``browser`` or
+    # ``current_browser_url``); the actual terminate + URL reset have
+    # to happen on this thread so they don't race a concurrent
+    # view_image / view_webpage mid-D-Bus call. The next view_*
+    # invocation below will see browser.is_alive()==False and
+    # respawn via load_browser() with the updated rotation env.
+    _consume_pending_rotation_bounce()
+
     asset = scheduler.get_next_asset()
 
     if asset is None:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -565,14 +565,22 @@ def _maybe_reapply_rotation() -> None:
         rotation,
     )
 
-    # Drop the cached media player either way — VLC bakes the
+    # Drop the cached media player on linuxfb only — VLC bakes the
     # transform filter into the instance at construction, so the new
-    # angle only takes effect after we re-init. mpv is unaffected
-    # (rotation is computed per play) but reset() is cheap. Safe to
-    # call from the subscriber thread: ``MediaPlayerProxy.INSTANCE``
-    # is only ever read by the main thread at the top of view_video,
-    # and reset() just stops + nulls the cached instance.
-    MediaPlayerProxy.reset()
+    # angle only takes effect after we re-init.
+    #
+    # On Wayland (x86) we explicitly DO NOT call reset(): mpv's
+    # wayland VO inherits the compositor transform from cage, so the
+    # currently-playing video doesn't need to be restarted to honour
+    # the new rotation. Calling reset() here would kill mpv mid-play
+    # and the main thread's view_video() would sit blocked on the
+    # asset's original ``duration`` skip_event with the screen on
+    # the 'null' black image (Copilot review of #2882). VLC isn't
+    # used on x86 at all (MediaPlayerProxy routes pi4-64/pi5/x86 to
+    # MPVMediaPlayer), so there's no transform-filter rebuild reason
+    # to reset() on Wayland either.
+    if not _is_wayland_board():
+        MediaPlayerProxy.reset()
 
     if _is_wayland_board():
         # Apply via wlr-randr from the subscriber thread directly:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -115,24 +115,48 @@ def _is_wayland_board() -> bool:
     return os.environ.get('DEVICE_TYPE') == 'x86'
 
 
+def _set_qpa_rotation(qpa: str, rotation: int) -> str:
+    """Return ``qpa`` with its ``rotation=`` option set to ``rotation``
+    (or removed entirely when ``rotation`` is 0).
+
+    The Qt QPA syntax is ``<plugin>[:opt1=val1,opt2=val2,...]`` — the
+    options are comma-separated *after* a single colon. A naive
+    ``split(':', 1)[0]`` would discard every other option an operator
+    might have set (e.g. ``linuxfb:fb=/dev/fb1,tty=/dev/tty1``), so
+    parse the option list and only touch the ``rotation`` entry.
+
+    Doing this unconditionally (even when ``rotation`` is 0) lets the
+    operator dial rotation back to 0 from a non-zero setting without
+    a leftover ``rotation=N`` suffix from a prior launch sticking
+    around — Copilot review of #2882.
+    """
+    plugin, _, options_str = qpa.partition(':')
+    options = [
+        opt.strip()
+        for opt in options_str.split(',')
+        if opt.strip() and not opt.strip().startswith('rotation=')
+    ]
+    if rotation:
+        options.append(f'rotation={rotation}')
+    if not options:
+        return plugin
+    return f'{plugin}:{",".join(options)}'
+
+
 def _build_webview_env() -> dict[str, str]:
     """Compose the env to pass when spawning AnthiasWebview.
 
-    Appends ``:rotation=N`` to QT_QPA_PLATFORM on linuxfb boards so the
-    Qt linuxfb plugin rotates the framebuffer for us at no perf cost.
-    On Wayland (x86) the QPA has no rotation= option — the compositor
-    owns transforms — so the env is unchanged and ``_apply_wlr_transform``
-    handles rotation separately.
+    Sets ``rotation=N`` inside QT_QPA_PLATFORM on linuxfb boards so
+    the Qt linuxfb plugin rotates the framebuffer for us at no perf
+    cost. On Wayland (x86) the QPA has no rotation= option — the
+    compositor owns transforms — so the env is left alone and
+    ``_apply_wlr_transform`` handles rotation separately.
     """
     env = dict(os.environ)
     rotation = _rotation_value()
     qpa = env.get('QT_QPA_PLATFORM', 'linuxfb')
-    if not _is_wayland_board() and rotation:
-        # Strip any preexisting ``:rotation=`` suffix from a prior
-        # launch so we don't double-up if the Dockerfile env ever
-        # carries one.
-        base = qpa.split(':', 1)[0]
-        env['QT_QPA_PLATFORM'] = f'{base}:rotation={rotation}'
+    if not _is_wayland_board():
+        env['QT_QPA_PLATFORM'] = _set_qpa_rotation(qpa, rotation)
     return env
 
 
@@ -175,18 +199,20 @@ def _wlr_output_names() -> list[str]:
 def _apply_wlr_transform(rotation_deg: int) -> bool:
     """Push the requested transform to every wlroots output.
 
-    Returns True when at least one output was successfully rotated,
-    False on a non-Wayland board (no-op success — the linuxfb path
-    handles rotation through QT_QPA_PLATFORM instead) cannot happen
-    here, because callers gate on ``_is_wayland_board()``. Callers
-    use the boolean to decide whether to latch
-    ``_last_applied_rotation`` — a transient startup failure (cage
-    not ready yet, wayland socket missing) should leave the latch
-    untouched so the next ``reload`` retries.
+    Returns:
+        * True on non-Wayland boards (no-op — the linuxfb path handles
+          rotation through QT_QPA_PLATFORM instead, so the caller is
+          safe to latch ``_last_applied_rotation``).
+        * True on Wayland when at least one output was successfully
+          rotated (a partial success — e.g. one output rotated, one
+          rejected — still counts so we don't loop forever on a
+          malfunctioning secondary connector).
+        * False on Wayland when no outputs were listed (cage / the
+          wayland socket not ready yet) or every wlr-randr invocation
+          failed. Callers must NOT latch ``_last_applied_rotation``
+          in that case so the next ``reload`` retries.
     """
     if not _is_wayland_board():
-        # Treat as success: nothing to do on linuxfb, so the caller
-        # latching is correct.
         return True
     transform = _wlr_transform_value(rotation_deg)
     names = _wlr_output_names()

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -167,12 +167,28 @@ def _wlr_transform_value(rotation_deg: int) -> str:
 
 
 def _wlr_output_names() -> list[str]:
-    """List connector names known to the wlroots compositor.
+    """List *enabled* connector names known to the wlroots compositor.
 
-    ``wlr-randr`` with no args prints one block per output, with the
-    name as the first non-whitespace token on the block's first line.
-    Empty list means nothing connected (or cage isn't running yet) —
-    callers treat that as "no rotation to apply" rather than an error.
+    ``wlr-randr`` with no args prints one block per output. Each block
+    looks like::
+
+        HDMI-A-1 "Foo Display"
+          Enabled: yes
+          Modes:
+            ...
+        HDMI-A-2 "Bar"
+          Enabled: no
+          ...
+
+    The connector name is the first non-whitespace token on the
+    block's first line; whether the output is currently active is
+    indicated by an indented ``Enabled: yes|no`` line within the
+    block. We skip ``Enabled: no`` outputs because ``wlr-randr
+    --output X --transform ...`` on a disabled connector fails with a
+    warning that adds noise to the journal without changing behaviour
+    (Copilot review of #2882). Empty list means nothing connected and
+    enabled (or cage isn't running yet) — callers treat that as "no
+    rotation to apply" rather than an error.
     """
     try:
         result = subprocess.run(
@@ -190,9 +206,28 @@ def _wlr_output_names() -> list[str]:
         )
         return []
     names: list[str] = []
+    current: str | None = None
+    current_enabled: bool | None = None
     for line in result.stdout.splitlines():
-        if line and not line[0].isspace():
-            names.append(line.split()[0])
+        if not line:
+            continue
+        if not line[0].isspace():
+            # New output block. Commit the previous one (if it was
+            # enabled — None means we never saw an explicit Enabled:
+            # line, which on modern wlr-randr versions means the
+            # output is implicitly enabled, so include it as a
+            # conservative default).
+            if current is not None and current_enabled is not False:
+                names.append(current)
+            current = line.split()[0]
+            current_enabled = None
+        else:
+            stripped = line.strip()
+            if stripped.startswith('Enabled:'):
+                _, _, value = stripped.partition(':')
+                current_enabled = value.strip().lower() == 'yes'
+    if current is not None and current_enabled is not False:
+        names.append(current)
     return names
 
 
@@ -571,6 +606,33 @@ def _maybe_reapply_rotation() -> None:
     get_skip_event().set()
 
 
+def _retry_wayland_rotation_if_pending() -> None:
+    """Main-thread retry for an unsuccessful Wayland rotation apply.
+
+    load_browser() at viewer startup tries to push the wlr-randr
+    transform before AnthiasWebview spawns, but cage may not have
+    fully come up at that point — its wayland socket can be missing
+    or its compositor not yet listing outputs. The first apply
+    returns False, load_browser() latches ``_last_applied_rotation
+    = -1`` (sentinel for "needs retry"), and without this helper the
+    display would stay unrotated until the operator next changed the
+    setting and triggered a `reload` (Copilot review of #2882).
+
+    Called from asset_loop on every tick. The early-return guard
+    means once the rotation has actually taken effect we drop back
+    to zero overhead. Linuxfb is unaffected (env-var path is
+    synchronous at QPA init, so it can't fail half-applied).
+    """
+    if not _is_wayland_board():
+        return
+    global _last_applied_rotation
+    rotation = _rotation_value()
+    if rotation == _last_applied_rotation:
+        return
+    if _apply_wlr_transform(rotation):
+        _last_applied_rotation = rotation
+
+
 def _consume_pending_rotation_bounce() -> None:
     """Main-thread half of the linuxfb rotation handoff.
 
@@ -725,6 +787,11 @@ def asset_loop(scheduler: Any) -> None:
     # invocation below will see browser.is_alive()==False and
     # respawn via load_browser() with the updated rotation env.
     _consume_pending_rotation_bounce()
+
+    # Issue #2856 — and retry the Wayland rotation if the boot-time
+    # attempt in load_browser() raced cage's wayland-socket setup.
+    # Cheap early-return when nothing's pending.
+    _retry_wayland_rotation_if_pending()
 
     asset = scheduler.get_next_asset()
 

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import os
+import subprocess
 import sys
 from os import getenv, path
 from signal import SIGALRM, signal
@@ -74,6 +76,120 @@ HOME: str | None = None
 
 scheduler: Any = None
 
+# Rotation last applied to the display, in degrees (0/90/180/270). On
+# linuxfb boards this is what we baked into QT_QPA_PLATFORM the last
+# time AnthiasWebview launched; on Wayland boards it's the wlr-randr
+# transform we last pushed. ``_handle_reload`` compares this to the
+# freshly-loaded ``settings['screen_rotation']`` to decide whether the
+# operator changed rotation from the UI and we need to re-apply.
+_last_applied_rotation: int = 0
+
+
+def _rotation_value() -> int:
+    """Coerce settings['screen_rotation'] to a known cardinal angle.
+
+    Defends against a hand-edited conf with a bogus value — the v2
+    serializer + page-form handler already clamp on write, but the
+    viewer is on the read side of an arbitrary on-disk file.
+    """
+    try:
+        value = int(settings['screen_rotation'])
+    except (KeyError, TypeError, ValueError):
+        return 0
+    return value if value in (0, 90, 180, 270) else 0
+
+
+def _is_wayland_board() -> bool:
+    """The x86 viewer runs under cage + wayland; everything else uses
+    linuxfb. Mirrors the docker/Dockerfile.viewer.j2 split."""
+    return os.environ.get('DEVICE_TYPE') == 'x86'
+
+
+def _build_webview_env() -> dict[str, str]:
+    """Compose the env to pass when spawning AnthiasWebview.
+
+    Appends ``:rotation=N`` to QT_QPA_PLATFORM on linuxfb boards so the
+    Qt linuxfb plugin rotates the framebuffer for us at no perf cost.
+    On Wayland (x86) the QPA has no rotation= option — the compositor
+    owns transforms — so the env is unchanged and ``_apply_wlr_transform``
+    handles rotation separately.
+    """
+    env = dict(os.environ)
+    rotation = _rotation_value()
+    qpa = env.get('QT_QPA_PLATFORM', 'linuxfb')
+    if not _is_wayland_board() and rotation:
+        # Strip any preexisting ``:rotation=`` suffix from a prior
+        # launch so we don't double-up if the Dockerfile env ever
+        # carries one.
+        base = qpa.split(':', 1)[0]
+        env['QT_QPA_PLATFORM'] = f'{base}:rotation={rotation}'
+    return env
+
+
+def _wlr_transform_value(rotation_deg: int) -> str:
+    return {0: 'normal', 90: '90', 180: '180', 270: '270'}.get(
+        rotation_deg, 'normal'
+    )
+
+
+def _wlr_output_names() -> list[str]:
+    """List connector names known to the wlroots compositor.
+
+    ``wlr-randr`` with no args prints one block per output, with the
+    name as the first non-whitespace token on the block's first line.
+    Empty list means nothing connected (or cage isn't running yet) —
+    callers treat that as "no rotation to apply" rather than an error.
+    """
+    try:
+        result = subprocess.run(
+            ['wlr-randr'],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        logging.debug('wlr-randr unavailable: %s', exc)
+        return []
+    if result.returncode != 0:
+        logging.debug(
+            'wlr-randr exit %d: %s', result.returncode, result.stderr
+        )
+        return []
+    names: list[str] = []
+    for line in result.stdout.splitlines():
+        if line and not line[0].isspace():
+            names.append(line.split()[0])
+    return names
+
+
+def _apply_wlr_transform(rotation_deg: int) -> None:
+    """Push the requested transform to every wlroots output.
+
+    No-op (and no error) on non-Wayland boards or when cage isn't up
+    yet — the linuxfb path handles rotation through QT_QPA_PLATFORM
+    instead, so the early-startup window before cage's socket exists
+    isn't a problem for Pi.
+    """
+    if not _is_wayland_board():
+        return
+    transform = _wlr_transform_value(rotation_deg)
+    for name in _wlr_output_names():
+        try:
+            subprocess.run(
+                ['wlr-randr', '--output', name, '--transform', transform],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            logging.info(
+                'Applied wlroots transform %s to output %s', transform, name
+            )
+        except (FileNotFoundError, subprocess.SubprocessError) as exc:
+            logging.warning(
+                'wlr-randr --transform failed for %s: %s', name, exc
+            )
+
 
 def send_current_asset_id_to_server(correlation_id: str | None) -> None:
     if not correlation_id:
@@ -124,6 +240,7 @@ BROWSER_HANDSHAKE_LINE = 'Anthias service start'
 
 def load_browser() -> None:
     global browser, _webview_supports_set_reload_interval
+    global _last_applied_rotation
     logging.info('Loading browser...')
 
     # Re-probe the setReloadInterval capability against the freshly
@@ -135,7 +252,17 @@ def load_browser() -> None:
     # actual running process, not the viewer's lifetime.
     _webview_supports_set_reload_interval = True
 
-    browser = sh.Command('AnthiasWebview')(_bg=True, _err_to_out=True)
+    # Apply screen rotation *before* the webview starts so it picks up
+    # the rotated geometry on first frame: the wlroots compositor
+    # needs the transform set before Qt queries the output size, and
+    # the linuxfb plugin reads ``:rotation=N`` once at QPA init.
+    rotation = _rotation_value()
+    _apply_wlr_transform(rotation)
+    _last_applied_rotation = rotation
+
+    browser = sh.Command('AnthiasWebview')(
+        _bg=True, _err_to_out=True, _env=_build_webview_env()
+    )
 
     # Bound the wait so we don't hang the viewer indefinitely if
     # AnthiasWebview fails to register on D-Bus (missing binary, broken
@@ -281,11 +408,78 @@ def _handle_reload() -> None:
     """Process a ``reload`` message from the server.
 
     Reloads settings (so a settings.patch() change takes effect
-    immediately) and then signals a skip when the currently-displayed
+    immediately), re-applies the screen rotation if it changed
+    (issue #2856), and then signals a skip when the currently-displayed
     asset has been deleted or deactivated — issue #2430.
     """
     load_settings()
+    _maybe_reapply_rotation()
     _skip_if_current_asset_inactive()
+
+
+def _maybe_reapply_rotation() -> None:
+    """Re-apply ``screen_rotation`` when the operator changed it in the UI.
+
+    Two distinct paths because the rotation primitive is platform-
+    specific (see issue #2856):
+
+    * Wayland (x86 under cage): push the new transform with
+      ``wlr-randr``. The compositor sends a resize event to its
+      surfaces; Qt's wayland QPA picks it up and re-lays out the
+      webview in-place. No process restart needed.
+
+    * linuxfb (every Pi board): the Qt linuxfb plugin only reads
+      ``QT_QPA_PLATFORM=linuxfb:rotation=N`` at QPA init, so a live
+      angle change requires a fresh AnthiasWebview process. Terminate
+      it; the next ``asset_loop`` tick sees ``browser.is_alive()`` as
+      false and calls ``load_browser()``, which spawns it with the
+      updated env.
+
+    No-op when the on-disk angle matches what we last applied, so
+    unrelated ``reload`` traffic (asset edits, etc.) doesn't blank
+    the screen.
+    """
+    global _last_applied_rotation
+    rotation = _rotation_value()
+    if rotation == _last_applied_rotation:
+        return
+
+    logging.info(
+        'Screen rotation changed: %d -> %d',
+        _last_applied_rotation,
+        rotation,
+    )
+
+    # Drop the cached media player either way — VLC bakes the
+    # transform filter into the instance at construction, so the new
+    # angle only takes effect after we re-init. mpv is unaffected
+    # (rotation is computed per play) but reset() is cheap.
+    MediaPlayerProxy.reset()
+
+    if _is_wayland_board():
+        _apply_wlr_transform(rotation)
+        _last_applied_rotation = rotation
+        return
+
+    # linuxfb path — kill the webview so asset_loop respawns it.
+    global browser
+    if browser is not None:
+        try:
+            browser.terminate()
+        except Exception as exc:
+            logging.warning(
+                'Could not terminate AnthiasWebview for rotation change: %s',
+                exc,
+            )
+    # Force the next view_image/view_webpage call to re-issue loadPage
+    # against the freshly spawned webview — without this, the URL
+    # short-circuit ``current_browser_url != uri`` would skip the
+    # reload and the new process would sit on a blank page.
+    global current_browser_url
+    current_browser_url = None
+    # Bump the skip event so the loop wakes immediately rather than
+    # sleeping out the current asset's full duration before noticing.
+    get_skip_event().set()
 
 
 def _skip_if_current_asset_inactive() -> None:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -42,6 +42,7 @@ django.setup()
 from anthias_common.internal_auth import INTERNAL_AUTH_HEADER  # noqa: E402
 from anthias_common.internal_auth import internal_auth_token  # noqa: E402
 from anthias_common.utils import (  # noqa: E402
+    clamp_screen_rotation,
     connect_to_redis,
     detect_screen_resolution,
     string_to_bool,
@@ -98,15 +99,15 @@ _rotation_bounce_pending: bool = False
 def _rotation_value() -> int:
     """Coerce settings['screen_rotation'] to a known cardinal angle.
 
-    Defends against a hand-edited conf with a bogus value — the v2
-    serializer + page-form handler already clamp on write, but the
-    viewer is on the read side of an arbitrary on-disk file.
+    Thin wrapper around the shared clamp_screen_rotation() helper —
+    keeps the viewer's call sites short while ensuring the allowed
+    set (0/90/180/270) lives in exactly one place.
     """
     try:
-        value = int(settings['screen_rotation'])
-    except (KeyError, TypeError, ValueError):
+        raw = settings['screen_rotation']
+    except KeyError:
         return 0
-    return value if value in (0, 90, 180, 270) else 0
+    return clamp_screen_rotation(raw)
 
 
 def _is_wayland_board() -> bool:

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -8,6 +8,20 @@ from anthias_server.settings import settings
 
 VIDEO_TIMEOUT = 20  # secs
 
+
+def _screen_rotation() -> int:
+    """Cardinal angle the operator selected on the Settings page.
+
+    Returns 0 for any unexpected value so a hand-edited conf can't
+    push a hostile string into mpv/VLC's CLI parser.
+    """
+    try:
+        value = int(settings['screen_rotation'])
+    except (KeyError, TypeError, ValueError):
+        return 0
+    return value if value in (0, 90, 180, 270) else 0
+
+
 # Last device that `_detect_hdmi_audio_device()` resolved to in this
 # process. `get_alsa_audio_device()` runs on every play()/set_asset(),
 # so we only emit INFO/WARNING when the result changes (transitions
@@ -187,6 +201,17 @@ class MPVMediaPlayer(MediaPlayer):
         else:
             vo_args = ['--vo=drm']
 
+        # Issue #2856. On x86, cage/wlroots is rotated via wlr-randr and
+        # mpv's wayland VO inherits the compositor transform — passing
+        # --video-rotate here too would double-rotate. On Pi --vo=drm
+        # writes straight to the framebuffer with no compositor in the
+        # path, so the rotation has to happen inside mpv. Skip the arg
+        # at 0° so unrotated displays stay on the existing CLI.
+        rotation = _screen_rotation()
+        rotate_args: list[str] = []
+        if rotation and device_type != 'x86':
+            rotate_args = [f'--video-rotate={rotation}']
+
         self.process = subprocess.Popen(
             [
                 'mpv',
@@ -194,6 +219,7 @@ class MPVMediaPlayer(MediaPlayer):
                 *vo_args,
                 '--hwdec=auto-safe',
                 *extra_args,
+                *rotate_args,
                 f'--audio-device=alsa/{get_alsa_audio_device()}',
                 '--',
                 self.uri,
@@ -227,6 +253,23 @@ class VLCMediaPlayer(MediaPlayer):
 
         self._vlc = vlc
         options = [f'--alsa-audio-device={get_alsa_audio_device()}']
+        # Issue #2856. Pi 1/2/3 fall through to VLC and write directly
+        # to the framebuffer — no compositor or KMS transform in the
+        # path — so any screen rotation has to be applied inside the
+        # pipeline. The transform filter is software-rotation but the
+        # SD-class boards on this branch only play SD-class assets, so
+        # the cost is bearable. VLC requires the filter to be in the
+        # chain at instance-init time; if the operator changes rotation
+        # from the UI, MediaPlayerProxy.reset() drops the singleton so
+        # we re-init with the new option list on the next play.
+        self._rotation = _screen_rotation()
+        if self._rotation:
+            options.extend(
+                [
+                    '--video-filter=transform',
+                    f'--transform-type={self._rotation}',
+                ]
+            )
         self.instance = vlc.Instance(options)
         self.player = self.instance.media_player_new()
 
@@ -275,3 +318,20 @@ class MediaPlayerProxy:
                 cls.INSTANCE = MPVMediaPlayer()
 
         return cls.INSTANCE
+
+    @classmethod
+    def reset(cls) -> None:
+        """Drop the cached player so the next ``get_instance`` rebuilds it.
+
+        VLC bakes the transform filter into ``vlc.Instance(options)``
+        at init time, so a rotation change from the Settings page only
+        takes effect on the next play after we re-init. mpv re-reads
+        rotation per play and is unaffected, but calling reset() is
+        cheap and harmless either way.
+        """
+        if cls.INSTANCE is not None:
+            try:
+                cls.INSTANCE.stop()
+            except Exception as exc:
+                logging.debug('reset(): stop() raised: %s', exc)
+        cls.INSTANCE = None

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -4,6 +4,7 @@ import subprocess
 from typing import ClassVar
 
 from anthias_common.device_helper import get_device_type
+from anthias_common.utils import clamp_screen_rotation
 from anthias_server.settings import settings
 
 VIDEO_TIMEOUT = 20  # secs
@@ -12,14 +13,15 @@ VIDEO_TIMEOUT = 20  # secs
 def _screen_rotation() -> int:
     """Cardinal angle the operator selected on the Settings page.
 
-    Returns 0 for any unexpected value so a hand-edited conf can't
-    push a hostile string into mpv/VLC's CLI parser.
+    Thin wrapper around the shared clamp_screen_rotation() helper so
+    both the viewer's QPA env composition and the video-player CLI
+    flags read from a single coercion path.
     """
     try:
-        value = int(settings['screen_rotation'])
-    except (KeyError, TypeError, ValueError):
+        raw = settings['screen_rotation']
+    except KeyError:
         return 0
-    return value if value in (0, 90, 180, 270) else 0
+    return clamp_screen_rotation(raw)
 
 
 # Last device that `_detect_hdmi_audio_device()` resolved to in this

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -604,6 +604,10 @@ def test_mpv_skips_video_rotate_on_x86(mock_popen: Any) -> None:
     """x86 inherits the compositor transform via wayland; double-
     rotating in mpv would undo wlr-randr's work."""
     player = MPVMediaPlayer()
+    # Patch get_device_type to 'x86' so get_alsa_audio_device() takes
+    # the HID-card fallback branch — patching it to 'pi5' while
+    # DEVICE_TYPE=x86 would route through _detect_hdmi_audio_device()
+    # and stat /sys/class/drm, making the test depend on the host.
     with (
         patch(
             'anthias_viewer.media_player.settings',
@@ -611,7 +615,7 @@ def test_mpv_skips_video_rotate_on_x86(mock_popen: Any) -> None:
         ),
         patch(
             'anthias_viewer.media_player.get_device_type',
-            return_value='pi5',  # routed through MPVMediaPlayer
+            return_value='x86',
         ),
         patch.dict('os.environ', {'DEVICE_TYPE': 'x86'}),
     ):

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -555,3 +555,107 @@ def test_get_instance_returns_same_instance(
     instance1 = MediaPlayerProxy.get_instance()
     instance2 = MediaPlayerProxy.get_instance()
     assert instance1 is instance2
+
+
+# ---------------------------------------------------------------------------
+# Screen rotation (issue #2856)
+
+
+def _rotated_mpv_settings(rotation: int) -> Any:
+    """Build a settings mock that answers `audio_output` like the
+    default fixture but also surfaces `screen_rotation`. Used by the
+    mpv rotation tests below."""
+    table = {'audio_output': 'hdmi', 'screen_rotation': rotation}
+    mock = MagicMock()
+    mock.__getitem__.side_effect = lambda key: table[key]
+    return mock
+
+
+@patch(
+    'anthias_viewer.media_player._detect_hdmi_audio_device',
+    return_value='sysdefault:CARD=vc4hdmi0',
+)
+@patch('anthias_viewer.media_player.subprocess.Popen')
+def test_mpv_passes_video_rotate_on_pi(
+    mock_popen: Any, _mock_detect: Any
+) -> None:
+    """On --vo=drm the framebuffer is written direct; rotation has to
+    happen inside mpv."""
+    player = MPVMediaPlayer()
+    with (
+        patch(
+            'anthias_viewer.media_player.settings',
+            _rotated_mpv_settings(180),
+        ),
+        patch(
+            'anthias_viewer.media_player.get_device_type',
+            return_value='pi5',
+        ),
+        patch.dict('os.environ', {'DEVICE_TYPE': 'pi5'}),
+    ):
+        player.set_asset('file:///test/video.mp4', 30)
+        player.play()
+    args, _ = mock_popen.call_args
+    assert '--video-rotate=180' in args[0]
+
+
+@patch('anthias_viewer.media_player.subprocess.Popen')
+def test_mpv_skips_video_rotate_on_x86(mock_popen: Any) -> None:
+    """x86 inherits the compositor transform via wayland; double-
+    rotating in mpv would undo wlr-randr's work."""
+    player = MPVMediaPlayer()
+    with (
+        patch(
+            'anthias_viewer.media_player.settings',
+            _rotated_mpv_settings(90),
+        ),
+        patch(
+            'anthias_viewer.media_player.get_device_type',
+            return_value='pi5',  # routed through MPVMediaPlayer
+        ),
+        patch.dict('os.environ', {'DEVICE_TYPE': 'x86'}),
+    ):
+        player.set_asset('file:///test/video.mp4', 30)
+        player.play()
+    args, _ = mock_popen.call_args
+    assert not any(arg.startswith('--video-rotate') for arg in args[0])
+
+
+@patch(
+    'anthias_viewer.media_player._detect_hdmi_audio_device',
+    return_value='sysdefault:CARD=vc4hdmi0',
+)
+@patch('anthias_viewer.media_player.subprocess.Popen')
+def test_mpv_no_video_rotate_at_zero(
+    mock_popen: Any, _mock_detect: Any
+) -> None:
+    """The default-orientation case must NOT add --video-rotate=0 —
+    keeps the CLI surface unchanged for the 99% of operators who never
+    touch the dropdown, matching the existing arg-list test."""
+    player = MPVMediaPlayer()
+    with (
+        patch(
+            'anthias_viewer.media_player.settings',
+            _rotated_mpv_settings(0),
+        ),
+        patch(
+            'anthias_viewer.media_player.get_device_type',
+            return_value='pi5',
+        ),
+        patch.dict('os.environ', {'DEVICE_TYPE': 'pi5'}),
+    ):
+        player.set_asset('file:///test/video.mp4', 30)
+        player.play()
+    args, _ = mock_popen.call_args
+    assert not any(arg.startswith('--video-rotate') for arg in args[0])
+
+
+def test_proxy_reset_clears_cached_instance(reset_media_proxy: None) -> None:
+    """When the operator changes rotation in Settings, the viewer
+    calls MediaPlayerProxy.reset() so the next play() rebuilds VLC
+    with the new transform-filter options."""
+    fake = MagicMock()
+    MediaPlayerProxy.INSTANCE = fake
+    MediaPlayerProxy.reset()
+    assert MediaPlayerProxy.INSTANCE is None
+    fake.stop.assert_called_once()

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -180,6 +180,7 @@ def test_page_context_device_settings_keys() -> None:
         'date_format',
         'auth_backend',
         'show_splash',
+        'screen_rotation',
         'date_format_options',
         'is_pi5',
     ):
@@ -417,6 +418,44 @@ def test_settings_save_round_trip(client: Client) -> None:
             },
         )
     assert response.status_code in (200, 302)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'posted, persisted',
+    [
+        ('90', 90),
+        ('270', 270),
+        # Non-cardinal / garbage angles clamp to 0 — defends the
+        # viewer's CLI argv against a hostile or buggy form.
+        ('45', 0),
+        ('definitely-not-a-number', 0),
+    ],
+)
+def test_settings_save_screen_rotation(
+    client: Client, posted: str, persisted: int
+) -> None:
+    """Issue #2856 — form path mirrors the v2 PATCH validation."""
+    from anthias_server.settings import settings
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:settings_save'),
+            data={
+                'player_name': 'Test',
+                'default_duration': '10',
+                'default_streaming_duration': '300',
+                'audio_output': 'hdmi',
+                'date_format': 'mm/dd/yyyy',
+                'auth_backend': '',
+                'screen_rotation': posted,
+            },
+        )
+    assert response.status_code in (200, 302)
+    assert settings['screen_rotation'] == persisted
 
 
 @pytest.mark.django_db

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -814,6 +814,42 @@ def test_apply_wlr_transform_invokes_wlr_randr_per_output() -> None:
         assert call.args[0][call.args[0].index('--transform') + 1] == '180'
 
 
+def test_apply_wlr_transform_logs_warning_on_nonzero_exit(
+    caplog: Any,
+) -> None:
+    """wlr-randr's exit code is informative — cage may not be ready
+    yet, the output name can vanish between list and apply, etc. The
+    helper must surface stderr on failure rather than blanket-logging
+    "Applied" on every invocation. Copilot review of #2882."""
+
+    def _fake_run(argv: Any, **kwargs: Any) -> mock.Mock:
+        result = mock.Mock()
+        if argv == ['wlr-randr']:
+            result.returncode = 0
+            result.stdout = 'HDMI-A-1\n  Enabled: yes\n'
+            result.stderr = ''
+        else:
+            result.returncode = 1
+            result.stdout = ''
+            result.stderr = 'invalid output\n'
+        return result
+
+    with (
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch('anthias_viewer.subprocess.run', side_effect=_fake_run),
+        caplog.at_level(logging.WARNING, logger='root'),
+    ):
+        viewer._apply_wlr_transform(90)
+
+    warning_records = [
+        r for r in caplog.records if r.levelno >= logging.WARNING
+    ]
+    assert any('invalid output' in r.getMessage() for r in warning_records)
+    assert not any(
+        'Applied wlroots transform' in r.getMessage() for r in caplog.records
+    )
+
+
 def test_handle_reload_reapplies_rotation_when_changed(
     reset_rotation_state: None,
 ) -> None:
@@ -876,4 +912,32 @@ def test_handle_reload_terminates_webview_on_linuxfb_rotation_change(
     # short-circuit on the value comparison against the freshly-spawned
     # webview (which knows nothing about the old URL).
     assert viewer.current_browser_url is None
+    skip.set.assert_called_once()
+    # _last_applied_rotation is latched immediately, NOT only after
+    # load_browser() respawns the webview. Otherwise a second `reload`
+    # arriving in the gap would treat rotation as still-changed and
+    # terminate the already-dying process a second time.
+    assert viewer._last_applied_rotation == 270
+
+
+def test_handle_reload_linuxfb_idempotent_under_repeat(
+    reset_rotation_state: None,
+) -> None:
+    """Two ``reload`` messages back-to-back with the same rotation must
+    not double-terminate AnthiasWebview — issue raised by Copilot in
+    review of #2882."""
+    fake_browser = mock.Mock()
+    skip = mock.Mock()
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 90}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'pi5'}, clear=False),
+        mock.patch.object(viewer, 'load_settings'),
+        mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
+        mock.patch.object(viewer, 'browser', fake_browser),
+        mock.patch.object(viewer, 'MediaPlayerProxy'),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip),
+    ):
+        viewer._handle_reload()
+        viewer._handle_reload()
+    fake_browser.terminate.assert_called_once()
     skip.set.assert_called_once()

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -11,6 +11,7 @@ from unittest import mock
 import pytest
 
 import anthias_viewer as viewer
+from anthias_server.settings import settings
 from anthias_viewer.scheduling import Scheduler
 
 logging.disable(logging.CRITICAL)
@@ -693,7 +694,7 @@ def reset_rotation_state() -> Iterator[None]:
     ],
 )
 def test_rotation_value_clamps(raw: Any, expected: int) -> None:
-    with mock.patch.dict(viewer.settings, {'screen_rotation': raw}):
+    with mock.patch.dict(settings, {'screen_rotation': raw}):
         assert viewer._rotation_value() == expected
 
 
@@ -701,7 +702,7 @@ def test_build_webview_env_appends_rotation_on_linuxfb() -> None:
     """Pi boards (linuxfb) get the rotation baked into QT_QPA_PLATFORM
     so the Qt plugin rotates the framebuffer for free."""
     with (
-        mock.patch.dict(viewer.settings, {'screen_rotation': 90}),
+        mock.patch.dict(settings, {'screen_rotation': 90}),
         mock.patch.dict(
             os.environ,
             {'DEVICE_TYPE': 'pi5', 'QT_QPA_PLATFORM': 'linuxfb'},
@@ -716,7 +717,7 @@ def test_build_webview_env_strips_existing_rotation_suffix() -> None:
     """If a prior launch (or the Dockerfile) baked in a rotation, the
     helper must not double-append."""
     with (
-        mock.patch.dict(viewer.settings, {'screen_rotation': 180}),
+        mock.patch.dict(settings, {'screen_rotation': 180}),
         mock.patch.dict(
             os.environ,
             {
@@ -734,7 +735,7 @@ def test_build_webview_env_no_op_on_wayland() -> None:
     """x86 runs Qt wayland under cage; rotation goes through wlr-randr,
     NOT through the QPA plugin which has no rotation= option."""
     with (
-        mock.patch.dict(viewer.settings, {'screen_rotation': 90}),
+        mock.patch.dict(settings, {'screen_rotation': 90}),
         mock.patch.dict(
             os.environ,
             {'DEVICE_TYPE': 'x86', 'QT_QPA_PLATFORM': 'wayland'},
@@ -750,7 +751,7 @@ def test_build_webview_env_no_suffix_at_zero_rotation() -> None:
     QT_QPA_PLATFORM string so we don't change behavior for the 99%
     case who never touches the Settings dropdown."""
     with (
-        mock.patch.dict(viewer.settings, {'screen_rotation': 0}),
+        mock.patch.dict(settings, {'screen_rotation': 0}),
         mock.patch.dict(
             os.environ,
             {'DEVICE_TYPE': 'pi5', 'QT_QPA_PLATFORM': 'linuxfb'},
@@ -820,7 +821,7 @@ def test_handle_reload_reapplies_rotation_when_changed(
     operator changes rotation in Settings — that's the whole point of
     issue #2856's UI-driven knob."""
     with (
-        mock.patch.dict(viewer.settings, {'screen_rotation': 90}),
+        mock.patch.dict(settings, {'screen_rotation': 90}),
         mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
         mock.patch.object(viewer, 'load_settings'),
         mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
@@ -840,7 +841,7 @@ def test_handle_reload_no_rotation_change_is_no_op(
     screen — the rotation-change path is keyed on a genuine delta."""
     viewer._last_applied_rotation = 90
     with (
-        mock.patch.dict(viewer.settings, {'screen_rotation': 90}),
+        mock.patch.dict(settings, {'screen_rotation': 90}),
         mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
         mock.patch.object(viewer, 'load_settings'),
         mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
@@ -861,7 +862,7 @@ def test_handle_reload_terminates_webview_on_linuxfb_rotation_change(
     fake_browser = mock.Mock()
     skip = mock.Mock()
     with (
-        mock.patch.dict(viewer.settings, {'screen_rotation': 270}),
+        mock.patch.dict(settings, {'screen_rotation': 270}),
         mock.patch.dict(os.environ, {'DEVICE_TYPE': 'pi5'}, clear=False),
         mock.patch.object(viewer, 'load_settings'),
         mock.patch.object(viewer, '_skip_if_current_asset_inactive'),

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -823,7 +823,7 @@ def test_apply_wlr_transform_skipped_on_linuxfb() -> None:
 
 
 def test_apply_wlr_transform_invokes_wlr_randr_per_output() -> None:
-    """On x86, list outputs then push the transform to each one."""
+    """On x86, list enabled outputs then push the transform to each."""
 
     def _fake_run(argv: Any, **kwargs: Any) -> mock.Mock:
         result = mock.Mock()
@@ -835,7 +835,7 @@ def test_apply_wlr_transform_invokes_wlr_randr_per_output() -> None:
                 '  Enabled: yes\n'
                 '  Modes:\n'
                 'HDMI-A-2 "Bar"\n'
-                '  Enabled: no\n'
+                '  Enabled: yes\n'
             )
         else:
             result.stdout = ''
@@ -861,6 +861,35 @@ def test_apply_wlr_transform_invokes_wlr_randr_per_output() -> None:
     for call in transform_calls:
         assert '--transform' in call.args[0]
         assert call.args[0][call.args[0].index('--transform') + 1] == '180'
+
+
+def test_wlr_output_names_skips_disabled_outputs() -> None:
+    """``wlr-randr --output X --transform ...`` on a disabled
+    connector fails noisily and changes nothing — Copilot review of
+    #2882 flagged that we were trying anyway. Parser must drop
+    blocks whose ``Enabled:`` line reads ``no``."""
+
+    def _fake_run(argv: Any, **kwargs: Any) -> mock.Mock:
+        result = mock.Mock()
+        result.returncode = 0
+        result.stdout = (
+            'HDMI-A-1 "Foo"\n'
+            '  Enabled: yes\n'
+            '  Modes:\n'
+            'HDMI-A-2 "Bar"\n'
+            '  Enabled: no\n'
+            'DP-1 "Baz"\n'
+            '  Enabled: yes\n'
+        )
+        result.stderr = ''
+        return result
+
+    with (
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch('anthias_viewer.subprocess.run', side_effect=_fake_run),
+    ):
+        names = viewer._wlr_output_names()
+    assert names == ['HDMI-A-1', 'DP-1']
 
 
 def test_apply_wlr_transform_logs_warning_on_nonzero_exit(
@@ -1041,11 +1070,98 @@ def test_asset_loop_consumes_pending_rotation_bounce(
         mock.patch.object(
             viewer, '_consume_pending_rotation_bounce'
         ) as consume,
+        mock.patch.object(viewer, '_retry_wayland_rotation_if_pending'),
         mock.patch.object(viewer, 'view_image'),
         mock.patch('anthias_viewer.get_skip_event', return_value=skip),
     ):
         viewer.asset_loop(fake_scheduler)
     consume.assert_called_once()
+
+
+def test_asset_loop_retries_wayland_rotation(
+    reset_rotation_state: None,
+) -> None:
+    """asset_loop must drive the Wayland startup-failure retry —
+    Copilot review of #2882 flagged that without it, an early-boot
+    wlr-randr failure (cage's wayland socket not yet up) leaves the
+    display unrotated forever, since no reload arrives unattended."""
+    fake_scheduler = mock.Mock()
+    fake_scheduler.get_next_asset.return_value = None
+    skip = mock.Mock()
+    skip.wait.return_value = False
+    with (
+        mock.patch.object(viewer, '_consume_pending_rotation_bounce'),
+        mock.patch.object(viewer, '_retry_wayland_rotation_if_pending') as r,
+        mock.patch.object(viewer, 'view_image'),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip),
+    ):
+        viewer.asset_loop(fake_scheduler)
+    r.assert_called_once()
+
+
+def test_retry_wayland_rotation_skips_when_already_applied(
+    reset_rotation_state: None,
+) -> None:
+    """Cheap early-return when rotation is already where it should
+    be — otherwise asset_loop would push wlr-randr on every tick."""
+    viewer._last_applied_rotation = 90
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 90}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch.object(viewer, '_apply_wlr_transform') as apply,
+    ):
+        viewer._retry_wayland_rotation_if_pending()
+    apply.assert_not_called()
+
+
+def test_retry_wayland_rotation_recovers_from_startup_failure(
+    reset_rotation_state: None,
+) -> None:
+    """Sentinel -1 (set by load_browser when the boot apply failed)
+    must trigger a retry. On success the latch advances to the real
+    angle so subsequent ticks early-return."""
+    viewer._last_applied_rotation = -1
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 270}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch.object(
+            viewer, '_apply_wlr_transform', return_value=True
+        ) as apply,
+    ):
+        viewer._retry_wayland_rotation_if_pending()
+    apply.assert_called_once_with(270)
+    assert viewer._last_applied_rotation == 270
+
+
+def test_retry_wayland_rotation_keeps_sentinel_on_failure(
+    reset_rotation_state: None,
+) -> None:
+    """A second-attempt failure must NOT latch the new angle —
+    otherwise we'd silently give up on rotation."""
+    viewer._last_applied_rotation = -1
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 270}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch.object(viewer, '_apply_wlr_transform', return_value=False),
+    ):
+        viewer._retry_wayland_rotation_if_pending()
+    assert viewer._last_applied_rotation == -1
+
+
+def test_retry_wayland_rotation_skipped_on_linuxfb(
+    reset_rotation_state: None,
+) -> None:
+    """Linuxfb rotation is applied synchronously at QPA init via
+    QT_QPA_PLATFORM, so there's no analogous failure mode — the
+    retry helper must short-circuit on Pi boards."""
+    viewer._last_applied_rotation = -1
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 90}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'pi5'}, clear=False),
+        mock.patch.object(viewer, '_apply_wlr_transform') as apply,
+    ):
+        viewer._retry_wayland_rotation_if_pending()
+    apply.assert_not_called()
 
 
 def test_handle_reload_linuxfb_idempotent_under_repeat(

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -766,6 +766,51 @@ def test_build_webview_env_no_suffix_at_zero_rotation() -> None:
     assert env['QT_QPA_PLATFORM'] == 'linuxfb'
 
 
+def test_build_webview_env_preserves_other_qpa_options() -> None:
+    """An operator who set QT_QPA_PLATFORM=linuxfb:fb=/dev/fb1 must
+    keep that option through a rotation change — Copilot review of
+    #2882 flagged that the previous naive split dropped it."""
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 90}),
+        mock.patch.dict(
+            os.environ,
+            {
+                'DEVICE_TYPE': 'pi5',
+                'QT_QPA_PLATFORM': 'linuxfb:fb=/dev/fb1,tty=/dev/tty1',
+            },
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    qpa = env['QT_QPA_PLATFORM']
+    plugin, _, opts = qpa.partition(':')
+    options = set(opts.split(','))
+    assert plugin == 'linuxfb'
+    assert options == {'fb=/dev/fb1', 'tty=/dev/tty1', 'rotation=90'}
+
+
+def test_build_webview_env_removes_stale_rotation_when_dialed_to_zero() -> (
+    None
+):
+    """If a previous launch set rotation=90 in QT_QPA_PLATFORM and the
+    operator now picks 0° from the dropdown, the rotation= option
+    must come back out — otherwise the screen stays rotated after a
+    webview respawn. Copilot review of #2882."""
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 0}),
+        mock.patch.dict(
+            os.environ,
+            {
+                'DEVICE_TYPE': 'pi5',
+                'QT_QPA_PLATFORM': 'linuxfb:fb=/dev/fb1,rotation=90',
+            },
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['QT_QPA_PLATFORM'] == 'linuxfb:fb=/dev/fb1'
+
+
 def test_apply_wlr_transform_skipped_on_linuxfb() -> None:
     """The wlr-randr binary isn't even shipped on Pi boards — make
     sure we never call it from a non-wayland viewer."""

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -661,17 +661,21 @@ def test_skip_swallows_db_errors() -> None:
 
 @pytest.fixture
 def reset_rotation_state() -> Iterator[None]:
-    """_last_applied_rotation is module state — snapshot and restore so
-    rotation tests don't bleed into each other (or into the prior
-    reload tests that don't mock _apply_wlr_transform)."""
+    """_last_applied_rotation + _rotation_bounce_pending are module
+    state — snapshot and restore so rotation tests don't bleed into
+    each other (or into the prior reload tests that don't mock
+    _apply_wlr_transform)."""
     prior_rot = viewer._last_applied_rotation
     prior_url = viewer.current_browser_url
+    prior_pending = viewer._rotation_bounce_pending
     try:
         viewer._last_applied_rotation = 0
+        viewer._rotation_bounce_pending = False
         yield
     finally:
         viewer._last_applied_rotation = prior_rot
         viewer.current_browser_url = prior_url
+        viewer._rotation_bounce_pending = prior_pending
 
 
 @pytest.mark.parametrize(
@@ -862,12 +866,36 @@ def test_handle_reload_reapplies_rotation_when_changed(
         mock.patch.object(viewer, 'load_settings'),
         mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
         mock.patch('anthias_viewer.MediaPlayerProxy.reset') as reset,
-        mock.patch.object(viewer, '_apply_wlr_transform') as apply,
+        mock.patch.object(
+            viewer, '_apply_wlr_transform', return_value=True
+        ) as apply,
     ):
         viewer._handle_reload()
     apply.assert_called_once_with(90)
     reset.assert_called_once()
     assert viewer._last_applied_rotation == 90
+
+
+def test_handle_reload_does_not_latch_when_wlr_transform_fails(
+    reset_rotation_state: None,
+) -> None:
+    """Issue #2856 (Copilot review #2): if wlr-randr can't apply the
+    transform (cage not ready, no outputs, every output failed), we
+    must NOT latch the new rotation as ``applied`` — the next reload
+    should retry rather than leaving the display stuck unrotated
+    until the user changes the setting again."""
+    viewer._last_applied_rotation = 0
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 90}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch.object(viewer, 'load_settings'),
+        mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
+        mock.patch('anthias_viewer.MediaPlayerProxy.reset'),
+        mock.patch.object(viewer, '_apply_wlr_transform', return_value=False),
+    ):
+        viewer._handle_reload()
+    # Latch unchanged — next reload retries.
+    assert viewer._last_applied_rotation == 0
 
 
 def test_handle_reload_no_rotation_change_is_no_op(
@@ -889,14 +917,18 @@ def test_handle_reload_no_rotation_change_is_no_op(
     reset.assert_not_called()
 
 
-def test_handle_reload_terminates_webview_on_linuxfb_rotation_change(
+def test_handle_reload_queues_bounce_on_linuxfb_rotation_change(
     reset_rotation_state: None,
 ) -> None:
     """linuxfb only reads :rotation=N at QPA init, so the live-rotation
-    path has to bounce AnthiasWebview. asset_loop's existing
-    ``browser.is_alive()`` check restarts it on the next tick."""
+    path has to bounce AnthiasWebview. _handle_reload runs on the
+    subscriber thread and MUST NOT terminate the browser directly —
+    that would race a concurrent view_*() call mid-D-Bus on the main
+    thread (Copilot review of #2882). It only sets a flag; the main
+    thread consumes it via _consume_pending_rotation_bounce()."""
     fake_browser = mock.Mock()
     skip = mock.Mock()
+    viewer._rotation_bounce_pending = False
     with (
         mock.patch.dict(settings, {'screen_rotation': 270}),
         mock.patch.dict(os.environ, {'DEVICE_TYPE': 'pi5'}, clear=False),
@@ -907,27 +939,81 @@ def test_handle_reload_terminates_webview_on_linuxfb_rotation_change(
         mock.patch('anthias_viewer.get_skip_event', return_value=skip),
     ):
         viewer._handle_reload()
-    fake_browser.terminate.assert_called_once()
-    # current_browser_url must be reset so the next loadPage doesn't
-    # short-circuit on the value comparison against the freshly-spawned
-    # webview (which knows nothing about the old URL).
-    assert viewer.current_browser_url is None
+    # NOT called from the subscriber thread.
+    fake_browser.terminate.assert_not_called()
+    # Flag set so the next asset_loop tick consumes it on the main
+    # thread.
+    assert viewer._rotation_bounce_pending is True
     skip.set.assert_called_once()
     # _last_applied_rotation is latched immediately, NOT only after
     # load_browser() respawns the webview. Otherwise a second `reload`
     # arriving in the gap would treat rotation as still-changed and
-    # terminate the already-dying process a second time.
+    # spam terminate() flags on an already-pending bounce.
     assert viewer._last_applied_rotation == 270
+
+
+def test_consume_pending_rotation_bounce_terminates_browser(
+    reset_rotation_state: None,
+) -> None:
+    """The main-thread half of the handoff: when the flag is set,
+    terminate the webview and clear current_browser_url so the next
+    view_*() call respawns it via load_browser()."""
+    fake_browser = mock.Mock()
+    viewer._rotation_bounce_pending = True
+    with mock.patch.object(viewer, 'browser', fake_browser):
+        viewer._consume_pending_rotation_bounce()
+    fake_browser.terminate.assert_called_once()
+    assert viewer.current_browser_url is None
+    # Flag cleared so a subsequent tick (with no new pending bounce)
+    # doesn't terminate the freshly-spawned process.
+    assert viewer._rotation_bounce_pending is False
+
+
+def test_consume_pending_rotation_bounce_no_op_when_flag_clear(
+    reset_rotation_state: None,
+) -> None:
+    """Most ticks have no pending bounce — must not touch the
+    browser; otherwise every asset_loop iteration would kill it."""
+    fake_browser = mock.Mock()
+    viewer._rotation_bounce_pending = False
+    with mock.patch.object(viewer, 'browser', fake_browser):
+        viewer._consume_pending_rotation_bounce()
+    fake_browser.terminate.assert_not_called()
+
+
+def test_asset_loop_consumes_pending_rotation_bounce(
+    reset_rotation_state: None,
+) -> None:
+    """asset_loop must consume the subscriber-set flag at the top of
+    each tick — that's the main-thread side of the cross-thread
+    handoff that keeps view_*() and rotation-change from racing on
+    ``browser``."""
+    fake_scheduler = mock.Mock()
+    fake_scheduler.get_next_asset.return_value = None
+    skip = mock.Mock()
+    skip.wait.return_value = False
+    with (
+        mock.patch.object(
+            viewer, '_consume_pending_rotation_bounce'
+        ) as consume,
+        mock.patch.object(viewer, 'view_image'),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip),
+    ):
+        viewer.asset_loop(fake_scheduler)
+    consume.assert_called_once()
 
 
 def test_handle_reload_linuxfb_idempotent_under_repeat(
     reset_rotation_state: None,
 ) -> None:
     """Two ``reload`` messages back-to-back with the same rotation must
-    not double-terminate AnthiasWebview — issue raised by Copilot in
-    review of #2882."""
+    not flap the pending-bounce flag or set the skip_event twice on
+    an already-pending bounce — issue raised by Copilot in review of
+    #2882. After the first reload latches the new rotation, the
+    second sees it unchanged and short-circuits."""
     fake_browser = mock.Mock()
     skip = mock.Mock()
+    viewer._rotation_bounce_pending = False
     with (
         mock.patch.dict(settings, {'screen_rotation': 90}),
         mock.patch.dict(os.environ, {'DEVICE_TYPE': 'pi5'}, clear=False),
@@ -939,5 +1025,6 @@ def test_handle_reload_linuxfb_idempotent_under_repeat(
     ):
         viewer._handle_reload()
         viewer._handle_reload()
-    fake_browser.terminate.assert_called_once()
+    fake_browser.terminate.assert_not_called()
     skip.set.assert_called_once()
+    assert viewer._rotation_bounce_pending is True

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -652,3 +652,227 @@ def test_skip_swallows_db_errors() -> None:
         # Must not raise.
         viewer._skip_if_current_asset_inactive()
     skip_event.set.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Screen rotation (issue #2856)
+
+
+@pytest.fixture
+def reset_rotation_state() -> Iterator[None]:
+    """_last_applied_rotation is module state — snapshot and restore so
+    rotation tests don't bleed into each other (or into the prior
+    reload tests that don't mock _apply_wlr_transform)."""
+    prior_rot = viewer._last_applied_rotation
+    prior_url = viewer.current_browser_url
+    try:
+        viewer._last_applied_rotation = 0
+        yield
+    finally:
+        viewer._last_applied_rotation = prior_rot
+        viewer.current_browser_url = prior_url
+
+
+@pytest.mark.parametrize(
+    'raw, expected',
+    [
+        (0, 0),
+        (90, 90),
+        (180, 180),
+        (270, 270),
+        ('90', 90),
+        # Anything outside the cardinal set collapses to 0 — the v2
+        # serializer and form handler already filter on write, but the
+        # viewer reads an arbitrary file off disk and must not propagate
+        # garbage values (CLI argv for mpv/VLC, env value for Qt) into
+        # the playback layer.
+        (45, 0),
+        (-1, 0),
+        ('garbage', 0),
+        (None, 0),
+    ],
+)
+def test_rotation_value_clamps(raw: Any, expected: int) -> None:
+    with mock.patch.dict(viewer.settings, {'screen_rotation': raw}):
+        assert viewer._rotation_value() == expected
+
+
+def test_build_webview_env_appends_rotation_on_linuxfb() -> None:
+    """Pi boards (linuxfb) get the rotation baked into QT_QPA_PLATFORM
+    so the Qt plugin rotates the framebuffer for free."""
+    with (
+        mock.patch.dict(viewer.settings, {'screen_rotation': 90}),
+        mock.patch.dict(
+            os.environ,
+            {'DEVICE_TYPE': 'pi5', 'QT_QPA_PLATFORM': 'linuxfb'},
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['QT_QPA_PLATFORM'] == 'linuxfb:rotation=90'
+
+
+def test_build_webview_env_strips_existing_rotation_suffix() -> None:
+    """If a prior launch (or the Dockerfile) baked in a rotation, the
+    helper must not double-append."""
+    with (
+        mock.patch.dict(viewer.settings, {'screen_rotation': 180}),
+        mock.patch.dict(
+            os.environ,
+            {
+                'DEVICE_TYPE': 'pi5',
+                'QT_QPA_PLATFORM': 'linuxfb:rotation=90',
+            },
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['QT_QPA_PLATFORM'] == 'linuxfb:rotation=180'
+
+
+def test_build_webview_env_no_op_on_wayland() -> None:
+    """x86 runs Qt wayland under cage; rotation goes through wlr-randr,
+    NOT through the QPA plugin which has no rotation= option."""
+    with (
+        mock.patch.dict(viewer.settings, {'screen_rotation': 90}),
+        mock.patch.dict(
+            os.environ,
+            {'DEVICE_TYPE': 'x86', 'QT_QPA_PLATFORM': 'wayland'},
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['QT_QPA_PLATFORM'] == 'wayland'
+
+
+def test_build_webview_env_no_suffix_at_zero_rotation() -> None:
+    """Default-orientation displays should stay on the existing
+    QT_QPA_PLATFORM string so we don't change behavior for the 99%
+    case who never touches the Settings dropdown."""
+    with (
+        mock.patch.dict(viewer.settings, {'screen_rotation': 0}),
+        mock.patch.dict(
+            os.environ,
+            {'DEVICE_TYPE': 'pi5', 'QT_QPA_PLATFORM': 'linuxfb'},
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['QT_QPA_PLATFORM'] == 'linuxfb'
+
+
+def test_apply_wlr_transform_skipped_on_linuxfb() -> None:
+    """The wlr-randr binary isn't even shipped on Pi boards — make
+    sure we never call it from a non-wayland viewer."""
+    with (
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'pi5'}, clear=False),
+        mock.patch('anthias_viewer.subprocess.run') as run,
+    ):
+        viewer._apply_wlr_transform(90)
+    run.assert_not_called()
+
+
+def test_apply_wlr_transform_invokes_wlr_randr_per_output() -> None:
+    """On x86, list outputs then push the transform to each one."""
+
+    def _fake_run(argv: Any, **kwargs: Any) -> mock.Mock:
+        result = mock.Mock()
+        result.returncode = 0
+        # The first call lists outputs; subsequent calls apply.
+        if argv == ['wlr-randr']:
+            result.stdout = (
+                'HDMI-A-1 "Foo Display"\n'
+                '  Enabled: yes\n'
+                '  Modes:\n'
+                'HDMI-A-2 "Bar"\n'
+                '  Enabled: no\n'
+            )
+        else:
+            result.stdout = ''
+        result.stderr = ''
+        return result
+
+    with (
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch(
+            'anthias_viewer.subprocess.run', side_effect=_fake_run
+        ) as run,
+    ):
+        viewer._apply_wlr_transform(180)
+
+    transform_calls = [
+        c
+        for c in run.call_args_list
+        if c.args
+        and c.args[0][:1] == ['wlr-randr']
+        and '--transform' in c.args[0]
+    ]
+    assert len(transform_calls) == 2
+    for call in transform_calls:
+        assert '--transform' in call.args[0]
+        assert call.args[0][call.args[0].index('--transform') + 1] == '180'
+
+
+def test_handle_reload_reapplies_rotation_when_changed(
+    reset_rotation_state: None,
+) -> None:
+    """The reload pub/sub message must re-push wlr-randr when the
+    operator changes rotation in Settings — that's the whole point of
+    issue #2856's UI-driven knob."""
+    with (
+        mock.patch.dict(viewer.settings, {'screen_rotation': 90}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch.object(viewer, 'load_settings'),
+        mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
+        mock.patch('anthias_viewer.MediaPlayerProxy.reset') as reset,
+        mock.patch.object(viewer, '_apply_wlr_transform') as apply,
+    ):
+        viewer._handle_reload()
+    apply.assert_called_once_with(90)
+    reset.assert_called_once()
+    assert viewer._last_applied_rotation == 90
+
+
+def test_handle_reload_no_rotation_change_is_no_op(
+    reset_rotation_state: None,
+) -> None:
+    """Most reload traffic (asset edits, etc.) must NOT blank the
+    screen — the rotation-change path is keyed on a genuine delta."""
+    viewer._last_applied_rotation = 90
+    with (
+        mock.patch.dict(viewer.settings, {'screen_rotation': 90}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
+        mock.patch.object(viewer, 'load_settings'),
+        mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
+        mock.patch('anthias_viewer.MediaPlayerProxy.reset') as reset,
+        mock.patch.object(viewer, '_apply_wlr_transform') as apply,
+    ):
+        viewer._handle_reload()
+    apply.assert_not_called()
+    reset.assert_not_called()
+
+
+def test_handle_reload_terminates_webview_on_linuxfb_rotation_change(
+    reset_rotation_state: None,
+) -> None:
+    """linuxfb only reads :rotation=N at QPA init, so the live-rotation
+    path has to bounce AnthiasWebview. asset_loop's existing
+    ``browser.is_alive()`` check restarts it on the next tick."""
+    fake_browser = mock.Mock()
+    skip = mock.Mock()
+    with (
+        mock.patch.dict(viewer.settings, {'screen_rotation': 270}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'pi5'}, clear=False),
+        mock.patch.object(viewer, 'load_settings'),
+        mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
+        mock.patch.object(viewer, 'browser', fake_browser),
+        mock.patch.object(viewer, 'MediaPlayerProxy'),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip),
+    ):
+        viewer._handle_reload()
+    fake_browser.terminate.assert_called_once()
+    # current_browser_url must be reset so the next loadPage doesn't
+    # short-circuit on the value comparison against the freshly-spawned
+    # webview (which knows nothing about the old URL).
+    assert viewer.current_browser_url is None
+    skip.set.assert_called_once()

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -933,7 +933,13 @@ def test_handle_reload_reapplies_rotation_when_changed(
 ) -> None:
     """The reload pub/sub message must re-push wlr-randr when the
     operator changes rotation in Settings — that's the whole point of
-    issue #2856's UI-driven knob."""
+    issue #2856's UI-driven knob.
+
+    Wayland-side rotation change must NOT call MediaPlayerProxy.reset()
+    — mpv's wayland VO inherits the compositor transform, so killing
+    the in-flight mpv would just leave the screen black until the
+    asset's original duration elapses (Copilot review of #2882).
+    """
     with (
         mock.patch.dict(settings, {'screen_rotation': 90}),
         mock.patch.dict(os.environ, {'DEVICE_TYPE': 'x86'}, clear=False),
@@ -946,8 +952,30 @@ def test_handle_reload_reapplies_rotation_when_changed(
     ):
         viewer._handle_reload()
     apply.assert_called_once_with(90)
-    reset.assert_called_once()
+    reset.assert_not_called()
     assert viewer._last_applied_rotation == 90
+
+
+def test_handle_reload_resets_media_player_on_linuxfb_rotation_change(
+    reset_rotation_state: None,
+) -> None:
+    """On linuxfb (Pi) the rotation change DOES need MediaPlayerProxy
+    reset, because VLC bakes the transform filter into the instance
+    at construction. Bound for the pi1/2/3 boards specifically."""
+    fake_browser = mock.Mock()
+    skip = mock.Mock()
+    viewer._rotation_bounce_pending = False
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 90}),
+        mock.patch.dict(os.environ, {'DEVICE_TYPE': 'pi3'}, clear=False),
+        mock.patch.object(viewer, 'load_settings'),
+        mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
+        mock.patch.object(viewer, 'browser', fake_browser),
+        mock.patch('anthias_viewer.MediaPlayerProxy.reset') as reset,
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip),
+    ):
+        viewer._handle_reload()
+    reset.assert_called_once()
 
 
 def test_handle_reload_does_not_latch_when_wlr_transform_fails(

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -274,6 +274,12 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
                     'cage',
                     'qt6-wayland',
                     'va-driver-all',
+                    # wlr-randr is how the viewer applies the Settings
+                    # page's "screen rotation" knob on x86 — Qt's
+                    # wayland QPA has no rotation= equivalent, so the
+                    # transform has to go through the compositor.
+                    # src/anthias_viewer/__init__.py drives this.
+                    'wlr-randr',
                 ]
             )
     else:


### PR DESCRIPTION
### Issues Fixed

Closes #2856 (consolidates #2693, #2326, #1997, #1545).

### Description

Adds a **Screen rotation** dropdown (0 / 90 / 180 / 270°) to the Settings page and plumbs it through the viewer playback layer so a single setting drives every supported target:

- **Pi (Qt linuxfb)** — viewer spawns AnthiasWebview with `QT_QPA_PLATFORM=linuxfb:rotation=N`. The Qt plugin rotates the framebuffer natively (no perf cost). mpv on Pi adds `--video-rotate=N`; VLC on SD Pi boards adds `--video-filter=transform`.
- **x86 (cage / wayland)** — viewer calls `wlr-randr --output … --transform N`. Qt's wayland QPA and mpv's wayland VO both inherit the compositor transform; no per-process flag needed.

Changing the dropdown reuses the existing `reload` pub/sub. On x86 the transform is re-pushed live; on Pi we bounce AnthiasWebview so the new env takes effect on the next `asset_loop` tick. `MediaPlayerProxy.reset()` drops the cached VLC instance so the next video re-inits with the new transform filter.

`wlr-randr` is added to the x86 apt list (`tools/image_builder/utils.py`).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)