### PR TITLE
fix(viewer): rotate Pi 4 (eglfs) display via QT_QPA_EGLFS_ROTATION

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -148,17 +148,41 @@ def _set_qpa_rotation(qpa: str, rotation: int) -> str:
 def _build_webview_env() -> dict[str, str]:
     """Compose the env to pass when spawning AnthiasViewer.
 
-    Sets ``rotation=N`` inside QT_QPA_PLATFORM on linuxfb boards so
-    the Qt linuxfb plugin rotates the framebuffer for us at no perf
-    cost. On Wayland (x86) the QPA has no rotation= option — the
-    compositor owns transforms — so the env is left alone and
-    ``_apply_wlr_transform`` handles rotation separately.
+    Rotation is applied differently per platform plugin:
+
+    * Wayland (x86 under cage): the compositor owns transforms, so the
+      env is left alone and ``_apply_wlr_transform`` handles rotation
+      with ``wlr-randr`` separately.
+
+    * eglfs (pi4-64): the linuxfb ``:rotation=N`` plugin option is NOT
+      understood by eglfs (it's silently ignored — issue #2882's
+      original code wrongly assumed Pi 4 was still linuxfb, which is
+      why the rotation menu was a no-op there). eglfs reads
+      ``QT_QPA_EGLFS_ROTATION`` at QPA init and applies the transform
+      to every top-level window through its QOpenGLCompositor;
+      AnthiasViewer is a QWidget app, so webpages, images and video
+      all rotate uniformly — no per-content rotation needed (and the
+      old ``video-rotate`` path in media_player must stay off here or
+      the video double-rotates).
+
+    * linuxfb (pi2/pi3, Qt5): the plugin reads ``:rotation=N`` from
+      QT_QPA_PLATFORM once at QPA init and rotates the framebuffer for
+      us at no perf cost.
     """
     env = dict(os.environ)
     rotation = _rotation_value()
+    if _is_wayland_board():
+        return env
     qpa = env.get('QT_QPA_PLATFORM', 'linuxfb')
