### PR TITLE
docs(website): promote Raspberry Pi Imager across the site

### DIFF
--- a/website/content/docs/installation-options.md
+++ b/website/content/docs/installation-options.md
@@ -6,14 +6,7 @@ aliases:
   - "/docs/installation-options/"
 ---
 
-> **Note**
->
-> Raspberry Pi 5 images are not yet available via the Raspberry Pi Imager. For Pi 5 installations, please use either:
-> * [balenaHub images](#using-the-images-from-balenahub)
-> * [Release images](#using-the-images-from-the-releases)
-> * [Manual installation](#installing-on-raspberry-pi-os-lite-or-debian)
-
-The quickest way to get started on supported devices is to use [Raspberry Pi Imager](https://www.screenly.io/blog/2022/12/13/anthias-and-screenly-now-in-rpi-imager/), where you can find Anthias under `Other specific-purpose OS`.
+The quickest way to get started on a Raspberry Pi is to use [Raspberry Pi Imager](https://www.raspberrypi.com/software/), where you can find Anthias under **Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias**. Pick the entry that matches your Pi (Pi 2, Pi 3, Pi 4, or Pi 5), select your SD card, and flash &mdash; the device boots straight into Anthias.
 
 ![Raspberry Pi Imager showing Other specific-purpose OS category](/docs/images/imager-01.png)
 

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -30,6 +30,12 @@
 
 - group: Installation & updates
   items:
+    - question: How do I install Anthias with Raspberry Pi Imager?
+      answer: |
+        Open [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (v1.9.4 or newer), click **Choose OS** &rarr; **Other specific-purpose OS** &rarr; **Digital signage and kiosks** &rarr; **Anthias**, then pick the entry that matches your Pi (Pi 2, Pi 3, Pi 4, or Pi 5). Select your SD card under **Choose Storage** and click **Write**. When the flash finishes, insert the card into the Pi and power it on — Anthias boots straight into the dashboard.
+
+        Open `http://<device-ip>` in a browser on the same network to start adding assets. If you want shell access on the device, enable SSH via Raspberry Pi Imager's **OS customization** (gear icon) before flashing — the Anthias image doesn't ship with SSH on by default.
+
     - question: How do I update Anthias?
       answer: |
         If you installed from a disk image or via balenaHub, updates are applied automatically over the air — the device tracks the latest stable release. For command-line installations, re-run the installer (`$HOME/anthias/bin/run_upgrade.sh`) or pull the latest Docker images.
@@ -48,8 +54,9 @@
       answer: |
         Whether SSH is enabled depends on the OS image, not on Anthias itself — the installer doesn't touch `sshd`.
 
-        * **Anthias Raspberry Pi Imager image** and **balenaHub fleets**: SSH is on out of the box.
-        * **Raspberry Pi OS Lite** (you flashed it yourself): use Raspberry Pi Imager's advanced options to pre-enable SSH and set a username, or drop an empty file named `ssh` into the `/boot` partition before first boot.
+        * **Anthias Raspberry Pi Imager image**: SSH is *not* on by default. Before flashing, click the gear icon in Raspberry Pi Imager ("OS customization") and check **Enable SSH**, set a username/password (or paste in a public key), and write the SD card. The same Imager dialog can preconfigure Wi-Fi, hostname, and locale.
+        * **balenaHub fleets**: SSH is on out of the box via the balena supervisor.
+        * **Raspberry Pi OS Lite** (you flashed it yourself): use Raspberry Pi Imager's OS customization to pre-enable SSH and set a username, or drop an empty file named `ssh` into the `/boot` partition before first boot.
         * **Debian on PC**: the Debian installer leaves SSH on if you selected the *SSH server* package during install.
 
         Then connect with `ssh <user>@<device-ip>`.

--- a/website/layouts/_default/get-started.html
+++ b/website/layouts/_default/get-started.html
@@ -51,8 +51,8 @@
         <div class="mt-8 space-y-6">
             <div class="bg-white border border-black/10 rounded-lg p-6">
                 <h3 class="text-lg font-bold">Raspberry Pi Imager</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">The quickest path for supported Raspberry Pi models. Open <a class="text-brand-purple no-underline hover:underline" href="https://www.raspberrypi.com/software/" target="_blank" rel="noopener">Raspberry Pi Imager</a> and find Anthias under <strong>Other specific-purpose OS</strong>. Flash the SD card and boot.</p>
-                <p class="text-zinc-400 text-xs mt-2">Pi 5 images are not yet available in the Imager. Use the command-line installer or disk images instead.</p>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">The quickest path for Raspberry Pi. Open <a class="text-brand-purple no-underline hover:underline" href="https://www.raspberrypi.com/software/" target="_blank" rel="noopener">Raspberry Pi Imager</a>, pick <strong>Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias</strong>, choose your Pi model, and flash the SD card. Boots straight into Anthias.</p>
+                <p class="text-zinc-400 text-xs mt-2">Raspberry Pi 2 through Pi 5.</p>
             </div>
 
             <div class="bg-white border border-black/10 rounded-lg p-6">

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -217,14 +217,26 @@
 <section class="bg-bg-light py-20 lg:py-28 px-6 md:px-12 lg:px-20">
     <div class="max-w-7xl mx-auto">
         <h2 class="text-3xl lg:text-4xl font-extrabold tracking-tight">Get running in minutes</h2>
-        <p class="text-zinc-500 mt-3 text-lg max-w-xl">Install Anthias on Raspberry Pi OS or Debian with a single command.</p>
+        <p class="text-zinc-500 mt-3 text-lg max-w-xl">Two ready-to-go paths: flash an SD card with Raspberry Pi Imager, or install over an existing Raspberry Pi OS / Debian system.</p>
 
-        <div class="mt-8 bg-brand-dark rounded-lg p-6 max-w-2xl">
-            <p class="text-white/50 text-xs font-mono mb-2">$ install on Raspberry Pi OS / Debian</p>
-            <code class="text-brand-yellow font-mono text-sm md:text-base break-all">bash &lt;(curl -sL https://install-anthias.srly.io)</code>
+        <div class="mt-8 grid md:grid-cols-2 gap-6 max-w-4xl">
+            <div class="bg-white border border-black/10 rounded-lg p-6 flex flex-col">
+                <h3 class="text-lg font-bold">Raspberry Pi Imager</h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed flex-grow">Open <a class="text-brand-purple no-underline hover:underline" href="https://www.raspberrypi.com/software/" target="_blank" rel="noopener">Raspberry Pi Imager</a>, pick <em>Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias</em>, choose your Pi model, and flash. The SD card boots straight into Anthias &mdash; no SSH, no installer prompts.</p>
+                <p class="text-zinc-400 text-xs mt-3">Raspberry Pi 2 through Pi 5.</p>
+            </div>
+
+            <div class="bg-brand-dark rounded-lg p-6 flex flex-col">
+                <h3 class="text-white text-lg font-bold">One-line install</h3>
+                <p class="text-white/60 text-sm mt-2 leading-relaxed">On a running Raspberry Pi OS Lite or Debian system, run:</p>
+                <div class="mt-3 bg-black/30 rounded-md p-4 flex-grow flex items-center">
+                    <code class="text-brand-yellow font-mono text-xs md:text-sm break-all">bash &lt;(curl -sL https://install-anthias.srly.io)</code>
+                </div>
+                <p class="text-white/50 text-xs mt-3">Raspberry Pi, x86, and 64-bit ARM SBCs.</p>
+            </div>
         </div>
 
-        <p class="text-zinc-500 mt-4 text-sm">Or use pre-built disk images for Raspberry Pi via <a class="text-brand-purple no-underline hover:underline" href="https://github.com/Screenly/Anthias/releases/latest" target="_blank" rel="noopener">GitHub Releases</a> or <a class="text-brand-purple no-underline hover:underline" href="https://www.raspberrypi.com/software/" target="_blank" rel="noopener">Raspberry Pi Imager</a>.</p>
+        <p class="text-zinc-500 mt-6 text-sm">Prefer fleet-managed, OTA-updated images? See <a class="text-brand-purple no-underline hover:underline" href="https://hub.balena.io/fleets-for-good" target="_blank" rel="noopener">balenaHub Fleets for Good</a>.</p>
 
         <div class="mt-8">
             <a class="text-brand-purple font-semibold text-sm no-underline hover:underline" href="/get-started/">All installation options &rarr;</a>


### PR DESCRIPTION
### Issues Fixed

Raspberry Pi Imager was buried as a one-line aside on the homepage and the get-started page still warned "Pi 5 images are not yet available in the Imager" — both stale now that the release pipeline publishes pi2/pi3/pi4-64/pi5 entries. The existing SSH FAQ also incorrectly claimed SSH was on by default on the Anthias Imager image.

### Description

- **Homepage hero**: replace the curl-only "Get running in minutes" panel with two side-by-side cards — Pi Imager (Pi 2–5) and the curl one-liner (Pi / x86 / ARM SBC) — so the Imager path is co-equal, not an aside.
- **Stale Pi 5 copy**: drop the "Pi 5 not yet in Imager" lines from `layouts/_default/get-started.html` and `content/docs/installation-options.md`.
- **New FAQ entry**: "How do I install Anthias with Raspberry Pi Imager?" walks through OS selection and notes that SSH must be enabled via the Imager's OS customization dialog before flashing.
- **Correct existing SSH FAQ**: the Anthias Imager image ships with SSH off, not on; updated to point users at the gear-icon dialog. balenaHub fleets retain SSH-on-by-default via the supervisor.

### Verification

- Rebased onto latest `master`; Hugo builds clean (`hugo --gc --minify`, 17 pages, no warnings).
- Navigation path verified against the **live official RPi Imager feed** (`os_list_imagingutility_v4.json`): Anthias appears at `Other specific-purpose OS → Digital signage and kiosks → Anthias → Anthias (Raspberry Pi 2/3/4/5)`, matching the copy in all three surfaces (post-#3090 grouping node + friendly per-model names).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] ~~I have done an end-to-end test for Raspberry Pi devices.~~ N/A — website copy/docs only.
- [ ] ~~I have tested my changes for x86 devices.~~ N/A — website copy/docs only.
- [x] I added a documentation for the changes I have made (when necessary).
