### PR TITLE
feat(http): identify Anthias outbound traffic with a User-Agent

### DIFF
--- a/src/anthias_common/http.py
+++ b/src/anthias_common/http.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import requests
 
-from anthias_server.lib import diagnostics
+from anthias_common.version import get_anthias_release
 
 
 ANTHIAS_HOMEPAGE = 'https://anthias.screenly.io'
@@ -27,10 +27,10 @@ def get_user_agent() -> str:
     ``Product/Version (+URL)`` convention used by well-behaved
     crawlers so ops at the receiving end can identify the source
     without parsing the path. Falls back to ``unknown`` only when
-    ``diagnostics.get_anthias_release()`` finds neither the installed
-    package metadata nor the repo-root pyproject.toml.
+    ``get_anthias_release()`` finds neither the installed package
+    metadata nor the repo-root pyproject.toml.
     """
-    release = diagnostics.get_anthias_release() or 'unknown'
+    release = get_anthias_release() or 'unknown'
     return f'Anthias/{release} (+{ANTHIAS_HOMEPAGE})'
 
 

--- a/src/anthias_common/http.py
+++ b/src/anthias_common/http.py
@@ -1,0 +1,49 @@
+"""Shared HTTP client helpers for outbound Anthias requests.
+
+A central place to set the ``User-Agent`` so any service Anthias
+talks to (Screenly's migration API today; future third-party calls
+later) sees a consistent ``Anthias/<version>`` label rather than the
+default ``python-requests/<x.y>``.
+
+Spoofed-UA traffic (the URL-availability probe in
+``anthias_common.utils`` that pretends to be Safari to dodge anti-bot
+pages) deliberately bypasses this — it sets its own header inline.
+"""
+
+from __future__ import annotations
+
+import requests
+
+from anthias_server.lib import diagnostics
+
+
+ANTHIAS_HOMEPAGE = 'https://anthias.screenly.io'
+
+
+def get_user_agent() -> str:
+    """Return the canonical Anthias ``User-Agent`` string.
+
+    Format: ``Anthias/<release> (+<homepage>)`` — the standard
+    ``Product/Version (+URL)`` convention used by well-behaved
+    crawlers so ops at the receiving end can identify the source
+    without parsing the path. Falls back to ``unknown`` only when
+    ``diagnostics.get_anthias_release()`` finds neither the installed
+    package metadata nor the repo-root pyproject.toml.
+    """
+    release = diagnostics.get_anthias_release() or 'unknown'
+    return f'Anthias/{release} (+{ANTHIAS_HOMEPAGE})'
+
+
+class AnthiasSession(requests.Session):
+    """A ``requests.Session`` pre-configured with the Anthias UA.
+
+    Use this anywhere Anthias makes an outbound call to a third party
+    so Screenly / GitHub / etc. see a consistent, identifiable label
+    instead of the default ``python-requests/<x.y>``. Per-call
+    ``headers={'User-Agent': ...}`` still wins — ``requests`` merges
+    request headers over session headers on each call.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.headers['User-Agent'] = get_user_agent()

