### PR TITLE
fix(ci): use --version latest for balena os download (was: default)

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -333,10 +333,14 @@ jobs:
           esac
 
       - name: Download OS image
+        # `--version` accepts an explicit version, a semver range,
+        # `latest`, `menu`, or `menu-esr` in balena-cli 25.x; the
+        # `default` keyword that worked under balena-cli 22.x was
+        # removed ("Version default is not available for ...").
         run: |
           balena os download "$BALENA_IMAGE" \
             --output "$BALENA_IMAGE.img" \
-            --version default
+            --version latest
 
       - name: Preload OS image
         run: |


### PR DESCRIPTION
### Issues Fixed

balena-cli 25.x dropped the \`default\` keyword from \`balena os download --version\`. Run [26116354667](https://github.com/Screenly/Anthias/actions/runs/26116354667) failed every \`balena-build-images\` matrix leg with:

\`\`\`
Version default is not available for the device type raspberrypi4-64
##[error]Process completed with exit code 1.
\`\`\`

This is the third v22→v25 transition foot-gun in the workflow, after #2921 (install-bun) and #2922 (compose-parser trust). Together they should get the disk-image pipeline running end-to-end.

### Description

Per \`balena os download --help\` in 25.1.3:

\`\`\`
--version=<value>
    version number (ESR or non-ESR versions),
    or semver range (non-ESR versions only),
    or 'latest' (excludes invalidated & pre-releases),
    or 'menu' (interactive menu, non-ESR versions),
    or 'menu-esr' (interactive menu, ESR versions)
\`\`\`

\`default\` is gone. \`latest\` mirrors the prior intent (most recent released balenaOS, excluding invalidated/pre-release builds) without committing the workflow to a hard-coded version. Other \`balena\` invocations in this workflow (\`deploy\`, \`preload\`, \`os configure\`, \`login\`) all check clean against the 25.x help output.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).