### PR TITLE
fix(csrf): CSRF_TRUSTED_ORIGINS env var for host-rewriting proxies

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -71,13 +71,27 @@ ALLOWED_HOSTS = [
     h.strip() for h in getenv('ALLOWED_HOSTS', '*').split(',') if h.strip()
 ]
 
-# CSRF_TRUSTED_ORIGINS is intentionally not set. Django only honours
-# subdomain wildcards there (e.g. https://*.example.com), so a leading
-# 'http://*' / 'https://*' would be a no-op rather than the broad
-# allowlist it appears to be. Same-host POSTs still pass through the
-# custom SameHostOriginCsrfMiddleware below, which also tolerates
-# scheme drift caused by a TLS-terminating proxy in front of
-# anthias-server (issue #2867).
+# CSRF_TRUSTED_ORIGINS handles the case where a reverse proxy serves
+# Anthias under a hostname different from the upstream Host the device
+# sees — IIS ARR with preserveHostHeader=false is the canonical
+# example (issue #2900): the browser sends ``Origin: https://signage.
+# example.com`` while uvicorn sees ``Host: anthias.localdomain``, so
+# neither Django's stock host-and-scheme check nor the same-host
+# fallback in SameHostOriginCsrfMiddleware can recognise the request
+# as same-origin. The operator opts in by listing the public origins
+# they actually serve Anthias under, e.g.
+# ``CSRF_TRUSTED_ORIGINS=https://signage.example.com``.
+#
+# A wildcard scheme like ``https://*`` is not accepted by Django and
+# isn't useful here — operators who proxy under a single fixed
+# hostname per device just list that one origin. Default is empty;
+# the same-host fallback continues to cover plain LAN / Caddy-sidecar
+# deployments where the proxy preserves Host upstream.
+CSRF_TRUSTED_ORIGINS = [
+    o.strip()
+    for o in getenv('CSRF_TRUSTED_ORIGINS', '').split(',')
+    if o.strip()
+]
 
 
 # Application definition

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -74,12 +74,13 @@ ALLOWED_HOSTS = [
 # CSRF_TRUSTED_ORIGINS handles the case where a reverse proxy serves
 # Anthias under a hostname different from the upstream Host the device
 # sees — IIS ARR with preserveHostHeader=false is the canonical
-# example (issue #2900): the browser sends ``Origin: https://signage.
-# example.com`` while uvicorn sees ``Host: anthias.localdomain``, so
-# neither Django's stock host-and-scheme check nor the same-host
-# fallback in SameHostOriginCsrfMiddleware can recognise the request
-# as same-origin. The operator opts in by listing the public origins
-# they actually serve Anthias under, e.g.
+# example (issue #2900): the browser sends
+# ``Origin: https://signage.example.com`` while uvicorn sees
+# ``Host: anthias.localdomain``, so neither Django's stock
+# host-and-scheme check nor the same-host fallback in
+# SameHostOriginCsrfMiddleware can recognise the request as
+# same-origin. The operator opts in by listing the public origins they
+# actually serve Anthias under, e.g.
 # ``CSRF_TRUSTED_ORIGINS=https://signage.example.com``.
 #
 # A wildcard scheme like ``https://*`` is not accepted by Django and

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -173,3 +173,72 @@ def test_no_origin_header_still_works() -> None:
         HTTP_HOST='anthias.local',
     )
     assert response.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# Issue #2900 — IIS ARR with preserveHostHeader=false rewrites Host