-    if not _is_wayland_board():
-        env['QT_QPA_PLATFORM'] = _set_qpa_rotation(qpa, rotation)
+    if qpa.partition(':')[0] == 'eglfs':
+        if rotation:
+            env['QT_QPA_EGLFS_ROTATION'] = str(rotation)
+        else:
+            # Drop a stale value so dialling back to 0 actually
+            # un-rotates on the respawned process.
+            env.pop('QT_QPA_EGLFS_ROTATION', None)
+        return env
+    env['QT_QPA_PLATFORM'] = _set_qpa_rotation(qpa, rotation)
     return env
 
 

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -287,24 +287,18 @@ def _build_video_options(uri: str) -> dict[str, Any]:
     but a future codec-specific tuning may re-introduce it.
     """
     del uri  # see docstring; kept for signature compatibility.
-    device_type = os.environ.get('DEVICE_TYPE', '')
 
     options: dict[str, Any] = {
         'audio-device': f'alsa/{get_alsa_audio_device()}',
     }
 
-    # Rotation: cage/wlroots boards rotate via wlr-randr (issue
-    # #2856, wired in src/anthias_viewer/__init__.py) and Qt's
-    # wayland QPA inherits the transform — passing video-rotate
-    # on top would double-rotate. On Pi 4 (eglfs, no compositor)
-    # Qt has no transform plumbing, so the video pipeline has to
-    # apply the rotation itself (via QGraphicsVideoItem::setRotation
-    # in VideoView). Sent as int so the C++ side parses it cleanly
-    # via ``QVariant::toInt`` without a string round-trip.
-    rotation = _screen_rotation()
-    if rotation and device_type == 'pi4-64':
-        options['video-rotate'] = rotation
-
+    # No per-video rotation here. Every Qt6 board now rotates at the
+    # platform layer and the QGraphicsVideoItem inherits the transform:
+    # cage/wlroots (x86) via wlr-randr (issue #2856) and eglfs (pi4-64)
+    # via QT_QPA_EGLFS_ROTATION (set in _build_webview_env). Sending
+    # ``video-rotate`` on top of either would double-rotate the frames.
+    # linuxfb VLC boards (pi1/2/3) apply rotation through the
+    # ``--transform`` filter in VLCMediaPlayer.__init__ instead.
     return options
 
 

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -153,9 +153,14 @@ void VideoView::play(const QString& uri, const QVariantMap& options)
         summary << QStringLiteral("audio-device=%1").arg(alsaSpec);
     }
 
-    // Rotation on QGraphicsVideoItem. Pi 4 (eglfs) is the only
-    // board that passes ``video-rotate`` — cage / wlroots boards
-    // get the transform from wlr-randr at the compositor level.
+    // Optional per-item rotation of the QGraphicsVideoItem. No board
+    // sends ``video-rotate`` any more: every platform now rotates the
+    // whole screen (eglfs via QT_QPA_EGLFS_ROTATION on Pi 4, wlroots
+    // via wlr-randr on x86) and the video item inherits that transform,
+    // so applying it again here would double-rotate. The parse is kept
+    // as a defensive no-op (default 0 = applyRotation(0)) so an old
+    // viewer that still passes the option degrades gracefully rather
+    // than erroring on an unknown key.
     int rotation = 0;
     if (options.contains(QStringLiteral("video-rotate"))) {
         bool ok = false;

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -734,19 +734,19 @@ def test_mpv_never_passes_video_rotate_under_cage(
     assert 'video-rotate' not in options
 
 
-@pytest.mark.parametrize('rotation', [90, 180, 270])
+@pytest.mark.parametrize('rotation', [0, 90, 180, 270])
 @patch(
     'anthias_viewer.media_player._detect_hdmi_audio_device',
     return_value='sysdefault:CARD=vc4hdmi0',
 )
-def test_mpv_passes_video_rotate_on_pi4_64(
+def test_mpv_never_passes_video_rotate_on_pi4_64(
     _mock_detect: Any, rotation: int
 ) -> None:
-    """Pi 4 (eglfs, no compositor) has no transform plumbing — the
-    video pipeline has to apply rotation itself via the
-    ``video-rotate`` option (forwarded to
-    ``QGraphicsVideoItem::setRotation`` on the C++ side; sent as an
-    ``int``, marshalled to ``Variant('i', …)``)."""
+    """Pi 4 (eglfs) rotates the whole screen via QT_QPA_EGLFS_ROTATION
+    (set in src/anthias_viewer/__init__.py:_build_webview_env), and the
+    QGraphicsVideoItem inherits that transform. Emitting ``video-rotate``
+    on top would double-rotate the frames, so the option must be omitted
+    at every angle — including 0°."""
     player = MPVMediaPlayer()
     mock_bus = MagicMock()
     with (
@@ -758,42 +758,6 @@ def test_mpv_passes_video_rotate_on_pi4_64(
         patch(
             'anthias_viewer.media_player.settings',
             _rotated_mpv_settings(rotation),
-        ),
-        patch(
-            'anthias_viewer.media_player.get_device_type',
-            return_value='pi5',
-        ),
-        patch.dict('os.environ', {'DEVICE_TYPE': 'pi4-64'}),
-    ):
-        player.set_asset('file:///test/video.mp4', 30)
-        player.play()
-    options = _last_play_options(mock_bus)
-    assert options['video-rotate'] == rotation
-    assert isinstance(options['video-rotate'], int)
-
-
-@patch(
-    'anthias_viewer.media_player._detect_hdmi_audio_device',
-    return_value='sysdefault:CARD=vc4hdmi0',
-)
-def test_mpv_skips_video_rotate_at_zero_on_pi4_64(
-    _mock_detect: Any,
-) -> None:
-    """0° must NOT emit ``video-rotate=0`` — keeps the D-Bus surface
-    unchanged for the 99% of operators who never touch the dropdown,
-    so the video pipeline falls back to its own default rather than
-    being told to rotate by zero."""
-    player = MPVMediaPlayer()
-    mock_bus = MagicMock()
-    with (
-        patch('anthias_viewer.media_player._browser_bus', mock_bus),
-        patch(
-            'anthias_viewer.media_player._marshal_dbus_options',
-            side_effect=lambda opts: opts,
-        ),
-        patch(
-            'anthias_viewer.media_player.settings',
-            _rotated_mpv_settings(0),
         ),
         patch(
             'anthias_viewer.media_player.get_device_type',

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -811,6 +811,63 @@ def test_build_webview_env_removes_stale_rotation_when_dialed_to_zero() -> (
     assert env['QT_QPA_PLATFORM'] == 'linuxfb:fb=/dev/fb1'
 
 
+@pytest.mark.parametrize('rotation', [90, 180, 270])
+def test_build_webview_env_sets_eglfs_rotation(rotation: int) -> None:
+    """Pi 4 runs eglfs, which ignores the linuxfb ``:rotation=N`` plugin
+    option (that silent no-op was the 2026.06.0 bug). eglfs reads
+    QT_QPA_EGLFS_ROTATION at QPA init instead, so we set that and leave
+    QT_QPA_PLATFORM untouched."""
+    with (
+        mock.patch.dict(settings, {'screen_rotation': rotation}),
+        mock.patch.dict(
+            os.environ,
+            {'DEVICE_TYPE': 'pi4-64', 'QT_QPA_PLATFORM': 'eglfs'},
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['QT_QPA_EGLFS_ROTATION'] == str(rotation)
+    # The platform string must stay a bare plugin — appending
+    # ``:rotation=N`` here is exactly the no-op that broke Pi 4.
+    assert env['QT_QPA_PLATFORM'] == 'eglfs'
+
+
+def test_build_webview_env_eglfs_zero_omits_rotation() -> None:
+    """Default orientation must not set QT_QPA_EGLFS_ROTATION at all."""
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 0}),
+        mock.patch.dict(
+            os.environ,
+            {'DEVICE_TYPE': 'pi4-64', 'QT_QPA_PLATFORM': 'eglfs'},
+            clear=False,
+        ),
+    ):
+        # Guard against a stray value leaking in from the real env.
+        os.environ.pop('QT_QPA_EGLFS_ROTATION', None)
+        env = viewer._build_webview_env()
+    assert 'QT_QPA_EGLFS_ROTATION' not in env
+    assert env['QT_QPA_PLATFORM'] == 'eglfs'
+
+
+def test_build_webview_env_eglfs_clears_stale_rotation() -> None:
+    """Dialling back to 0° after a rotated launch must drop a stale
+    QT_QPA_EGLFS_ROTATION so the respawned webview un-rotates."""
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 0}),
+        mock.patch.dict(
+            os.environ,
+            {
+                'DEVICE_TYPE': 'pi4-64',
+                'QT_QPA_PLATFORM': 'eglfs',
+                'QT_QPA_EGLFS_ROTATION': '270',
+            },
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert 'QT_QPA_EGLFS_ROTATION' not in env
+
+
 def test_apply_wlr_transform_skipped_on_linuxfb() -> None:
     """The wlr-randr binary isn't even shipped on Pi boards — make
     sure we never call it from a non-wayland viewer."""


### PR DESCRIPTION
### Issues Fixed

[Forum #6699 — "Anthias 2026.06.0 screen rotation menu doesn't work"](https://forums.screenly.io/t/new-anthias-2026-06-0-screen-rotation-menu-doesnt-work/6699) on Raspberry Pi 4.

### Description

The 2026.06.0 screen-rotation dropdown is a no-op on Pi 4. The rotation feature appends the **linuxfb** `:rotation=N` plugin option to `QT_QPA_PLATFORM`, but Pi 4 moved to **eglfs** (for HW video), and eglfs silently ignores that option. Only video rotated (via the per-item `video-rotate` hack); webpages and images — i.e. most signage — never did.

`QT_QPA_EGLFS_ROTATION` is the right primitive: AnthiasViewer is a QWidget app, so eglfs's `QOpenGLCompositor` applies the transform to every top-level window (web, image, video) uniformly.

- `_build_webview_env`: set `QT_QPA_EGLFS_ROTATION=<deg>` on the eglfs board and leave `QT_QPA_PLATFORM` bare. linuxfb (Pi 2/3) `:rotation=N` and x86 wlr-randr paths unchanged.
- Drop the `video-rotate` option on `pi4-64` — the whole eglfs screen now rotates and the `QGraphicsVideoItem` inherits it, so per-item rotation would double-rotate. C++ parse kept as a defensive no-op.
- Tests updated to assert the eglfs env and that `video-rotate` is no longer emitted.

Pure Python + env change — no C++/image rebuild required.

**Validated on a Pi 4 testbed** through the real `v2/device_settings` API (probe page reporting `window.innerWidth/Height` via the server access log):

| `screen_rotation` | Env produced | Webview layout |
|---|---|---|
| 90° | `eglfs` + `QT_QPA_EGLFS_ROTATION=90` | 1080×1920 (portrait) |
| 0° | `eglfs` (no rotation var) | 1920×1080 (landscape) |

**Known follow-ups (out of scope here):**
- A rotation *change* crashes the viewer mid-transition (stale `browser_bus` D-Bus proxy after the existing bounce terminates AnthiasViewer → `GDBus NoReply`), recovered by `restart: always`. End state is correct; this is pre-existing bounce machinery, unchanged here.
- `_is_wayland_board()` only treats `x86` as Wayland, but Pi 5 / arm64 also run cage/wayland — their rotation is likely broken the same way (wlr-randr never invoked).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices. (x86 Wayland path unchanged by this PR.)
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)