### PR TITLE
fix(balena): quit Plymouth before cage so x86 viewer gets DRM master

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -244,6 +244,76 @@ EOF
     fi
 fi
 
+# Release the Plymouth boot splash before launching the display.
+#
+# On a normal systemd host — including our Debian/apt install —
+# `plymouth-quit.service` runs once boot completes and tells Plymouth to
+# drop the display, so whatever takes over (cage's KMS backend, Qt's
+# eglfs) finds DRM master free. balenaOS deliberately disables that:
+# it ships a `plymouth-disable-containerized.conf` drop-in gating
+# plymouth-quit on `ConditionVirtualization=!container`, expecting the
+# application to own the handoff. So on balena Plymouth keeps running.
+# On x86 that's fatal: efifb->i915 hands Plymouth an early KMS device,
+# so it takes DRM *master*; cage then can't (libseat logs "Could not
+# make device fd drm master: Device or resource busy"), runs as a
+# non-master client, and every atomic commit is rejected — the screen
+# freezes on the splash while the scheduler keeps cycling assets
+# (the "Swapchain for output 'DP-1' failed test" spam). On Pi/arm64
+# Plymouth draws to /dev/fb0 and never takes DRM master, so this is a
+# harmless early splash teardown there.
+#
+# Reproduce what systemd does for us on Debian: ask the *host* systemd
+# to start plymouth-quit.service over the host system bus (mounted by
+# the `io.balena.features.dbus` label at DBUS_SYSTEM_BUS_ADDRESS). Two
+# constraints force this here rather than inside the viewer process:
+#   * Authorisation — balenaOS has no polkit, so host systemd grants
+#     Manager.StartUnit to uid 0 only. start_viewer.sh runs as root;
+#     the `viewer` user the viewer later drops to would be denied.
+#   * Ordering — cage takes (or fails to take) DRM master at its own
+#     startup and the viewer is cage's child, so quitting Plymouth any
+#     later is too late to matter.
+# No-op on the Debian/apt install: DBUS_SYSTEM_BUS_ADDRESS is unset and
+# the socket is absent, so the guard below short-circuits (and
+# plymouth-quit already ran at boot there).
+release_boot_splash() {
+    local bus="${DBUS_SYSTEM_BUS_ADDRESS#unix:path=}"
+    [ -n "${DBUS_SYSTEM_BUS_ADDRESS:-}" ] && [ -S "$bus" ] || return 0
+
+    echo "start_viewer: quitting Plymouth via host systemd to free DRM master"
+    if ! dbus-send --system --print-reply \
+        --dest=org.freedesktop.systemd1 \
+        /org/freedesktop/systemd1 \
+        org.freedesktop.systemd1.Manager.StartUnit \
+        string:"plymouth-quit.service" string:"replace" >/dev/null 2>&1; then
+        echo "start_viewer: StartUnit plymouth-quit failed; continuing"
+        return 0
+    fi
+
+    # StartUnit is asynchronous (it returns a job path, not a result).
+    # plymouth-quit's ExecStart (`plymouth quit`) blocks until plymouthd
+    # has exited and dropped DRM master, so poll the unit until the
+    # oneshot reaches a terminal state before we hand the display to
+    # cage. Bounded so a board where the unit is condition-skipped (the
+    # master was never held) can't stall startup.
+    local unit state _
+    unit=$(dbus-send --system --print-reply --dest=org.freedesktop.systemd1 \
+        /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.GetUnit \
+        string:"plymouth-quit.service" 2>/dev/null \
+        | awk -F'"' '/object path/{print $2}')
+    [ -n "$unit" ] || return 0
+    for _ in $(seq 1 15); do
+        state=$(dbus-send --system --print-reply --dest=org.freedesktop.systemd1 \
+            "$unit" org.freedesktop.DBus.Properties.Get \
+            string:"org.freedesktop.systemd1.Unit" string:"ActiveState" 2>/dev/null \
+            | awk -F'"' '/string/{print $2}')
+        case "$state" in
+            active|failed) return 0 ;;
+        esac
+        sleep 0.2
+    done
+}
+release_boot_splash
+
 # x86 / arm64 / pi5 run under `cage`, a kiosk wlroots compositor.
 # cage acquires DRM master as root, exports WAYLAND_DISPLAY for its
 # child, and exits when the child exits — so the existing kill -0

--- a/docker-compose.balena.dev.yml.tmpl
+++ b/docker-compose.balena.dev.yml.tmpl
@@ -40,6 +40,11 @@ services:
       - PORT=8080
       - NOREFRESH=1
       - LISTEN=anthias-server
+      # See docker-compose.balena.yml.tmpl: lets start_viewer.sh quit the
+      # Plymouth boot splash over the host system bus (mounted by
+      # io.balena.features.dbus below) so it releases DRM master before
+      # cage starts. See release_boot_splash() in bin/start_viewer.sh.
+      - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
     privileged: true
     restart: always
     shm_size: ${SHM_SIZE}
@@ -47,6 +52,7 @@ services:
       - resin-data:/data
     labels:
       io.balena.features.supervisor-api: '1'
