### PR TITLE
fix(balena): stamp real release version into balena.yml

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -169,60 +169,22 @@ jobs:
           BALENA_TOKEN: ${{ secrets.BALENA_TOKEN }}
         run: balena login --token "$BALENA_TOKEN"
 
-      - name: Resolve fleet slug + env vars
+      # `balena deploy` (vs `balena push`) points the fleet at the
+      # existing <short-hash>-<board> GHCR images — no remote build.
+      # bin/balena_ota_deploy.sh owns the fleet mapping, compose render
+      # (incl. the pi5/x86 vchiq strip), version stamping, and retry;
+      # the manual deploy hook (deploy-balena-manual.yaml) calls the same
+      # script. `${TAG#v}` strips the leading `v` so the release tag
+      # (v2026.05.1) becomes the raw CalVer the script normalizes and
+      # stamps into balena.yml — so the fleet's Releases page shows our
+      # real version instead of 0.0.0+revN.
+      - name: Deploy to balena fleet
         env:
+          TAG: ${{ needs.resolve-context.outputs.tag }}
           SHORT_HASH: ${{ needs.resolve-context.outputs.short-hash }}
         run: |
-          case "${{ matrix.board }}" in
-            pi2)    FLEET=anthias-pi2 ;;
-            pi3)    FLEET=anthias-pi3 ;;
-            pi4-64) FLEET=anthias-pi4 ;;
-            pi5)    FLEET=anthias-pi5 ;;
-            x86)    FLEET=anthias-x86 ;;
-          esac
-          {
-            echo "FLEET_SLUG=$FLEET"
-            echo "GIT_SHORT_HASH=$SHORT_HASH"
-            echo "BOARD=${{ matrix.board }}"
-            echo "SHM_SIZE=256mb"
-          } >> "$GITHUB_ENV"
-
-      - name: Render balena docker-compose
-        env:
-          # Strip the leading `v` so the release tag (v2026.05.1) becomes
-          # the raw CalVer; render_balena_yml.sh normalizes it to balena
-          # semver and stamps balena.yml so the fleet's Releases page
-          # shows our real version instead of 0.0.0+revN.
-          TAG: ${{ needs.resolve-context.outputs.tag }}
-        run: |
-          bin/render_balena_yml.sh balena-deploy "${TAG#v}"
-          envsubst < docker-compose.balena.yml.tmpl > balena-deploy/docker-compose.yml
-
-          # Pi 5 and x86 don't expose /dev/vchiq; strip the bind mount.
-          case "${{ matrix.board }}" in
-            pi5|x86)
-              sed -i '/devices:/ {N; /\n.*\/dev\/vchiq:\/dev\/vchiq/d}' \
-                balena-deploy/docker-compose.yml
-              ;;
-          esac
-
-      # `balena deploy` (vs `balena push`) takes the rendered compose
-      # file and points the fleet at the existing GHCR images — no
-      # remote build. Wrapped in a 3-attempt retry because balena
-      # cloud routinely 5xx/ESOCKETTIMEDOUTs the upload step.
-      - name: Deploy to balena fleet
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            if balena deploy "screenly_ose/$FLEET_SLUG" \
-                --source balena-deploy; then
-              exit 0
-            fi
-            echo "balena deploy attempt $attempt failed; backing off"
-            sleep $((30 + RANDOM % 120))
-          done
-          echo "::error::balena deploy failed for $FLEET_SLUG after 3 attempts"
-          exit 1
+          bin/balena_ota_deploy.sh \
+            "${{ matrix.board }}" "${TAG#v}" "$SHORT_HASH"
 
   # Download balena OS, preload with the fleet's `latest` (the commit
   # we just pushed in balena-cloud-deploy), package as .img.zst, and

--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -188,9 +188,14 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Render balena docker-compose
+        env:
+          # Strip the leading `v` so the release tag (v2026.05.1) becomes
+          # the raw CalVer; render_balena_yml.sh normalizes it to balena
+          # semver and stamps balena.yml so the fleet's Releases page
+          # shows our real version instead of 0.0.0+revN.
+          TAG: ${{ needs.resolve-context.outputs.tag }}
         run: |
