### PR TITLE
fix(balena): migrate legacy screenly data in-container so upgrades don't wipe the playlist

### DIFF
--- a/bin/migrate_in_container_paths.sh
+++ b/bin/migrate_in_container_paths.sh
@@ -2,21 +2,95 @@
 #
 # In-container companion to bin/migrate_legacy_paths.sh.
 #
-# After the rebrand, container code reads from /data/.anthias and
-# /data/anthias_assets. Defensively expose the legacy paths as symlinks
-# in case:
-#   - The user is running an older docker-compose.yml that still mounts
-#     `~/.screenly:/data/.screenly` while the host data has already been
-#     migrated (so the bind mount lands on a symlink, which docker
-#     dereferences).
-#   - DB rows or external integrations stored absolute container paths
-#     beginning with /data/.screenly or /data/screenly_assets.
+# bin/migrate_legacy_paths.sh renames the pre-rebrand host paths
+# (~/.screenly -> ~/.anthias, ~/screenly_assets -> ~/anthias_assets,
+# screenly.db -> anthias.db). It runs from bin/install.sh and
+# bin/upgrade_containers.sh — i.e. only on the apt/ansible host install.
+# On balena there is no host install step, so the persistent /data volume
+# of a pre-rebrand device still holds /data/.screenly + /data/screenly_assets
+# and the new container code, which reads /data/.anthias + /data/anthias_assets,
+# would start against an EMPTY database (issue: upgraded legacy devices lose
+# their playlist). This script performs the equivalent migration in-container
+# so balena devices are covered too.
 #
-# Idempotent. Skips creation if the legacy path already exists (e.g. a
-# bind mount took precedence).
+# Idempotent and safe to run on every container start.
 
 set -euo pipefail
 