+      io.balena.features.dbus: '1'
 
   anthias-celery:
     # Runs on the same image as anthias-server with a CMD override.

--- a/docker-compose.balena.yml.tmpl
+++ b/docker-compose.balena.yml.tmpl
@@ -37,6 +37,12 @@ services:
       - PORT=8080
       - NOREFRESH=1
       - LISTEN=anthias-server
+      # Lets start_viewer.sh reach the host systemd over the host system
+      # bus (mounted by io.balena.features.dbus below) to quit the
+      # Plymouth boot splash before launching the display. balenaOS
+      # leaves Plymouth running and on x86 it holds DRM master, which
+      # blocks cage. See release_boot_splash() in bin/start_viewer.sh.
+      - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
     privileged: true
     restart: always
     shm_size: ${SHM_SIZE}
@@ -44,6 +50,7 @@ services:
       - resin-data:/data
     labels:
       io.balena.features.supervisor-api: '1'
+      io.balena.features.dbus: '1'
 
   anthias-celery:
     # Runs on the same image as anthias-server with a CMD override.


### PR DESCRIPTION
### Issues Fixed

Fixes the x86 balena symptom where the viewer logs flood with
`[types/output/swapchain.c] Swapchain for output 'DP-1' failed test` and
the screen stays frozen on the balena boot splash while assets appear to
cycle in the logs. Diagnosed on the `screenly_ose/anthias-x86` fleet.

### Description

On balenaOS the Plymouth boot splash is never told to quit — its
`plymouth-quit.service` carries a `plymouth-disable-containerized` drop-in
gating it on `ConditionVirtualization=!container`, so unlike a normal
systemd host (and our Debian/apt install, where it runs at boot) nothing
hands the display off.

On **x86**, `efifb`→`i915` gives Plymouth an early KMS device, so it takes
DRM **master**. cage then can't (`libseat: Could not make device fd drm
master: Device or resource busy`), runs as a non-master client, and every
atomic commit is rejected before it reaches the GPU — the panel freezes on
the splash while the scheduler keeps cycling assets into the void. On
Pi/arm64 Plymouth draws to `/dev/fb0` and never takes DRM master, so they
are unaffected.

Fix — reproduce what systemd does for us on Debian, the balena-native way:

- `bin/start_viewer.sh` gains `release_boot_splash()`, which asks the host
  systemd to start `plymouth-quit.service` over the host system bus, then
  polls the unit's `ActiveState` until it is terminal (StartUnit is async;
  cage must not launch until DRM master is actually freed).
- Both balena compose templates mount the host system bus into
  `anthias-viewer` via `io.balena.features.dbus` +
  `DBUS_SYSTEM_BUS_ADDRESS=…/host/run/dbus/system_bus_socket`.

Why this shape:

- **Authorization** — balenaOS has no polkit, so host systemd grants
  `Manager.StartUnit` to uid 0 only. The helper runs as root in
  `start_viewer.sh`; the unprivileged `viewer` user the viewer drops to
  would be denied. The env var is deliberately kept out of
  `sudo --preserve-env`, so host-bus reach never leaks to the viewer.
- **Ordering** — cage takes (or fails to take) DRM master at its own
  startup and the viewer process is cage's child, so quitting Plymouth any
  later would be too late.
- **No-op on Debian/apt** — guarded on the host bus socket existing.

### Testing

**Debian x86 (Debian 13 trixie), on real hardware — validates the no-op /
regression-safety path:**

- Confirmed the guard's premise holds on the apt install:
  `DBUS_SYSTEM_BUS_ADDRESS` is unset and `/host/run/dbus/system_bus_socket`
  is absent (it is a balena-only `io.balena.features.dbus` mount).
- `bin/start_viewer.sh` runs with default bash options (no `set -u`), so
  the un-defaulted `${DBUS_SYSTEM_BUS_ADDRESS#unix:path=}` expands to empty
  rather than aborting; `bash -n` is clean.
- `release_boot_splash()` is a true no-op there: returns 0, emits no
  output, and never invokes `dbus-send` — both when the env var is unset
  and when it is set but the socket is missing.
- End-to-end: swapped the modified script into the running
  `anthias-anthias-viewer-1` container and restarted it. The viewer booted
  cleanly (cage + AnthiasViewer + Qt up), cage acquired DRM master
  (`Applied wlroots transform normal to output DP-1`), and content
  rendered — with no `quitting Plymouth` log line, no
  `Could not make device fd drm master`, and no swapchain spam. Device
  restored to its deployed baseline afterwards.

The actual balena fix (quitting Plymouth so cage gets DRM master) cannot
be reproduced on Debian — systemd already runs `plymouth-quit.service` at
boot there. That path is exercised by CI's `docker buildx` image build and
the normal `balena deploy` to the fleet; `balena push` is not a valid test
here (it forces balena's remote builder to compile the generated
Dockerfiles, whose `FROM --platform=$BUILDPLATFORM` bun-builder stage —
correct for buildx — has no value on balena's builder).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices. (Debian x86 no-op / boot
  path validated on hardware; balena x86 fix validates via CI build +
  fleet deploy — see Testing.)
- [ ] I added a documentation for the changes I have made (when necessary).