### PR TITLE
chore(cec): tidy up follow-ups from #2886

### DIFF
--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -163,7 +163,10 @@ class RecoverViewMixin(APIView):
 class RebootViewMixin(APIView):
     serializer_class = RebootViewSerializerMixin
 
-    @extend_schema(summary='Reboot system')
+    # Empty body on success; declare it so drf-spectacular doesn't
+    # invent a default schema from the (empty) request serializer.
+    # Matches the pattern DisplayPowerViewMixin uses below.
+    @extend_schema(summary='Reboot system', responses={200: None})
     @authorized
     def post(self, request: Request) -> Response:
         reboot_anthias.apply_async()
@@ -173,7 +176,7 @@ class RebootViewMixin(APIView):
 class ShutdownViewMixin(APIView):
     serializer_class = ShutdownViewSerializerMixin
 
-    @extend_schema(summary='Shut down system')
+    @extend_schema(summary='Shut down system', responses={200: None})
     @authorized
     def post(self, request: Request) -> Response:
         shutdown_anthias.apply_async()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -894,7 +894,12 @@ def test_skip_buttons_publish_correct_command(
 # design tweaks). Relative path mirrors the `--output test-artifacts`
 # convention pytest-playwright already uses in pyproject.toml.
 _SCREENSHOT_DIR = 'test-artifacts/cec'
-_CAPTURE_SCREENSHOTS = bool(os.environ.get('PYTEST_CAPTURE_SCREENSHOTS'))
+# Explicit truthy parse so `PYTEST_CAPTURE_SCREENSHOTS=0` keeps the
+# gate OFF — bool(os.environ.get(...)) would flip on for any non-empty
+# string, including '0'/'false'.
+_CAPTURE_SCREENSHOTS = os.environ.get(
+    'PYTEST_CAPTURE_SCREENSHOTS', ''
+).lower() in {'1', 'true', 'yes', 'on'}
 
 
 def _maybe_screenshot(page: Page, filename: str, **kwargs: Any) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -885,16 +885,24 @@ def test_skip_buttons_publish_correct_command(
 # visible state we stub /dev/vchiq with a plain file before navigating
 # and remove it on teardown.
 
-# Relative to wherever pytest is invoked. Matches the `--output
-# test-artifacts` convention pytest-playwright already uses in
-# pyproject.toml's addopts, so CI's upload-artifact step picks up
-# these PNGs alongside any failure traces.
+# Screenshot capture is OFF by default. The original PR (#2886) used
+# screenshots for a one-time UX review; running them on every CI cycle
+# is pure overhead because the `Upload integration test artifacts` step
+# in .github/workflows/test-runner.yml is gated on `if: failure()` —
+# the PNGs on a green run get written and immediately discarded. Set
+# `PYTEST_CAPTURE_SCREENSHOTS=1` when you want them locally (UX work,
+# design tweaks). Relative path mirrors the `--output test-artifacts`
+# convention pytest-playwright already uses in pyproject.toml.
 _SCREENSHOT_DIR = 'test-artifacts/cec'
+_CAPTURE_SCREENSHOTS = bool(os.environ.get('PYTEST_CAPTURE_SCREENSHOTS'))
 
 
-def _ensure_screenshot_dir() -> str:
+def _maybe_screenshot(page: Page, filename: str, **kwargs: Any) -> None:
+    """No-op unless PYTEST_CAPTURE_SCREENSHOTS is set in the env."""
+    if not _CAPTURE_SCREENSHOTS:
+        return
     os.makedirs(_SCREENSHOT_DIR, exist_ok=True)
-    return _SCREENSHOT_DIR
+    page.screenshot(path=f'{_SCREENSHOT_DIR}/{filename}', **kwargs)
 
 
 @pytest.fixture
@@ -956,26 +964,24 @@ def test_display_power_section_visible_with_cec_adapter(
     )
 
     # Screenshot 1: full settings page with the new section
-    _ensure_screenshot_dir()
-    page.screenshot(
-        path=f'{_SCREENSHOT_DIR}/01-settings-page-with-cec.png',
-        full_page=True,
-    )
+    _maybe_screenshot(page, '01-settings-page-with-cec.png', full_page=True)
 
     # Screenshot 2: just the Display power card (tight crop)
-    section = page.locator('section', has_text='Display power').last
-    section.scroll_into_view_if_needed()
-    box = section.bounding_box()
-    assert box, 'display-power section has no bounding box'
-    page.screenshot(
-        path=f'{_SCREENSHOT_DIR}/02-display-power-card.png',
-        clip={
-            'x': max(box['x'] - 8, 0),
-            'y': max(box['y'] - 8, 0),
-            'width': box['width'] + 16,
-            'height': box['height'] + 16,
-        },
-    )
+    if _CAPTURE_SCREENSHOTS:
+        section = page.locator('section', has_text='Display power').last
+        section.scroll_into_view_if_needed()
+        box = section.bounding_box()
+        assert box, 'display-power section has no bounding box'
+        _maybe_screenshot(
+            page,
+            '02-display-power-card.png',
+            clip={
+                'x': max(box['x'] - 8, 0),
+                'y': max(box['y'] - 8, 0),
+                'width': box['width'] + 16,
+                'height': box['height'] + 16,
+            },
+        )
 
 
 @pytest.mark.integration
@@ -1001,38 +1007,4 @@ def test_display_power_button_click_surfaces_error_toast(
     expect(error_toast).to_contain_text('Display turn-on')
 
     # Screenshot 3: error toast in context
-    _ensure_screenshot_dir()
-    page.screenshot(
-        path=f'{_SCREENSHOT_DIR}/03-error-toast.png',
-        full_page=False,
-    )
-
-
-@pytest.mark.integration
-@pytest.mark.django_db(transaction=True)
-def test_display_power_success_toast_appearance(
-    reset_assets: None, page: Page, cec_stub_device: str
-) -> None:
-    """Real success path requires a working HDMI-CEC TV, which the
-    test container cannot supply. To exercise the *visual* success
-    treatment (green check, dismissible) we drive Alpine's toast store
-    directly — same call path the server-rendered django-messages
-    drain uses (vendor.ts:50). This isn't asserting on the redirect
-    flow; it's a UX-coverage screenshot for the success kind."""
-    page.goto(SETTINGS_URL)
-    expect(page.get_by_role('heading', name='Display power')).to_be_visible()
-
-    page.evaluate(
-        """() => window.Alpine.store('toasts').push(
-            'success', 'Display turn-on command sent.', 60000
-        )"""
-    )
-    success_toast = page.locator('.app-toast--success').first
-    expect(success_toast).to_be_visible()
-    expect(success_toast).to_contain_text('Display turn-on command sent.')
-
-    _ensure_screenshot_dir()
-    page.screenshot(
-        path=f'{_SCREENSHOT_DIR}/04-success-toast.png',
-        full_page=False,
-    )
+    _maybe_screenshot(page, '03-error-toast.png', full_page=False)


### PR DESCRIPTION
### Issues Fixed

Follow-up to #2886. No new issue — these are honest cleanups I flagged after the original PR merged.

### Description

Three small tidies, all narrowly scoped:

- **Gate Playwright screenshot captures behind `PYTEST_CAPTURE_SCREENSHOTS=1`.** The original PR captured PNGs for every integration test run, but CI's `Upload integration test artifacts` step is gated on `if: failure()` — so on green runs the files were written and immediately discarded. Default is now off; set the env var when you want them locally for UX work.
- **Drop `test_display_power_success_toast_appearance`.** It drove `Alpine.store('toasts').push('success', ...)` directly because the test container cannot perform a real CEC success. Its only assertion was that the existing toast store accepts a `success` kind — already covered by every other toast in the app. It only existed to capture a screenshot for the one-time UX review; with that motivation gone, the test goes too.
- **Declare `responses={200: None}` on `RebootViewMixin` / `ShutdownViewMixin`** so the generated OpenAPI schema accurately reflects the empty body those endpoints return. Aligns with how `DisplayPowerViewMixin` (from #2886) declared its responses explicitly.

### Test plan

- [x] `pytest -m "not integration"` — 863 pass.
- [x] `pytest -m integration tests/test_app.py -k display_power` — 3 pass (down from 4 with the contrived success-toast test removed).
- [x] `PYTEST_CAPTURE_SCREENSHOTS=1 pytest -m integration ... -k display_power` — confirms the env-var path still drops PNGs into `test-artifacts/cec/`.
- [x] `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)