### PR TITLE
fix(viewer): chown the config dir so upgraded devices don't crash-loop

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -57,9 +57,19 @@ for dev_node in /dev/video*; do
     esac
 done
 
-# Set permission for sha file
 chown -f viewer /dev/snd/*
-chown -f viewer /data/.anthias/latest_anthias_sha
+
+# The viewer runs unprivileged (sudo -u viewer below), and Django settings
+# init writes anthias.conf when it can't stat an existing one
+# (AnthiasSettings.__init__ -> save()). On devices upgraded from an older
+# release the config dir and its files (anthias.conf, latest_anthias_sha,
+# …) were created by a root-running container, so the viewer user can't
+# read or write them and crash-loops on
+# `PermissionError: '/data/.anthias/anthias.conf'`. Recursively give the
+# viewer ownership of the config dir (root server/celery are unaffected —
+# root ignores ownership). -f stays quiet on a fresh install where the dir
+# doesn't exist yet (the viewer creates its own on first run).
+chown -Rf viewer /data/.anthias
 
 # QtWebEngine state dirs. On upgraded devices the old AnthiasWebview
 # tree is left in place — a fresh AnthiasViewer cache is cheap to


### PR DESCRIPTION
### Issues Fixed

Viewer crash-loop on devices upgraded from an older release:
```
PermissionError: [Errno 13] Permission denied: '/data/.anthias/anthias.conf'
```

### Description

The viewer runs unprivileged (`sudo -u viewer` in `start_viewer.sh`). Django settings init writes `anthias.conf` when it can't stat an existing one (`AnthiasSettings.__init__` → `save()` → `open(conf,'w')`, `src/anthias_server/settings.py:85`). On devices upgraded from an older release, `/data/.anthias` and its files were created by a **root**-running container, so the `viewer` user can't read/write them → the viewer crash-loops and never renders.

`start_viewer.sh` already chowned `latest_anthias_sha` and the cache dirs to `viewer`, but not the config dir / conf. This recursively chowns the whole config dir:

```sh
chown -Rf viewer /data/.anthias
```

- `-R` covers `anthias.conf`, `latest_anthias_sha`, `anthias.db` and anything else root-owned in there — so the separate `latest_anthias_sha` chown is now redundant and is removed.
- Root server/celery are unaffected (root ignores ownership).
- `-f` stays quiet on a fresh install where the dir doesn't exist yet.

### How it was found

A 1% staged balenaOS-upgrade + release-unpin rollout: a small number of upgraded devices (a Pi 2 and a Pi 4) had the viewer crash-looping on this every ~70s, while the rest of the tranche (including 2.x→6.x OS jumps) came up healthy. Tiny, **force-deployable** hotfix.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [x] Root cause reproduced on real upgraded devices (live logs).
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
