### PR TITLE
fix(docker): pin viewer UID/GID across all images for deterministic ownership

### DIFF
--- a/docker/Dockerfile.base.j2
+++ b/docker/Dockerfile.base.j2
@@ -62,3 +62,19 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     {% endfor %}
 
 {% include 'labels.j2' %}
+
+# Pin the unprivileged runtime user to a fixed UID/GID so ownership of
+# files under /data — notably ~/.anthias, the config dir shared by the
+# viewer, server and celery containers — is identical in every image.
+# Without an explicit id `useradd` picks the next free uid per image (it
+# happened to land on 1000), so the uid a file is written as in one
+# container and a `chown viewer …` in another could silently disagree —
+# the class of bug behind the upgraded-device config-permission
+# crash-loop. The viewer process drops to this user; server/celery run as
+# root but the user must still exist and resolve to the same id for chowns
+# to be deterministic wherever they run. `video` (the DRM/ALSA device
+# nodes the viewer opens) is kept as a supplementary group.
+ARG ANTHIAS_UID=1000
+ARG ANTHIAS_GID=1000
+RUN groupadd -g ${ANTHIAS_GID} viewer && \
+    useradd -u ${ANTHIAS_UID} -g viewer -G video viewer

--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -131,7 +131,10 @@ ENV DJANGO_SETTINGS_MODULE="anthias_server.django_project.settings"
 ENV PYTHONPATH="/usr/src/app/src"
 ENV ANTHIAS_SERVICE="viewer"
 
-RUN useradd -g video viewer
+# The `viewer` user is created with a pinned UID/GID in Dockerfile.base.j2
+# (shared by viewer, server and celery) so ownership under /data is
+# identical across containers. It is added to the `video` group there for
+# the DRM/ALSA device nodes this image's compositor opens.
 
 RUN rm -f /etc/localtime
 


### PR DESCRIPTION
### Issues Fixed

Hardens against the upgraded-device config-permission crash-loop, where
the viewer (`uid 1000`) couldn't write `~/.anthias/anthias.conf` because
the file was created by a root-running container. The recursive
`chown -Rf viewer /data/.anthias` in `start_viewer.sh` corrects ownership
at runtime, but it only works if `viewer` resolves to the *same* id in
every image — which wasn't guaranteed.

### Description

The `viewer` user was created with no explicit id (`useradd -g video
viewer`), so it landed on whatever uid was next-free per image (1000 by
luck) and didn't exist at all in the server/celery image. With
`/data/.anthias` shared across the viewer, server and celery containers,
the uid a file was written as in one container and a `chown viewer …` in
another could silently disagree.

This pins the user deterministically:

- Create `viewer` with a fixed `UID`/`GID` (1000) in the shared
  `Dockerfile.base.j2`, so it exists and resolves identically in the
  viewer, server and celery images.
- Remove the implicit `useradd` from the viewer image; `video` is kept
  as a supplementary group for the DRM/ALSA device nodes the compositor
  opens.

Verified: the x86 server image builds cleanly and `id viewer` reports
`uid=1000 gid=1000` with `video` as a supplementary group.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
