### PR TITLE
fix(ci): trust @balena/compose-parser so balena deploy can parse compose

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -164,7 +164,20 @@ jobs:
         run: bash .github/workflows/scripts/install-bun.sh
 
       - name: Install balena CLI
-        run: bun install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
+        run: |
+          bun install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
+          # balena-cli 25 parses docker-compose.yml via @balena/compose-parser,
+          # which ships a Go binary fetched by a postinstall script. Bun
+          # blocks lifecycle scripts by default, so without an explicit
+          # trust the binary is missing and `balena deploy` later fails
+          # with "Unexpected end of JSON input" on a perfectly valid
+          # compose file. Trust only compose-parser — `--trust` (all)
+          # also triggers @ronomon/direct-io's native build which fails
+          # on the runner without being needed for `balena deploy`.
+          (
+            cd "$HOME/.bun/install/global"
+            bun pm trust @balena/compose-parser
+          )
 
       - name: Login to balena
         env:
@@ -250,7 +263,20 @@ jobs:
         run: bash .github/workflows/scripts/install-bun.sh
 
       - name: Install balena CLI
-        run: bun install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
+        run: |
+          bun install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
+          # balena-cli 25 parses docker-compose.yml via @balena/compose-parser,
+          # which ships a Go binary fetched by a postinstall script. Bun
+          # blocks lifecycle scripts by default, so without an explicit
+          # trust the binary is missing and `balena deploy` later fails
+          # with "Unexpected end of JSON input" on a perfectly valid
+          # compose file. Trust only compose-parser — `--trust` (all)
+          # also triggers @ronomon/direct-io's native build which fails
+          # on the runner without being needed for `balena deploy`.
+          (
+            cd "$HOME/.bun/install/global"
+            bun pm trust @balena/compose-parser
+          )
 
       - name: Login to balena
         env:


### PR DESCRIPTION
### Issues Fixed

Re-dispatching \`build-balena-disk-image.yaml\` against v2026.05.0 after merging #2921 now fails all matrix legs at the \`Deploy to balena fleet\` step:

\`\`\`
Error parsing composition file "/home/runner/work/Anthias/Anthias/balena-deploy/docker-compose.yml":
Unexpected end of JSON input
\`\`\`

Failed run: https://github.com/Screenly/Anthias/actions/runs/26115123191/job/76802347247

### Description

The compose file is well-formed (~2 KB of valid YAML, parses cleanly with \`@balena/compose-parser\` locally). The error is misleading — it actually comes from \`JSON.parse(\"\")\` deep in the parser, which happens when its underlying Go binary is missing.

**Root cause.** balena-cli 25.x parses compose files via \`@balena/compose-parser\`, a Node wrapper around a Go binary (compose-go) downloaded into \`node_modules/@balena/compose-parser/bin/balena-compose-parser\` by a postinstall script. \`bun install -g\` blocks lifecycle scripts by default (\"Blocked 9 postinstalls\" in the install log), so the Go binary never lands. At deploy time the spawn returns empty stdout, the parser JSON.parses an empty string, and balena-cli rewraps it as \"Error parsing composition file\".

Reproduced locally:
\`\`\`
bun install -g balena-cli@25.1.3
find ~/.bun -name balena-compose-parser  → empty

cd ~/.bun/install/global && bun pm trust @balena/compose-parser
node -e "require('@balena/compose-parser').parse('balena-deploy/docker-compose.yml')"
  → SUCCESS: anthias-celery, anthias-server, anthias-viewer, redis
\`\`\`

**Why now?** balena-cli 22.x (pre-#2854) used a pure-JS YAML parser. #2854 bumped balena-cli to 25.1.3 (which switched to the Go-binary path) AND moved the install from \`npm install -g\` to \`bun install -g\`. Either change alone would have been fine; the combination breaks deploy.

**Fix.** Targeted \`bun pm trust @balena/compose-parser\` after the install. Trusts only the package we actually need a postinstall for; avoids \`--trust\` (all) which also triggers \`@ronomon/direct-io\`'s native build, which fails on the runner and isn't needed for \`balena deploy\`.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).