### PR TITLE
fix(diagnostics): stop CEC probe from dumping cores on Pi 5

### DIFF
--- a/src/anthias_server/lib/diagnostics.py
+++ b/src/anthias_server/lib/diagnostics.py
@@ -14,43 +14,66 @@ from anthias_common import device_helper, utils
 from anthias_common.version import get_anthias_release as get_anthias_release
 
 
+# Never let this probe reach normal interpreter teardown. On hardware
+# without a usable CEC adapter (e.g. Raspberry Pi 5) libcec's adapter
+# thread aborts as it is torn down ("FATAL: exception not rethrown",
+# SIGABRT), which dumps a multi-MB core every run and eventually fills
+# the disk. The answer is already on stdout by then, so the helper
+# flushes and os._exit(0)s to skip Python/libcec teardown entirely.
 _CEC_QUERY_SCRIPT = """
+import os
 import sys
+
+
+def _done(text):
+    sys.stdout.write(text)
+    sys.stdout.flush()
+    os._exit(0)
+
+
 try:
     import cec
     cec.init()
     tv = cec.Device(cec.CECDEVICE_TV)
 except Exception:
-    sys.stdout.write('CEC error')
-    sys.exit(0)
+    _done('CEC error')
 try:
-    sys.stdout.write('True' if tv.is_on() else 'False')
+    _done('True' if tv.is_on() else 'False')
 except IOError:
-    sys.stdout.write('Unknown')
+    _done('Unknown')
 """
 
 # Issued from the settings page / REST endpoint, *not* from a celery
 # worker, so a hung libcec call would block the request thread until
 # the subprocess timeout fires. Same subprocess+timeout shape as
 # `_CEC_QUERY_SCRIPT` for the same reason: libcec C calls don't
-# honour Python signals.
+# honour Python signals. Same os._exit(0) on the way out, too, to
+# avoid the teardown abort + core dump described above.
 _CEC_SET_SCRIPT = """
+import os
 import sys
+
+
+def _done(text):
+    sys.stdout.write(text)
+    sys.stdout.flush()
+    os._exit(0)
+
+
 try:
     import cec
     cec.init()
     tv = cec.Device(cec.CECDEVICE_TV)
 except Exception as exc:
-    sys.stdout.write('ERROR: ' + (str(exc) or 'CEC stack unavailable'))
-    sys.exit(0)
+    _done('ERROR: ' + (str(exc) or 'CEC stack unavailable'))
 try:
     if {on}:
         tv.power_on()
     else:
         tv.standby()
-    sys.stdout.write('OK')
+    _done('OK')
 except Exception as exc:
-    sys.stdout.write('ERROR: ' + (str(exc) or 'CEC command failed'))
+    _done('ERROR: ' + (str(exc) or 'CEC command failed'))
 """
 
 


### PR DESCRIPTION
### Issues Fixed

Not tied to a tracked issue. On Raspberry Pi 5 (and any board without a usable CEC adapter), the celery container would slowly fill the SD card with core dumps and eventually crash-loop once the disk hit 100%.

### Description

The `get_display_power` celery-beat task (every 5 min) runs the CEC probe as a `python -c` subprocess (`_CEC_QUERY_SCRIPT` in `src/anthias_server/lib/diagnostics.py`). On a Pi 5 there's no usable CEC adapter, so `cec.init()` succeeds but `tv.is_on()` raises `IOError` → the probe reports `Unknown`. Then, **during interpreter teardown**, libcec's adapter thread aborts (`FATAL: exception not rethrown`, SIGABRT), dumping a ~38 MB core every run. The script's `try/except` can't catch it because it's a C++/pthread teardown abort, not a Python exception.

Fix: once the answer is on stdout, `flush()` and `os._exit(0)` to skip the Python/libcec teardown that aborts. Applied to both `_CEC_QUERY_SCRIPT` and `_CEC_SET_SCRIPT`. The reported value is unchanged — the probe already has its answer before teardown.

Verified on a live Pi 5: dispatching the task 3× through the worker produces no cores (previously one per run) and still reports `Unknown`. `ruff check`/`ruff format --check` clean; all 36 `test_diagnostics.py` tests pass.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)