### PR TITLE
fix(viewer): pi2/pi3 video via GStreamer HW pipeline (replace VLC)

### DIFF
--- a/docs/board-enablement.md
+++ b/docs/board-enablement.md
@@ -6,9 +6,9 @@ stack, or `src/anthias_viewer/media_player.py`.
 
 The viewer is tuned per-board (see `media_player.py` and `bin/start_viewer.sh`):
 
-| Device   | Qt platform | Compositor | mpv VO                          |
-|----------|-------------|-----------|---------------------------------|
-| Pi 2 / 3 | Qt5 linuxfb | none       | VLC                              |
+| Device   | Qt platform | Compositor | video output                     |
+|----------|-------------|-----------|----------------------------------|
+| Pi 1/2/3 | Qt5 linuxfb | none       | GStreamer `v4l2h264dec ! v4l2convert ! fbdevsink` |
 | Pi 4-64  | Qt6 linuxfb | none       | `--vo=gpu --gpu-context=drm`     |
 | Pi 5     | Qt6 wayland | cage       | `--vo=gpu --gpu-context=wayland` |
 | arm64    | Qt6 wayland | cage       | `--vo=gpu --gpu-context=wayland` |
@@ -17,6 +17,41 @@ The viewer is tuned per-board (see `media_player.py` and `bin/start_viewer.sh`):
 Each combination has different hwdec, scaling, and compositing characteristics,
 so a regression on one board can hide behind a clean run on another. Run the
 same asset rotation everywhere and compare drop counts.
