### PR TITLE
fix(ci): x86 fleet uses generic-amd64, not genericx86-64-ext

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -274,11 +274,14 @@ jobs:
               echo "FLEET_SLUG=anthias-pi5" >> "$GITHUB_ENV"
               ;;
             x86)
-              # genericx86-64-ext is balena's UEFI-boot generic
-              # x86_64 device type — works on most modern PCs / NUCs.
-              # Users without UEFI need a different image; intel-nuc
-              # is the legacy alternative.
-              echo "BALENA_IMAGE=genericx86-64-ext" >> "$GITHUB_ENV"
+              # generic-amd64 is balena's GPT-boot generic x86_64
+              # device type (the screenly_ose/anthias-x86 fleet is
+              # provisioned for this slug, not the older MBR-boot
+              # genericx86-64-ext). Mismatching the two yields
+              # "The device type of the provided OS image …, does
+              # not match the expected device type …" at
+              # `balena os configure` time.
+              echo "BALENA_IMAGE=generic-amd64" >> "$GITHUB_ENV"
               echo "FLEET_SLUG=anthias-x86" >> "$GITHUB_ENV"
               ;;
           esac


### PR DESCRIPTION
### Issues Fixed

Run [26119779970](https://github.com/Screenly/Anthias/actions/runs/26119779970/job/76818832956) failed only on \`balena-build-images (x86)\` at \`balena os configure\`:

\`\`\`
The device type of the provided OS image genericx86-64-ext, does not match the expected device type generic-amd64
##[error]Process completed with exit code 1.
\`\`\`

The other matrix legs (pi2/pi3/pi4-64/pi5) completed download/preload/configure cleanly — so the npm switch from #2925 worked, the only remaining issue is the x86 device-type mismatch.

### Description

The \`screenly_ose/anthias-x86\` balena fleet is provisioned for \`generic-amd64\` (GPT-boot generic x86_64). The workflow was downloading \`genericx86-64-ext\` (the older MBR-boot variant) — a distinct device type in balena's catalogue:

\`\`\`
genericx86-64-ext -> Generic x86_64 (NEW)        state= NEW
generic-amd64     -> Generic x86_64 (GPT) (NEW)  state= NEW
\`\`\`

Switch \`BALENA_IMAGE\` for the x86 leg to \`generic-amd64\` so the downloaded OS image matches the fleet's provisioned device type.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).