### PR TITLE
fix(viewer): skip the Writeback connector in the eglfs headless guard

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -210,9 +210,20 @@ fi
 # sees the connected connector once a display appears; a genuinely
 # headless device idles quietly and self-heals on hotplug.
 eglfs_has_display() {
-    local status_file
+    local status_file connector
     for status_file in /sys/class/drm/card*-*/status; do
         [ -r "$status_file" ] || continue
+        connector=$(basename "$(dirname "$status_file")")  # e.g. card0-HDMI-A-1
+        # Skip virtual / non-display connectors. The KMS "Writeback"
+        # connector is not a real output and always reports "unknown";
+        # counting it as a display defeats the headless wait and sends
+        # eglfs into a "no screens available" crash-loop on a screenless
+        # board. balenaOS 2026.x exposes card0-Writeback-1, which is what
+        # broke this on Pi 4 (both HDMI ports disconnected, yet the
+        # writeback connector kept the guard from ever waiting).
+        case "$connector" in
+            *[Ww]riteback*) continue ;;
+        esac
         # Treat "connected" — and the occasional bridge that reports
         # "unknown" — as present; only an all-"disconnected" board waits.
         case "$(cat "$status_file" 2>/dev/null)" in


### PR DESCRIPTION
### Issues Fixed

Pi 4 devices on **balenaOS 2026.x** crash-loop the viewer with `no screens available` / `AnthiasViewer exited before emitting D-Bus handshake`, despite the headless guard from #2962.

Root cause: `2026.x` exposes a KMS **`card0-Writeback-1`** virtual connector that always reports `unknown`. `#2962`'s `eglfs_has_display()` counted any non-`disconnected` status as "display present" (to tolerate bridge chips reporting `unknown`). On a **headless** Pi 4 (both `HDMI-A-1`/`HDMI-A-2` = `disconnected`), the writeback connector's `unknown` made the guard think a display was attached → it skipped the wait → launched eglfs → crash-loop. Confirmed on live devices `094231c3`, `098fa957` (both: HDMI disconnected, `Writeback-1` unknown).

### Description

Skip `*Writeback*` connectors in `eglfs_has_display()` so only real display outputs (HDMI/DSI/DP/…) count toward "a display is present." A genuinely headless board now waits gracefully (as #2962 intended) instead of crash-looping; the `unknown`-as-present hedge is kept for real connectors.

Verified locally: headless (HDMI disconnected + Writeback unknown) → **waits**; HDMI connected → launches; HDMI `unknown` (bridge) → launches. `bash -n` + `shellcheck` clean.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)