### PR TITLE
fix(api,app): UI asset delete must remove the on-disk file

### DIFF
--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -581,7 +581,7 @@ def test_create_youtube_asset_dispatches_celery_task(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
-@mock.patch('anthias_server.api.views.mixins.ViewerPublisher')
+@mock.patch('anthias_server.app.helpers.ViewerPublisher')
 def test_delete_asset_publishes_reload(
     publisher_mock: Any, api_client: APIClient, version: str
 ) -> None:

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -17,6 +17,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from anthias_server.app.helpers import delete_asset_with_file
 from anthias_server.app.models import Asset
 from anthias_server.api.helpers import save_active_assets_ordering
 from anthias_server.api.serializers.mixins import (
@@ -43,21 +44,7 @@ class DeleteAssetViewMixin:
     @authorized
     def delete(self, request: Request, asset_id: str) -> Response:
         asset = get_object_or_404(Asset, asset_id=asset_id)
-
-        try:
-            if asset.uri and asset.uri.startswith(settings['assetdir']):
-                remove(asset.uri)
-        except OSError:
-            pass
-
-        asset.delete()
-
-        # Wake the viewer so it can advance past the just-deleted asset
-        # instead of finishing its remaining ``duration`` on screen
-        # (issue #2430). The viewer's reload handler checks whether the
-        # currently-displayed asset is still active and skips if not.
-        ViewerPublisher.get_instance().send_to_viewer('reload')
-
+        delete_asset_with_file(asset)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/src/anthias_server/app/helpers.py
+++ b/src/anthias_server/app/helpers.py
@@ -1,5 +1,6 @@
+import logging
 import uuid
-from os import getenv, path
+from os import getenv, path, remove
 from typing import Any
 
 import yaml
@@ -10,7 +11,9 @@ from django.utils import timezone
 from anthias_server.app.models import Asset
 from anthias_server.app.page_context import navbar as _navbar_context
 from anthias_common.utils import get_video_duration
-from anthias_server.settings import settings
+from anthias_server.settings import ViewerPublisher, settings
+
+logger = logging.getLogger(__name__)
 
 
 def template(
@@ -111,3 +114,37 @@ def remove_default_assets() -> None:
     for asset in Asset.objects.all():
         if asset.asset_id.startswith('default_'):
             asset.delete()
+
+
+def delete_asset_with_file(asset: Asset) -> None:
+    """Delete an ``Asset`` row, remove its on-disk file (if owned), and
+    nudge the viewer to advance past it.
+
+    Shared by the v1/v1.1/v1.2/v2 API delete endpoint and the HTML form
+    delete route on the home page. Both must behave identically — GH
+    #2908 was the case where the UI form-post handler dropped the row
+    but left the binary in ``settings['assetdir']`` indefinitely.
+
+    File removal is gated on ``asset.uri`` starting with
+    ``settings['assetdir']`` so rows whose URI is a remote URL
+    (webpage, RTSP, streaming video) are left untouched. Failures are
+    logged and swallowed: the row is the operator's source of truth,
+    and a stray file is eventually cleaned up by the periodic
+    ``cleanup()`` orphan sweep — letting an unlink error block the DB
+    delete would leave the operator unable to remove the row at all.
+    """
+    if asset.uri and asset.uri.startswith(settings['assetdir']):
+        try:
+            remove(asset.uri)
+        except OSError as exc:
+            logger.warning(
+                'Failed to remove asset file %s: %s', asset.uri, exc
+            )
+
+    asset.delete()
+
+    # Wake the viewer so it skips a now-deleted asset that's still on
+    # screen instead of finishing its remaining ``duration`` (#2430).
+    # The viewer's reload handler checks whether the currently-shown
+    # asset is still active and advances if not.
+    ViewerPublisher.get_instance().send_to_viewer('reload')

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -617,10 +617,12 @@ def assets_toggle(request: HttpRequest, asset_id: str) -> HttpResponse:
 @authorized
 @require_http_methods(['POST'])
 def assets_delete(request: HttpRequest, asset_id: str) -> HttpResponse:
+    from anthias_server.app.helpers import delete_asset_with_file
     from anthias_server.app.models import Asset
 
-    Asset.objects.filter(asset_id=asset_id).delete()
-    ViewerPublisher.get_instance().send_to_viewer('reload')
+    asset = Asset.objects.filter(asset_id=asset_id).first()
+    if asset is not None:
+        delete_asset_with_file(asset)
     return _asset_table_response(request, toast=('success', 'Asset deleted'))
 
 

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -337,6 +337,62 @@ def test_assets_delete_removes_row(client: Client, asset: Asset) -> None:
 
 
 @pytest.mark.django_db
+def test_assets_delete_removes_local_file(
+    client: Client, tmp_path: Any
+) -> None:
+    """Regression for GH #2908: deleting an uploaded asset from the
+    UI form-post route must also remove the binary on disk. Before
+    the fix, ``assets_delete`` only ran ``Asset.objects.filter(...
+    ).delete()`` and left the file in ``settings['assetdir']``
+    forever — a Pi 4 with churn through uploads would fill its SD
+    card from operator-deleted assets that "looked" gone in the UI.
+    """
+    from anthias_server.settings import settings as anthias_settings
+
+    asset_path = (
+        tmp_path / anthias_settings['assetdir'].lstrip('/') / 'video.mp4'
+    )
+    asset_path.parent.mkdir(parents=True, exist_ok=True)
+    asset_path.write_bytes(b'\x00\x01video-payload')
+
+    now = timezone.now()
+    asset = Asset.objects.create(
+        name='Local video',
+        uri=str(asset_path),
+        mimetype='video',
+        duration=10,
+        is_enabled=True,
+        is_processing=False,
+        play_order=0,
+        start_date=now,
+        end_date=now + timedelta(days=30),
+    )
+
+    # ``settings['assetdir']`` is fixed at import time to
+    # ``<HOME>/anthias_assets``. Repoint it at the tmp_path mirror so
+    # the delete view's startswith() check matches the on-disk path.
+    with (
+        mock.patch.dict(
+            anthias_settings,
+            {'assetdir': str(asset_path.parent)},
+        ),
+        mock.patch(
+            'anthias_server.settings.ViewerPublisher.send_to_viewer',
+            return_value=None,
+        ),
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_delete', args=[asset.asset_id])
+        )
+
+    assert response.status_code in (200, 302)
+    assert not Asset.objects.filter(asset_id=asset.asset_id).exists()
+    assert not asset_path.exists(), (
+        f'asset file {asset_path} survived UI delete'
+    )
+
+
+@pytest.mark.django_db
 def test_assets_order_persists_play_order(client: Client) -> None:
     a1 = Asset.objects.create(
         name='a1',


### PR DESCRIPTION
### Issues Fixed

Fixes #2908.

### Description

The web UI's delete button submits a form to `anthias_app:assets_delete`, which only ran `Asset.objects.filter(...).delete()` and left the binary in `settings['assetdir']` indefinitely. The v2 REST DELETE already cleaned up the file via `DeleteAssetViewMixin`, but the two paths had drifted, so deleting an uploaded asset from the home page accumulated dead files on the SD card while looking gone in the UI.

I audited every asset / file API path (v1, v1.1, v1.2, v2, plus the HTML form-post routes) — the UI form-post `assets_delete` was the only leak. PUT/PATCH on assets cannot change `uri`, normalize-image already removes the source after WebP conversion, backup recovery cleans up its upload, and the periodic `cleanup()` task sweeps any straggler.

**Fix:** consolidate the file-removal contract into a single `delete_asset_with_file()` helper in `app/helpers.py`. Both the API mixin and the HTML form-post view call it. Failed unlinks now log a warning instead of being silently swallowed.

**Tests:** added `test_assets_delete_removes_local_file` (fails on master, passes on this branch). Retargeted the existing `test_delete_asset_publishes_reload` mock since the publish now lives in `app.helpers`. Full unit suite: 865 passed.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).