-          mkdir -p balena-deploy
-          cp balena.yml balena-deploy/
+          bin/render_balena_yml.sh balena-deploy "${TAG#v}"
           envsubst < docker-compose.balena.yml.tmpl > balena-deploy/docker-compose.yml
 
           # Pi 5 and x86 don't expose /dev/vchiq; strip the bind mount.

--- a/.github/workflows/deploy-balena-manual.yaml
+++ b/.github/workflows/deploy-balena-manual.yaml
@@ -78,7 +78,8 @@ jobs:
         board: ${{ fromJSON(needs.resolve.outputs.boards) }}
     runs-on: ubuntu-24.04
     permissions:
-      packages: read
+      contents: read   # actions/checkout
+      packages: read   # docker login ghcr.io for the image-existence check
     steps:
       - name: Checkout at tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/deploy-balena-manual.yaml
+++ b/.github/workflows/deploy-balena-manual.yaml
@@ -52,11 +52,13 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          # Accept either "2026.05.1" or "v2026.05.1".
-          version="${VERSION#v}"
+          # Accept either "2026.05.1" or "v2026.05.1". `ver` (not
+          # `version`) avoids shellcheck SC2153 flagging the $VERSION env
+          # var as a misspelling of a same-named local.
+          ver="${VERSION#v}"
           {
-            echo "version=$version"
-            echo "tag=v$version"
+            echo "version=$ver"
+            echo "tag=v$ver"
           } >> "$GITHUB_OUTPUT"
 
       - name: Build board matrix

