### PR TITLE
fix(upgrade): remove legacy srly-ose-redis container

### DIFF
--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -106,12 +106,16 @@ fi
 #     so the old container (still pointing at the deleted celery image)
 #     must be removed first or the server-image-backed replacement
 #     can't take its name.
+#   * srly-ose-redis — pre-rebrand Redis container. Still bound to
+#     127.0.0.1:6379, so the new anthias-redis can't claim the port
+#     until it's gone (forum.screenly.io/t/6688).
 # Volumes are shared across services, so removing the containers is safe.
 set +e
 docker rm -f \
     anthias-nginx anthias-websocket anthias-wifi-connect \
     srly-ose-nginx srly-ose-websocket srly-ose-wifi-connect \
     anthias-celery srly-ose-celery \
+    srly-ose-redis \
     >/dev/null 2>&1
 set -e
 


### PR DESCRIPTION
### Issues Fixed

Forum report: [Upgrade fails during 'Initialize / Upgrade Docker Containers'](https://forums.screenly.io/t/upgrade-fails-during-initialize-upgrade-docker-containers/6688) — three Pi 4B / Bookworm Lite units fail upgrade with:

> Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint anthias-redis-1 [...]: Bind for 127.0.0.1:6379 failed: port is already allocated

### Description

`bin/upgrade_containers.sh` already sweeps legacy containers no longer in the compose file (`srly-ose-{nginx,websocket,wifi-connect,celery}`, etc.) but not `srly-ose-redis`. On pre-rebrand Screenly OSE installs that container stays running and holds `127.0.0.1:6379`, so the new `anthias-redis` can't claim the port and `compose up` fails.

Adds `srly-ose-redis` to the `docker rm -f` cleanup list. The compose stack will recreate Redis under the new name; `redis-data` is on a named volume so no data is lost.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).