### PR TITLE
feat(viewer,server): 1 GB SBC enablement — low-RAM degradation gates

### DIFF
--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -21,6 +21,20 @@ export SHM_SIZE_KB="$(echo "$TOTAL_MEMORY_KB" \* 0.3 | bc | cut -d'.' -f1)"
 # against a decompression-bomb fixture or runaway ffprobe, not
 # because routine workloads come anywhere near it.
 export CELERY_MEMORY_LIMIT_KB=$(echo "$TOTAL_MEMORY_KB * 0.6" | bc | cut -d'.' -f1)
+# Low-RAM gate. Boards with < 1.5 GiB MemTotal (Pi 2/Pi 3 1GB, Pi 4 1GB,
+# Rock Pi 4 1GB, generic-arm64 SBCs in that class) can't keep two
+# QtWebEngine renderer processes resident *and* play 1080p+ video
+# without OOM-thrashing through swap. The viewer reads this env to
+# drop into single-WebEngineView mode (no preloaded crossfade); the
+# asset processor reads it via Redis (host:total_mem_kb) and rejects
+# uploads above 1080p. Threshold is 1.5 GiB so 1 GB SKUs land below
+# and 2 GB SKUs sit above; both 1024 MB and 2048 MB boards exist in
+# the supported fleet.
+if [ "${TOTAL_MEMORY_KB:-0}" -lt 1572864 ]; then
+    export ANTHIAS_LOW_RAM=1
+else
+    export ANTHIAS_LOW_RAM=0
+fi
 GIT_BRANCH="${GIT_BRANCH:-master}"
 
 MODE="${MODE:-pull}"

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -59,6 +59,14 @@ services:
       - LANG=${LANG}
       - LANGUAGE=${LANGUAGE}
       - LC_ALL=${LC_ALL}
+      # ``1`` on boards with < 1.5 GiB MemTotal. AnthiasViewer reads
+      # this to fall into single-QWebEngineView mode (no preloaded
+      # crossfade — the inactive renderer cost ~100 MB physical RAM
+      # per box, untenable on 1 GB SBCs). Derived from /proc/meminfo
+      # in bin/upgrade_containers.sh so the server side
+      # (host_agent → ``host:total_mem_kb`` in Redis) and the viewer
+      # side both observe the same total.
+      - ANTHIAS_LOW_RAM=${ANTHIAS_LOW_RAM}
     privileged: true
     restart: always
     # cage (the wlroots kiosk compositor used on Pi 5 / x86 /

--- a/docs/board-enablement.md
+++ b/docs/board-enablement.md
@@ -80,20 +80,83 @@ upstream of the upload.
 `bin/install.sh` sets `DEVICE_TYPE=arm64` for every aarch64 SBC it doesn't
 recognise as a Pi. `anthias_host_agent` runs on the host and reads
 `/proc/device-tree/model`; when it sees "Radxa ROCK Pi 4" it writes