--- a/src/anthias_common/version.py
+++ b/src/anthias_common/version.py
@@ -1,0 +1,67 @@
+"""Project version lookup for code that must stay layer-agnostic.
+
+Lives in ``anthias_common`` so both ``anthias_server`` (System Info
+HTML, v2 info API) and ``anthias_common.http`` (outbound User-Agent)
+can read the CalVer release without reaching into Django-land. The
+old ``anthias_server.lib.diagnostics.get_anthias_release`` re-exports
+from here for backwards compatibility — nothing else lived in that
+function, so the move is a pure relocation.
+"""
+
+from __future__ import annotations
+
+
+def get_anthias_release() -> str:
+    """Read the project version, sourced from pyproject.toml's
+    [project].version (currently CalVer ``YYYY.M.MICRO``).
+
+    Resolution order:
+      1. ``importlib.metadata.version('anthias')`` — works for
+         editable installs (``pip install -e .``) and any path where
+         the project ships as a wheel.
+      2. Fallback: parse ``pyproject.toml`` directly with ``tomllib``.
+         Required because every production / test / host environment
+         runs ``uv sync --no-install-project`` (see
+         docker/uv-builder.j2, docker/Dockerfile.{server,test,viewer},
+         bin/install.sh) — that flag installs the project's deps but
+         NOT the project itself, so importlib.metadata has no record
+         of an ``anthias`` distribution to read.
+
+    Cached after first successful read so the System Info HTML render
+    (called per request) and the v2 info API don't re-open the file.
+    Returns the empty string only when both sources fail.
+    """
+    cached: str | None = getattr(get_anthias_release, '_cached', None)
+    if cached is not None:
+        return cached
+    value: str
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            value = version('anthias')
+        except PackageNotFoundError:
+            value = _read_version_from_pyproject()
+    except Exception:
+        value = ''
+    setattr(get_anthias_release, '_cached', value)
+    return value
+
+
+def _read_version_from_pyproject() -> str:
+    """Last-ditch source for the project version when the package
+    isn't installed in the active venv. Walks up from this file to
+    find the repo-root pyproject.toml — ``__file__`` lives at
+    ``src/anthias_common/version.py``, so parents[2] is the checkout
+    root in both editable installs and the ``uv sync
+    --no-install-project`` Docker layout."""
+    try:
+        import tomllib
+        from pathlib import Path
+
+        pyproject = Path(__file__).resolve().parents[2] / 'pyproject.toml'
+        with pyproject.open('rb') as f:
+            data = tomllib.load(f)
+        return str(data.get('project', {}).get('version', ''))
+    except Exception:
+        return ''

