### PR TITLE
fix(installer): keep dtoverlay and max_framebuffers on separate lines in config.txt

### DIFF
--- a/ansible/roles/system/templates/config.txt.j2
+++ b/ansible/roles/system/templates/config.txt.j2
@@ -24,11 +24,11 @@ region first; reusing the v3d overlay's own cma-512 param is the
 documented merge. Pi 4 already gets 512 MB CMA by default so the
 override is a no-op there; the Pi 5 conditional below keeps the
 extra arg local to the board that strictly needs it. #}
-{% if device_type == 'pi5' -%}
+{% if device_type == 'pi5' %}
 dtoverlay=vc4-kms-v3d,cma-512
-{%- else -%}
+{% else %}
 dtoverlay=vc4-kms-v3d
-{%- endif %}
+{% endif %}
 max_framebuffers=2
 
 # Don't have the firmware add a video= line to cmdline.txt — let the


### PR DESCRIPTION
### Issues Fixed

Fixes #2910

### Description

`ansible/roles/system/templates/config.txt.j2` produced a glued line in the generated `/boot/firmware/config.txt`:

```
dtoverlay=vc4-kms-v3dmax_framebuffers=2
```

`{%- endif %}` stripped the trailing newline from `dtoverlay=vc4-kms-v3d`, and Ansible's `trim_blocks=True` then stripped the newline after `endif %}`, concatenating the two directives. Dropping the `-` whitespace-trim markers from the `{% if %}` / `{% else %}` / `{% endif %}` lets each branch keep its trailing newline.

### Failure modes (before fix)

The bug manifests **differently per board**:

- **Pi 4** — `vc4-kms-v3dmax_framebuffers=2` is an unknown overlay name → vc4 overlay fails to load entirely. No DRM device registers, framebuffer falls back to `1920x1280`, 16:9 TVs pillarbox. (This is the user-visible report in #2910.)
- **Pi 5** — `vc4-kms-v3d,cma-512max_framebuffers=2` still loads `vc4-kms-v3d` (the firmware parser sees the comma as the overlay/param separator), but `cma-512` is corrupted into `cma-512max_framebuffers=2` (unrecognized param) and the standalone `max_framebuffers=2` line is lost. Silently breaks two things: **CMA stays at default 64 MiB instead of 512 MiB** (kneecaps 4K HEVC decode headroom added in #2885), and `max_framebuffers` drops from 2 → 1.

### Reproduction & verification on the test fleet

Rendered the **broken** (pre-fix) and **fixed** templates for each `device_type`, deployed both to real hardware, rebooted between, and inspected the system state.

| Check                    | Pi 4 (broken)         | Pi 4 (fixed)        | Pi 5 (broken)         | Pi 5 (fixed)        |
| ------------------------ | --------------------- | ------------------- | --------------------- | ------------------- |
| config.txt line 19       | glued (bug)           | `dtoverlay=vc4-kms-v3d` | glued (bug)       | `dtoverlay=vc4-kms-v3d,cma-512` |
| `lsmod \| grep ^vc4`     | empty                 | loaded              | loaded                | loaded              |
| `/sys/class/drm/`        | only `version`        | card0, card1, …     | card0, card1, …       | card0, card1, …     |
| Framebuffer (`fbset -i`) | `1920x1280` (pillarbox)| `3840x2160` (16:9) | `3840x2160`           | `3840x2160`         |
| `CmaTotal` (`/proc/meminfo`) | n/a (Pi 4 default) | n/a               | **65536 kB (64 MiB)** | **524288 kB (512 MiB)** |
| `max_framebuffers`       | n/a                   | 2                   | **1** (firmware default) | **2**            |
| `rpi_hevc_dec`           | n/a                   | n/a                 | loaded (but starved)  | loaded              |
| `/dev/video*` HEVC nodes | n/a                   | n/a                 | present               | present (19–35)     |

Local Jinja2 rendering also verified for the remaining device types (`pi2`, `pi3`, `x86`, `arm64`) — all render `dtoverlay=…` and `max_framebuffers=2` on separate lines after the fix.

Also audited `cmdline.txt.j2` — clean (no control-flow tags between literal lines; token list is joined with explicit `' '`).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices. (Pi 4 + Pi 5 testbeds — see table above.)
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).