### PR TITLE
fix(ci): fetch install-bun.sh from workflow ref, not tag workspace

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -160,8 +160,19 @@ jobs:
       # than piping a remote shell script into bash. Node ships with
       # ubuntu-24.04 so balena-cli's runtime is available without
       # extra setup.
+      #
+      # The helper is fetched from the workflow's own ref rather than
+      # the tag-checked-out workspace: a workflow_dispatch against a
+      # release tag predating this helper (e.g. v2026.05.0) would
+      # otherwise fail with "No such file or directory".
       - name: Install bun
-        run: bash .github/workflows/scripts/install-bun.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/scripts/install-bun.sh?ref=${WORKFLOW_SHA}" \
+            --jq .content | base64 -d > /tmp/install-bun.sh
+          bash /tmp/install-bun.sh
 
       - name: Install balena CLI
         run: bun install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
@@ -246,8 +257,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y zstd
 
+      # See balena-cloud-deploy's "Install bun" step for why this fetches
+      # install-bun.sh from the workflow's own ref instead of the
+      # tag-checked-out workspace.
       - name: Install bun
-        run: bash .github/workflows/scripts/install-bun.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/scripts/install-bun.sh?ref=${WORKFLOW_SHA}" \
+            --jq .content | base64 -d > /tmp/install-bun.sh
+          bash /tmp/install-bun.sh
 
       - name: Install balena CLI
         run: bun install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"


### PR DESCRIPTION
### Issues Fixed

Re-dispatching \`build-balena-disk-image.yaml\` against v2026.05.0 (to regenerate \`rpi-imager.json\`) failed all matrix legs at the \`Install bun\` step:

\`\`\`
bash: .github/workflows/scripts/install-bun.sh: No such file or directory
\`\`\`

\`Checkout at tag\` puts v2026.05.0's source on disk, which predates the install-bun helper (added by #2865 after v2026.05.0). The master workflow YAML calls a helper that doesn't exist in the checked-out tree. Failed run: https://github.com/Screenly/Anthias/actions/runs/26113516440

### Description

Fetch \`install-bun.sh\` from the workflow's own ref via the GitHub contents API instead of reading it out of the tag-checked-out workspace. This decouples the workflow YAML from the dispatched tag's tree, so a workflow_dispatch against any older tag still picks up the current bun-install logic.

Two call sites updated (\`balena-cloud-deploy\` and \`balena-build-images\`).

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).