--- a/src/anthias_server/api/tests/test_screenly_migration.py
+++ b/src/anthias_server/api/tests/test_screenly_migration.py
@@ -1,9 +1,10 @@
 """Unit tests for the Screenly v4.1 migration helper + API endpoints.
 
-These tests never reach the network. ``requests.get`` / ``requests.post``
-are patched on the ``anthias_server.lib.screenly_migration`` module so
-we drive each branch deterministically — token-validation outcomes,
-group get-or-create idempotency, file-vs-URL asset routing, filename
+These tests never reach the network. The module-level
+``_session`` (an ``AnthiasSession``) is patched on the
+``anthias_server.lib.screenly_migration`` module so we drive each
+branch deterministically — token-validation outcomes, group
+get-or-create idempotency, file-vs-URL asset routing, filename
 reconstruction, error surfaces.
 
 The HTTP-level tests use DRF's ``APIClient`` against the registered v2
@@ -163,6 +164,15 @@ class TestAuthHeaders:
             'Prefer': 'return=representation',
         }
 
+    def test_session_carries_anthias_user_agent(self) -> None:
+        # Screenly ops should be able to spot migration traffic in
+        # their access logs without parsing the path — otherwise it
+        # looks identical to any other ``python-requests/*`` client.
+        ua = screenly_migration._session.headers['User-Agent']
+        assert isinstance(ua, str)
+        assert ua.startswith('Anthias/')
+        assert '(+https://anthias.screenly.io)' in ua
+
 
 # ---------------------------------------------------------------------------
 # validate_token
@@ -170,7 +180,7 @@ class TestAuthHeaders:
 
 
 class TestValidateToken:
-    @patch('anthias_server.lib.screenly_migration.requests.get')
+    @patch('anthias_server.lib.screenly_migration._session.get')
     def test_returns_true_on_200(self, get_mock: MagicMock) -> None:
         get_mock.return_value = _fake_response(200, json_body=[])
         assert screenly_migration.validate_token('good') is True
@@ -178,7 +188,7 @@ class TestValidateToken:
         _, kwargs = get_mock.call_args
         assert kwargs['headers']['Authorization'] == 'Token good'
 
-    @patch('anthias_server.lib.screenly_migration.requests.get')
+    @patch('anthias_server.lib.screenly_migration._session.get')
     @pytest.mark.parametrize('code', [401, 403])
     def test_returns_false_on_auth_failure(
         self, get_mock: MagicMock, code: int
@@ -186,7 +196,7 @@ class TestValidateToken:
         get_mock.return_value = _fake_response(code, json_body={'error': 'no'})
         assert screenly_migration.validate_token('bad') is False
 
-    @patch('anthias_server.lib.screenly_migration.requests.get')
+    @patch('anthias_server.lib.screenly_migration._session.get')
     def test_raises_on_5xx(self, get_mock: MagicMock) -> None:
         # 5xx should propagate as a RequestException so the caller can
         # distinguish "your token is bad" from "Screenly is down".
@@ -194,7 +204,7 @@ class TestValidateToken:
         with pytest.raises(requests.HTTPError):
             screenly_migration.validate_token('x')
 
-    @patch('anthias_server.lib.screenly_migration.requests.get')
+    @patch('anthias_server.lib.screenly_migration._session.get')
     def test_propagates_network_error(self, get_mock: MagicMock) -> None:
         get_mock.side_effect = requests.ConnectionError('boom')
         with pytest.raises(requests.ConnectionError):
@@ -207,8 +217,8 @@ class TestValidateToken:
 
 
 class TestEnsureAssetGroup:
-    @patch('anthias_server.lib.screenly_migration.requests.post')
-    @patch('anthias_server.lib.screenly_migration.requests.get')
+    @patch('anthias_server.lib.screenly_migration._session.post')
+    @patch('anthias_server.lib.screenly_migration._session.get')
     def test_returns_existing_id_without_post(
         self, get_mock: MagicMock, post_mock: MagicMock
     ) -> None:
@@ -221,8 +231,8 @@ class TestEnsureAssetGroup:
         assert gid == 'GROUP123'
         post_mock.assert_not_called()
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
-    @patch('anthias_server.lib.screenly_migration.requests.get')
+    @patch('anthias_server.lib.screenly_migration._session.post')
+    @patch('anthias_server.lib.screenly_migration._session.get')
     def test_creates_group_when_lookup_empty(
         self, get_mock: MagicMock, post_mock: MagicMock
     ) -> None:
@@ -235,8 +245,8 @@ class TestEnsureAssetGroup:
         _, kwargs = post_mock.call_args
         assert kwargs['json'] == {'title': 'g'}
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
-    @patch('anthias_server.lib.screenly_migration.requests.get')
+    @patch('anthias_server.lib.screenly_migration._session.post')
+    @patch('anthias_server.lib.screenly_migration._session.get')
     def test_falls_back_to_create_when_lookup_fails(
         self, get_mock: MagicMock, post_mock: MagicMock
     ) -> None:
@@ -250,8 +260,8 @@ class TestEnsureAssetGroup:
         gid = screenly_migration.ensure_asset_group('t', 'g')
         assert gid == 'NEW999'
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
-    @patch('anthias_server.lib.screenly_migration.requests.get')
+    @patch('anthias_server.lib.screenly_migration._session.post')
+    @patch('anthias_server.lib.screenly_migration._session.get')
     def test_raises_screenly_error_on_create_failure(
         self, get_mock: MagicMock, post_mock: MagicMock
     ) -> None:
@@ -286,7 +296,7 @@ class TestMigrateAsset:
             uri=str(target),
         )
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
+    @patch('anthias_server.lib.screenly_migration._session.post')
     def test_url_asset_uses_source_url(self, post_mock: MagicMock) -> None:
         post_mock.return_value = _fake_response(
             201, json_body=[{'id': 'OUTID'}]
@@ -307,7 +317,7 @@ class TestMigrateAsset:
         assert isinstance(result, list)
         assert result[0]['id'] == 'OUTID'
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
+    @patch('anthias_server.lib.screenly_migration._session.post')
     def test_local_asset_uses_multipart_with_pretty_filename(
         self,
         post_mock: MagicMock,
@@ -335,7 +345,7 @@ class TestMigrateAsset:
         filename, _ = kwargs['files']['file']
         assert filename == 'My Day 2.png'
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
+    @patch('anthias_server.lib.screenly_migration._session.post')
     def test_local_asset_missing_file_raises_error(
         self,
         post_mock: MagicMock,
@@ -355,7 +365,7 @@ class TestMigrateAsset:
         assert 'File not found' in str(exc.value)
         post_mock.assert_not_called()
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
+    @patch('anthias_server.lib.screenly_migration._session.post')
     def test_local_asset_open_oserror_surfaces_as_per_asset_error(
         self,
         post_mock: MagicMock,
@@ -386,7 +396,7 @@ class TestMigrateAsset:
         assert 'Permission denied' in str(exc.value)
         post_mock.assert_not_called()
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
+    @patch('anthias_server.lib.screenly_migration._session.post')
     def test_screenly_rejection_surfaces_status_and_detail(
         self, post_mock: MagicMock
     ) -> None:
@@ -400,7 +410,7 @@ class TestMigrateAsset:
         assert '413' in msg
         assert 'payload too large' in msg
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
+    @patch('anthias_server.lib.screenly_migration._session.post')
     def test_no_uri_asset_raises_before_request(
         self, post_mock: MagicMock
     ) -> None:
@@ -409,7 +419,7 @@ class TestMigrateAsset:
             screenly_migration.migrate_asset('tok', asset)
         post_mock.assert_not_called()
 
-    @patch('anthias_server.lib.screenly_migration.requests.post')
+    @patch('anthias_server.lib.screenly_migration._session.post')
     def test_html_error_body_collapses_to_one_line(
         self, post_mock: MagicMock
     ) -> None:

--- a/src/anthias_server/lib/diagnostics.py
+++ b/src/anthias_server/lib/diagnostics.py
@@ -195,8 +195,6 @@ def get_git_hash() -> str | None:
 _RELEASE_BRANCHES = frozenset({'master', 'main'})
 
 
-
-
 def get_anthias_version_head() -> str:
     """The primary version line — ``v{calver}``. Returns ``''`` only
     when ``get_anthias_release()`` finds neither the installed package

