### PR TITLE
fix(viewer): wait for /dev/fb0 instead of crash-looping when headless

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -244,6 +244,40 @@ EOF
     fi
 fi
 
+# Qt's linuxfb platform (pi2/pi3) opens /dev/fb0 at startup and cannot
+# recover if it is absent. Under full KMS (dtoverlay=vc4-kms-v3d) the
+# framebuffer only exists while a display is connected, so a headless
+# box, a powered-off panel, or a TV slow to negotiate HDMI at boot leaves
+# no /dev/fb0 — and Qt doesn't fail cleanly there: it logs "Unable to
+# figure out framebuffer device / no screens available" and aborts with
+# heap corruption ("malloc(): unaligned tcache chunk detected"). The
+# container then crash-loops, spamming the logs, and never settles.
+#
+# Wait for the framebuffer instead of launching into a guaranteed crash.
+# No assumptions about which connector the panel is on or its resolution:
+# when a display is (re)connected the KMS driver creates /dev/fb0 and we
+# proceed; a genuinely headless device idles here quietly and self-heals
+# on hotplug. Only the linuxfb path needs this — the cage (wayland) and
+# eglfs (KMS) boards render straight to /dev/dri with no /dev/fb0
+# dependency, so the QT_QPA_PLATFORM guard makes this a no-op there.
+wait_for_framebuffer() {
+    [ "${QT_QPA_PLATFORM:-}" = 'linuxfb' ] || return 0
+    [ -e /dev/fb0 ] && return 0
+
+    echo "start_viewer: no framebuffer (/dev/fb0) yet — waiting for a display." \
+        "Connect or power on the screen; the viewer starts automatically once one is present."
+    local waited=0
+    until [ -e /dev/fb0 ]; do
+        sleep 5
+        waited=$((waited + 5))
+        if [ "$((waited % 60))" -eq 0 ]; then
+            echo "start_viewer: still no /dev/fb0 after ${waited}s; waiting for a display."
+        fi
+    done
+    echo "start_viewer: /dev/fb0 present after ${waited}s — starting the viewer."
+}
+wait_for_framebuffer
+
 # x86 / arm64 / pi5 run under `cage`, a kiosk wlroots compositor.
 # cage acquires DRM master as root, exports WAYLAND_DISPLAY for its
 # child, and exits when the child exits — so the existing kill -0


### PR DESCRIPTION
> **Draft** — logic + behaviour validated on-device (see Validation);
> leaving as draft pending a build/deploy of the pi3 viewer image with
> this change.

### Issues Fixed

Headless / display-off 32-bit Pi (pi2/pi3) devices crash-loop the viewer
and show nothing. Diagnosed live on the pi3 fleet.

Qt's `linuxfb` platform opens `/dev/fb0` at startup and can't recover if
it's absent. Under full KMS (`dtoverlay=vc4-kms-v3d`) the framebuffer
only exists while a display is connected, so a device that boots with no
panel attached — display powered off, TV switched on after the Pi, slow
HDMI handshake, panel swapped — has no `/dev/fb0`. Qt then doesn't fail
cleanly: it logs `Unable to figure out framebuffer device` /
`no screens available` and aborts with heap corruption (`malloc():
unaligned tcache chunk detected`), so the container crash-loops.

**This is not a boot-time race.** When a display is present at boot,
`/dev/fb0` is created by the kernel at driver-bind (~t=23 s), ~30 s
before the container engine even starts — it's always there in time. The
problem is purely the **display-absent-at-boot** case, and crucially the
framebuffer is **dynamic**: the vc4 fbdev layer creates `/dev/fb0` when a
connector transitions to connected *after* boot (verified — see below).

### Description

Add `wait_for_framebuffer()` to `bin/start_viewer.sh`: on the `linuxfb`
path, if `/dev/fb0` is missing, wait for it instead of launching into a
guaranteed heap-corruption crash. When a display is attached/powered on,
the KMS driver creates `/dev/fb0` and the viewer starts immediately —
replacing a noisy crash-loop (which only recovers on a later restart that
happens to land after the display appears) with a quiet idle that
recovers the instant the framebuffer exists.

Makes **no** assumptions about which connector the display is on or its
resolution. Guarded on `QT_QPA_PLATFORM=linuxfb`, so it's a no-op on the
cage (`wayland`) and eglfs (KMS) boards, which render straight to
`/dev/dri` and have no `/dev/fb0` dependency.

Companion to the UID/GID-pinning fix (independent). The analogous
"headless" behaviour on the eglfs/cage boards is a separate concern, out
of scope here.

### Validation (on live pi3 hardware)

- **No boot race**: on a device with a display, `dmesg` shows
  `vc4drmfb fb0` created at monotonic **t≈23 s**; `balena.service` (the
  container engine) starts at **t≈53 s**. fb0 is present ~30 s before any
  container.
- **fb0 is dynamic on connect**: on a headless device (connector
  `disconnected`, no `/dev/fb0`), forcing the connector connected
  (`echo on > /sys/class/drm/card0-HDMI-A-1/status`) created `/dev/fb0`
  at **t≈1074 s** post-boot (`dmesg`: `vc4drmfb fb0`). So a display
  attached after boot does make the framebuffer appear — which is exactly
  what the wait recovers on.
- TODO before un-drafting: build the pi3 viewer image on this branch,
  deploy to a headless device, confirm it idles on the new log line and
  starts the viewer when a display is connected.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).