+# upstream, so the request lands on uvicorn with ``Host: anthias.local``
+# (the rewrite target) while the browser's Origin is
+# ``https://signage.example.com``. The same-host fallback can't reconcile
+# them — the hostnames really are different — so operators have to opt
+# the public hostname into CSRF_TRUSTED_ORIGINS explicitly.
+# ---------------------------------------------------------------------------
+
+_IIS_PUBLIC_ORIGIN = 'https://signage.example.com'
+
+
+@pytest.mark.django_db
+def test_iis_rewrite_host_proxy_without_trusted_origin_rejected() -> None:
+    """Today's behaviour: IIS rewrites Host upstream, no trusted
+    origin is configured, and the same-host fallback can't bridge
+    two genuinely different hostnames. POST stays 403 — pinning this
+    is what justifies the CSRF_TRUSTED_ORIGINS escape hatch."""
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_csrf_cookie(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local',
+        HTTP_ORIGIN=_IIS_PUBLIC_ORIGIN,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_iis_rewrite_host_proxy_with_trusted_origin_passes(
+    settings: pytest.FixtureRequest,
+) -> None:
+    """Issue #2900 fix: when the operator lists the public hostname
+    they actually serve Anthias under in CSRF_TRUSTED_ORIGINS,
+    Django's stock check accepts the Origin even though uvicorn sees
+    a different upstream Host."""
+    settings.CSRF_TRUSTED_ORIGINS = [_IIS_PUBLIC_ORIGIN]
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_csrf_cookie(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local',
+        HTTP_ORIGIN=_IIS_PUBLIC_ORIGIN,
+    )
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_trusted_origin_does_not_open_other_hosts(
+    settings: pytest.FixtureRequest,
+) -> None:
+    """Trusting ``https://signage.example.com`` must not implicitly
+    trust ``https://attacker.example``. The trusted-origin allowlist
+    is exact: only the listed origin passes, everything else still
+    has to clear the same-host fallback (or 403)."""
+    settings.CSRF_TRUSTED_ORIGINS = [_IIS_PUBLIC_ORIGIN]
+    client = Client(enforce_csrf_checks=True)
+    token = _seed_csrf_cookie(client, 'anthias.local')
+    response = client.post(
+        reverse('anthias_app:assets_control', args=['next']),
+        data={'csrfmiddlewaretoken': token},
+        HTTP_HOST='anthias.local',
+        HTTP_ORIGIN=_HTTP_CROSS_HOST_ORIGIN,
+    )
+    assert response.status_code == 403

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 from django.test import Client
 from django.urls import reverse
+from pytest_django.fixtures import SettingsWrapper
 
 # The whole point of this suite is exercising plain-HTTP Origin headers
 # against an HTTP-served Anthias — that's the deployment shape the bug
@@ -206,7 +207,7 @@ def test_iis_rewrite_host_proxy_without_trusted_origin_rejected() -> None:
 
 @pytest.mark.django_db
 def test_iis_rewrite_host_proxy_with_trusted_origin_passes(
-    settings: pytest.FixtureRequest,
+    settings: SettingsWrapper,
 ) -> None:
     """Issue #2900 fix: when the operator lists the public hostname
     they actually serve Anthias under in CSRF_TRUSTED_ORIGINS,
@@ -226,7 +227,7 @@ def test_iis_rewrite_host_proxy_with_trusted_origin_passes(
 
 @pytest.mark.django_db
 def test_trusted_origin_does_not_open_other_hosts(
-    settings: pytest.FixtureRequest,
+    settings: SettingsWrapper,
 ) -> None:
     """Trusting ``https://signage.example.com`` must not implicitly
     trust ``https://attacker.example``. The trusted-origin allowlist

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -9,10 +9,14 @@ bad / missing tokens must still fail.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from django.test import Client
 from django.urls import reverse
-from pytest_django.fixtures import SettingsWrapper
+
+if TYPE_CHECKING:
+    from pytest_django.fixtures import SettingsWrapper
 
 # The whole point of this suite is exercising plain-HTTP Origin headers
 # against an HTTP-served Anthias — that's the deployment shape the bug

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -178,6 +178,34 @@
       answer: |
         From `~/anthias/`, run `./bin/enable_ssl.sh`. The default mode uses Caddy's built-in local CA, which is fine for IP-based LAN access. For Let's Encrypt or bring-your-own certificate, see the [TLS / SSL section in the docs](/docs/#tls-ssl).
 
+    - question: How do I run Anthias behind my own reverse proxy?
+      answer: |
+        Most reverse proxies — nginx, Apache (`mod_proxy`), IIS ARR — rewrite the upstream `Host` header by default. When that happens, Django's CSRF protection rejects every POST with `Origin checking failed` and uploads, asset changes, and settings updates all fail.
+
+        You have two options:
+
+        **1. Preserve the upstream `Host` (preferred).** Tell the proxy to pass the original `Host` through:
+
+        | Proxy   | Directive                                       |
+        | ------- | ----------------------------------------------- |
+        | nginx   | `proxy_set_header Host $host;`                  |
+        | Apache  | `ProxyPreserveHost On`                          |
+        | IIS ARR | `preserveHostHeader="true"` (or the GUI toggle) |
+        | Caddy   | preserved by default — no action needed         |
+        | Traefik | preserved by default (`passHostHeader: true`)   |
+
+        With `Host` preserved, Anthias's built-in same-host CSRF fallback handles HTTP-to-HTTPS scheme drift automatically.
+
+        **2. Tell Anthias the public hostname directly.** If you can't (or don't want to) change the proxy config, list the public origin in `CSRF_TRUSTED_ORIGINS`. From `~/anthias/`, edit `.env` (or your compose override) and add:
+
+        ```
+        CSRF_TRUSTED_ORIGINS=https://signage.example.com
+        ```
+
+        Multiple origins are comma-separated. Restart with `docker compose up -d`.
+
+        The bundled `./bin/enable_ssl.sh` Caddy sidecar handles all of this for you — the above is only relevant if you're terminating TLS or proxying with something else.
+
     - question: Where is the API reference?
       answer: |
         See the [API page](/api/) for endpoints grouped by tag with their parameters and response schemas. The live ReDoc-rendered docs are also served straight from each device at `http://<device-ip>/api/docs/`.


### PR DESCRIPTION
### Issues Fixed

Fixes #2900.

### Description

IIS ARR with the default `preserveHostHeader=false` rewrites `Host` upstream before forwarding to anthias-server, so the browser's `Origin: https://signage.example.com` and uvicorn's `Host: anthias.localdomain` are genuinely different hostnames. `SameHostOriginCsrfMiddleware`'s fallback only tolerates scheme drift on the *same* host, not different hosts, so every unsafe POST (uploads, asset controls, etc.) 403s with `Origin checking failed`.

The pre-rebrand React+DRF stack didn't hit this because uploads went through DRF's Basic-auth API; the new Django+HTMX upload runs through `CsrfViewMiddleware` directly.

**Fix:** expose Django's first-class `CSRF_TRUSTED_ORIGINS` as a comma-separated env var. Operators behind a host-rewriting reverse proxy list the public origin they actually serve under:

```env
CSRF_TRUSTED_ORIGINS=https://signage.example.com
```

Default is empty — no behaviour change for plain LAN / Caddy-sidecar deployments where the proxy preserves Host upstream. The same-host fallback continues to cover those.

No new proxy-header trust added; no change to `request.get_host()`, `is_secure()`, or `build_absolute_uri()`. Operator opts in explicitly per-deployment.

Three regression tests pin the behaviour: 403 without the knob, 302 with it, and the allowlist stays exact (one trusted origin doesn't open others).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)