--- a/.github/workflows/deploy-balena-manual.yaml
+++ b/.github/workflows/deploy-balena-manual.yaml
@@ -1,0 +1,136 @@
+name: Deploy to Balena (manual)
+
+# Manually push an OTA release to one (or all) balena fleets, without
+# rebuilding disk images. Use this to re-deploy an already-released
+# version — balena auto-appends +rev1, +rev2, ... each time the same
+# version is deployed, so the Releases page tracks the redeploys.
+#
+# The full release pipeline (build-balena-disk-image.yaml) already does
+# this deploy on `release: published`; this workflow is the standalone
+# "just deploy" hook for re-runs and out-of-band pushes. Both call
+# bin/balena_ota_deploy.sh so the deploy behaviour stays identical.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Released version to deploy, e.g. 2026.05.1. Must match an
+          existing tag v<version> whose <short-hash>-<board> images are
+          in GHCR.
+        required: true
+        type: string
+      board:
+        description: Board fleet to deploy (or all of them).
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - pi2
+          - pi3
+          - pi4-64
+          - pi5
+          - x86
+
+env:
+  BALENA_CLI_VERSION: '25.1.3'
+
+jobs:
+  # Normalize the version into a tag and expand the board choice into a
+  # JSON array the deploy matrix can fan out over (one entry, or all
+  # five when `all` is selected).
+  resolve:
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+      boards: ${{ steps.matrix.outputs.boards }}
+    steps:
+      - name: Normalize version + tag
+        id: tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Accept either "2026.05.1" or "v2026.05.1".
+          version="${VERSION#v}"
+          {
+            echo "version=$version"
+            echo "tag=v$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build board matrix
+        id: matrix
+        env:
+          BOARD: ${{ inputs.board }}
+        run: |
+          if [[ "$BOARD" == "all" ]]; then
+            echo 'boards=["pi2","pi3","pi4-64","pi5","x86"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "boards=[\"$BOARD\"]" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: resolve
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ${{ fromJSON(needs.resolve.outputs.boards) }}
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: read
+    steps:
+      - name: Checkout at tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Compute short hash
+        id: hash
+        run: |
+          # --short=7 matches the tag length docker-build.yaml publishes
+          # (<7-char>-<board>); see build-balena-disk-image.yaml.
+          echo "short-hash=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Fail before touching the fleet if the release commit's images
+      # for this board aren't in GHCR (e.g. wrong tag, or a build that
+      # never finished). Mirrors the release pipeline's preflight.
+      - name: Verify GHCR images exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHORT_HASH: ${{ steps.hash.outputs.short-hash }}
+          BOARD: ${{ matrix.board }}
+        run: |
+          set -euo pipefail
+          echo "$GH_TOKEN" | docker login ghcr.io \
+            -u "${{ github.actor }}" --password-stdin
+          missing=()
+          for service in server viewer redis; do
+            ref="ghcr.io/screenly/anthias-${service}:${SHORT_HASH}-${BOARD}"
+            if ! docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
+              missing+=("$ref")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing GHCR images for ${SHORT_HASH}-${BOARD}:"
+            printf '  %s\n' "${missing[@]}"
+            exit 1
+          fi
+
+      # See build-balena-disk-image.yaml's "Install balena CLI" step for
+      # why this uses npm rather than bun.
+      - name: Install balena CLI
+        run: npm install -g "balena-cli@${{ env.BALENA_CLI_VERSION }}"
+
+      - name: Login to balena
+        env:
+          BALENA_TOKEN: ${{ secrets.BALENA_TOKEN }}
+        run: balena login --token "$BALENA_TOKEN"
+
+      - name: Deploy to balena fleet
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          SHORT_HASH: ${{ steps.hash.outputs.short-hash }}
+        run: |
+          bin/balena_ota_deploy.sh \
+            "${{ matrix.board }}" "$VERSION" "$SHORT_HASH"

--- a/bin/balena_ota_deploy.sh
+++ b/bin/balena_ota_deploy.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Deploy a pre-built Anthias release to one board's balenaCloud fleet via
+# `balena deploy` — i.e. point the fleet at the GHCR images already
+# tagged <short-hash>-<board>, no remote build. Shared by the release
+# pipeline (.github/workflows/build-balena-disk-image.yaml) and the
+# manual deploy hook (.github/workflows/deploy-balena-manual.yaml) so the
+# fleet mapping, compose rendering, and retry logic live in exactly one
+# place instead of being copy-pasted per workflow.
+#
+# Assumes `balena login` has already run (the caller owns the token).
+# Re-deploying a version that's already on the fleet is expected and
+# safe: balena auto-appends +rev1, +rev2, ... to the release version.
+#
+# Usage: balena_ota_deploy.sh <board> <version> <git-short-hash>
+#   board   one of pi2 | pi3 | pi4-64 | pi5 | x86
+#   version raw CalVer, e.g. 2026.05.1 (render_balena_yml.sh normalizes it)
+
+set -euo pipefail
+
+BOARD="${1:?usage: balena_ota_deploy.sh <board> <version> <short-hash>}"
+RELEASE_VERSION="${2:?usage: balena_ota_deploy.sh <board> <version> <short-hash>}"
+GIT_SHORT_HASH="${3:?usage: balena_ota_deploy.sh <board> <version> <short-hash>}"
+export GIT_SHORT_HASH
+export SHM_SIZE="${SHM_SIZE:-256mb}"
+
+case "$BOARD" in
+    pi2)    FLEET=anthias-pi2 ;;
+    pi3)    FLEET=anthias-pi3 ;;
+    pi4-64) FLEET=anthias-pi4 ;;
+    pi5)    FLEET=anthias-pi5 ;;
+    x86)    FLEET=anthias-x86 ;;
+    *)
+        echo "balena_ota_deploy.sh: unknown board '$BOARD'" >&2
+        exit 1
+        ;;
+esac
+export BOARD
+
+# Stamp balena.yml with the release version, then render the compose
+# pinned to the <short-hash>-<board> GHCR images.
+bin/render_balena_yml.sh balena-deploy "$RELEASE_VERSION"
+envsubst < docker-compose.balena.yml.tmpl > balena-deploy/docker-compose.yml
+
+# Pi 5 and x86 don't expose /dev/vchiq; strip the bind mount.
+if [[ "$BOARD" =~ ^(pi5|x86)$ ]]; then
+    sed -i '/devices:/ {N; /\n.*\/dev\/vchiq:\/dev\/vchiq/d}' \
+        balena-deploy/docker-compose.yml
+fi
+
+# Wrapped in a 3-attempt retry because balena cloud routinely
+# 5xx/ESOCKETTIMEDOUTs the upload step.
+for attempt in 1 2 3; do
+    if balena deploy "screenly_ose/$FLEET" --source balena-deploy; then
+        exit 0
+    fi
+    echo "balena deploy attempt $attempt failed; backing off"
+    sleep $((30 + RANDOM % 120))
+done
+echo "::error::balena deploy failed for $FLEET after 3 attempts"
+exit 1