-`host:board_subtype = 'rockpi4'` to Redis. The viewer reads that key to
-upgrade its `--hwdec=` choice from the catch-all `arm64` default to the
-RK3399-specific `--hwdec=drm-copy` (v4l2_request, served by `rkvdec` for HEVC
-and the Hantro VPU for H.264).
+`host:board_subtype = 'rockpi4'` to Redis. The server reads that key to
+pick the right entry in `processing._HW_DECODE_VIDEO_CODECS` — Rock Pi 4
+accepts H.264 + HEVC uploads, the catch-all `arm64` accepts nothing
+(because we can't certify a decoder on an unknown SBC).
 
 The arm64 viewer image pulls `ffmpeg` and the libav* family from
 `archive.raspberrypi.com` (the `+rpt1` build), which adds
 `--enable-v4l2-request --enable-libudev --enable-vout-drm` — the same package
-family Pi 4 / Pi 5 use, so the RK3399's stateless decoders are reachable via
-the same mpv flag. The `start_viewer.sh` entrypoint creates the `/dev/video-dec*`
-symlinks the v4l2_request decoder discovery code expects (privileged docker
-mounts its own /dev tmpfs without udev's symlinks). The `+rpt1` repo is pinned
-to only override ffmpeg + libav* + mpv on arm64; Pi userspace baseline is
-unaffected on every board.
+family Pi 4 / Pi 5 use. The `start_viewer.sh` entrypoint creates the
+`/dev/video-dec*` symlinks the v4l2_request decoder discovery code expects
+(privileged docker mounts its own /dev tmpfs without udev's symlinks). The
+`+rpt1` repo is pinned to only override ffmpeg + libav* on arm64; Pi
+userspace baseline is unaffected on every board.
+
+### Decode path (post-#2905)
+
+Playback runs through QtMultimedia (`QMediaPlayer` + `QGraphicsVideoItem`)
+embedded in `AnthiasViewer`. Qt 6.5 dropped the upstream gstreamer media
+backend, so Debian Trixie ships only the ffmpeg-backed
+`libffmpegmediaplugin.so`, which calls libavcodec internally. The libmpv
+subprocess and the per-codec `--hwdec=` dispatch the prior viewer revisions
+relied on are both gone — Anthias no longer hand-selects a decoder. **As a
+consequence: libavcodec's default decoder choice is what runs on this board.**
+
+### Known hardware-decode limitation on RK3399
+
+On-device validation against Armbian community 6.18 (`rkvdec` mainline driver)
+confirmed that QtMultimedia's libavcodec backend does **not** request a
+hwaccel — `ffmpeg -i sample.mp4 -f null -` picks `h264 (native)` / `hevc
+(native)` (software). Forcing `-hwaccel drm` engages rkvdec via
+`/dev/media0,/dev/video2` (the stateless v4l2_request entry point), but the
+Armbian 6.18 driver produces `frame_post_process: Decode fail` errors at
+0.77× real-time. The H.264 path (`rk3399-vpu-dec` / Hantro VPU) has no
+libavcodec `v4l2_request` binding in the `+rpt1` 7.1.3 build — it would have
+to ship through `h264_v4l2m2m`, but that wrapper is stateful and the RK3399
+nodes are stateless, so the M2M discovery fails with "Could not find a valid
+device".
+
+Practical state on Rock Pi 4 today:
+
+* H.264 1080p30 SW-decode delivers ~99 % of frames on the A72 (measured: 1
+  dropped per 14 s); below the threshold where HW would matter.
+* HEVC 1080p30 SW-decode drops ~22 % even with 5 idle cores — single-thread
+  libavcodec stall + paging on 1 GB SKUs.
+* 4K HEVC OOM-kills the viewer container on 1 GB SKUs and is rejected at
+  upload by the low-RAM resolution gate (see "Low-RAM mode" below).
+
+Fixing this requires either an upstream `rkvdec` driver fix landing in
+Debian-shipped Armbian kernels, or a v4l2_request H.264 binding in libavcodec
+that targets Hantro's stateless API. Both are outside the Anthias repo;
+Anthias does not maintain a custom kernel or distro
+(["we don't want to maintain our own Yocto distro"]). When that day comes,
+the QtMultimedia side will also need a hwaccel-selection hook — Qt 6.5+ has
+no public knob today.
+
+### Low-RAM mode
+
+Boards with less than 1.5 GiB MemTotal (Pi 2/Pi 3 1GB, Pi 4 1GB, Rock Pi 4
+1GB, generic-arm64 1GB SKUs) run in a degraded "low-RAM" mode:
+
+* `bin/upgrade_containers.sh` reads `/proc/meminfo` and exports
+  `ANTHIAS_LOW_RAM=1` to the viewer container.
+* `AnthiasViewer` instantiates one `QWebEngineView` instead of two — no
+  preloaded crossfade between URL assets; the page swaps in place with a
+  brief blank during load.
+* `anthias_host_agent` publishes `host:total_mem_kb` to Redis;
+  `anthias_server.processing` rejects uploads above 1920×1080 with the
+  existing recipe machinery (`-vf scale=1920:1080:force_original_aspect_ratio=decrease`).
+* The diagnostics page's Memory card surfaces a "Low-RAM mode" banner so
+  operators can see *why* the device degraded.
+
+The 1.5 GiB threshold cleanly separates 1 GB SKUs from 2 GB+ SKUs in the
+supported fleet. The cap was sized against on-device measurements: idle
+viewer + 2 QtWebEngine renderers + zygotes consume ~440 MB RSS on Rock Pi 4
+1GB, leaving roughly 500 MB for the kernel, host services, and decode
+pipeline. A 4K HEVC capture-buffer allocation pushes the container past the
+cgroup limit; the kernel logs `global_oom` and the container restart-loops.
 
 ## Sample pack
 

--- a/src/anthias_common/board.py
+++ b/src/anthias_common/board.py
@@ -50,6 +50,68 @@ def get_board_subtype() -> str | None:
     return None
 
 
+def get_total_mem_kb() -> int | None:
+    """Return the host's MemTotal in kibibytes from Redis, or ``None``.
+
+    ``anthias_host_agent`` publishes ``host:total_mem_kb`` at startup
+    by reading ``/proc/meminfo`` on the host. The server reads this
+    instead of opening ``/proc/meminfo`` itself so the value is
+    consistent across server and viewer (both observe whatever the
+    host_agent measured).
+
+    ``None`` means "unknown" — host_agent never ran, redis is down,
+    or the key was written empty because /proc/meminfo couldn't be
+    read. Callers treat unknown as "don't restrict" rather than
+    locking the operator out from uploads on a measurement gap.
+    """
+    try:
+        r = connect_to_redis()
+        value = r.get('host:total_mem_kb')
+    except Exception:
+        return None
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        try:
+            value = value.decode('utf-8')
+        except UnicodeDecodeError:
+            return None
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+# Boards with less than this much MemTotal can't keep two QtWebEngine
+# renderers resident *and* play 1080p+ video without OOM-thrashing
+# through swap (measured 1 GB Rock Pi 4: ~440 MB idle viewer RSS, OOM
+# loop on 4K HEVC load). 1.5 GiB is the cleanest cut between 1 GB and
+# 2 GB SKUs in the supported fleet — Pi 2/Pi 3 1GB, Pi 4 1GB, Rock Pi
+# 4 1GB fall below; every 2 GB+ SKU sits above. Tests can compare
+# against this directly rather than re-hardcoding the threshold.
+LOW_RAM_THRESHOLD_KB = 1_572_864  # 1.5 GiB in kibibytes
+
+
+def is_low_ram_device() -> bool:
+    """``True`` when the host has less than ``LOW_RAM_THRESHOLD_KB``.
+
+    Returns ``False`` when total RAM is unknown — uploading is the
+    operator action we'd rather over-accept than block on a missing
+    measurement. The codec gate keeps its existing per-codec
+    rejection regardless of this flag, so an "unknown RAM" device
+    still gets the codec safety net.
+    """
+    total = get_total_mem_kb()
+    if total is None:
+        return False
+    return total < LOW_RAM_THRESHOLD_KB
+
+
 def resolve_device_key() -> str:
     """Return ``DEVICE_TYPE`` upgraded via the host_agent's published
     board subtype when applicable.

--- a/src/anthias_host_agent/__main__.py
+++ b/src/anthias_host_agent/__main__.py
@@ -178,6 +178,63 @@ def detect_board_subtype() -> str | None:
     return None
 
 
+def detect_total_mem_kb() -> int | None:
+    """Return the host's ``MemTotal`` (kibibytes) from ``/proc/meminfo``.
+
+    Anthias's codec gate uses this to refuse 1080p+ uploads on devices
+    that can't keep them in physical RAM alongside a QtWebEngine
+    renderer. Returning ``None`` for an unreadable / unparseable
+    ``/proc/meminfo`` is treated by the consumer as "unknown, don't
+    restrict" — the gate would rather over-accept than reject a
+    legitimate upload on a host where we can't measure RAM.
+
+    The host_agent runs on the host (outside the container) so it
+    reads the *physical* host's MemTotal, not a per-container cgroup
+    limit. Inside a container, ``/proc/meminfo`` reports the same
+    host-wide value too (cgroup memory accounting doesn't rewrite it),
+    so we could read this from the server, but routing through the
+    host_agent + Redis keeps the existing pattern: anything board /
+    host-shape-related lives in host_agent and lands in Redis under
+    ``host:*``.
+    """
+    try:
+        with open('/proc/meminfo') as f:
+            for line in f:
+                if not line.startswith('MemTotal:'):
+                    continue
+                # Format: ``MemTotal:       12345678 kB``
+                parts = line.split()
+                if len(parts) >= 2:
+                    try:
+                        return int(parts[1])
+                    except ValueError:
+                        return None
+    except OSError:
+        return None
+    return None
+
+
+def set_total_mem_kb(rdb: 'redis.Redis') -> None:
+    """Publish the host's MemTotal (kibibytes) to Redis.
+
+    Written before ``host_agent_ready`` flips so a consumer waiting on
+    readiness never observes a stale missing key. An unreadable
+    ``/proc/meminfo`` writes the empty string — the server-side
+    reader (``anthias_common.board.get_total_mem_kb``) treats empty
+    / missing identically as "unknown".
+    """
+    value = detect_total_mem_kb()
+    rdb.set('host:total_mem_kb', '' if value is None else str(value))
+    if value is None:
+        logging.warning(
+            'Could not read MemTotal from /proc/meminfo; low-RAM '
+            'detection will fall back to "unknown" and not enforce '
+            'the resolution cap.'
+        )
+    else:
+        logging.info('Published host total_mem_kb=%s to redis', value)
+
+
 def set_board_subtype(rdb: 'redis.Redis') -> None:
     """Publish the host's board subtype to Redis.
 
@@ -226,6 +283,7 @@ def subscriber_loop() -> None:
             pubsub = rdb.pubsub(ignore_subscribe_messages=True)
             pubsub.subscribe(CHANNEL_NAME)
     set_board_subtype(rdb)
+    set_total_mem_kb(rdb)
     rdb.set('host_agent_ready', 'true')
     logging.info(
         'Subscribed to channel %s, ready to process messages', CHANNEL_NAME

--- a/src/anthias_server/api/tests/test_info_endpoints.py
+++ b/src/anthias_server/api/tests/test_info_endpoints.py
@@ -201,6 +201,10 @@ def test_info_v2_endpoint(
             'shared': 0,
             'buff': 1024,
             'available': 7168,
+            # mock total=8 GiB is well above the 1.5 GiB low-RAM
+            # cutoff, so the gate is inactive on this synthetic
+            # device.
+            'low_ram': False,
         },
         'ip_addresses': ['http://192.168.1.100', 'http://10.0.0.50'],
         'mac_address': '00:11:22:33:44:55',

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -875,8 +875,17 @@ class InfoViewV2(InfoViewMixin):
             'hours': round(system_uptime.seconds / 3600, 2),
         }
 
-    def get_memory(self) -> dict[str, int]:
+    def get_memory(self) -> dict[str, int | bool]:
+        from anthias_common.board import LOW_RAM_THRESHOLD_KB
+
         virtual_memory = psutil.virtual_memory()
+        # ``low_ram`` echoes the same gate that drives the viewer's
+        # single-QWebEngineView mode and the asset processor's
+        # 1080p upload cap. Exposed via /api/v2/info so external
+        # clients can render a "degraded mode" badge alongside the
+        # other memory fields. ``int | bool`` covers the field union;
+        # ``bool`` is a subclass of ``int`` in Python so static
+        # type-checkers don't flag the mixed dict.
         return {
             'total': virtual_memory.total >> 20,
             'used': virtual_memory.used >> 20,
@@ -884,6 +893,7 @@ class InfoViewV2(InfoViewMixin):
             'shared': virtual_memory.shared >> 20,
             'buff': virtual_memory.buffers >> 20,
             'available': virtual_memory.available >> 20,
+            'low_ram': virtual_memory.total < LOW_RAM_THRESHOLD_KB * 1024,
         }
 
     def get_ip_addresses(self) -> list[str]:
@@ -924,6 +934,7 @@ class InfoViewV2(InfoViewMixin):
                             'shared': {'type': 'integer'},
                             'buff': {'type': 'integer'},
                             'available': {'type': 'integer'},
+                            'low_ram': {'type': 'boolean'},
                         },
                     },
                     'ip_addresses': {

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -15,6 +15,7 @@ import psutil
 from django.template.defaultfilters import filesizeformat
 
 from anthias_common import device_helper
+from anthias_common.board import LOW_RAM_THRESHOLD_KB
 from anthias_common.utils import (
     clamp_screen_rotation,
     connect_to_redis,
@@ -145,6 +146,19 @@ def system_info() -> dict[str, Any]:
             'used_pct': _pct(mem_used, mem_total),
             'cache_pct': _pct(mem_cache, mem_total),
             'free_pct': _pct(mem_free, mem_total),
+        },
+        # Surface the low-RAM gate alongside Memory so an operator
+        # whose 4K HEVC upload was rejected (or who notices an asset
+        # crossfade has degraded into a hard cut) can see *why* on
+        # the same screen. ``threshold_mib`` is the same cutoff
+        # ``is_low_ram_device`` consults — exposing it keeps the
+        # operator from having to spelunk the codebase to learn what
+        # qualifies. Compares against psutil's measurement (same
+        # /proc/meminfo source host_agent reads) so the page is
+        # accurate even if host_agent hasn't published yet.
+        'low_ram': {
+            'active': virtual_memory.total < LOW_RAM_THRESHOLD_KB * 1024,
+            'threshold_mib': LOW_RAM_THRESHOLD_KB >> 10,
         },
         # Uptime as "2 days, 3 hours" via Django's timesince — pass the
         # boot-time so timesince computes against now(). Pass depth=2 so

--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -1297,6 +1297,15 @@ label { text-align: left; }
   }
   .stat-card__meta a { color: $anthias-purple-5; text-decoration: none; }
   .stat-card__meta a:hover { text-decoration: underline; }
+  // Variant for advisory/warning text inside a stat card (e.g. the
+  // low-RAM degradation badge on Memory). Borrows the warning
+  // colour token already used by .loadavg-row--warn so the palette
+  // stays consistent and a future theme swap touches one token.
+  .stat-card__meta--warn {
+    color: var(--color-warning);
+    margin-top: 0.5rem;
+    line-height: 1.4;
+  }
 }
 
 .stat-card--span-2 { grid-column: span 2; @media (max-width: 540px) { grid-column: span 1; } }

--- a/src/anthias_server/app/templates/system_info.html
+++ b/src/anthias_server/app/templates/system_info.html
@@ -84,6 +84,14 @@
             </li>
           </ul>
         </div>
+        {% if low_ram.active %}
+        <p class="stat-card__meta stat-card__meta--warn">
+          <i class="ti ti-alert-triangle mr-1"></i>
+          <strong>Low-RAM mode:</strong> single-QWebEngineView (no
+          preloaded crossfade), 1080p upload cap on video. Engages
+          below {{ low_ram.threshold_mib|intcomma }} MiB MemTotal.
+        </p>
+        {% endif %}
       </div>
 
       <div class="stat-card stat-card--span-2">

--- a/src/anthias_server/processing.py
+++ b/src/anthias_server/processing.py
@@ -61,7 +61,7 @@ import sh
 from celery import Task
 from PIL import Image, UnidentifiedImageError
 
-from anthias_common.board import resolve_device_key
+from anthias_common.board import is_low_ram_device, resolve_device_key
 from anthias_server.app.models import Asset
 
 
@@ -869,6 +869,36 @@ _HW_DECODE_VIDEO_CODECS: dict[str, frozenset[str]] = {
 }
 
 
+# Pixel cap for low-RAM boards (< 1.5 GiB MemTotal — Pi 2/Pi 3 1GB,
+# Pi 4 1GB, Rock Pi 4 1GB, generic-arm64 1GB SKUs). 1080p = 2 073 600
+# pixels is the line where a 1 GB board can keep a QtWebEngine
+# renderer resident *and* play video without OOM-thrashing. 4K = 8 294
+# 400 pixels is 4× this and triggered an OOM-kill in on-device
+# testing (Rock Pi 4 1GB, dmesg: ``global_oom`` on the docker
+# container's bash process). Resolution above this cap is rejected
+# at upload — the operator gets the same "Failed" pill + recipe UX
+# the codec gate already uses.
+_LOW_RAM_MAX_PIXELS = 1920 * 1080
+
+
+def _exceeds_low_ram_pixel_cap(width: int | None, height: int | None) -> bool:
+    """``True`` when this board is low-RAM and the asset exceeds 1080p.
+
+    Returns ``False`` when the host's MemTotal couldn't be measured
+    (host_agent never ran, Redis down) — same "don't block on a
+    measurement gap" principle as ``is_low_ram_device`` itself.
+    Returns ``False`` when ffprobe couldn't read dimensions — that
+    upload already collapsed to ``video_codec='unknown'`` and the
+    codec gate will reject it; we don't pile on a second rejection
+    against a None dimension.
+    """
+    if not is_low_ram_device():
+        return False
+    if width is None or height is None or width <= 0 or height <= 0:
+        return False
+    return width * height > _LOW_RAM_MAX_PIXELS
+
+
 def _hw_decoded_codecs() -> frozenset[str]:
     """Codecs the *current* board can hardware-decode through mpv.
 
@@ -884,10 +914,11 @@ def _hw_decoded_codecs() -> frozenset[str]:
 def _ffmpeg_reencode_recipe(
     supported: frozenset[str],
     source_filename: str = '',
+    cap_to_1080p: bool = False,
 ) -> str:
     """Return an ``ffmpeg`` command line the operator can run on
     their workstation to transcode an unsupported upload into a
-    codec this board hardware-decodes.
+    codec (and, optionally, resolution) this board accepts.
 
     Prefers libx264 when H.264 is in the board's supported set —
     libx264 is roughly 5-10× faster than libx265 at comparable
@@ -901,16 +932,35 @@ def _ffmpeg_reencode_recipe(
     filename (no path) for the ``INPUT`` placeholder and reuses its
     stem for ``OUTPUT.mp4`` so the operator can copy the recipe
     verbatim into their terminal without hand-editing it.
+
+    ``cap_to_1080p`` injects ``-vf scale=1920:1080:force_original_aspect_ratio=decrease``
+    so the recipe also downscales an over-resolution source onto the
+    1920×1080 envelope. ``force_original_aspect_ratio=decrease``
+    means the output fits *inside* 1920×1080 (no padding, no
+    stretch) — a 4K 16:9 source becomes exactly 1920×1080, a 4K 21:9
+    ultrawide lands at 1920×823, a portrait 1080×1920 lands at
+    608×1080 (height-bound). Used by the low-RAM resolution gate;
+    omitted in the codec-only rejection path so we don't suggest a
+    needless re-encode when an HD codec swap is all that's wanted.
     """
+    scale_clause = (
+        '-vf scale=1920:1080:force_original_aspect_ratio=decrease '
+        if cap_to_1080p
+        else ''
+    )
     if 'h264' in supported:
         template = (
-            'ffmpeg -i {input} -c:v libx264 -preset medium -crf 23 '
+            'ffmpeg -i {input} '
+            + scale_clause
+            + '-c:v libx264 -preset medium -crf 23 '
             '-c:a aac -b:a 192k -movflags +faststart {output}'
         )
         target_suffix = 'h264'
     elif 'hevc' in supported:
         template = (
-            'ffmpeg -i {input} -c:v libx265 -preset medium -crf 28 '
+            'ffmpeg -i {input} '
+            + scale_clause
+            + '-c:v libx265 -preset medium -crf 28 '
             '-tag:v hvc1 -c:a aac -b:a 192k -movflags +faststart '
             '{output}'
         )
@@ -993,7 +1043,41 @@ def _run_video_normalisation(asset: Asset) -> None:
 
     src_codec = (summary.get('video_codec') or '').lower()
     supported = _hw_decoded_codecs()
+    video_width = summary.get('video_width')
+    video_height = summary.get('video_height')
+    # ``upload_name`` is stashed by the dashboard / API at upload
+    # time — the on-disk file gets renamed to ``<uuid>.<ext>`` but
+    # the recipe wants a name the operator can paste straight into
+    # their workstation terminal. YouTube / pre-rebrand rows that
+    # don't carry the field fall through to a stable
+    # ``upload<ext>`` placeholder so the recipe still teaches the
+    # operator the input extension. Resolved once so both the codec-
+    # and the resolution-rejection paths share the same recipe stem.
+    upload_name = metadata.get('upload_name') or (
+        f'upload{path.splitext(src_uri)[1]}'
+    )
+
     if src_codec in supported:
+        if _exceeds_low_ram_pixel_cap(video_width, video_height):
+            # Codec is fine but resolution exceeds the 1080p envelope
+            # on this 1 GB-class board. On-device validation (Rock
+            # Pi 4 1GB, 4K HEVC) showed the docker viewer container
+            # OOM-loops the moment QtMultimedia tries to allocate the
+            # decode pipeline — kernel logs ``global_oom``. Reject at
+            # upload with a downscale recipe so the operator sees a
+            # clear failure and a copy-pasteable fix instead of a
+            # device stuck in an OOM cycle.
+            Asset.objects.filter(asset_id=asset_id).update(**update_dict)
+            recipe = _ffmpeg_reencode_recipe(
+                supported, upload_name, cap_to_1080p=True
+            )
+            message = (
+                f'Video resolution {video_width}x{video_height} '
+                'exceeds the 1080p cap on this device. Boards with '
+                'less than 1.5 GiB of RAM OOM when decoding above '
+                '1920x1080 alongside the web UI.'
+            )
+            raise UnsupportedVideoCodecError(message, recipe=recipe)
         update_dict['is_processing'] = False
         Asset.objects.filter(asset_id=asset_id).update(**update_dict)
         _notify(asset_id)
@@ -1008,17 +1092,13 @@ def _run_video_normalisation(asset: Asset) -> None:
     display_codec = (
         src_codec if src_codec and src_codec != 'unknown' else 'unknown'
     )
-    # ``upload_name`` is stashed by the dashboard / API at upload
-    # time — the on-disk file gets renamed to ``<uuid>.<ext>`` but
-    # the recipe wants a name the operator can paste straight into
-    # their workstation terminal. YouTube / pre-rebrand rows that
-    # don't carry the field fall through to a stable
-    # ``upload<ext>`` placeholder so the recipe still teaches the
-    # operator the input extension.
-    upload_name = metadata.get('upload_name') or (
-        f'upload{path.splitext(src_uri)[1]}'
-    )
-    recipe = _ffmpeg_reencode_recipe(supported, upload_name)
+    # If the upload would *also* fail the low-RAM 1080p gate, fold
+    # the downscale into the codec recipe so the operator doesn't
+    # have to re-upload twice (once for the codec swap, once for the
+    # resolution shrink). The message remains codec-focused because
+    # the codec is the strictly stronger rejection.
+    cap = _exceeds_low_ram_pixel_cap(video_width, video_height)
+    recipe = _ffmpeg_reencode_recipe(supported, upload_name, cap_to_1080p=cap)
     if supported:
         supported_str = ', '.join(sorted(supported))
         message = (

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -96,12 +96,46 @@ QString detectAcceptLanguage()
 }
 
 
+namespace {
+// ``ANTHIAS_LOW_RAM=1`` is exported by bin/upgrade_containers.sh when
+// the host has < 1.5 GiB MemTotal (Pi 2/Pi 3 1GB, Pi 4 1GB, Rock Pi
+// 4 1GB, generic-arm64 1GB SKUs). On those boards we collapse the
+// double-buffer ``webView1`` / ``webView2`` design to a single shared
+// QWebEngineView — the inactive Chromium renderer cost ~100 MB
+// physical RAM per device and was the leading edge of the OOM
+// cascade measured on a Rock Pi 4 1GB. UX trade-off: loadPage
+// switches to in-place (brief blank during navigation), no
+// preloaded-then-swap crossfade. Documented in
+// docs/board-enablement.md.
+bool isLowRamMode()
+{
+    const QByteArray value = qgetenv("ANTHIAS_LOW_RAM");
+    return value == "1";
+}
+}
+
 View::View(QWidget* parent) : QWidget(parent)
 {
     webView1 = new QWebEngineView(this);
-    webView2 = new QWebEngineView(this);
     configureWebView(webView1);
-    configureWebView(webView2);
+    if (isLowRamMode()) {
+        // Single-view mode: alias the second pointer onto the first
+        // so the rest of the file's dual-buffer logic still compiles
+        // and runs — every operation that would have targeted the
+        // off-screen ``webView2`` now lands on the same widget, and
+        // the visibility swap in switchToNextWebView() becomes a
+        // no-op. The net effect for the operator: a loadPage call
+        // shows the page's own ``page()->backgroundColor()`` (black)
+        // during the load, then the page itself; no smooth fade
+        // between assets. Acceptable degradation; the alternative
+        // is the box OOM-cycling on 1 GB.
+        webView2 = webView1;
+        qInfo() << "View: ANTHIAS_LOW_RAM=1 — single-QWebEngineView "
+                << "mode (no preloaded crossfade).";
+    } else {
+        webView2 = new QWebEngineView(this);
+        configureWebView(webView2);
+    }
 
     // Both webViews share the default profile, so the HTTP-cache setup
     // is per-process, not per-view. Use in-memory only — the default
@@ -129,8 +163,13 @@ View::View(QWidget* parent) : QWidget(parent)
 
     connect(webView1->page(), &QWebEnginePage::authenticationRequired,
             this, &View::handleAuthRequest);
-    connect(webView2->page(), &QWebEnginePage::authenticationRequired,
-            this, &View::handleAuthRequest);
+    if (webView2 != webView1) {
+        // Skip the duplicate connect when low-RAM aliased webView2
+        // onto webView1 — Qt's connect would otherwise fire the auth
+        // handler twice per challenge.
+        connect(webView2->page(), &QWebEnginePage::authenticationRequired,
+                this, &View::handleAuthRequest);
+    }
 
     // QtMultimedia-backed video surface. Created hidden — only
     // made visible when ``playVideo`` fires. The QMediaPlayer +

--- a/tests/test_host_agent_board_subtype.py
+++ b/tests/test_host_agent_board_subtype.py
@@ -19,7 +19,12 @@ from unittest import mock
 
 import pytest
 
-from anthias_host_agent.__main__ import detect_board_subtype, set_board_subtype
+from anthias_host_agent.__main__ import (
+    detect_board_subtype,
+    detect_total_mem_kb,
+    set_board_subtype,
+    set_total_mem_kb,
+)
 
 
 @pytest.mark.parametrize(
@@ -123,10 +128,12 @@ def test_subscriber_loop_calls_set_board_subtype(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The ``subscriber_loop`` orchestration must call
-    ``set_board_subtype`` before flipping ``host_agent_ready``
-    — otherwise a consumer that polls for ``host_agent_ready=true``
-    and immediately reads ``host:board_subtype`` could observe
-    the stale (or empty) value."""
+    ``set_board_subtype`` *and* ``set_total_mem_kb`` before flipping
+    ``host_agent_ready`` — otherwise a consumer that polls for
+    ``host_agent_ready=true`` and immediately reads either
+    ``host:board_subtype`` or ``host:total_mem_kb`` could observe a
+    stale (or empty) value. The two host-shape publishers run before
+    readiness; the order between them doesn't matter for consumers."""
     from anthias_host_agent import __main__ as ha
 
     fake_redis = mock.MagicMock()
@@ -134,6 +141,9 @@ def test_subscriber_loop_calls_set_board_subtype(
 
     def fake_set_subtype(rdb: Any) -> None:
         call_order.append('subtype')
+
+    def fake_set_total_mem(rdb: Any) -> None:
+        call_order.append('total_mem')
 
     def fake_set(key: str, value: Any) -> None:
         if key == 'host_agent_ready':
@@ -148,10 +158,110 @@ def test_subscriber_loop_calls_set_board_subtype(
 
     monkeypatch.setattr(redis_pkg, 'Redis', lambda **kw: fake_redis)
     monkeypatch.setattr(ha, 'set_board_subtype', fake_set_subtype)
+    monkeypatch.setattr(ha, 'set_total_mem_kb', fake_set_total_mem)
 
     ha.subscriber_loop()
 
-    assert call_order == ['subtype', 'ready'], (
-        'set_board_subtype must complete before host_agent_ready '
-        'flips, otherwise consumers race the publish'
+    assert call_order[-1] == 'ready', (
+        'host_agent_ready must flip last so consumers polling on it '
+        'never observe a stale host:* publish'
     )
+    assert set(call_order[:-1]) == {'subtype', 'total_mem'}, (
+        'subscriber_loop must call both publishers exactly once '
+        'before flipping readiness'
+    )
+
+
+@pytest.mark.parametrize(
+    ('meminfo_body', 'expected'),
+    [
+        # Pi 4 4 GB: typical /proc/meminfo on a healthy box. The
+        # function reads the kB count, not the trailing unit token.
+        (
+            b'MemTotal:        3947648 kB\nMemFree:          200000 kB\n',
+            3947648,
+        ),
+        # Rock Pi 4 1 GB: the on-device measurement that motivated
+        # the low-RAM mode.
+        (
+            b'MemTotal:         990044 kB\nMemFree:           32500 kB\n',
+            990044,
+        ),
+        # Tab whitespace instead of spaces — split() handles both.
+        (b'MemTotal:\t8123456\tkB\n', 8123456),
+        # Pre-MemTotal junk lines (e.g. kernel writes a leading
+        # comment on some boards) — the loop scans until it finds
+        # the line, so prefix garbage is tolerated.
+        (b'Garbage: 0 kB\nMemTotal:    1572864 kB\n', 1572864),
+    ],
+)
+def test_detect_total_mem_kb(meminfo_body: bytes, expected: int) -> None:
+    """The kB count from /proc/meminfo is the source of truth for
+    low-RAM gating. Tests pin the parsing against the kernel's actual
+    formats (space- and tab-separated, decoy lines, …)."""
+    mocked_open = mock.mock_open(read_data=meminfo_body.decode('utf-8'))
+    with mock.patch(
+        'anthias_host_agent.__main__.open', mocked_open, create=True
+    ):
+        assert detect_total_mem_kb() == expected
+
+
+def test_detect_total_mem_kb_missing_line() -> None:
+    """A truncated /proc/meminfo without a MemTotal line returns
+    ``None`` so the caller treats RAM as unknown — same recovery
+    path as a missing /proc/meminfo or unparseable value."""
+    mocked_open = mock.mock_open(read_data='MemFree: 100000 kB\n')
+    with mock.patch(
+        'anthias_host_agent.__main__.open', mocked_open, create=True
+    ):
+        assert detect_total_mem_kb() is None
+
+
+def test_detect_total_mem_kb_unparseable_value() -> None:
+    """A non-integer in the MemTotal field returns ``None`` rather
+    than crashing the host_agent unit."""
+    mocked_open = mock.mock_open(
+        read_data='MemTotal:        not-a-number kB\n'
+    )
+    with mock.patch(
+        'anthias_host_agent.__main__.open', mocked_open, create=True
+    ):
+        assert detect_total_mem_kb() is None
+
+
+def test_detect_total_mem_kb_unreadable_proc() -> None:
+    """A host where /proc/meminfo can't be opened (container, balena
+    restricted /proc) returns ``None``."""
+    with mock.patch(
+        'anthias_host_agent.__main__.open',
+        side_effect=OSError('no such file'),
+        create=True,
+    ):
+        assert detect_total_mem_kb() is None
+
+
+def test_set_total_mem_kb_writes_value() -> None:
+    """A successful detect publishes the integer as a string —
+    redis-py serialises bytes/str natively; integers go through
+    ``str(int)`` for round-trip parity with the get-side parser."""
+    fake_redis = mock.MagicMock()
+    with mock.patch(
+        'anthias_host_agent.__main__.detect_total_mem_kb',
+        return_value=990044,
+    ):
+        set_total_mem_kb(fake_redis)
+    fake_redis.set.assert_called_once_with('host:total_mem_kb', '990044')
+
+
+def test_set_total_mem_kb_writes_empty_string_on_unknown() -> None:
+    """Mirrors set_board_subtype: "unknown RAM" is the empty string,
+    distinguishable from "key never set" but treated identically by
+    the server-side reader (``get_total_mem_kb`` returns ``None``
+    for both)."""
+    fake_redis = mock.MagicMock()
+    with mock.patch(
+        'anthias_host_agent.__main__.detect_total_mem_kb',
+        return_value=None,
+    ):
+        set_total_mem_kb(fake_redis)
+    fake_redis.set.assert_called_once_with('host:total_mem_kb', '')

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -885,6 +885,258 @@ def test_video_arm64_with_rockpi4_subtype_accepts_h264(
     assert asset.metadata.get('video_codec') == 'h264'
 
 
+# ---------------------------------------------------------------------------
+# Low-RAM resolution gate (boards with < 1.5 GiB MemTotal). On-device
+# measurement on a 1 GB Rock Pi 4 showed 4K HEVC OOM-kills the viewer
+# container (dmesg ``global_oom`` on the docker container's bash); the
+# codec gate rejects above-1080p uploads on those boards so an operator
+# gets a clear failure pill + downscale recipe instead of a wedged
+# device.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_video_low_ram_rejects_4k_with_resolution_message(
+    asset_dir: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 4K HEVC upload on a low-RAM board (codec is in the supported
+    set, but resolution exceeds 1920×1080) is rejected with a
+    resolution-specific message and a recipe that includes the
+    downscale ``-vf scale=`` clause. Validates the gate fires *only*
+    on the resolution leg — codec is otherwise fine."""
+    monkeypatch.setenv('DEVICE_TYPE', 'arm64')
+    src = path.join(asset_dir, 'big.mp4')
+    with open(src, 'wb') as f:
+        f.write(b'\x00')
+    asset = _make_processing_asset(
+        'vid-4k-lowram',
+        src,
+        mimetype='video',
+        metadata={'upload_name': 'beach-4k.mp4'},
+    )
+
+    fake_summary = {
+        'container': 'mp4',
+        'video_codec': 'hevc',
+        'video_pixels': 3840 * 2160,
+        'video_width': 3840,
+        'video_height': 2160,
+        'video_fps': 30.0,
+        'audio_codec': 'aac',
+        'duration_seconds': 60,
+    }
+    with (
+        mock.patch.object(processing, '_notify'),
+        mock.patch.object(
+            processing, '_ffprobe_summary', return_value=fake_summary
+        ),
+        mock.patch(
+            'anthias_common.board.get_board_subtype', return_value='rockpi4'
+        ),
+        mock.patch(
+            'anthias_server.processing.is_low_ram_device', return_value=True
+        ),
+        pytest.raises(processing.UnsupportedVideoCodecError) as excinfo,
+    ):
+        processing._run_video_normalisation(asset)
+
+    msg = str(excinfo.value)
+    assert '3840x2160' in msg
+    assert '1080p' in msg
+    assert '1.5 GiB' in msg
+    # Recipe carries the downscale clause + a board-appropriate
+    # codec. rockpi4 supports H.264 so libx264 is preferred.
+    recipe = excinfo.value.recipe
+    assert '-vf scale=1920:1080:force_original_aspect_ratio=decrease' in recipe
+    assert 'libx264' in recipe
+    # Metadata still captured (operator sees what they uploaded).
+    asset.refresh_from_db()
+    assert asset.metadata.get('video_width') == 3840
+
+
+@pytest.mark.django_db
+def test_video_low_ram_accepts_1080p(
+    asset_dir: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """1080p HEVC on the same low-RAM board passes the gate — exactly
+    the boundary the on-device measurement said survives."""
+    monkeypatch.setenv('DEVICE_TYPE', 'arm64')
+    src = path.join(asset_dir, 'hd.mp4')
+    with open(src, 'wb') as f:
+        f.write(b'\x00')
+    asset = _make_processing_asset('vid-1080-lowram', src, mimetype='video')
+
+    fake_summary = {
+        'container': 'mp4',
+        'video_codec': 'hevc',
+        'video_pixels': 1920 * 1080,
+        'video_width': 1920,
+        'video_height': 1080,
+        'video_fps': 30.0,
+        'audio_codec': 'aac',
+        'duration_seconds': 15,
+    }
+    with (
+        mock.patch.object(processing, '_notify'),
+        mock.patch.object(
+            processing, '_ffprobe_summary', return_value=fake_summary
+        ),
+        mock.patch(
+            'anthias_common.board.get_board_subtype', return_value='rockpi4'
+        ),
+        mock.patch(
+            'anthias_server.processing.is_low_ram_device', return_value=True
+        ),
+    ):
+        processing._run_video_normalisation(asset)
+
+    asset.refresh_from_db()
+    assert asset.is_processing is False
+    assert asset.metadata.get('video_codec') == 'hevc'
+
+
+@pytest.mark.django_db
+def test_video_high_ram_accepts_4k(
+    asset_dir: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 4K upload on a high-RAM board (Pi 5, Pi 4 4GB) is NOT gated
+    by resolution — the low-RAM cap only fires when MemTotal sits
+    below the threshold."""
+    monkeypatch.setenv('DEVICE_TYPE', 'pi5')
+    src = path.join(asset_dir, 'big.mp4')
+    with open(src, 'wb') as f:
+        f.write(b'\x00')
+    asset = _make_processing_asset('vid-4k-pi5', src, mimetype='video')
+
+    fake_summary = {
+        'container': 'mp4',
+        'video_codec': 'hevc',
+        'video_pixels': 3840 * 2160,
+        'video_width': 3840,
+        'video_height': 2160,
+        'video_fps': 30.0,
+        'audio_codec': 'aac',
+        'duration_seconds': 60,
+    }
+    with (
+        mock.patch.object(processing, '_notify'),
+        mock.patch.object(
+            processing, '_ffprobe_summary', return_value=fake_summary
+        ),
+        # High-RAM device — gate inactive.
+        mock.patch(
+            'anthias_server.processing.is_low_ram_device', return_value=False
+        ),
+    ):
+        processing._run_video_normalisation(asset)
+
+    asset.refresh_from_db()
+    assert asset.is_processing is False
+    assert asset.metadata.get('video_width') == 3840
+
+
+@pytest.mark.django_db
+def test_video_low_ram_unsupported_codec_recipe_includes_downscale(
+    asset_dir: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the upload fails BOTH the codec gate and the resolution
+    gate (e.g. 4K MPEG-2 on Rock Pi 4 1GB), the codec message wins
+    (codec is the strictly stronger rejection — operator has to
+    re-encode either way) but the recipe folds in the downscale so
+    the operator's re-encode also lands within the 1080p envelope.
+    Saves them an iteration of "re-encoded the codec, now it fails
+    the resolution gate too"."""
+    monkeypatch.setenv('DEVICE_TYPE', 'arm64')
+    src = path.join(asset_dir, 'old.mpg')
+    with open(src, 'wb') as f:
+        f.write(b'\x00')
+    asset = _make_processing_asset('vid-mpeg2-4k', src, mimetype='video')
+
+    fake_summary = {
+        'container': 'mpeg',
+        'video_codec': 'mpeg2video',  # Not in rockpi4's HW set.
+        'video_pixels': 3840 * 2160,
+        'video_width': 3840,
+        'video_height': 2160,
+        'video_fps': 30.0,
+        'audio_codec': 'mp2',
+        'duration_seconds': 60,
+    }
+    with (
+        mock.patch.object(processing, '_notify'),
+        mock.patch.object(
+            processing, '_ffprobe_summary', return_value=fake_summary
+        ),
+        mock.patch(
+            'anthias_common.board.get_board_subtype', return_value='rockpi4'
+        ),
+        mock.patch(
+            'anthias_server.processing.is_low_ram_device', return_value=True
+        ),
+        pytest.raises(processing.UnsupportedVideoCodecError) as excinfo,
+    ):
+        processing._run_video_normalisation(asset)
+
+    msg = str(excinfo.value)
+    # Codec message wins (strictly stronger rejection).
+    assert 'codec' in msg.lower()
+    assert "'mpeg2video'" in msg
+    # Recipe folds in the downscale so a single re-encode satisfies
+    # both gates.
+    recipe = excinfo.value.recipe
+    assert '-vf scale=1920:1080:force_original_aspect_ratio=decrease' in recipe
+
+
+def test_ffmpeg_recipe_omits_scale_clause_by_default() -> None:
+    """The codec-only rejection path passes ``cap_to_1080p=False``
+    (the default). Recipe must NOT include a scale clause then — we
+    don't want to suggest a needless downscale when an HD codec
+    swap is all that's wanted."""
+    recipe = processing._ffmpeg_reencode_recipe(frozenset({'h264'}), 'foo.mkv')
+    assert '-vf scale' not in recipe
+    assert '-c:v libx264' in recipe
+
+
+def test_ffmpeg_recipe_includes_scale_clause_when_capping() -> None:
+    """``cap_to_1080p=True`` injects the
+    ``-vf scale=1920:1080:force_original_aspect_ratio=decrease`` clause
+    between the input and the codec arguments, so the operator's
+    re-encode lands inside the 1920×1080 envelope. The
+    ``force_original_aspect_ratio=decrease`` keeps the aspect ratio
+    intact for landscape, ultrawide, and portrait sources alike."""
+    recipe = processing._ffmpeg_reencode_recipe(
+        frozenset({'h264'}), 'foo.mkv', cap_to_1080p=True
+    )
+    assert '-vf scale=1920:1080:force_original_aspect_ratio=decrease' in recipe
+    # Order matters — scale must be before the encoder so the encoder
+    # sees the downscaled frames.
+    scale_idx = recipe.index('-vf')
+    encoder_idx = recipe.index('-c:v')
+    assert scale_idx < encoder_idx
+
+
+def test_exceeds_low_ram_pixel_cap_unknown_dims_returns_false() -> None:
+    """ffprobe-failed uploads (``video_width=None``) skip the
+    resolution gate — the codec gate already collapsed to ``unknown``
+    and will reject them; double-rejecting on dimensions we can't
+    measure would just be noise."""
+    with mock.patch(
+        'anthias_server.processing.is_low_ram_device', return_value=True
+    ):
+        assert processing._exceeds_low_ram_pixel_cap(None, None) is False
+        assert processing._exceeds_low_ram_pixel_cap(0, 0) is False
+        assert processing._exceeds_low_ram_pixel_cap(1920, None) is False
+
+
+def test_exceeds_low_ram_pixel_cap_high_ram_returns_false() -> None:
+    """High-RAM devices never hit the cap, even for >1080p sources."""
+    with mock.patch(
+        'anthias_server.processing.is_low_ram_device', return_value=False
+    ):
+        assert processing._exceeds_low_ram_pixel_cap(3840, 2160) is False
+        assert processing._exceeds_low_ram_pixel_cap(1920, 1080) is False
+
+
 def test_format_subprocess_stderr_decodes_and_trims() -> None:
     """``_format_subprocess_stderr`` must produce operator-readable
     text: bytes decoded as UTF-8 (with replacement for malformed


### PR DESCRIPTION
## Summary

Boards with less than 1.5 GiB MemTotal (Pi 2/Pi 3 1GB, Pi 4 1GB, Rock Pi 4 1GB,
generic-arm64 1GB SKUs) OOM-cycled when QtMultimedia loaded a 4K HEVC asset
alongside the two QtWebEngine renderers introduced by #2905. On-device repro on
a 1 GB Rock Pi 4 captured `global_oom` on the docker container's bash process
followed by a restart loop, plus the kernel keeping sshd in banner-exchange
until power-cycle. This patch puts the device into a graceful degraded mode
before the OOM cascade fires.

- Viewer collapses to a single `QWebEngineView` on low-RAM (no preloaded
  crossfade; page swap in-place with a brief blank during load). Saves
  ~100 MB physical RAM per device by dropping the second Chromium renderer.
- Codec gate gains a 1080p resolution cap on low-RAM boards. Above-1080p
  uploads are rejected at upload with the existing recipe machinery, extended
  to inject `-vf scale=1920:1080:force_original_aspect_ratio=decrease` so the
  operator's re-encode also lands within the envelope.
- `anthias_host_agent` publishes `host:total_mem_kb` to Redis alongside the
  existing `host:board_subtype`; `anthias_common.board` gains `LOW_RAM_THRESHOLD_KB`
  / `get_total_mem_kb()` / `is_low_ram_device()` so server-side code reads
  MemTotal without re-opening `/proc/meminfo`.
- Diagnostics page (Memory card + `/api/v2/info`) surfaces a "Low-RAM mode"
  badge with the threshold MiB so operators can see *why* the device degraded.
- `docs/board-enablement.md` — rewrote the stale `--hwdec=drm-copy` /
  per-codec dispatch text removed in #2905; documented the known mainline
  rkvdec limitation on Armbian 6.18 (HEVC stateless engages via `-hwaccel drm`
  but produces decode errors; H.264 has no v4l2_request binding in `+rpt1`
  7.1.3) and the new low-RAM mode.

## On-device measurements (Rock Pi 4 1 GB, RK3399)

|                       | Before (`db999f1`) | After (`22abfb2`, low-RAM gate active) |
|---|---|---|
| Idle viewer + Chromium RSS | ~440 MB                  | **~244 MB**                                  |
| QtWebEngine renderers      | 2                        | **1**                                        |
| 4K HEVC asset              | OOM-loops the container  | Rejected at upload with downscale recipe     |
| CMA free at idle           | ~1.5 MB                  | ~12 MB                                       |

## Out of scope (separate work)

HEVC HW-decode on arm64 is gated by an upstream rkvdec/Hantro driver fix that
isn't in any Debian-shipped Armbian kernel today. Anthias is userspace-only and
doesn't carry its own kernel patches, so this PR ships graceful degradation
rather than chasing the driver.

## Test plan

- [x] Unit tests: 130 in `tests/test_processing.py` + `tests/test_host_agent_board_subtype.py` pass, including new coverage for the four matrix cells (low/high-RAM × in/over-cap), recipe shape with/without `cap_to_1080p`, the cap defence against unknown / zero dimensions, host_agent's MemTotal parser, and the API endpoint's new `low_ram` field. Full suite: **894 passed** non-integration.
- [x] `ruff check` + `ruff format --check` clean across changed files.
- [x] **On-device validation — all four testbeds**:
  - x86 (8 GB): `ANTHIAS_LOW_RAM=0`, 2 renderers, `low_ram=False`.
  - Pi 4 (4 GB): `ANTHIAS_LOW_RAM=0`, 2 renderers, `low_ram=False`.
  - Pi 5 (8 GB): `ANTHIAS_LOW_RAM=0`, 2 renderers, `low_ram=False`.
  - Rock Pi 4 (1 GB): `ANTHIAS_LOW_RAM=1`, **1 renderer**, `low_ram=True`, 4K HEVC upload **rejected** with the downscale recipe (`ffmpeg -i upload.mp4 -vf scale=1920:1080:force_original_aspect_ratio=decrease -c:v libx264 …`).
- [ ] Manual: confirm the diagnostics page badge renders correctly (browser, not headless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)