### PR TITLE
fix(balena): repair Pi 4 graphics overlay + manage fleet host config as IAC (#2947)

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -202,9 +202,21 @@ jobs:
           set -euo pipefail
           slug="screenly_ose/$FLEET_SLUG"
 
-          # Desired config.txt keys for this board.
-          mapfile -t desired < <(jq -r --arg b "$BOARD" \
-            '.boards[$b] // {} | keys[]' balena-host-config.json)
+          # Resolve this board's desired config in one shot, and HARD-FAIL if
+          # the board key is absent or the file doesn't parse. Without this,
+          # an empty desired set makes the prune below delete every config
+          # var on the fleet (incl. dtoverlay=vc4-kms-v3d) — a fleet-wide
+          # #2947. `jq -e` exits non-zero on null (missing board) or a parse
+          # error; the command substitution under `set -e` then aborts. A
+          # board declared as `{}` (e.g. x86) is a truthy object, so it
+          # passes the guard and correctly reconciles to "no config.txt".
+          if ! board_json=$(jq -ec --arg b "$BOARD" '.boards[$b]' \
+              balena-host-config.json); then
+            echo "::error::balena-host-config.json: board '$BOARD' is not declared (or the file is invalid) — refusing to reconcile, the prune would wipe the fleet" >&2
+            exit 1
+          fi
+
+          mapfile -t desired < <(printf '%s' "$board_json" | jq -r 'keys[]')
           is_desired() {
             local k="$1" d
             for d in "${desired[@]}"; do [ "$d" = "$k" ] && return 0; done
@@ -216,14 +228,20 @@ jobs:
             [ -n "$key" ] || continue
             echo "set BALENA_HOST_CONFIG_$key=$value on $slug"
             balena env set "BALENA_HOST_CONFIG_$key" "$value" --fleet "$slug"
-          done < <(jq -r --arg b "$BOARD" \
-            '.boards[$b] // {} | to_entries[] | "\(.key)\t\(.value)"' \
-            balena-host-config.json)
+          done < <(printf '%s' "$board_json" \
+            | jq -r 'to_entries[] | "\(.key)\t\(.value)"')
 
           # 2) Prune so the file is authoritative: drop every legacy
           #    RESIN_HOST_CONFIG_* and any BALENA_HOST_CONFIG_* whose key is
-          #    not in the file. Match only *_HOST_CONFIG_* so supervisor
-          #    vars are never removed.
+          #    not in the file. The regex is ANCHORED so only true config.txt
+          #    vars match — a var merely containing "HOST_CONFIG" (or
+          #    supervisor vars) is never touched. Capture the listing into a
+          #    var first so a balena/jq failure aborts the step (pipefail
+          #    does not propagate out of a process substitution) rather than
+          #    silently skipping the prune and leaving a stale duplicate.
+          host_vars=$(balena env list --fleet "$slug" --config --json \
+            | jq -r '.[] | select(.name|test("^(BALENA|RESIN)_HOST_CONFIG_"))
+                     | "\(.id)\t\(.name)"')
           while IFS=$'\t' read -r id name; do
             [ -n "$id" ] || continue
             suffix="${name#*_HOST_CONFIG_}"
@@ -234,9 +252,7 @@ jobs:
               echo "rm unmanaged $name (id $id) on $slug"
               balena env rm "$id" --config --yes
             fi
-          done < <(balena env list --fleet "$slug" --config --json \
-            | jq -r '.[] | select(.name|test("HOST_CONFIG"))
-                     | "\(.id)\t\(.name)"')
+          done <<< "$host_vars"
 
       - name: Render balena docker-compose
         run: |

--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -363,13 +363,6 @@ jobs:
             --output "$BALENA_IMAGE.img" \
             --version latest
 
-      # `--commit latest` seeds the image with the current release's
-      # container images so a freshly flashed device boots fully offline.
-      # We deliberately do NOT pass `--pin-device-to-release`: pinning
-      # (added in #2098) froze flashed devices to the downloaded release,
-      # so they never received OTA fixes. Anthias balena devices should
-      # track the fleet's latest stable release, so the device joins the
-      # fleet unpinned and auto-updates from here on.
       - name: Preload OS image
         run: |
           balena preload \

--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -187,6 +187,57 @@ jobs:
             echo "SHM_SIZE=256mb"
           } >> "$GITHUB_ENV"
 
+      # Reconcile the fleet's config.txt knobs to balena-host-config.json.
+      # This is the IAC home for settings previously hand-edited in the
+      # dashboard, and the file is authoritative: we upsert every listed key
+      # under the canonical BALENA_ prefix, then prune any config var not in
+      # the file (including legacy RESIN_HOST_CONFIG_* duplicates). That is
+      # what fixes issue #2947 — the Pi 4 fleet had a malformed, quote-
+      # wrapped `dtoverlay="vc4-kms-v3d"` that stopped full KMS loading, so
+      # the viewer's eglfs_kms renderer (since #2905) couldn't start the
+      # display. Supervisor vars (RESIN_SUPERVISOR_*) are not config.txt and
+      # are deliberately left untouched. `balena env set` is idempotent.
+      - name: Apply fleet host configuration
+        run: |
+          set -euo pipefail
+          slug="screenly_ose/$FLEET_SLUG"
+
+          # Desired config.txt keys for this board.
+          mapfile -t desired < <(jq -r --arg b "$BOARD" \
+            '.boards[$b] // {} | keys[]' balena-host-config.json)
+          is_desired() {
+            local k="$1" d
+            for d in "${desired[@]}"; do [ "$d" = "$k" ] && return 0; done
+            return 1
+          }
+
+          # 1) Upsert each desired key under the canonical BALENA_ prefix.
+          while IFS=$'\t' read -r key value; do
+            [ -n "$key" ] || continue
+            echo "set BALENA_HOST_CONFIG_$key=$value on $slug"
+            balena env set "BALENA_HOST_CONFIG_$key" "$value" --fleet "$slug"
+          done < <(jq -r --arg b "$BOARD" \
+            '.boards[$b] // {} | to_entries[] | "\(.key)\t\(.value)"' \
+            balena-host-config.json)
+
+          # 2) Prune so the file is authoritative: drop every legacy
+          #    RESIN_HOST_CONFIG_* and any BALENA_HOST_CONFIG_* whose key is
+          #    not in the file. Match only *_HOST_CONFIG_* so supervisor
+          #    vars are never removed.
+          while IFS=$'\t' read -r id name; do
+            [ -n "$id" ] || continue
+            suffix="${name#*_HOST_CONFIG_}"
+            if [[ "$name" == RESIN_HOST_CONFIG_* ]]; then
+              echo "rm legacy $name (id $id) on $slug"
+              balena env rm "$id" --config --yes
+            elif ! is_desired "$suffix"; then
+              echo "rm unmanaged $name (id $id) on $slug"
+              balena env rm "$id" --config --yes
+            fi
+          done < <(balena env list --fleet "$slug" --config --json \
+            | jq -r '.[] | select(.name|test("HOST_CONFIG"))
+                     | "\(.id)\t\(.name)"')
+
       - name: Render balena docker-compose
         run: |
           mkdir -p balena-deploy
@@ -296,12 +347,18 @@ jobs:
             --output "$BALENA_IMAGE.img" \
             --version latest
 
+      # `--commit latest` seeds the image with the current release's
+      # container images so a freshly flashed device boots fully offline.
+      # We deliberately do NOT pass `--pin-device-to-release`: pinning
+      # (added in #2098) froze flashed devices to the downloaded release,
+      # so they never received OTA fixes. Anthias balena devices should
+      # track the fleet's latest stable release, so the device joins the
+      # fleet unpinned and auto-updates from here on.
       - name: Preload OS image
         run: |
           balena preload \
             "$BALENA_IMAGE.img" \
             --fleet "screenly_ose/$FLEET_SLUG" \
-            --pin-device-to-release \
             --splash-image ansible/roles/splashscreen/files/splashscreen.png \
             --commit latest
 

--- a/balena-host-config.json
+++ b/balena-host-config.json
@@ -1,0 +1,61 @@
+{
+  "//": [
+    "Declarative balena fleet host configuration (the config.txt knobs).",
+    "Source of truth for what .github/workflows/build-balena-disk-image.yaml",
+    "applies to each `screenly_ose/anthias-*` fleet: it upserts every entry",
+    "below under the canonical `BALENA_HOST_CONFIG_<key>` name and prunes any",
+    "config var not listed here (including legacy `RESIN_HOST_CONFIG_*`",
+    "duplicates), so this file is authoritative. Supervisor vars",
+    "(RESIN_SUPERVISOR_*) are platform settings, not config.txt, and are out",
+    "of scope. See docs/balena-fleet-host-config.md for the full audit.",
+    "",
+    "Reconciled from the live fleets on 2026-05-30. Corrections vs what was",
+    "live:",
+    "  * pi4-64 dtoverlay was the malformed `\"vc4-kms-v3d\"` (literal quotes)",
+    "    on the RESIN_ prefix; the quotes stopped the firmware loading the",
+    "    overlay, so the board fell back to firmware-KMS and Qt eglfs_kms",
+    "    (the viewer's renderer since #2905) could not start the display ->",
+    "    boot-splash hang (issue #2947). Stored clean. Its dtparam also had a",
+    "    bogus trailing `vc4-kms-v3d` (an overlay, not a param) -> dropped.",
+    "  * pi2 / pi3 dtoverlay was on the legacy RESIN_ prefix -> standardized.",
+    "  * pi5 carried `gpu_mem=1024`, which a Pi 5 ignores entirely (BCM2712",
+    "    has no firmware memory split; it is CMA-only) -> dropped. Added",
+    "    `cma-512` to the overlay, which docs/board-enablement.md documents as",
+    "    required for 4K HEVC hardware decode.",
+    "",
+    "Notes:",
+    "  * gpu_mem is retained on Pi <=4: it still backs the VideoCore hardware",
+    "    video decoders (bcm2835-codec / V4L2 M2M) used for playback.",
+    "  * framebuffer_depth / framebuffer_ignore_alpha are legacy firmware-",
+    "    framebuffer knobs that the full-KMS driver ignores. They are inert,",
+    "    so they are kept as-is rather than churned on working boards."
+  ],
+  "boards": {
+    "pi2": {
+      "dtoverlay": "vc4-kms-v3d",
+      "gpu_mem": "128",
+      "disable_overscan": "1",
+      "framebuffer_depth": "32",
+      "framebuffer_ignore_alpha": "1"
+    },
+    "pi3": {
+      "dtoverlay": "vc4-kms-v3d",
+      "gpu_mem": "128",
+      "disable_overscan": "1",
+      "framebuffer_depth": "32",
+      "framebuffer_ignore_alpha": "1"
+    },
+    "pi4-64": {
+      "dtoverlay": "vc4-kms-v3d",
+      "dtparam": "i2c_arm=on,spi=on,audio=on",
+      "gpu_mem": "256",
+      "disable_overscan": "1",
+      "framebuffer_depth": "32",
+      "framebuffer_ignore_alpha": "1"
+    },
+    "pi5": {
+      "dtoverlay": "vc4-kms-v3d,cma-512"
+    },
+    "x86": {}
+  }
+}

--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -189,6 +189,51 @@ if [ -e /dev/dri/renderD128 ]; then
     fi
 fi
 
+# Pi 4 renders through Qt's eglfs_kms platform (see Dockerfile.viewer.j2),
+# whose JSON config pins the DRM card device. The vc4-drm (display) and
+# v3d (render-only) nodes race during probe, so the *display* card is
+# /dev/dri/card1 on some boots/images and /dev/dri/card0 on others — the
+# v3d node carries no connectors. A hardcoded device (issue #2947) points
+# eglfs at the render-only node on the boots where vc4 loses the race; Qt
+# then finds no connectors, never takes DRM master, and the device hangs
+# on the balena splash forever. Detect the card that actually owns
+# connectors at runtime and rewrite the device path before launch.
+if [ "$DEVICE_TYPE" = "pi4-64" ] && [ -n "${QT_QPA_EGLFS_KMS_CONFIG:-}" ]; then
+    kms_card=""
+    # Prefer a card with a *connected* connector; otherwise fall back to
+    # any card that exposes connectors at all. The render-only v3d node
+    # has no `cardN-<connector>` entries, so this excludes it even on a
+    # headless boot where nothing reads as "connected".
+    for status_file in /sys/class/drm/card*-*/status; do
+        [ -r "$status_file" ] || continue
+        connector=$(basename "$(dirname "$status_file")")  # e.g. card1-HDMI-A-1
+        card="${connector%%-*}"                            # e.g. card1
+        [ -e "/dev/dri/$card" ] || continue
+        [ -n "$kms_card" ] || kms_card="$card"
+        if [ "$(cat "$status_file" 2>/dev/null)" = "connected" ]; then
+            kms_card="$card"
+            break
+        fi
+    done
+    if [ -n "$kms_card" ]; then
+        echo "start_viewer: eglfs DRM device = /dev/dri/$kms_card"
+        # Connector names stay HDMI1/HDMI2 — Qt derives those from the
+        # connector type + type-id (the `-N` suffix in sysfs), which is
+        # stable on Pi 4 regardless of which card number vc4 landed on.
+        cat > "$QT_QPA_EGLFS_KMS_CONFIG" <<EOF
+{
+  "device": "/dev/dri/$kms_card",
+  "hwcursor": false,
+  "pbuffers": true,
+  "outputs": [
+    { "name": "HDMI1", "mode": "1920x1080" },
+    { "name": "HDMI2", "mode": "1920x1080" }
+  ]
+}
+EOF
+    fi
+fi
+
 # x86 / arm64 / pi5 run under `cage`, a kiosk wlroots compositor.
 # cage acquires DRM master as root, exports WAYLAND_DISPLAY for its
 # child, and exits when the child exits — so the existing kill -0

--- a/docs/balena-fleet-host-config.md
+++ b/docs/balena-fleet-host-config.md
@@ -31,30 +31,25 @@ alone.
 Since [#2905](https://github.com/Screenly/Anthias/pull/2905) the Pi 4 viewer
 renders through Qt's `eglfs_kms` platform (and Pi 5 / x86 through `cage` /
 wlroots). Both require the **full-KMS** atomic driver `vc4-kms-v3d`. Under
-firmware-KMS (`vc4-fkms-v3d`) or a missing/unparseable overlay, the display
-never comes up and the device hangs on the boot splash. Before #2905 the Pi 4
-used `linuxfb`, which worked over the firmware framebuffer and masked this
-dependency.
+firmware-KMS (`vc4-fkms-v3d`), or if the overlay value is malformed (e.g. stray
+quotes that the firmware can't parse), the display never comes up and the device
+hangs on the boot splash. Codifying the overlay here is what keeps that value
+correct and identical across the fleet — exactly the kind of dashboard typo that
+caused [#2947](https://github.com/Screenly/Anthias/issues/2947).
 
-## Audit (2026-05-30)
+## Settings reference
 
-State pulled from the live fleets with
-`balena env list --fleet <slug> --config --json`.
+Why each key is set the way it is in `balena-host-config.json`:
 
-| Board   | Setting (live)                                   | Verdict | Action |
-| ------- | ------------------------------------------------ | ------- | ------ |
-| pi4-64  | `dtoverlay="vc4-kms-v3d"` (RESIN_, **quoted**)   | **Broken** — stray quotes stop the overlay loading → fkms fallback → eglfs can't start → boot-splash hang ([#2947](https://github.com/Screenly/Anthias/issues/2947)) | Fixed: clean `vc4-kms-v3d`, BALENA_ prefix |
-| pi4-64  | `dtparam=...,"vc4-kms-v3d"`                       | **Bug** — `vc4-kms-v3d` is an overlay, not a dtparam | Dropped; kept `i2c_arm=on,spi=on,audio=on` |
-| pi2/pi3 | `dtoverlay=vc4-kms-v3d` on `RESIN_` prefix        | Works, legacy prefix | Standardized to `BALENA_` |
-| pi5     | `gpu_mem=1024`                                    | **No-op** — Pi 5 (BCM2712) has no firmware memory split; CMA-only | Dropped |
-| pi5     | `dtoverlay=vc4-kms-v3d` (no `cma`)                | Suboptimal — `docs/board-enablement.md` documents `cma-512` as required for 4K HEVC HW decode | Changed to `vc4-kms-v3d,cma-512` |
-| pi2/3/4 | `framebuffer_depth=32`, `framebuffer_ignore_alpha=1` | Inert — legacy firmware-framebuffer knobs ignored by full KMS | Retained (harmless), not churned |
-| ≤ pi4   | `gpu_mem` (128 / 256)                             | Useful — backs the VideoCore HW video decoders (bcm2835-codec / V4L2 M2M) | Retained |
-| x86     | (none)                                            | Correct — `config.txt` is Pi-only | — |
-
-The Pi 4 corruption was repaired on the live fleet immediately; every other
-change above is encoded in `balena-host-config.json` and converges on the next
-release build.
+| Key | Boards | Rationale |
+| --- | ------ | --------- |
+| `dtoverlay=vc4-kms-v3d` | pi2, pi3, pi4-64 | Full-KMS driver required by the viewer's display stack (see above). |
+| `dtoverlay=vc4-kms-v3d,cma-512` | pi5 | Full KMS plus a 512 MB CMA pool, which `docs/board-enablement.md` documents as required for 4K HEVC hardware decode. |
+| `dtparam=i2c_arm=on,spi=on,audio=on` | pi4-64 | Enable the I²C/SPI buses and onboard audio. |
+| `gpu_mem` (128 / 256) | pi2, pi3, pi4-64 | Backs the VideoCore hardware video decoders (`bcm2835-codec` / V4L2 M2M). **Not set on pi5** — the BCM2712 has no firmware memory split and ignores `gpu_mem` (it is CMA-only). |
+| `disable_overscan=1` | pi2, pi3, pi4-64 | Drop the default overscan border so the image fills the panel. |
+| `framebuffer_depth=32`, `framebuffer_ignore_alpha=1` | pi2, pi3, pi4-64 | Legacy firmware-framebuffer hints. Inert under full KMS but retained to avoid changing long-standing fleet config; safe to drop if the fleets are ever re-baselined. |
+| _(none)_ | x86 | `config.txt` is Raspberry-Pi-only; the x86 fleet has no host config. |
 
 ## Editing
 

--- a/docs/balena-fleet-host-config.md
+++ b/docs/balena-fleet-host-config.md
@@ -1,0 +1,67 @@
+# Balena fleet host configuration (IAC)
+
+Anthias's official balena fleets (`screenly_ose/anthias-{pi2,pi3,pi4,pi5,x86}`)
+need a handful of `config.txt`-level device settings — most importantly the
+graphics driver overlay. These used to be set by hand in the balena dashboard,
+which drifted per fleet and was easy to corrupt. They are now declared as code
+in [`balena-host-config.json`](../balena-host-config.json) and applied by the
+`Apply fleet host configuration` step in
+[`.github/workflows/build-balena-disk-image.yaml`](../.github/workflows/build-balena-disk-image.yaml).
+
+## How it works
+
+On each release build, per board, the workflow:
+
+1. **Upserts** every key in `balena-host-config.json` under the canonical
+   `BALENA_HOST_CONFIG_<key>` name via `balena env set` (idempotent).
+2. **Prunes** any fleet *config* variable not listed in the file — including
+   legacy `RESIN_HOST_CONFIG_*` duplicates — so the file is authoritative.
+
+Only `*_HOST_CONFIG_*` variables are touched. Supervisor variables
+(`RESIN_SUPERVISOR_*`) are platform settings, not `config.txt`, and are left
+alone.
+
+> Note: a freshly flashed device boots once on stock balenaOS defaults, then
+> the supervisor fetches the fleet's target state, rewrites `config.txt`, and
+> reboots into the configured graphics stack. This requires connectivity on
+> first boot.
+
+## Why `dtoverlay=vc4-kms-v3d` matters
+
+Since [#2905](https://github.com/Screenly/Anthias/pull/2905) the Pi 4 viewer
+renders through Qt's `eglfs_kms` platform (and Pi 5 / x86 through `cage` /
+wlroots). Both require the **full-KMS** atomic driver `vc4-kms-v3d`. Under
+firmware-KMS (`vc4-fkms-v3d`) or a missing/unparseable overlay, the display
+never comes up and the device hangs on the boot splash. Before #2905 the Pi 4
+used `linuxfb`, which worked over the firmware framebuffer and masked this
+dependency.
+
+## Audit (2026-05-30)
+
+State pulled from the live fleets with
+`balena env list --fleet <slug> --config --json`.
+
+| Board   | Setting (live)                                   | Verdict | Action |
+| ------- | ------------------------------------------------ | ------- | ------ |
+| pi4-64  | `dtoverlay="vc4-kms-v3d"` (RESIN_, **quoted**)   | **Broken** — stray quotes stop the overlay loading → fkms fallback → eglfs can't start → boot-splash hang ([#2947](https://github.com/Screenly/Anthias/issues/2947)) | Fixed: clean `vc4-kms-v3d`, BALENA_ prefix |
+| pi4-64  | `dtparam=...,"vc4-kms-v3d"`                       | **Bug** — `vc4-kms-v3d` is an overlay, not a dtparam | Dropped; kept `i2c_arm=on,spi=on,audio=on` |
+| pi2/pi3 | `dtoverlay=vc4-kms-v3d` on `RESIN_` prefix        | Works, legacy prefix | Standardized to `BALENA_` |
+| pi5     | `gpu_mem=1024`                                    | **No-op** — Pi 5 (BCM2712) has no firmware memory split; CMA-only | Dropped |
+| pi5     | `dtoverlay=vc4-kms-v3d` (no `cma`)                | Suboptimal — `docs/board-enablement.md` documents `cma-512` as required for 4K HEVC HW decode | Changed to `vc4-kms-v3d,cma-512` |
+| pi2/3/4 | `framebuffer_depth=32`, `framebuffer_ignore_alpha=1` | Inert — legacy firmware-framebuffer knobs ignored by full KMS | Retained (harmless), not churned |
+| ≤ pi4   | `gpu_mem` (128 / 256)                             | Useful — backs the VideoCore HW video decoders (bcm2835-codec / V4L2 M2M) | Retained |
+| x86     | (none)                                            | Correct — `config.txt` is Pi-only | — |
+
+The Pi 4 corruption was repaired on the live fleet immediately; every other
+change above is encoded in `balena-host-config.json` and converges on the next
+release build.
+
+## Editing
+
+Edit `balena-host-config.json` and let the next release build reconcile, or for
+an out-of-band change use `balena env set` / `balena env rm` directly and mirror
+it back into the file so the two stay in sync.
+
+> The manual, per-setting instructions at
+> <https://anthias.screenly.io/docs/balena/> remain the path for
+> **self-hosted** fleets, which this pipeline does not manage.

--- a/website/content/docs/balena-fleet-deployment.md
+++ b/website/content/docs/balena-fleet-deployment.md
@@ -48,15 +48,15 @@ We'll be doing the initial fleet configuration via CLI. Open your terminal and
 run the following commands:
 
 ```bash
-$ balena env add BALENA_HOST_CONFIG_gpu_mem $GPU_MEM_VALUE --fleet $FLEET_NAME
-$ balena env add BALENA_HOST_CONFIG_dtoverlay vc4-kms-v3d --fleet $FLEET_NAME
+$ balena env set BALENA_HOST_CONFIG_gpu_mem $GPU_MEM_VALUE --fleet $FLEET_NAME
+$ balena env set BALENA_HOST_CONFIG_dtoverlay vc4-kms-v3d --fleet $FLEET_NAME
 ```
 
 If your display does have overscan issues like having a black border around the
 screen, you can disable overscan by running the following command:
 
 ```bash
-$ balena env add BALENA_HOST_CONFIG_disable_overscan 1 --fleet $FLEET_NAME
+$ balena env set BALENA_HOST_CONFIG_disable_overscan 1 --fleet $FLEET_NAME
 ```
 
 Replace `$GPU_MEM_VALUE` with the GPU memory value you want to use, as long as

--- a/website/content/docs/installation-options.md
+++ b/website/content/docs/installation-options.md
@@ -61,7 +61,7 @@ The image file looks something like `<yyyy>-<mm>-<dd>-raspberry<version>.zst`. T
 > zstd -d <yyyy>-<mm>-<dd>-raspberry<version>.zst
 > ```
 
-Starting with [v0.19.0](https://github.com/Screenly/Anthias/releases/tag/v0.19.0), devices installed using this option will be pinned to the version that you've downloaded. This means that the devices will still be in the same version even if a new release (e.g., v0.19.1, etc.) is available.
+Devices installed from a disk image join the balena fleet and track the latest stable release. The image ships preloaded with the release it was built from, so the device boots and runs fully offline out of the box, then receives later releases automatically over the air once it has connectivity.
 
 # Installing on Raspberry Pi OS Lite or Debian
 

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -32,7 +32,7 @@
   items:
     - question: How do I update Anthias?
       answer: |
-        If you installed via balenaHub, updates are applied automatically over the air. For command-line installations, re-run the installer (`$HOME/anthias/bin/run_upgrade.sh`) or pull the latest Docker images. Disk image installations are pinned to the version you downloaded.
+        If you installed from a disk image or via balenaHub, updates are applied automatically over the air — the device tracks the latest stable release. For command-line installations, re-run the installer (`$HOME/anthias/bin/run_upgrade.sh`) or pull the latest Docker images.
 
     - question: How do I configure Wi-Fi or change networks?
       answer: |


### PR DESCRIPTION
### Issues Fixed

Fixes #2947 — Raspberry Pi 4 hangs on the Anthias boot splash and never starts the viewer.

### Root cause (verified against the live fleet)

Pulling the live balena fleet config (`balena env list --fleet ... --config`) showed the `anthias-pi4` fleet — the *only* affected board — had its graphics overlay stored **malformed**:

```
RESIN_HOST_CONFIG_dtoverlay = "vc4-kms-v3d"          # literal quotes, legacy prefix
RESIN_HOST_CONFIG_dtparam   = "...","spi=on","audio=on","vc4-kms-v3d"   # bogus overlay-as-param
```

Every other board has a clean `dtoverlay=vc4-kms-v3d`. The stray quotes stop the firmware loading the overlay, so the Pi 4 fell back to firmware-KMS. Since #2905 the viewer renders through Qt `eglfs_kms`, which needs **full KMS** — under fkms it can't bring up the display, so the device hangs on the splash. Before #2905 the Pi 4 used `linuxfb`, which didn't care, which is why this surfaced only now. The malformed value was a hand-edit in the dashboard; the config was never codified.

The same malformed value also made the supervisor's `config.txt` reconcile never converge — affected devices sit in a continuous "Reboot has been scheduled" loop (confirmed in live logs; the clean-config pi2/pi3 fleets show no such loop).

### Fix

1. **Repaired the live `anthias-pi4` fleet** — clean `BALENA_HOST_CONFIG_dtoverlay=vc4-kms-v3d`, fixed dtparam, removed the malformed legacy `RESIN_` copies. **Verified on real devices:** sampled Pi 4 units that have since rebooted now show clean `dtoverlay:["vc4-kms-v3d"]` and the reboot loop is gone (matching the healthy pi3 control); the rest converge on their next reboot.
2. **`balena-host-config.json`** — declarative per-board `config.txt` config, reconciled from the live fleets and corrected. The pipeline (`build-balena-disk-image.yaml`) now reconciles each fleet to this file: upsert under the canonical `BALENA_` prefix, then prune anything not listed (incl. legacy `RESIN_HOST_CONFIG_*` dupes). Supervisor vars untouched.
3. **`bin/start_viewer.sh`** — runtime DRM-card detection: even with full KMS the `v3d`/`vc4` card numbering varies, so the device hardcoded in `docker/eglfs-kms-pi4.json` can still be wrong. Picks the card that owns connectors before launch.
4. **Unpinned release-image devices** — dropped `--pin-device-to-release` from `balena preload` so devices track latest stable instead of freezing; corrected `installation-options.md` / `faq.yaml`.

### Cross-board audit (documented in `docs/balena-fleet-host-config.md`)

- pi2/pi3 `dtoverlay` was on the legacy `RESIN_` prefix → standardized.
- pi5 carried `gpu_mem=1024`, a **no-op on Pi 5** (CMA-only) → dropped; added `cma-512` (required for 4K HEVC per `docs/board-enablement.md`).
- `framebuffer_*` are inert under full KMS → retained, not churned. `gpu_mem` retained on Pi ≤4 (backs the HW video decoders).

### Note on the hardcoded 1080p mode

`docker/eglfs-kms-pi4.json` pins `1920x1080` deliberately (#2905): the Pi 4 V3D can't composite Chromium + the video graphics-view on 4K. It's a real perf cap but fragile on displays lacking an exact 1080p EDID mode — flagged for a follow-up that derives the cap from the connector.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices. *(verified live: malformed config reproduced the failure + reboot loop on Pi 4; clean config converges, loop clears)*
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