--- a/bin/deploy_to_balena.sh
+++ b/bin/deploy_to_balena.sh
@@ -79,9 +79,15 @@ export DEFAULT_SHM_SIZE='256mb'
 # Single source of truth for the release version: pyproject's
 # [project].version (CalVer YYYY.M.MICRO). render_balena_yml.sh
 # normalizes it to balena-compliant semver before stamping balena.yml.
+# `|| true` keeps a failed grep (line missing/reformatted) from aborting
+# under pipefail with no message; the explicit check below fails clearly.
 RELEASE_VERSION="$(
-    grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"$/\1/'
+    grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"$/\1/' || true
 )"
+if [[ -z "$RELEASE_VERSION" ]]; then
+    echo "Could not read [project].version from pyproject.toml" >&2
+    exit 1
+fi
 
 if [[ -z "${SHM_SIZE+x}" ]]; then
     echo "Using default /dev/shm size of $DEFAULT_SHM_SIZE for the viewer service"

--- a/bin/deploy_to_balena.sh
+++ b/bin/deploy_to_balena.sh
@@ -76,14 +76,20 @@ fi
 export GIT_SHORT_HASH=${GIT_SHORT_HASH:-latest}
 export DEFAULT_SHM_SIZE='256mb'
 
+# Single source of truth for the release version: pyproject's
+# [project].version (CalVer YYYY.M.MICRO). render_balena_yml.sh
+# normalizes it to balena-compliant semver before stamping balena.yml.
+RELEASE_VERSION="$(
+    grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"$/\1/'
+)"
+
 if [[ -z "${SHM_SIZE+x}" ]]; then
     echo "Using default /dev/shm size of $DEFAULT_SHM_SIZE for the viewer service"
     export SHM_SIZE=$DEFAULT_SHM_SIZE
 fi
 
 function prepare_balena_file() {
-    mkdir -p balena-deploy
-    cp balena.yml balena-deploy/
+    bin/render_balena_yml.sh balena-deploy "$RELEASE_VERSION"
     cat docker-compose.balena.yml.tmpl | \
     envsubst > balena-deploy/docker-compose.yml
 

--- a/bin/render_balena_yml.sh
+++ b/bin/render_balena_yml.sh
@@ -18,17 +18,25 @@ DEST_DIR="${1:?usage: render_balena_yml.sh <dest-dir> <raw-version>}"
 RAW_VERSION="${2:?usage: render_balena_yml.sh <dest-dir> <raw-version>}"
 SRC_YML="${SRC_YML:-balena.yml}"
 
-# Drop leading zeros per segment via base-10 arithmetic. The 10# prefix
-# is mandatory: a bare $((05)) is parsed as octal and errors out. Empty
-# segments default to 0 so a malformed input fails as 0.0.0 rather than
-# crashing mid-deploy.
+# Strip leading zeros per segment via base-10 arithmetic (2026.05.1 ->
+# 2026.5.1). Reject anything that isn't three dot-separated decimal
+# integers up front: a non-numeric segment (a pre-release tag like
+# 2026.05.1-rc1, or a stray branch name from a manual dispatch) would
+# otherwise make the `10#` arithmetic abort with a cryptic "unbound
+# variable" / "value too great for base" under `set -u`. Failing loudly
+# here beats both that crash and silently stamping a bogus 0.0.0 — which
+# would reintroduce the default-version bug this script exists to fix.
 normalize_semver() {
-    local raw="$1" major minor patch
-    IFS='.' read -r major minor patch _ <<< "$raw"
-    printf '%d.%d.%d\n' \
-        "$((10#${major:-0}))" \
-        "$((10#${minor:-0}))" \
-        "$((10#${patch:-0}))"
+    local raw="$1"
+    if [[ ! "$raw" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "render_balena_yml.sh: '$raw' is not a 3-segment numeric" \
+             "semver (expected MAJOR.MINOR.PATCH, e.g. 2026.5.1)" >&2
+        exit 1
+    fi
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$raw"
+    # The 10# prefix is mandatory: a bare $((05)) is parsed as octal.
+    printf '%d.%d.%d\n' "$((10#$major))" "$((10#$minor))" "$((10#$patch))"
 }
 
 VERSION="$(normalize_semver "$RAW_VERSION")"

--- a/bin/render_balena_yml.sh
+++ b/bin/render_balena_yml.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copy balena.yml into a deploy directory and stamp it with the release
+# version, so balenaCloud's Releases page shows our real CalVer version
+# (e.g. 2026.5.1) instead of the default 0.0.0+revN it assigns when no
+# version field is present.
+#
+# balenaCloud reads `version` from the balena.yml in the deploy source
+# directory on `balena push`/`balena deploy`. It requires a strict
+# 3-segment semver with NO leading zeros (SemVer §9). Our CalVer
+# zero-pads the month (2026.05.1), which balena rejects as non-compliant
+# and silently displays as 0.0.0 — so each numeric segment is normalized
+# (2026.05.1 -> 2026.5.1) before stamping.
+
+set -euo pipefail
+
+DEST_DIR="${1:?usage: render_balena_yml.sh <dest-dir> <raw-version>}"
+RAW_VERSION="${2:?usage: render_balena_yml.sh <dest-dir> <raw-version>}"
+SRC_YML="${SRC_YML:-balena.yml}"
+
+# Drop leading zeros per segment via base-10 arithmetic. The 10# prefix
+# is mandatory: a bare $((05)) is parsed as octal and errors out. Empty
+# segments default to 0 so a malformed input fails as 0.0.0 rather than
+# crashing mid-deploy.
+normalize_semver() {
+    local raw="$1" major minor patch
+    IFS='.' read -r major minor patch _ <<< "$raw"
+    printf '%d.%d.%d\n' \
+        "$((10#${major:-0}))" \
+        "$((10#${minor:-0}))" \
+        "$((10#${patch:-0}))"
+}
+
+VERSION="$(normalize_semver "$RAW_VERSION")"
+
+mkdir -p "$DEST_DIR"
+
+# Strip any existing top-level `version:` line so re-stamping is
+# idempotent and a future static version in balena.yml can't produce a
+# duplicate key.
+grep -v '^version:' "$SRC_YML" > "$DEST_DIR/balena.yml"
+
+# Append unquoted — single-quoted values have tripped balena-cli's
+# semver parser into ignoring the field (balenaForums: "balena.yml
+# version is not working at all").
+printf 'version: %s\n' "$VERSION" >> "$DEST_DIR/balena.yml"
+
+echo "Stamped balena.yml with version $VERSION (from $RAW_VERSION)"


### PR DESCRIPTION
### Issues Fixed

The balenaCloud **Releases** page (the "Release" tracker) displayed every release as `0.0.0+revXXX` instead of our real release version.

### Description

`0.0.0+revN` is balenaCloud's default when a release carries no `version` field. Both deploy paths copied `balena.yml` verbatim, and it has no `version`, so the fleet only ever got the auto-incrementing `rev` counter.

Passing our CalVer (`2026.05.1`) directly wouldn't fix it either: balena requires a strict 3-segment semver with **no leading zeros** (SemVer §9), and our zero-padded month is non-compliant — it would still render as `0.0.0`. So the version has to be normalized before stamping.

This PR adds `bin/render_balena_yml.sh`, a shared helper that:
- normalizes each numeric segment, dropping leading zeros (`2026.05.1` → `2026.5.1`);
- stamps an **unquoted** `version:` line into `balena.yml` (quoted values have tripped balena-cli's semver parser per the balena forums);
- is idempotent (strips any existing `version:` line before appending).

Wired into both deploy paths:
- **`.github/workflows/build-balena-disk-image.yaml`** (OTA release pipeline) — version derived from the release tag (`v2026.05.1`).
- **`bin/deploy_to_balena.sh`** (manual deploys) — version derived from `pyproject.toml`'s `[project].version`.

The `--dev` path is intentionally untouched: it pushes from the repo root for local-change testing where version tracking doesn't matter.

After the next release, the Releases page will show `2026.5.1`; a rebuild of the same tag becomes `2026.5.1+rev1`, which is the intended semantics.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)