### PR TITLE
fix(viewer): default x86 audio fallback to ALSA 'default'

### DIFF
--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -213,7 +213,13 @@ def get_alsa_audio_device() -> str:
         elif device_type in ['pi1', 'pi2', 'pi3']:
             return 'sysdefault:CARD=vc4hdmi'
         else:
-            return 'sysdefault:CARD=HID'
+            # x86 fallback: ALSA card names vary across Intel/AMD/Nvidia
+            # HDA chipsets, so there is no portable per-SoC name we can
+            # hard-code. Defer to ALSA's `default` device and let
+            # operators override via ~/.asoundrc (already bind-mounted
+            # into the viewer container — see docker-compose.yml.tmpl),
+            # mirroring the ARM64 path above.
+            return 'default'
 
 
 class MediaPlayer:


### PR DESCRIPTION
On x86, `get_alsa_audio_device()` returns `sysdefault:CARD=HID` as the fallback, which matches no real ALSA card on Intel/AMD/Nvidia HDA chipsets. This bypasses the container's `~/.asoundrc` bind mount and leaves operators with no way to route audio.

The ARM64 branch a few lines above already returns `'default'` for the same reason — heterogeneous SoCs, no portable card name — and lets operators override via `~/.asoundrc`. This PR mirrors that approach for x86.

## Reproduction
- x86 host (Intel HDA `PCH` card with HDMI output to a TV)
- Debian minimal install, Anthias v2026.05.0+
- mpv launched by the viewer logs `--audio-device=alsa/sysdefault:CARD=HID` → no audio
- `/proc/asound/cards` shows only card 0 (`HDA Intel PCH`); no `HID` card exists

## Verification
After this patch, `~/.asoundrc` (e.g. routing `default` to `hw:0,3` for the HDMI sink) is honored, and audio plays correctly on the TV.