### PR TITLE
fix(security): address open CodeQL alerts (path-injection, url-redirection, stack-trace-exposure)

### DIFF
--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -660,9 +660,10 @@ class DeviceSettingsViewV2(APIView):
             publisher.send_to_viewer('reload')
 
             return Response({'message': 'Settings were successfully saved.'})
-        except Exception as e:
+        except Exception:
+            logger.exception('Settings save failed')
             return Response(
-                {'error': f'An error occurred while saving settings: {e}'},
+                {'error': 'An error occurred while saving settings.'},
                 status=400,
             )
 

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import tarfile
 import uuid
 from datetime import datetime
@@ -383,6 +384,12 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
         candidate_ext = f'.{subtype}'
         if mimetype == 'image' and candidate_ext in NORMALIZE_IMAGE_EXTS:
             src_ext = candidate_ext
+
+    # Drop anything that isn't a plain ``.<alnum>`` extension so a
+    # hostile ``Content-Disposition: filename=`` value can't smuggle
+    # ``/`` or ``..`` into ``final_path`` (CodeQL py/path-injection).
+    if src_ext and not re.fullmatch(r'\.[A-Za-z0-9]{1,16}', src_ext):
+        src_ext = ''
 
     # uuid4 (random) instead of uuid5(NAMESPACE_URL, name): the
     # deterministic v5 form would collide on disk for two files
@@ -977,22 +984,6 @@ def system_info(request: HttpRequest) -> HttpResponse:
     return template(request, 'system_info.html', context)
 
 
-def _safe_login_next(request: HttpRequest, candidate: str) -> str:
-    """Whitelist `next` to same-host paths so the login flow can't be
-    weaponised as an open redirect. Falls back to the dashboard for
-    empty / off-host / scheme-mismatched values."""
-    home = reverse('anthias_app:home')
-    if not candidate:
-        return home
-    if url_has_allowed_host_and_scheme(
-        url=candidate,
-        allowed_hosts={request.get_host()},
-        require_https=request.is_secure(),
-    ):
-        return candidate
-    return home
-
-
 @require_http_methods(['GET', 'POST'])
 def login(request: HttpRequest) -> HttpResponse:
     # Read `next` from the form on POST (login.html round-trips the
@@ -1011,7 +1002,19 @@ def login(request: HttpRequest) -> HttpResponse:
         user = authenticate(request, username=username, password=password)
         if user is not None:
             django_login(request, user)
-            return redirect(_safe_login_next(request, next_url))
+            # Run the host/scheme allow-list inline so CodeQL's
+            # py/url-redirection sees the sanitiser guarding the
+            # redirect target (it doesn't propagate sanitisers
+            # through a helper). reverse() also rebuilds the
+            # fallback so none of the inbound string survives.
+            redirect_target = reverse('anthias_app:home')
+            if next_url and url_has_allowed_host_and_scheme(
+                url=next_url,
+                allowed_hosts={request.get_host()},
+                require_https=request.is_secure(),
+            ):
+                redirect_target = next_url
+            return redirect(redirect_target)
         else:
             messages.error(request, 'Invalid username or password')
             return template(request, 'login.html', {'next': next_url})

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -43,6 +43,12 @@ r = connect_to_redis()
 
 _ANTHIAS_REPO_URL = 'https://github.com/Screenly/Anthias'
 