--- a/src/anthias_server/lib/diagnostics.py
+++ b/src/anthias_server/lib/diagnostics.py
@@ -7,6 +7,12 @@ from datetime import datetime
 
 from anthias_common import device_helper, utils
 
+# Re-exported from ``anthias_common.version`` (the ``as`` form marks
+# this as an explicit re-export so it stays importable from the old
+# diagnostics path without a lint suppression). Layer-agnostic code
+# imports it from ``anthias_common.version`` directly.
+from anthias_common.version import get_anthias_release as get_anthias_release
+
 
 _CEC_QUERY_SCRIPT = """
 import sys
@@ -189,60 +195,6 @@ def get_git_hash() -> str | None:
 _RELEASE_BRANCHES = frozenset({'master', 'main'})
 
 
-def get_anthias_release() -> str:
-    """Read the project version, sourced from pyproject.toml's
-    [project].version (currently CalVer ``YYYY.M.MICRO``).
-
-    Resolution order:
-      1. ``importlib.metadata.version('anthias')`` — works for
-         editable installs (``pip install -e .``) and any path where
-         the project ships as a wheel.
-      2. Fallback: parse ``pyproject.toml`` directly with ``tomllib``.
-         Required because every production / test / host environment
-         runs ``uv sync --no-install-project`` (see
-         docker/uv-builder.j2, docker/Dockerfile.{server,test,viewer},
-         bin/install.sh) — that flag installs the project's deps but
-         NOT the project itself, so importlib.metadata has no record
-         of an ``anthias`` distribution to read.
-
-    Cached after first successful read so the System Info HTML render
-    (called per request) and the v2 info API don't re-open the file.
-    Returns the empty string only when both sources fail.
-    """
-    cached: str | None = getattr(get_anthias_release, '_cached', None)
-    if cached is not None:
-        return cached
-    value: str
-    try:
-        from importlib.metadata import PackageNotFoundError, version
-
-        try:
-            value = version('anthias')
-        except PackageNotFoundError:
-            value = _read_version_from_pyproject()
-    except Exception:
-        value = ''
-    setattr(get_anthias_release, '_cached', value)
-    return value
-
-
-def _read_version_from_pyproject() -> str:
-    """Last-ditch source for the project version when the package
-    isn't installed in the active venv. Walks up from this file to
-    find the repo-root pyproject.toml — `__file__` lives at
-    ``src/anthias_server/lib/diagnostics.py``, so parents[3] is the
-    checkout root in both editable installs and the
-    ``uv sync --no-install-project`` Docker layout."""
-    try:
-        import tomllib
-        from pathlib import Path
-
-        pyproject = Path(__file__).resolve().parents[3] / 'pyproject.toml'
-        with pyproject.open('rb') as f:
-            data = tomllib.load(f)
-        return str(data.get('project', {}).get('version', ''))
-    except Exception:
-        return ''
 
 
 def get_anthias_version_head() -> str:

--- a/src/anthias_server/lib/screenly_migration.py
+++ b/src/anthias_server/lib/screenly_migration.py
@@ -20,11 +20,18 @@ from typing import Any
 
 import requests
 
+from anthias_common.http import AnthiasSession
 from anthias_server.app.models import Asset
 from anthias_server.app.views_files import ANTHIAS_ASSETS_ROOT
 
 
 SCREENLY_API_BASE = 'https://api.screenlyapp.com/api/v4.1'
+
+# Module-level session so every outbound migration call carries the
+# Anthias User-Agent (see ``AnthiasSession``). The session is cheap to
+# keep open and also gives us connection reuse across the typically
+# 10-100 sequential per-asset calls a migration produces.
+_session = AnthiasSession()
 
 # Title used for the Screenly asset-group that migrated assets are
 # placed under. Lives here so the prepare and per-asset paths agree
@@ -85,7 +92,7 @@ def validate_token(token: str) -> bool:
     into a user-visible message — we don't want to silently treat a
     transient outage as "bad token".
     """
