### PR TITLE
chore(release): bump to 2026.06.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.05.2",
+  "version": "2026.06.0",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.05.2"
+version = "2026.06.0"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.5.2"
+version = "2026.6.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
### Description

CalVer bump `2026.05.2` → **`2026.06.0`** (June 2026 → new month, micro resets to 0).

Cutting this release ships, to the balena fleets via the `release: published` pipeline:
- **#2964** (supersedes #2963) — fold the balena legacy migration into the canonical `migrate_legacy_paths.sh`; upgraded pre-rebrand devices recover their playlist (and the field-remediation backstop).
- **#2961** — pi4 `dtparam=audio=on` so the host-config reconcile no longer reboot-loops.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)