+# Plain ``.<alnum>`` literal — anything else is rejected by
+# ``assets_upload`` so a hostile ``Content-Disposition: filename=``
+# can't smuggle ``/`` or ``..`` into the on-disk path (CodeQL
+# py/path-injection on ``open(final_path, ...)``).
+_SAFE_EXT_RE = re.compile(r'\.[A-Za-z0-9]{1,16}')
+
 
 def _parse_local_datetime(value: str) -> datetime:
     """Parse a date/time the edit-form posts back from Flatpickr.
@@ -360,6 +366,16 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
     # lands extensionless if we can possibly avoid it (an
     # extensionless file silently bypasses the normalise pipeline
     # via ``needs_image_normalisation`` returning False).
+    #
+    # Every candidate must clear ``_SAFE_EXT_RE`` (a plain
+    # ``.<alnum>`` literal) before we accept it — a hostile
+    # ``Content-Disposition: filename=`` value can otherwise smuggle
+    # ``/`` or ``..`` into ``final_path`` (CodeQL py/path-injection).
+    # Each step also falls back to the next one if its own candidate
+    # fails the regex, so an upload with a junk filename ext still
+    # gets the MIME-subtype fallback that keeps the HEIC-on-sparse-DB
+    # pipeline-routing test green.
+    #
     #   1. ``guess_extension(file_type)`` — works for every MIME
     #      that's in the host's mimetypes DB.
     #   2. ``path.splitext(upload_name)[1]`` — operator-supplied
@@ -374,22 +390,19 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
     #      ``image/jp2`` entries — without it, a HEIC upload from
     #      a clean Pi base image could slip past normalisation
     #      and fail to render.
-    src_ext = guess_extension(file_type) or ''
+    def _safe_ext(candidate: str) -> str:
+        return candidate if _SAFE_EXT_RE.fullmatch(candidate) else ''
+
+    src_ext = _safe_ext(guess_extension(file_type) or '')
     if not src_ext:
-        src_ext = path.splitext(upload_name)[1].lower()
+        src_ext = _safe_ext(path.splitext(upload_name)[1].lower())
     if not src_ext:
         from anthias_server.processing import NORMALIZE_IMAGE_EXTS
 
         subtype = file_type.split('/', 1)[1] if '/' in file_type else ''
         candidate_ext = f'.{subtype}'
         if mimetype == 'image' and candidate_ext in NORMALIZE_IMAGE_EXTS:
-            src_ext = candidate_ext
-
-    # Drop anything that isn't a plain ``.<alnum>`` extension so a
-    # hostile ``Content-Disposition: filename=`` value can't smuggle
-    # ``/`` or ``..`` into ``final_path`` (CodeQL py/path-injection).
-    if src_ext and not re.fullmatch(r'\.[A-Za-z0-9]{1,16}', src_ext):
-        src_ext = ''
+            src_ext = _safe_ext(candidate_ext)
 
     # uuid4 (random) instead of uuid5(NAMESPACE_URL, name): the
     # deterministic v5 form would collide on disk for two files

--- a/tests/test_login_view.py
+++ b/tests/test_login_view.py
@@ -101,9 +101,8 @@ def test_login_post_rejects_offhost_next(operator: User) -> None:
         },
     )
     assert response.status_code == 302
-    # url_has_allowed_host_and_scheme rejects off-host targets, so
-    # _safe_login_next falls back to anthias_app:home (which reverses
-    # to '/').
+    # url_has_allowed_host_and_scheme rejects off-host targets, so the
+    # view falls back to anthias_app:home (which reverses to '/').
     assert response['Location'] == '/'
 
 


### PR DESCRIPTION
## Summary

Closes the three currently-actionable CodeQL alerts on `master` HEAD:

- **#91 `py/path-injection`** (`src/anthias_server/app/views.py:393`) — `assets_upload` now drops any `src_ext` that isn't a plain `.<alnum>` extension before it's joined onto `assetdir`, so a hostile `Content-Disposition: filename=` can't smuggle `/` or `..` into the on-disk path. The random-UUID basename was already the safe component; this is defence-in-depth on the extension.
- **#90 `py/url-redirection`** (`src/anthias_server/app/views.py:1014`) — `login` runs `django.utils.http.url_has_allowed_host_and_scheme` inline at the `redirect()` site so CodeQL sees the canonical Django sanitiser guarding the target. The now-only-internal `_safe_login_next` helper is removed because the check lives at the call site.
- **#77 `py/stack-trace-exposure`** (`src/anthias_server/api/views/v2.py:665`) — `DeviceSettingsViewV2.patch` logs the failure via `logger.exception` and returns a generic 400 instead of interpolating the exception into the response body.

## Other open alerts (not addressed in code)

- **#92 `py/csrf-protection-disabled`** (`django_project/settings.py:121`) — false positive: `SameHostOriginCsrfMiddleware` subclasses `django.middleware.csrf.CsrfViewMiddleware`. CodeQL doesn't follow class hierarchy; the existing `NOSONAR` comment already documents this for SonarQube's S4502. Will dismiss via `gh code-scanning alert update` once the rest land.
- **#1–#10** point at paths (`auth.py`, `lib/auth.py`, `server.py`, `static/js/moment.js`, `static/js/bootstrap-datepicker.js`) that no longer exist after the React→Django (`e9738288`), `src/` layout (`133ec78f`), and `django.contrib.auth` (`8e2f38b1`) refactors. They should auto-transition to `fixed` after the next master scan; any stragglers can be dismissed.

## Test plan

- [ ] `uv run ruff check` — green locally for the changed files.
- [ ] CodeQL on the PR — `py/path-injection`, `py/url-redirection`, and `py/stack-trace-exposure` no longer flagged on these files.
- [ ] Existing `tests/test_login_view.py` (off-host `next` rejection) and `tests/test_template_views.py` (HEIC/JPEG/video upload extension preservation) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)