### PR TITLE
chore(release): bump to 2026.05.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.05.1",
+  "version": "2026.05.2",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.05.1"
+version = "2026.05.2"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.5.1"
+version = "2026.5.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
### Description

Bumps the CalVer release version `2026.05.1` → `2026.05.2` ahead of cutting the `v2026.05.2` release.

- `pyproject.toml` + `package.json` — the authoritative version sources.
- `uv.lock` — regenerated so the editable `anthias` package entry matches (`2026.5.2` after PEP 440 normalization). Without it, `uv sync --frozen` in `Dockerfile.{server,viewer}` aborts on the lock/manifest drift. `uv lock --check` passes.
- `bun.lock` needs no change — it records the package name but not its version.

Once this lands and its `docker-build.yaml` run has pushed the `<short-hash>-<board>` images to GHCR, the `v2026.05.2` GitHub release is cut from this commit, which fires `build-balena-disk-image.yaml` (OTA-deploy all five fleets + roll fresh disk images + rpi-imager.json + website).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)