### PR TITLE
fix(ci): install balena-cli via npm so native postinstalls run

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -19,9 +19,6 @@ on:
 env:
   # Bumped from 22.4.15. Same npm package name (`balena-cli`).
   BALENA_CLI_VERSION: '25.1.3'
-  # Pin to match deploy-website.yaml so disk-image builds and the site
-  # build use the same Bun, and so balena-cli installs are deterministic.
-  BUN_VERSION: '1.3.13'
 
 jobs:
   # Single source of truth for tag/commit/short-hash so every downstream
@@ -154,41 +151,18 @@ jobs:
         with:
           ref: ${{ needs.resolve-context.outputs.tag }}
 
-      # Bun replaces actions/setup-node + npm: same toolchain we use
-      # for the website / frontend. The install script verifies the
-      # archive checksum against the release's SHASUMS256.txt rather
-      # than piping a remote shell script into bash. Node ships with
-      # ubuntu-24.04 so balena-cli's runtime is available without
-      # extra setup.
-      #
-      # The helper is fetched from the workflow's own ref rather than
-      # the tag-checked-out workspace: a workflow_dispatch against a
-      # release tag predating this helper (e.g. v2026.05.0) would
-      # otherwise fail with "No such file or directory".
-      - name: Install bun
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_SHA: ${{ github.sha }}
-        run: |
-          gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/scripts/install-bun.sh?ref=${WORKFLOW_SHA}" \
-            --jq .content | base64 -d > /tmp/install-bun.sh
-          bash /tmp/install-bun.sh
-
+      # Install balena-cli via npm rather than bun: balena-cli depends
+      # on native modules (drivelist for `balena preload`, the
+      # compose-parser Go binary for `balena deploy`) whose `install`
+      # / `postinstall` lifecycle scripts bun blocks by default. The
+      # blocked binaries surface much later as misleading runtime
+      # errors ("Unexpected end of JSON input" parsing compose,
+      # `drivelist.node` ENOENT in preload). npm runs them inline.
+      # Node 20 ships with ubuntu-24.04; balena-cli 25 prefers
+      # Node 24+ but the warning is cosmetic for the commands used
+      # here (deploy / os / preload all worked on Node 22 locally).
       - name: Install balena CLI
-        run: |
-          bun install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
-          # balena-cli 25 parses docker-compose.yml via @balena/compose-parser,
-          # which ships a Go binary fetched by a postinstall script. Bun
-          # blocks lifecycle scripts by default, so without an explicit
-          # trust the binary is missing and `balena deploy` later fails
-          # with "Unexpected end of JSON input" on a perfectly valid
-          # compose file. Trust only compose-parser — `--trust` (all)
-          # also triggers @ronomon/direct-io's native build which fails
-          # on the runner without being needed for `balena deploy`.
-          (
-            cd "$HOME/.bun/install/global"
-            bun pm trust @balena/compose-parser
-          )
+        run: npm install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
 
       - name: Login to balena
         env:
@@ -270,33 +244,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y zstd
 
-      # See balena-cloud-deploy's "Install bun" step for why this fetches
-      # install-bun.sh from the workflow's own ref instead of the
-      # tag-checked-out workspace.
-      - name: Install bun
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_SHA: ${{ github.sha }}
-        run: |
-          gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/scripts/install-bun.sh?ref=${WORKFLOW_SHA}" \
-            --jq .content | base64 -d > /tmp/install-bun.sh
-          bash /tmp/install-bun.sh
-
+      # See balena-cloud-deploy's "Install balena CLI" step for why
+      # this uses npm rather than bun.
       - name: Install balena CLI
-        run: |
-          bun install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
-          # balena-cli 25 parses docker-compose.yml via @balena/compose-parser,
-          # which ships a Go binary fetched by a postinstall script. Bun
-          # blocks lifecycle scripts by default, so without an explicit
-          # trust the binary is missing and `balena deploy` later fails
-          # with "Unexpected end of JSON input" on a perfectly valid
-          # compose file. Trust only compose-parser — `--trust` (all)
-          # also triggers @ronomon/direct-io's native build which fails
-          # on the runner without being needed for `balena deploy`.
-          (
-            cd "$HOME/.bun/install/global"
-            bun pm trust @balena/compose-parser
-          )
+        run: npm install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
 
       - name: Login to balena
         env:


### PR DESCRIPTION
### Issues Fixed

Run [26116718700](https://github.com/Screenly/Anthias/actions/runs/26116718700/job/76808264818) failed every \`balena-build-images\` matrix leg during \`Install balena CLI\`:

\`\`\`
error: install script from "drivelist" exited with 1
##[error]Process completed with exit code 1.
\`\`\`

Root cause: drivelist's \`install\` lifecycle script runs node-gyp to build a native addon used by \`balena preload\`. bun fetched node-gyp via bunx into a broken cache state (the bundled \`undici\` was missing \`./pool\`), so the rebuild crashed at module-resolve time.

This is the second class of "bun blocks/breaks native postinstalls" failure in the same workflow — #2922 already worked around it for \`@balena/compose-parser\` via \`bun pm trust\`. Chasing per-package escape hatches isn't sustainable.

### Description

Install balena-cli via \`npm install -g\` instead of \`bun install -g\` in both balena-cli-using jobs. Verified locally on Node 22.22.1:

\`\`\`
$ npm install -g balena-cli@25.1.3
added 1102 packages in 21s
$ find ~/.npm-prefix -name "drivelist.node" -o -name "balena-compose-parser"
  …/drivelist/build/Release/drivelist.node                  ← native build ✓
  …/@balena/compose-parser/bin/balena-compose-parser        ← Go binary ✓
\`\`\`

Removes from \`build-balena-disk-image.yaml\`:
- \`Install bun\` step from \`balena-cloud-deploy\` and \`balena-build-images\` (used only to bootstrap the now-removed \`bun install -g\`).
- \`bun pm trust @balena/compose-parser\` workaround introduced by #2922.
- \`BUN_VERSION\` env var (no remaining references in this workflow).

\`install-bun.sh\` stays — \`deploy-website.yaml\`, \`javascript-lint.yaml\`, and \`test-runner.yml\` still use bun for local \`package.json\` installs, where bun's \`trustedDependencies\` field works.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).