### PR TITLE
fix(upgrade): bind-mount /dev/cec0 on Pi 5 / mainline-KMS hosts

### DIFF
--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -137,10 +137,32 @@ cat /home/${USER}/anthias/docker-compose.yml.tmpl \
     | envsubst \
     > /home/${USER}/anthias/docker-compose.yml
 
-if [[ "$DEVICE_TYPE" =~ ^(x86|pi5|arm64)$ ]]; then
-    sed -i '/devices:/ {N; /\n.*\/dev\/vchiq:\/dev\/vchiq/d}' \
-        /home/${USER}/anthias/docker-compose.yml
-fi
+# CEC device routing. Pi 1-4 reaches libcec via /dev/vchiq
+# (closed-firmware VideoCore IV), which is what the template's
+# `devices:` block bind-mounts. Pi 5 and mainline-KMS x86/arm64 boards
+# expose v4l2 CEC adapters at /dev/cec0 instead (Pi 5 also exposes
+# /dev/cec1 for the second HDMI output, so we map both). docker
+# compose's `devices:` fails container start if a listed host node is
+# missing, so we surgically rewrite the rendered mount per device
+# type — and on x86/arm64 we only swap in /dev/cec0 if the host
+# actually has it (a box without an HDMI-CEC adapter keeps the
+# pre-fix behaviour of dropping the bind mount entirely). Fixes
+# the "CEC error" toast on Pi 5 reported in issue #2863.
+case "$DEVICE_TYPE" in
+    pi5)
+        sed -i 's|^\([[:space:]]*\)- "/dev/vchiq:/dev/vchiq"$|\1- "/dev/cec0:/dev/cec0"\n\1- "/dev/cec1:/dev/cec1"|' \
+            /home/${USER}/anthias/docker-compose.yml
+        ;;
+    x86|arm64)
+        if [ -e /dev/cec0 ]; then
+            sed -i 's|/dev/vchiq:/dev/vchiq|/dev/cec0:/dev/cec0|g' \
+                /home/${USER}/anthias/docker-compose.yml
+        else
+            sed -i '/devices:/ {N; /\n.*\/dev\/vchiq:\/dev\/vchiq/d}' \
+                /home/${USER}/anthias/docker-compose.yml
+        fi
+        ;;
+esac
 
 COMPOSE_FILES=(-f /home/${USER}/anthias/docker-compose.yml)
 SSL_OVERRIDE=/home/${USER}/anthias/docker-compose.ssl.override.yml


### PR DESCRIPTION
### Issues Fixed

Fixes #2863

### Description

The settings page surfaced **"CEC error"** on Pi 5. Root cause: `docker-compose.yml.tmpl` only bind-mounts `/dev/vchiq` (the closed-firmware VideoCore IV CEC path used by Pi 1–4), and `bin/upgrade_containers.sh` strips even that mount on `x86|pi5|arm64`. So `cec.init()` ran inside a container with no CEC device node and raised, which `diagnostics.get_display_power()` reports as the catch-all `'CEC error'`.

Pi 5 (and mainline-KMS x86/arm64) expose v4l2 CEC adapters at `/dev/cec0` instead — `/dev/cec1` too on the Pi 5, for the second HDMI output. The fix extends the existing post-`envsubst` surgery in `upgrade_containers.sh` to bind-mount those device nodes per device type:

- **Pi 5**: rewrite `/dev/vchiq` to `/dev/cec0` + `/dev/cec1`.
- **x86 / arm64**: rewrite to `/dev/cec0` only when the host has it; otherwise keep the pre-fix behaviour of dropping the mount (compose's `devices:` fails container start on a missing host node).
- **Pi 1–4**: unchanged.

Verified on a Pi 5 testbed: before the patch the container has no `/dev/cec*` and `get_display_power()` returns `'CEC error'`; after the patch the container has `/dev/cec0` + `/dev/cec1`, `cec_available()` returns `True`, and `get_display_power()` returns `'Unknown'` (correct — `cec.init()` succeeded against the adapter, then `tv.is_on()` raised IOError because no TV is connected to the test rig). On a real Pi 5 + TV setup this will return the actual on/off state instead of `'CEC error'`.

`bin/deploy_to_balena.sh` carries the same vchiq-strip surgery and needs the equivalent fix for the Balena flow; tracking that as a follow-up.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)