+ANTHIAS_DIR=/data/.anthias
+SCREENLY_DIR=/data/.screenly
+ANTHIAS_ASSETS=/data/anthias_assets
+SCREENLY_ASSETS=/data/screenly_assets
+
+log() {
+    echo "[migrate_in_container_paths] $*"
+}
+
+# 1. Adopt legacy data into the new paths. A rename within /data is a
+#    cheap same-filesystem move. Only fires when the legacy dir is real
+#    (not already a back-compat symlink) and the new path doesn't exist
+#    yet — so it is a no-op on clean installs and on already-migrated
+#    devices.
+adopt_legacy_dir() {
+    local legacy="$1"
+    local new="$2"
+    if [ -d "${legacy}" ] && [ ! -L "${legacy}" ] && [ ! -e "${new}" ]; then
+        log "Adopting ${legacy} -> ${new}"
+        mv "${legacy}" "${new}"
+    fi
+}
+
+adopt_legacy_dir "${SCREENLY_DIR}" "${ANTHIAS_DIR}"
+adopt_legacy_dir "${SCREENLY_ASSETS}" "${ANTHIAS_ASSETS}"
+
+# 1b. Expose the legacy db / conf under the new names inside the config
+#     dir (mirrors migrate_legacy_paths.sh's screenly.db -> anthias.db).
+if [ -e "${ANTHIAS_DIR}/screenly.db" ] && [ ! -e "${ANTHIAS_DIR}/anthias.db" ]; then
+    ln -s screenly.db "${ANTHIAS_DIR}/anthias.db"
+fi
+if [ -e "${ANTHIAS_DIR}/screenly.conf" ] && [ ! -e "${ANTHIAS_DIR}/anthias.conf" ]; then
+    ln -s screenly.conf "${ANTHIAS_DIR}/anthias.conf"
+fi
+
+# 1c. Recover the already-broken state. A device that booted a
+#     post-rebrand release before this fix shipped created an EMPTY
+#     /data/.anthias/anthias.db (a fresh `migrate`) while its real data
+#     stayed behind in /data/.screenly/screenly.db. adopt_legacy_dir
+#     can't help there (the new dir already exists), so detect an empty
+#     anthias.db sitting next to a populated legacy screenly.db and adopt
+#     the latter. The empty db is preserved as a timestamped .emptybak.
+if [ -f "${ANTHIAS_DIR}/anthias.db" ] && [ -f "${SCREENLY_DIR}/screenly.db" ] \
+    && [ ! -L "${ANTHIAS_DIR}/anthias.db" ]; then
+    python3 - "${ANTHIAS_DIR}/anthias.db" "${SCREENLY_DIR}/screenly.db" <<'PY' || true
+import shutil
+import sqlite3
+import sys
+import time
+
+anthias_db, screenly_db = sys.argv[1], sys.argv[2]
+
+
+def asset_count(path):
+    try:
+        conn = sqlite3.connect(path)
+        return conn.execute('SELECT COUNT(*) FROM assets').fetchone()[0]
+    except Exception:
+        return -1
+
+
+if asset_count(anthias_db) == 0 and asset_count(screenly_db) > 0:
+    shutil.copy2(anthias_db, f'{anthias_db}.emptybak.{int(time.time())}')
+    shutil.copy2(screenly_db, anthias_db)
+    print('[migrate_in_container_paths] recovered playlist from legacy '
+          'screenly.db (empty anthias.db replaced)')
+PY
+fi
+
+# 2. Reverse-compat symlinks: once data lives under the new paths, expose
+#    the legacy names too, in case an older docker-compose.yml still binds
+#    `~/.screenly:/data/.screenly` or a DB row / integration stored an
+#    absolute /data/.screenly or /data/screenly_assets path. No-op if the
+#    legacy path already exists (e.g. a bind mount took precedence).
 create_symlink_if_absent() {
     local link="$1"
     local target="$2"
@@ -26,5 +100,5 @@ create_symlink_if_absent() {
     fi
 }
 
-create_symlink_if_absent /data/.screenly        /data/.anthias
-create_symlink_if_absent /data/screenly_assets  /data/anthias_assets
+create_symlink_if_absent "${SCREENLY_DIR}" "${ANTHIAS_DIR}"
+create_symlink_if_absent "${SCREENLY_ASSETS}" "${ANTHIAS_ASSETS}"


### PR DESCRIPTION
### Issues Fixed

**P0 — upgrading pre-rebrand balena devices wiped their playlist.** `bin/migrate_legacy_paths.sh` (which renames `~/.screenly`→`~/.anthias`, `screenly.db`→`anthias.db`, etc.) only runs on the apt/ansible host install — **never on balena**. So a legacy balena device keeps its data in `/data/.screenly` + `/data/screenly_assets`, while post-rebrand container code reads `/data/.anthias` + `/data/anthias_assets`. On the 2026.5.2 roll-forward, `start_server.sh` found no `/data/.anthias/anthias.db`, ran a **fresh `migrate`**, and the viewer came up with an empty playlist — while the real DB (with assets) sat untouched in `/data/.screenly`.

Confirmed on live devices: e.g. `anthias.db` had `assets=0` while `/data/.screenly/screenly.db` had `assets=16` and `/data/screenly_assets/` had the 16 media files. No data was lost — just unreferenced.

### Description

`migrate_in_container_paths.sh` previously only created **reverse-compat** symlinks (`/data/.screenly → /data/.anthias`), which no-op when `/data/.screenly` already exists — so legacy data was never migrated forward. Now it does the in-container equivalent of the host migration:

- **adopts** legacy dirs into the new paths (`mv /data/.screenly → /data/.anthias`, `screenly_assets → anthias_assets`) when the new path is absent;
- symlinks `screenly.db → anthias.db` and `screenly.conf → anthias.conf`;
- **recovers the already-broken state**: if `anthias.db` is empty but a populated legacy `screenly.db` exists, adopts the latter (keeping the empty db as `.emptybak`);
- keeps the existing reverse-compat symlinks afterwards.

Idempotent and safe on clean installs and already-migrated devices (`bash -n` + `shellcheck` clean). Already-affected field devices are being remediated out-of-band with the same logic; this makes the container self-heal so the rest of the fleet's legacy devices don't break on their next upgrade.

> ⚠️ Rollout of further OS/release tranches should pause until this lands.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)