+
+### Pi 1 / 2 / 3 video: GStreamer V4L2 → fbdev (`GstFbdevMediaPlayer`)
+
+The Qt5 linuxfb boards play video by spawning `gst-launch-1.0 playbin` with a
+fully-hardware sink: `v4l2h264dec` (auto-plugged by decodebin at PRIMARY rank)
+decodes on the `bcm2835-codec` (`/dev/video10`), `v4l2convert` hardware-scales
+and color-converts (YUV→framebuffer format) on the bcm2835 ISP, and `fbdevsink`
+paints frames straight to the framebuffer (`/dev/fb0`). This is deliberate: on a
+bare linuxfb console with no compositor, a uid-1000 process **cannot acquire DRM
+master** (the viewer's python process already holds `card0`), so every
+DRM/KMS-master video output fails — VLC's `kms` vout and mpv's `--vo=drm` both
+return `EBUSY`/`EPERM`, and the rpidistro VLC `drm_vout` only knows how to lease
+a connector from a Wayland/X compositor (`Failed to get xlease`). fbdev needs
+none of that.
+
+History: these boards used to play video with VLC's Broadcom `--vout=mmal_vout`
+(HW decode **and** HW scale/convert/scanout, no DRM master). The Bookworm
+upgrade (#1980) dropped `mmal`, and nothing replaced the vout, so VLC silently
+rendered to nowhere — `Showing asset … (video)` was logged but the screen
+stayed black on *every* OS version. `GstFbdevMediaPlayer` is the modern
+equivalent and drives the **same VPU + ISP silicon** mmal used: decode, scale,
+and color-convert all stay in hardware, only the final fbdev write is a CPU
+memcpy. On a Pi 3 it sustains 1080p30 → rgb565 at ~40 fps with zero dropped
+frames. (An interim `ffmpeg → fbdev` attempt was abandoned: the bcm2835 HW
+*decode* worked, but doing the YUV→RGB convert + scale on the ARM CPU via
+swscale managed only ~6 fps to rgb565 — swscale has no NEON rgb565 path and CPU
+scaling is unaccelerated. `v4l2convert` moves that work back onto the ISP.)
+`playbin` is used so demux is container-agnostic, the HW decoder is auto-plugged,
+and a clip with no audio track degrades gracefully. Validate with the BBB sample
+pack below and confirm `dropped: 0` at the source framerate.
+
+> **Note:** validated on a Pi 3 (the only linuxfb board in the testbed pool).
+> Pi 1 / Pi 2 share the same VideoCore IV decode + ISP block, so the hardware
+> path is identical; their slower ARM cores only affect demux/parse + the fb
+> memcpy, not the offloaded decode/scale/convert.
 
 ## Goal: hardware-accelerated playback on every board
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ viewer = [
     "netifaces==0.11.0",
     "pydbus==0.6.0",
     "python-dateutil==2.9.0.post0",
-    "python-vlc==3.0.21203",
     "pytz==2026.2",
     "redis==7.4.0",
     "requests==2.33.1",
@@ -145,7 +144,7 @@ mypy = [
     # to type-check the upload-time normalisation pipeline.
     # pillow-heif is intentionally not pinned here — it's listed in
     # tool.mypy.overrides above so its missing-import error is
-    # ignored, mirroring the cec / pydbus / sh / vlc pattern.
+    # ignored, mirroring the cec / pydbus / sh pattern.
     "Pillow==12.2.0",
     "pytz==2026.2",
     "whitenoise==6.12.0",
@@ -242,7 +241,6 @@ module = [
     "pillow_heif",
     "pydbus",
     "sh",
-    "vlc",
     "yt_dlp",
     "yt_dlp.*",
 ]

--- a/src/anthias_server/processing.py
+++ b/src/anthias_server/processing.py
@@ -845,13 +845,14 @@ _VIDEO_METADATA_KEYS = (
 )
 
 
-# Per-board hardware-decode codec set. Mirrors
-# ``anthias_viewer.media_player._PI_HWDEC_BY_CODEC`` — the two tables
-# must list the same codecs for each board, because the upload-side
-# gate decides what to accept and the playback-side dispatch decides
-# how to play. If they drift, an asset accepted at upload will fail
-# at the viewer with mpv's silent SW-decode fallback (which the gate
-# exists to prevent).
+# Per-board hardware-decode codec set. This upload-side gate must
+# stay in sync with what each board's player can actually decode in
+# hardware: pi2/pi3 through GStreamer's V4L2 elements
+# (``GstFbdevMediaPlayer`` — bcm2835 codec, H.264 only), every other
+# board through mpv/QtMultimedia + libavcodec. If the gate accepts a
+# codec the board can't HW-decode, playback falls back to a silent
+# software decode at the viewer (drops / black screen) — which this
+# gate exists to prevent.
 #
 # Empty / missing entry means "no codec on this device decodes in
 # hardware" — every video upload is rejected. The catch-all ``arm64``

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -1,13 +1,15 @@
 import logging
 import os
+import re
+import signal
+import subprocess
 from typing import Any, ClassVar
+from urllib.parse import quote
 
 from anthias_common.board import ARM64_DEVICE_TYPES
 from anthias_common.device_helper import get_device_type
 from anthias_common.utils import clamp_screen_rotation
 from anthias_server.settings import settings
-
-VIDEO_TIMEOUT = 20  # secs
 
 
 # Lazy import for the pydbus proxy: the viewer service hands
@@ -15,7 +17,7 @@ VIDEO_TIMEOUT = 20  # secs
 # loadPage / loadImage (created in src/anthias_viewer/__init__.py
 # during load_browser()). Tests inject a mock; importing pydbus at
 # module load time would force every test to have pydbus available
-# even when only exercising VLCMediaPlayer.
+# even when only exercising GstFbdevMediaPlayer.
 _browser_bus: Any = None
 
 
@@ -297,8 +299,8 @@ def _build_video_options(uri: str) -> dict[str, Any]:
     # cage/wlroots (x86) via wlr-randr (issue #2856) and eglfs (pi4-64)
     # via QT_QPA_EGLFS_ROTATION (set in _build_webview_env). Sending
     # ``video-rotate`` on top of either would double-rotate the frames.
-    # linuxfb VLC boards (pi1/2/3) apply rotation through the
-    # ``--transform`` filter in VLCMediaPlayer.__init__ instead.
+    # linuxfb boards (pi1/2/3) apply rotation through the GStreamer
+    # ``videoflip`` element in GstFbdevMediaPlayer instead.
     return options
 
 
@@ -320,7 +322,7 @@ class MPVMediaPlayer(MediaPlayer):
     def play(self) -> None:
         # Re-read settings each play so the audio_output dropdown
         # takes effect without a viewer restart, matching the prior
-        # subprocess path and VLCMediaPlayer.
+        # subprocess path and GstFbdevMediaPlayer.
         settings.load()
 
         options = _build_video_options(self.uri)
@@ -359,61 +361,203 @@ class MPVMediaPlayer(MediaPlayer):
         return self._playing
 
 
-class VLCMediaPlayer(MediaPlayer):
+FB_DEVICE = '/dev/fb0'
+
+
+def _fb_geometry(
+    fb_sys: str = '/sys/class/graphics/fb0',
+) -> tuple[int, int, str]:
+    """Read the framebuffer resolution + GStreamer pixel format.
+
+    Returns (width, height, gst_format). 16bpp → RGB16 (the Pi vc4 fbcon
+    rgb565 default), 32bpp → BGRx. Falls back to 1920x1080/RGB16 if the
+    sysfs nodes are unreadable so playback degrades rather than crashes.
+    The format pins the ``v4l2convert`` (bcm2835 ISP) output so the
+    hardware color-convert lands in the framebuffer's pixel layout.
+    """
+    width, height = 1920, 1080
+    try:
+        with open(f'{fb_sys}/virtual_size') as handle:
+            width, height = (int(x) for x in handle.read().strip().split(','))
+    except (OSError, ValueError):
+        pass
+    bpp = 16
+    try:
+        with open(f'{fb_sys}/bits_per_pixel') as handle:
+            bpp = int(handle.read().strip())
+    except (OSError, ValueError):
+        pass
+    return width, height, 'BGRx' if bpp >= 32 else 'RGB16'
+
+
+# Operator screen_rotation → GStreamer ``videoflip`` method. None for an
+# unrotated panel (the common case) so the videoflip element is omitted
+# entirely and the pipeline stays fully hardware.
+_GST_VIDEOFLIP_METHODS = {
+    90: 'clockwise',
+    180: 'rotate-180',
+    270: 'counterclockwise',
+}
+
+# A bare URI scheme: ``http``, ``https``, ``file``, ``rtsp`` …
+_URI_SCHEME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9+.\-]*://')
+
+
+def _as_gst_uri(uri: str) -> str:
+    """Coerce an asset URI into one ``playbin`` accepts.
+
+    Local assets store a bare absolute path
+    (``settings['assetdir']/<asset_id>`` — see the API serializers), and
+    ``playbin``'s ``uri`` property rejects anything without a scheme, so
+    a bare path is wrapped as ``file://`` (``quote`` so a path with
+    spaces stays a valid URI; ``/`` is left intact). A URI that already
+    carries a scheme (``http(s)://`` streaming, ``file://``) is passed
+    through unchanged. Without this, ``gst-launch ... uri=/data/...``
+    fails with "Invalid URI" and the clip black-screens — the same
+    failure this player exists to fix.
+    """
+    if _URI_SCHEME_RE.match(uri):
+        return uri
+    return 'file://' + quote(uri)
+
+
+class GstFbdevMediaPlayer(MediaPlayer):
+    """Pi 1/2/3 (Qt5 linuxfb) video player: GStreamer HW pipeline → fb.
+
+    Spawns ``gst-launch-1.0 playbin`` with a custom video sink that
+    hardware-decodes through the board's V4L2 M2M decoder
+    (``v4l2h264dec`` → /dev/video10, bcm2835-codec; auto-selected by
+    decodebin at PRIMARY rank), hardware scales + color-converts through
+    the bcm2835 ISP (``v4l2convert``), and paints straight to the
+    framebuffer (``fbdevsink`` → /dev/fb0). fbdev needs no DRM master /
+    X / Wayland — exactly what a bare uid-1000 viewer with no compositor
+    cannot acquire (the python viewer holds card0's DRM master, so VLC's
+    ``kms`` vout and mpv's ``--vo=drm`` both fail with EBUSY/EPERM here).
+
+    This restores hardware-decoded video on these boards after #1980
+    (the Bookworm upgrade) dropped the Broadcom ``mmal_vout`` VLC path —
+    mmal did HW decode *and* HW scale/convert/scanout with no DRM master,
+    and once it was gone VLC was left with only compositor/DRM outputs
+    that render to nowhere on linuxfb. The VPU + ISP this pipeline drives
+    is the same silicon mmal used: on a Pi 3 it sustains 1080p30 → rgb565
+    at ~40 fps with zero dropped frames, where a CPU color-convert path
+    (ffmpeg → fbdev) managed only ~6 fps because swscale's YUV→rgb565 has
+    no NEON path and CPU scaling is unaccelerated. Documented in
+    docs/board-enablement.md.
+
+    ``playbin`` is used rather than a hand-built pipeline so demux is
+    container-agnostic, the HW decoder is auto-plugged, and a missing
+    audio track degrades gracefully (no audio pad → audio sink simply
+    unused) instead of dead-locking an explicitly-linked branch.
+    """
+
     def __init__(self) -> None:
         MediaPlayer.__init__(self)
-
-        # Imported here so Qt6 boards (which route to MPVMediaPlayer
-        # via MediaPlayerProxy) don't need libvlc available just to
-        # load this module.
-        import vlc
-
-        self._vlc = vlc
-        options = [f'--alsa-audio-device={get_alsa_audio_device()}']
-        # Issue #2856. Pi 1/2/3 fall through to VLC and write directly
-        # to the framebuffer — no compositor or KMS transform in the
-        # path — so any screen rotation has to be applied inside the
-        # pipeline. The transform filter is software-rotation but the
-        # SD-class boards on this branch only play SD-class assets, so
-        # the cost is bearable. VLC requires the filter to be in the
-        # chain at instance-init time; if the operator changes rotation
-        # from the UI, MediaPlayerProxy.reset() drops the singleton so
-        # we re-init with the new option list on the next play.
-        self._rotation = _screen_rotation()
-        if self._rotation:
-            options.extend(
-                [
-                    '--video-filter=transform',
-                    f'--transform-type={self._rotation}',
-                ]
-            )
-        self.instance = vlc.Instance(options)
-        self.player = self.instance.media_player_new()
-
-        self.player.audio_output_set('alsa')
+        self.uri: str = ''
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._fb_w, self._fb_h, self._fb_fmt = _fb_geometry()
 
     def set_asset(self, uri: str, duration: int | str) -> None:
-        self.player.set_mrl(uri)
+        del duration  # the asset_loop owns the on-screen duration
+        self.uri = uri
         settings.load()
-        self.player.audio_output_device_set('alsa', get_alsa_audio_device())
-        # Use synchronous parse() to pre-load file metadata before play() is
-        # called. parse_with_options() is async and returns before metadata is
-        # ready, which negates the pre-loading benefit and causes the same
-        # startup gap we're trying to reduce.
-        self.player.get_media().parse()
+
+    def _video_sink(self) -> str:
+        """playbin ``video-sink`` bin: HW scale + color-convert → fb.
+
+        ``v4l2convert`` (bcm2835 ISP) does the YUV→fb-format conversion
+        and any scale to the framebuffer geometry in hardware. Rotation
+        rides ``videoflip`` ahead of it, and only when the operator
+        actually rotated the screen — an unrotated panel keeps the bin
+        fully hardware.
+        """
+        parts: list[str] = []
+        flip = _GST_VIDEOFLIP_METHODS.get(_screen_rotation())
+        if flip:
+            parts.append(f'videoflip method={flip}')
+        parts.append('v4l2convert')
+        parts.append(
+            f'video/x-raw,format={self._fb_fmt},'
+            f'width={self._fb_w},height={self._fb_h}'
+        )
+        parts.append(f'fbdevsink device={FB_DEVICE}')
+        return ' ! '.join(parts)
+
+    def _build_command(self) -> list[str]:
+        return [
+            'gst-launch-1.0',
+            '-q',
+            'playbin',
+            f'uri={_as_gst_uri(self.uri)}',
+            f'video-sink={self._video_sink()}',
+            f'audio-sink=alsasink device={get_alsa_audio_device()}',
+        ]
 
     def play(self) -> None:
-        self.player.play()
+        self.stop()  # never leave a previous pipeline holding the fb
+        gst = self._build_command()
+        logging.info('GstFbdev play: %s', ' '.join(gst))
+        # Loop the clip for the whole on-screen slot (the asset_loop
+        # sleeps for ``duration`` then stop()s us). gst-launch can't loop
+        # a single playbin, so re-launch on clean EOS; break on a pipeline
+        # error so a persistent failure doesn't spin. Pass the argv as
+        # ``"$@"`` so the video-sink bin string (with spaces and ``!``)
+        # survives without shell re-splitting. start_new_session puts the
+        # bash + gst-launch child in their own group so stop() can kill
+        # both — terminate()ing only bash would orphan gst-launch on the
+        # framebuffer.
+        argv = [
+            'bash',
+            '-c',
+            'while true; do "$@" || break; done',
+            'gstloop',
+            *gst,
+        ]
+        try:
+            self._proc = subprocess.Popen(
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                # Inherit stderr (not DEVNULL): with playbin's ``-q`` the
+                # pipeline is silent except for errors, so a device-side
+                # failure (caps negotiation, missing /dev/fb0, decoder
+                # busy) surfaces in the viewer's container log instead of
+                # vanishing — the silent-failure mode this player exists
+                # to escape.
+                stderr=None,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            logging.error('GstFbdev: failed to spawn gst-launch: %s', exc)
+            self._proc = None
 
     def stop(self) -> None:
-        self.player.stop()
+        if self._proc is None:
+            return
+        if self._proc.poll() is None:
+            try:
+                pgid = os.getpgid(self._proc.pid)
+                os.killpg(pgid, signal.SIGTERM)
+                self._proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                # SIGTERM didn't take in time — SIGKILL the group, then
+                # wait() to reap the bash leader so we don't leak a
+                # zombie before dropping the handle.
+                try:
+                    os.killpg(pgid, signal.SIGKILL)
+                    self._proc.wait(timeout=3)
+                except (
+                    ProcessLookupError,
+                    OSError,
+                    subprocess.TimeoutExpired,
+                ):
+                    pass
+            except (ProcessLookupError, OSError):
+                pass
+        self._proc = None
 
     def is_playing(self) -> bool:
-        return self.player.get_state() in [
-            self._vlc.State.Playing,
-            self._vlc.State.Buffering,
-            self._vlc.State.Opening,
-        ]
+        return self._proc is not None and self._proc.poll() is None
 
 
 class MediaPlayerProxy:
@@ -422,28 +566,28 @@ class MediaPlayerProxy:
     @classmethod
     def get_instance(cls) -> MediaPlayer:
         if cls.INSTANCE is None:
-            # Force MPV (over VLC) on the device_types that otherwise
-            # match the Pi-name dispatch below:
+            # The Qt5 linuxfb boards (pi1/pi2/pi3) use
+            # GstFbdevMediaPlayer: HW decode + HW scale/convert via V4L2
+            # (bcm2835 codec + ISP) → fbdevsink. Every other board is
+            # Qt6 + in-process QtMultimedia (MPVMediaPlayer over D-Bus).
+            # Pi 4 is intentionally NOT in the dispatch list: it reports
+            # device_type 'pi4' (eglfs/Qt6), so it falls straight to the
+            # else → mpv, even if DEVICE_TYPE is missing/mis-set.
             #
-            #   * pi4-64 — Qt6 + linuxfb like pi5/x86, so VLC's
-            #     GL/GLES2/XCB outputs have no parent window to draw
-            #     into. MPV renders straight to KMS via --vo=drm.
-            #   * arm64 / generic-arm64 —
-            #     device_helper.get_device_type() falls back to
-            #     'pi1' on any aarch64 host whose
-            #     /proc/device-tree/model isn't a Pi regex match
-            #     (Rock Pi, Orange Pi, Banana Pi, …); without this
-            #     override they'd silently route to VLC, which has
-            #     no working backend on those boards (no vc4 KMS,
-            #     no XCB under cage). ``generic-arm64`` covers
-            #     pre-rename images still in the wild.
+            # force_mpv guards only the masquerade case:
+            # get_device_type() falls back to 'pi1' for any host whose
+            # /proc/device-tree/model doesn't match a Pi regex — a non-Pi
+            # aarch64 SBC (Rock Pi, Orange Pi, …) or a Pi whose model node
+            # is unreadable. DEVICE_TYPE is authoritative there, so an
+            # image built for a Qt6 board overrides the 'pi1' fallback
+            # back to mpv:
+            #   * pi4-64 — the 64-bit Pi 4 image (Qt6/eglfs).
+            #   * arm64 / generic-arm64 — non-Pi aarch64 SBCs
+            #     (``generic-arm64`` covers pre-rename images).
             device_env = os.environ.get('DEVICE_TYPE')
             force_mpv = device_env in ('pi4-64', 'arm64', 'generic-arm64')
-            if (
-                get_device_type() in ['pi1', 'pi2', 'pi3', 'pi4']
-                and not force_mpv
-            ):
-                cls.INSTANCE = VLCMediaPlayer()
+            if get_device_type() in ['pi1', 'pi2', 'pi3'] and not force_mpv:
+                cls.INSTANCE = GstFbdevMediaPlayer()
             else:
                 cls.INSTANCE = MPVMediaPlayer()
 
@@ -453,11 +597,12 @@ class MediaPlayerProxy:
     def reset(cls) -> None:
         """Drop the cached player so the next ``get_instance`` rebuilds it.
 
-        VLC bakes the transform filter into ``vlc.Instance(options)``
-        at init time, so a rotation change from the Settings page only
-        takes effect on the next play after we re-init. mpv re-reads
-        rotation per play and is unaffected, but calling reset() is
-        cheap and harmless either way.
+        Both players now re-read ``screen_rotation`` per play()
+        (GstFbdevMediaPlayer composes the ``videoflip`` element in
+        _video_sink; MPVMediaPlayer sends it over D-Bus), so a
+        rotation change from the Settings page takes effect on the next
+        play without a rebuild — but calling reset() is cheap and
+        harmless, and it also re-probes the framebuffer geometry.
         """
         if cls.INSTANCE is not None:
             try:

--- a/src/anthias_webview/AnthiasViewer.pro
+++ b/src/anthias_webview/AnthiasViewer.pro
@@ -19,8 +19,8 @@ CONFIG += c++17
 # caught the prior ``setProperty("rotation", …)`` shortcut as a
 # silent no-op on Pi 4).
 #
-# VideoView only builds against Qt 6. The Qt 5 boards (Pi 2 /
-# Pi 3) route video through VLCMediaPlayer on the Python side
+# VideoView only builds against Qt 6. The Qt 5 boards (Pi 1 /
+# Pi 2 / Pi 3) route video through GstFbdevMediaPlayer on the Python side
 # (see ``src/anthias_viewer/media_player.py::MediaPlayerProxy``)
 # which paints straight to the framebuffer and never talks to the
 # AnthiasViewer ``playVideo`` D-Bus slot — so the Qt5 build skips

--- a/src/anthias_webview/src/mainwindow.h
+++ b/src/anthias_webview/src/mainwindow.h
@@ -25,7 +25,7 @@ class MainWindow : public QMainWindow
         // argv: ``hwdec``, ``audio-device``, ``video-sync``,
         // ``vd-lavc-threads``, ``video-rotate``. Values are coerced
         // to UTF-8 strings via QVariant::toString(). Qt 5 boards
-        // (Pi 2 / Pi 3) route video through VLCMediaPlayer on the
+        // (Pi 1 / Pi 2 / Pi 3) route video through GstFbdevMediaPlayer on the
         // Python side and never call these slots, so they're
         // compiled out below the Qt-version gate.
         void playVideo(const QString &uri, const QVariantMap &options);

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -176,8 +176,8 @@ View::View(QWidget* parent) : QWidget(parent)
     // made visible when ``playVideo`` fires. The QMediaPlayer +
     // QGraphicsVideoItem live for the lifetime of this widget so
     // repeated plays don't pay pipeline-rebuild cost on every
-    // asset. Qt 5 boards (Pi 2 / Pi 3) skip this — video plays via
-    // VLCMediaPlayer painting straight to the framebuffer.
+    // asset. Qt 5 boards (Pi 1 / Pi 2 / Pi 3) skip this — video plays via
+    // GstFbdevMediaPlayer painting straight to the framebuffer.
     videoView = new VideoView(this);
     videoView->setVisible(false);
     connect(videoView, &VideoView::videoEnded, this, &View::videoEnded);

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -32,7 +32,7 @@ public:
     // image canvas. Pauses background URL loads so a parked
     // QWebEngineView doesn't keep streaming while video plays.
     //
-    // Qt 5 boards (Pi 2 / Pi 3) route video through VLCMediaPlayer
+    // Qt 5 boards (Pi 1 / Pi 2 / Pi 3) route video through GstFbdevMediaPlayer
     // painting straight to the framebuffer (see
     // ``MediaPlayerProxy.get_instance`` in
     // ``src/anthias_viewer/media_player.py``), so the in-process

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -1,4 +1,5 @@
 import logging
+import signal
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -6,11 +7,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from anthias_viewer.media_player import (
+    GstFbdevMediaPlayer,
     MPVMediaPlayer,
     MediaPlayerProxy,
-    VLCMediaPlayer,
     get_alsa_audio_device,
 )
+from anthias_viewer import media_player as media_player_module
 
 logging.disable(logging.CRITICAL)
 
@@ -536,45 +538,162 @@ def test_detect_hdmi_falls_back_on_oserror() -> None:
         assert _detect_hdmi_audio_device() == 'sysdefault:CARD=vc4hdmi0'
 
 
-class _VLCFixtures:
-    player: VLCMediaPlayer
-    mock_media: Any
-    mock_vlc_player: Any
+class _GstFixtures:
+    player: GstFbdevMediaPlayer
     mock_settings: Any
 
 
 @pytest.fixture
-def vlc() -> Iterator[_VLCFixtures]:
-    fixtures = _VLCFixtures()
-    with patch.object(VLCMediaPlayer, '__init__', return_value=None):
-        fixtures.player = VLCMediaPlayer()
-
-    fixtures.mock_media = MagicMock()
-    fixtures.mock_vlc_player = MagicMock()
-    fixtures.mock_vlc_player.get_media.return_value = fixtures.mock_media
-    fixtures.player.player = fixtures.mock_vlc_player
+def gstfb() -> Iterator[_GstFixtures]:
+    fixtures = _GstFixtures()
+    # Pin the framebuffer geometry/format so the test doesn't depend on
+    # the host's /sys/class/graphics/fb0.
+    with patch(
+        'anthias_viewer.media_player._fb_geometry',
+        return_value=(1920, 1080, 'RGB16'),
+    ):
+        fixtures.player = GstFbdevMediaPlayer()
 
     patch_settings = patch('anthias_viewer.media_player.settings')
-    patch_device_type = patch(
-        'anthias_viewer.media_player.get_device_type', return_value='pi4'
+    patch_rotation = patch(
+        'anthias_viewer.media_player._screen_rotation', return_value=0
     )
-
+    patch_alsa = patch(
+        'anthias_viewer.media_player.get_alsa_audio_device',
+        return_value='sysdefault:CARD=vc4hdmi0',
+    )
     fixtures.mock_settings = patch_settings.start()
-    fixtures.mock_settings.__getitem__.return_value = 'hdmi'
-    patch_device_type.start()
-
+    patch_rotation.start()
+    patch_alsa.start()
     try:
         yield fixtures
     finally:
         patch_settings.stop()
-        patch_device_type.stop()
+        patch_rotation.stop()
+        patch_alsa.stop()
 
 
-def test_set_asset_invokes_parse(vlc: _VLCFixtures) -> None:
-    vlc.player.set_asset('file:///test/video.mp4', 30)
+def test_set_asset_stores_uri_and_reloads_settings(
+    gstfb: _GstFixtures,
+) -> None:
+    gstfb.player.set_asset('file:///test/video.mp4', 30)
+    assert gstfb.player.uri == 'file:///test/video.mp4'
+    gstfb.mock_settings.load.assert_called_once()
 
-    vlc.mock_vlc_player.get_media.assert_called_once()
-    vlc.mock_media.parse.assert_called_once()
+
+def test_build_command_uses_playbin_hw_pipeline(gstfb: _GstFixtures) -> None:
+    gstfb.player.uri = 'file:///test/video.mp4'
+    cmd = gstfb.player._build_command()
+    assert cmd[0] == 'gst-launch-1.0'
+    assert 'playbin' in cmd
+    assert 'uri=file:///test/video.mp4' in cmd
+    video_sink = next(a for a in cmd if a.startswith('video-sink='))
+    # HW decode (playbin auto-plugs v4l2h264dec) + HW scale/convert via
+    # the bcm2835 ISP (v4l2convert) → framebuffer, no DRM/X.
+    assert 'v4l2convert' in video_sink
+    assert 'fbdevsink device=/dev/fb0' in video_sink
+    assert 'format=RGB16,width=1920,height=1080' in video_sink
+    # Unrotated panel → no videoflip, pipeline stays fully hardware.
+    assert 'videoflip' not in video_sink
+    audio_sink = next(a for a in cmd if a.startswith('audio-sink='))
+    assert 'alsasink device=sysdefault:CARD=vc4hdmi0' in audio_sink
+
+
+def test_build_command_wraps_bare_path_as_file_uri(
+    gstfb: _GstFixtures,
+) -> None:
+    # Local assets store a bare absolute path; playbin's uri property
+    # rejects anything without a scheme, so it must be file://-wrapped
+    # (regression: a bare path black-screened every local video).
+    gstfb.player.uri = '/data/.anthias/assets/abc123'
+    cmd = gstfb.player._build_command()
+    assert 'uri=file:///data/.anthias/assets/abc123' in cmd
+
+
+def test_build_command_passes_through_scheme_uris(
+    gstfb: _GstFixtures,
+) -> None:
+    for uri in (
+        # NOSONAR: the http:// case is the point — _as_gst_uri must pass
+        # any already-schemed URI through untouched; no connection is made.
+        'http://example.com/v.mp4',  # NOSONAR
+        'https://host/v.mp4',
+        'file:///already/a/uri.mp4',
+    ):
+        gstfb.player.uri = uri
+        cmd = gstfb.player._build_command()
+        assert f'uri={uri}' in cmd
+
+
+def test_build_command_quotes_spaces_in_bare_path(
+    gstfb: _GstFixtures,
+) -> None:
+    gstfb.player.uri = '/data/.anthias/assets/my clip.mp4'
+    cmd = gstfb.player._build_command()
+    assert 'uri=file:///data/.anthias/assets/my%20clip.mp4' in cmd
+
+
+def test_build_command_rotation_adds_videoflip(gstfb: _GstFixtures) -> None:
+    gstfb.player.uri = 'file:///test/video.mp4'
+    with patch(
+        'anthias_viewer.media_player._screen_rotation', return_value=90
+    ):
+        cmd = gstfb.player._build_command()
+    video_sink = next(a for a in cmd if a.startswith('video-sink='))
+    assert 'videoflip method=clockwise' in video_sink
+
+
+def test_play_spawns_gst_loop_and_is_playing(gstfb: _GstFixtures) -> None:
+    gstfb.player.uri = 'file:///test/video.mp4'
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None  # alive
+    with patch(
+        'anthias_viewer.media_player.subprocess.Popen', return_value=fake_proc
+    ) as mock_popen:
+        gstfb.player.play()
+    mock_popen.assert_called_once()
+    argv = mock_popen.call_args.args[0]
+    # Looping wrapper re-launches playbin on EOS; gst argv passed via
+    # "$@" so the video-sink bin survives without shell re-splitting.
+    assert argv[0] == 'bash'
+    assert 'gst-launch-1.0' in argv and 'playbin' in argv
+    # New session group so stop() can kill bash + gst-launch together.
+    assert mock_popen.call_args.kwargs['start_new_session'] is True
+    assert gstfb.player.is_playing() is True
+
+
+def test_stop_kills_process_group(gstfb: _GstFixtures) -> None:
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+    fake_proc.pid = 4242
+    gstfb.player._proc = fake_proc
+    with (
+        patch('anthias_viewer.media_player.os.getpgid', return_value=4242),
+        patch('anthias_viewer.media_player.os.killpg') as mock_killpg,
+    ):
+        gstfb.player.stop()
+    mock_killpg.assert_called_once_with(4242, signal.SIGTERM)
+    assert gstfb.player._proc is None
+
+
+def test_is_playing_false_when_process_exited(gstfb: _GstFixtures) -> None:
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = 0  # exited
+    gstfb.player._proc = fake_proc
+    assert gstfb.player.is_playing() is False
+
+
+def test_fb_geometry_parses_sysfs() -> None:
+    def fake_open(path: str, *a: Any, **k: Any) -> Any:
+        data = '1280,720\n' if 'virtual_size' in path else '32\n'
+        return MagicMock(
+            __enter__=lambda s: MagicMock(read=lambda: data),
+            __exit__=lambda *a: None,
+        )
+
+    with patch('builtins.open', side_effect=fake_open):
+        w, h, fb_fmt = media_player_module._fb_geometry()
+    assert (w, h, fb_fmt) == (1280, 720, 'BGRx')
 
 
 @pytest.fixture
@@ -586,8 +705,8 @@ def reset_media_proxy() -> Iterator[None]:
         MediaPlayerProxy.INSTANCE = None
 
 
-@pytest.mark.parametrize('device_type', ['pi1', 'pi2', 'pi3', 'pi4'])
-def test_get_instance_returns_vlc_for_pi_devices(
+@pytest.mark.parametrize('device_type', ['pi1', 'pi2', 'pi3'])
+def test_get_instance_returns_gst_fbdev_for_pi_devices(
     reset_media_proxy: None, device_type: str
 ) -> None:
     MediaPlayerProxy.INSTANCE = None
@@ -597,10 +716,28 @@ def test_get_instance_returns_vlc_for_pi_devices(
             return_value=device_type,
         ),
         patch.dict('os.environ', {'DEVICE_TYPE': device_type}),
+        patch.object(GstFbdevMediaPlayer, '__init__', return_value=None),
     ):
-        with patch.object(VLCMediaPlayer, '__init__', return_value=None):
-            instance = MediaPlayerProxy.get_instance()
-    assert isinstance(instance, VLCMediaPlayer)
+        instance = MediaPlayerProxy.get_instance()
+    assert isinstance(instance, GstFbdevMediaPlayer)
+
+
+def test_get_instance_pi4_never_routes_to_fbdev(
+    reset_media_proxy: None,
+) -> None:
+    # A Pi 4 reports device_type 'pi4' (Qt6/eglfs). Even when DEVICE_TYPE
+    # is missing/mis-set (here: not the 'pi4-64' the override looks for,
+    # so force_mpv is False), it must NOT fall to the linuxfb fbdev
+    # player — 'pi4' is deliberately absent from the dispatch list.
+    MediaPlayerProxy.INSTANCE = None
+    with (
+        patch(
+            'anthias_viewer.media_player.get_device_type', return_value='pi4'
+        ),
+        patch.dict('os.environ', {'DEVICE_TYPE': 'pi4'}),
+    ):
+        instance = MediaPlayerProxy.get_instance()
+    assert isinstance(instance, MPVMediaPlayer)
 
 
 @pytest.mark.parametrize('device_type', ['pi5', 'x86'])

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -336,13 +336,36 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
         # libgst-dev / libsqlite0-dev / libsrtp0-dev were dropped in
         # trixie — libsqlite3-dev and libsrtp2-dev are already in the
         # main viewer apt list above; libgstreamer1.0-dev is Qt 5-only
-        # and is added in the extend() below. VLC is Qt5-only because
-        # MediaPlayerProxy only routes pi2/pi3 to VLCMediaPlayer.
+        # and is added in the extend() below.
+        #
+        # GstFbdevMediaPlayer (src/anthias_viewer/media_player.py)
+        # plays pi1/pi2/pi3 video by shelling out to ``gst-launch-1.0
+        # playbin`` with a fully-hardware sink: v4l2h264dec (bcm2835
+        # codec) decodes, v4l2convert (bcm2835 ISP) HW-scales + converts
+        # YUV→framebuffer-format, fbdevsink paints /dev/fb0 (no DRM
+        # master / compositor needed). The +rpt1 GStreamer stack from
+        # archive.raspberrypi.org (added in base for libraspberrypi0)
+        # supplies the runtime pieces:
+        #   * gstreamer1.0-tools — the gst-launch-1.0 binary
+        #   * -plugins-base — playbin, videoconvert
+        #   * -plugins-good — the V4L2 elements (v4l2h264dec /
+        #     v4l2convert) + qtdemux
+        #   * -plugins-bad — fbdevsink
+        #   * -alsa — alsasink (Debian ships the ALSA sink in its own
+        #     package, NOT in -plugins-base; the player's
+        #     ``audio-sink=alsasink device=...`` fails pipeline
+        #     construction without it, black-screening *all* video).
+        # VLC was dropped when GstFbdevMediaPlayer replaced
+        # VLCMediaPlayer — nothing on pi1/pi2/pi3 links it anymore.
         viewer_extra_apt_dependencies.extend(
             [
+                'gstreamer1.0-alsa',
+                'gstreamer1.0-plugins-bad',
+                'gstreamer1.0-plugins-base',
+                'gstreamer1.0-plugins-good',
+                'gstreamer1.0-tools',
                 'libgstreamer1.0-dev',
                 'qt5-image-formats-plugins',
-                'vlc',
             ]
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,6 @@ test = [
     { name = "pytest-playwright" },
     { name = "pytest-xdist" },
     { name = "python-dateutil" },
-    { name = "python-vlc" },
     { name = "pytz" },
     { name = "pyyaml" },
     { name = "redis" },
@@ -245,7 +244,6 @@ viewer = [
     { name = "netifaces" },
     { name = "pydbus" },
     { name = "python-dateutil" },
-    { name = "python-vlc" },
     { name = "pytz" },
     { name = "redis" },
     { name = "requests" },
@@ -391,7 +389,6 @@ test = [
     { name = "pytest-playwright", specifier = "==0.8.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
-    { name = "python-vlc", specifier = "==3.0.21203" },
     { name = "pytz", specifier = "==2026.2" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "redis", specifier = "==7.4.0" },
@@ -412,7 +409,6 @@ viewer = [
     { name = "netifaces", specifier = "==0.11.0" },
     { name = "pydbus", specifier = "==0.6.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
-    { name = "python-vlc", specifier = "==3.0.21203" },
     { name = "pytz", specifier = "==2026.2" },
     { name = "redis", specifier = "==7.4.0" },
     { name = "requests", specifier = "==2.33.1" },
@@ -1832,15 +1828,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
-]
-
-[[package]]
-name = "python-vlc"
-version = "3.0.21203"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/5b/f9ce6f0c9877b6fe5eafbade55e0dcb6b2b30f1c2c95837aef40e390d63b/python_vlc-3.0.21203.tar.gz", hash = "sha256:52d0544b276b11e58b6c0b748c3e0518f94f74b1b4cd328c83a59eacabead1ec", size = 162211, upload-time = "2024-10-07T14:39:54.755Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/ee/7d76eb3b50ccb1397621f32ede0fb4d17aa55a9aa2251bc34e6b9929fdce/python_vlc-3.0.21203-py3-none-any.whl", hash = "sha256:1613451a31b692ec276296ceeae0c0ba82bfc2d094dabf9aceb70f58944a6320", size = 87651, upload-time = "2024-10-07T14:39:50.021Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Issue Fixed

**pi2/pi3 (Qt5 linuxfb) video plays black fleet-wide.** Reproduced + root-caused on a Pi 3B+ (across *every* OS version, so not a recent regression in itself): `Showing asset … (video)` is logged but nothing reaches the screen. Images/webpages are fine; pi4/pi5/x86 are fine (Qt6 in-process QtMultimedia).

### Root cause

- These boards used to play video with VLC's Broadcom **`--vout=mmal_vout`** (HW decode, HW scale, HW color-convert, HW scanout — no DRM master). The Bookworm upgrade (#1980) dropped `mmal` and **nothing replaced the vout**.
- With no `--vout`, VLC falls back to outputs that can't drive a bare linuxfb console: the rpidistro `drm_vout` wants a **compositor DRM lease** (`Failed to get xlease` — there's no X/Wayland), and the KMS/master vouts need **DRM master**, which a **uid-1000 viewer can't acquire** (the viewer's python process already holds `card0` → `EBUSY`/`EPERM`). mpv `--vo=drm` hits the same `EBUSY`.

### Fix

Replace `VLCMediaPlayer` with **`GstFbdevMediaPlayer`** for the linuxfb boards (pi1/pi2/pi3): spawn `gst-launch-1.0 playbin` with a **fully-hardware** video sink that reaches `/dev/fb0` without any DRM master / compositor:

```
playbin → v4l2h264dec (bcm2835 codec, HW decode)
        → v4l2convert (bcm2835 ISP, HW scale + YUV→fb-format)
        → fbdevsink /dev/fb0
```

This drives the **same VPU + ISP silicon mmal used** — decode, scale and color-convert all stay in hardware; only the final framebuffer write is a CPU memcpy. `playbin` gives container-agnostic demux, auto-plugs the HW decoder (`v4l2h264dec` at PRIMARY rank), and degrades gracefully when a clip has no audio track. Rotation rides `videoflip`, inserted only when the panel is actually rotated.

### Why not ffmpeg → fbdev

An interim `FFmpegFbdevMediaPlayer` (ffmpeg HW-decode → CPU convert → `-f fbdev`) was built and then **abandoned after benchmarking on the Pi 3**: HW decode worked (~60 fps), but doing the YUV→RGB convert + scale on the ARM CPU via swscale managed only **~6 fps to rgb565** (no NEON rgb565 path) and ~28 fps to bgra — and any real scaling collapsed it further. `v4l2convert` moves that work back onto the ISP, which is what the **~40 fps, 0-drop** benchmark above measures. (An earlier "decode hang" scare turned out to be a malformed *trimmed* test clip that didn't start on an IDR — the strict HW decoder waits for a random-access point; well-formed clips decode fine.)

### Description

- New `GstFbdevMediaPlayer`: builds the `gst-launch playbin` argv, loops the on-screen slot by re-launching on EOS (breaks on error), and kills by **process group** so no `gst-launch` orphan keeps the framebuffer. Reads fb geometry/format from `/sys/class/graphics/fb0` to pin the `v4l2convert` output caps.
- `MediaPlayerProxy` routes pi1/pi2/pi3 → `GstFbdevMediaPlayer`; everything else (incl. forced `pi4-64`/`arm64`) stays on `MPVMediaPlayer`.
- Image: add `gstreamer1.0-{tools,plugins-base,plugins-good,plugins-bad}` to the Qt5 viewer; **drop the now-unused `vlc` apt package + `python-vlc` dep** (+ its mypy override).
- Docs (`docs/board-enablement.md`), the upload-gate comment in `processing.py`, and C++/`.pro` comments updated.


### On-device validation

Run on a live fleet Pi 3 (HDMI attached). This surfaced — and the PR fixes — two bugs that the headless benchmark could not (it used `file://` URIs and `fakesink` audio):

1. **Bare-path URI** — local assets store a bare absolute path, but `playbin`'s `uri` needs a scheme; `_as_gst_uri()` now wraps bare paths as `file://`.
2. **Missing `alsasink`** — Debian ships the ALSA sink in `gstreamer1.0-alsa` (not `-plugins-base`); without it the `audio-sink=alsasink …` fails pipeline construction and black-screens *all* video. Added to the image deps.

After both fixes the full pipeline renders correctly on real hardware.
### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally (962 passed) and lint/format are clean.
- [x] **End-to-end validated on a live balena Pi 3** (HDMI connected, 1920×1080 @16bpp rgb565): the full pipeline (`v4l2h264dec` → `v4l2convert`→RGB16 → `fbdevsink` + `alsasink` HDMI audio) constructs and writes motion video to the real `/dev/fb0` with zero pipeline errors (verified by capturing the framebuffer across frames). HW decode + scale + convert benchmarked at ~40 fps / 0 drops.
- [x] x86 — N/A (linuxfb-only path; x86 uses QtMultimedia).
- [x] Documentation updated (`docs/board-enablement.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

