### PR TITLE
fix(ci,device): drop workflow_dispatch ref input + narrow bare except in CPU info parser

### DIFF
--- a/.github/workflows/marketing-screenshots.yaml
+++ b/.github/workflows/marketing-screenshots.yaml
@@ -17,11 +17,6 @@ name: Marketing Screenshots
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Branch / tag / SHA to capture from (default: current branch)'
-        required: false
-        type: string
 
 # workflow_dispatch lets an operator run this against any ref, so the
 # job token must not inherit write-level scopes from the repo default.
@@ -38,10 +33,13 @@ jobs:
     env:
       COMPOSE_FILE: docker-compose.test.yml
     steps:
+      # No ref input — the workflow_dispatch UI's "Use workflow from"
+      # picker already sets github.ref, so an explicit ref input would
+      # only add capability to API callers. A stolen GITHUB_TOKEN with
+      # actions:write could then dispatch this workflow against an
+      # attacker-supplied SHA / fork ref and execute it on a runner.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Python 3.13
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ website/.hugo_build.lock
 
 # Linting
 .coffeelint.json
+.shoulder/

--- a/src/anthias_common/device_helper.py
+++ b/src/anthias_common/device_helper.py
@@ -7,11 +7,11 @@ def parse_cpu_info() -> dict[str, int | str]:
 
     with open('/proc/cpuinfo', 'r') as cpuinfo:
         for line in cpuinfo:
-            try:
-                key = line.split(':')[0].strip()
-                value = line.split(':')[1].strip()
-            except Exception:
-                pass
+            parts = line.split(':', 1)
+            if len(parts) != 2:
+                continue
+            key = parts[0].strip()
+            value = parts[1].strip()
 
             if key == 'processor':
                 cpu_info['cpu_count'] = (


### PR DESCRIPTION
### Issues Fixed

Addresses two legitimate findings from a shoulder.dev security scan. The rest of the report was triaged as false positives (the upload path-traversal sinks are protected by `uuid.*().hex` + `_SAFE_EXT_RE`; the `@authorized` decorator covers the routes shoulder flagged as "missing authz"; `mark_safe` in `asset_filters.to_json` is preceded by JSON-encode and `&<>'` hex-escape; the open-redirect sink uses `reverse()` + `url_has_allowed_host_and_scheme`; etc.).

### Description

- **`.github/workflows/marketing-screenshots.yaml`** — drop the `workflow_dispatch` `inputs.ref`. The GH UI's "Use workflow from" picker already sets `github.ref` for operator-triggered runs, so the explicit input only added capability to API callers — a stolen `GITHUB_TOKEN` with `actions:write` could otherwise dispatch this workflow against an attacker-supplied SHA / fork ref and execute it on a runner.
- **`src/anthias_common/device_helper.py`** — replace `except Exception: pass` in `parse_cpu_info` with an explicit split-length guard + `continue`. Also fixes a latent bug: under the old `pass` fall-through, a malformed `/proc/cpuinfo` line would land in the `if key in [...]: cpu_info[key.lower()] = value` block with `value` carried over from the previous iteration (or unbound on the first line).
- **`.gitignore`** — shoulder.dev's local cache directory.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)