-    response = requests.get(
+    response = _session.get(
         f'{SCREENLY_API_BASE}/assets',
         headers=_auth_headers(token),
         params={'limit': 1},
@@ -139,7 +146,7 @@ def ensure_asset_group(token: str, title: str) -> str:
     # dict[str, object] form here doesn't match any of the params
     # type unions.
     lookup_params: dict[str, str] = {'title': f'eq.{title}', 'limit': '1'}
-    lookup = requests.get(
+    lookup = _session.get(
         f'{SCREENLY_API_BASE}/asset-groups',
         headers=_auth_headers(token),
         params=lookup_params,
@@ -150,7 +157,7 @@ def ensure_asset_group(token: str, title: str) -> str:
         if group_id is not None:
             return group_id
 
-    create = requests.post(
+    create = _session.post(
         f'{SCREENLY_API_BASE}/asset-groups',
         headers={
             **_auth_headers(token),
@@ -310,7 +317,7 @@ def migrate_asset(
         data['source_url'] = asset.uri
 
     try:
-        response = requests.post(
+        response = _session.post(
             f'{SCREENLY_API_BASE}/assets',
             headers=_auth_headers(token),
             data=data,


### PR DESCRIPTION
### Issues Fixed

No tracked issue — improvement noted while reviewing the Screenly migration code.

### Description

Adds `anthias_common.http.AnthiasSession`, a `requests.Session` subclass that sets `User-Agent: Anthias/<release> (+https://anthias.screenly.io)` on every outbound call. The Screenly migration helper (`validate_token`, `ensure_asset_group`, `migrate_asset`) now routes through a module-level `AnthiasSession`, so Screenly's logs can identify migration traffic instead of seeing the default `python-requests/<x.y>` label. Other outbound call sites can adopt the class as needed; the deliberate Safari-UA spoof in `anthias_common.utils` (anti-bot bypass on user-supplied URLs) stays as-is.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)