### PR TITLE
docs: rpi-imager macOS "Error writing to storage device" guidance (#2948)

### DIFF
--- a/website/content/docs/installation-options.md
+++ b/website/content/docs/installation-options.md
@@ -53,13 +53,23 @@ The image file looks something like `<yyyy>-<mm>-<dd>-raspberry<version>.zst`. T
 >
 > We started to release the images in `.zst` format in [v0.20.0](https://github.com/Screenly/Anthias/releases/tag/v0.20.0) so that the images are smaller in size. Using `zip` with the `-9` flag won't make the each of the images smaller than 2 GB.
 >
-> At the moment, only the Raspberry Pi Imager&mdash;starting from version [v1.9.4](https://github.com/raspberrypi/rpi-imager/releases/tag/v1.9.4)&mdash;supports the `.zst` format.
->
-> For those who are using [balenaEtcher](https://etcher.balena.io/), you can use the `zstd` command to decompress the image file.
+> Raspberry Pi Imager supports the `.zst` format from version [v1.9.4](https://github.com/raspberrypi/rpi-imager/releases/tag/v1.9.4) onwards. For those who are using [balenaEtcher](https://etcher.balena.io/), you can use the `zstd` command to decompress the image file first:
 >
 > ```
 > zstd -d <yyyy>-<mm>-<dd>-raspberry<version>.zst
 > ```
+
+> **macOS: "Error writing to storage device"**
+>
+> Raspberry Pi Imager **2.0.2 through at least 2.0.7** has a macOS bug that aborts mid-write with *"Error writing to storage device. Some writes failed to complete."* It is triggered by writing any image that is decompressed on the fly &mdash; not just our `.zst` images, but also `.img.xz` and even uncompressed `.img` files (see rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605) and [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)). The card itself is fine.
+>
+> The fix was merged upstream in [rpi-imager#1621](https://github.com/raspberrypi/rpi-imager/pull/1621) (May 2026), so the simplest solution is to **update Raspberry Pi Imager to a release newer than 2.0.7**. If you can't update, work around it by decompressing the image yourself and flashing the resulting `.img`:
+>
+> ```
+> zstd -d <yyyy>-<mm>-<dd>-raspberry<version>.zst
+> ```
+>
+> Then select the extracted `.img` in Raspberry Pi Imager (or [balenaEtcher](https://etcher.balena.io/)), which skips the on-the-fly decompression path that trips the bug.
 
 Starting with [v0.19.0](https://github.com/Screenly/Anthias/releases/tag/v0.19.0), devices installed using this option will be pinned to the version that you've downloaded. This means that the devices will still be in the same version even if a new release (e.g., v0.19.1, etc.) is available.
 

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -69,6 +69,18 @@
 
         If you instead reinstall Debian and leave the root password blank, the Debian installer wires your regular user up as a `sudo` user automatically and you can skip this step.
 
+    - question: Raspberry Pi Imager fails with "Error writing to storage device" on macOS — what's wrong?
+      answer: |
+        This is a bug in **Raspberry Pi Imager 2.0.2–2.0.7 on macOS**, not in the Anthias image or your SD card. Those versions abort mid-write with *"Error writing to storage device. Some writes failed to complete."* whenever the image is decompressed on the fly — it affects our `.zst` images as well as `.img.xz` and even plain `.img` files (rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605), [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)).
+
+        The fix was merged upstream in [rpi-imager#1621](https://github.com/raspberrypi/rpi-imager/pull/1621) (May 2026), so the cleanest fix is to **update Raspberry Pi Imager to a release newer than 2.0.7**. If you can't update yet, decompress the image yourself and flash the resulting `.img`:
+
+        ```bash
+        zstd -d <yyyy>-<mm>-<dd>-raspberry<version>.zst
+        ```
+
+        Then point Raspberry Pi Imager (or [balenaEtcher](https://etcher.balena.io/)) at the extracted `.img` — flashing an already-decompressed file skips the code path that trips the bug.
+
 - group: Display & playback
   items:
     - question: How do I rotate the screen for portrait orientation?


### PR DESCRIPTION
## Summary

Resolves #2948.

The reported failure is **Raspberry Pi Imager v2.0.7 on macOS** throwing *"Error writing to storage device"* — not an Anthias or SD-card fault. It's an upstream rpi-imager regression introduced in 2.0.2: macOS raw block devices (`/dev/rdisk*`) reject `pwrite()` calls whose length isn't a multiple of the logical block size, and the on-the-fly decompressor emits arbitrary-length chunks (rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605), [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)). It was fixed upstream in [rpi-imager#1621](https://github.com/raspberrypi/rpi-imager/pull/1621) (merged May 2026).

Because the bug also hits `.img.xz` and even plain `.img` files, **there is no image-side change that fixes it** — re-compressing or shipping uncompressed wouldn't help. The fix on our side is documentation:

- Add a clear warning + workaround to the install docs and a matching FAQ entry: update Raspberry Pi Imager past 2.0.7, or decompress with `zstd -d` and flash the resulting `.img`.
- Drop the stale "only Raspberry Pi Imager supports `.zst`" claim.

## Test plan

- [x] `faq.yaml` validates as YAML
- [x] Docs render as two separate blockquotes (existing `.zst` note + new macOS warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)