### PR TITLE
docs(faq): running Anthias behind a custom reverse proxy

### DIFF
--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -178,6 +178,34 @@
       answer: |
         From `~/anthias/`, run `./bin/enable_ssl.sh`. The default mode uses Caddy's built-in local CA, which is fine for IP-based LAN access. For Let's Encrypt or bring-your-own certificate, see the [TLS / SSL section in the docs](/docs/#tls-ssl).
 
+    - question: How do I run Anthias behind my own reverse proxy?
+      answer: |
+        Most reverse proxies — nginx, Apache (`mod_proxy`), IIS ARR — rewrite the upstream `Host` header by default. When that happens, Django's CSRF protection rejects every POST with `Origin checking failed` and uploads, asset changes, and settings updates all fail.
+
+        You have two options:
+
+        **1. Preserve the upstream `Host` (preferred).** Tell the proxy to pass the original `Host` through:
+
+        | Proxy   | Directive                                       |
+        | ------- | ----------------------------------------------- |
+        | nginx   | `proxy_set_header Host $host;`                  |
+        | Apache  | `ProxyPreserveHost On`                          |
+        | IIS ARR | `preserveHostHeader="true"` (or the GUI toggle) |
+        | Caddy   | preserved by default — no action needed         |
+        | Traefik | preserved by default (`passHostHeader: true`)   |
+
+        With `Host` preserved, Anthias's built-in same-host CSRF fallback handles HTTP-to-HTTPS scheme drift automatically.
+
+        **2. Tell Anthias the public hostname directly.** If you can't (or don't want to) change the proxy config, list the public origin in `CSRF_TRUSTED_ORIGINS`. From `~/anthias/`, edit `.env` (or your compose override) and add:
+
+        ```
+        CSRF_TRUSTED_ORIGINS=https://signage.example.com
+        ```
+
+        Multiple origins are comma-separated. Restart with `docker compose up -d`.
+
+        The bundled `./bin/enable_ssl.sh` Caddy sidecar handles all of this for you — the above is only relevant if you're terminating TLS or proxying with something else.
+
     - question: Where is the API reference?
       answer: |
         See the [API page](/api/) for endpoints grouped by tag with their parameters and response schemas. The live ReDoc-rendered docs are also served straight from each device at `http://<device-ip>/api/docs/`.


### PR DESCRIPTION
### Issues Fixed

Follow-up doc to PR #2901 — surfaces the `CSRF_TRUSTED_ORIGINS` knob (and the cleaner Host-preservation path) on the website FAQ so operators hitting the symptom can find the fix without spelunking through `settings.py`.

### Description

New FAQ entry under **Operations**, right after "How do I enable HTTPS?".

Names the symptom (`Origin checking failed` 403 on every POST after wiring up nginx / Apache / IIS), gives the one-line Host-preservation directive for the five reverse proxies operators actually deploy, and documents `CSRF_TRUSTED_ORIGINS=https://signage.example.com` as the escape hatch when the proxy can't be reconfigured. Notes that the bundled `./bin/enable_ssl.sh` Caddy sidecar already does the right thing — the entry is only relevant for third-party proxy setups.

No code change — `website/data/faq.yaml` only.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)