### PR TITLE
fix(viewer): emit 270° eglfs rotation as -90 so portrait-inverted isn't stretched

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -176,7 +176,15 @@ def _build_webview_env() -> dict[str, str]:
     qpa = env.get('QT_QPA_PLATFORM', 'linuxfb')
     if qpa.partition(':')[0] == 'eglfs':
         if rotation:
-            env['QT_QPA_EGLFS_ROTATION'] = str(rotation)
+            # eglfs only understands 180, 90 and -90. A literal 270
+            # hits the "Invalid rotation" default branch in
+            # QEglFSScreen::geometry(), so the QOpenGLCompositor still
+            # rotates the content but the screen geometry never swaps
+            # to portrait — the window lays out landscape and renders
+            # stretched (issue #2970). Spell 270° as -90 instead.
+            env['QT_QPA_EGLFS_ROTATION'] = str(
+                -90 if rotation == 270 else rotation
+            )
         else:
             # Drop a stale value so dialling back to 0 actually
             # un-rotates on the respawned process.

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -939,12 +939,20 @@ def test_build_webview_env_removes_stale_rotation_when_dialed_to_zero() -> (
     assert env['QT_QPA_PLATFORM'] == 'linuxfb:fb=/dev/fb1'
 
 
-@pytest.mark.parametrize('rotation', [90, 180, 270])
-def test_build_webview_env_sets_eglfs_rotation(rotation: int) -> None:
+@pytest.mark.parametrize(
+    ('rotation', 'expected'),
+    [(90, '90'), (180, '180'), (270, '-90')],
+)
+def test_build_webview_env_sets_eglfs_rotation(
+    rotation: int, expected: str
+) -> None:
     """Pi 4 runs eglfs, which ignores the linuxfb ``:rotation=N`` plugin
     option (that silent no-op was the 2026.06.0 bug). eglfs reads
     QT_QPA_EGLFS_ROTATION at QPA init instead, so we set that and leave
-    QT_QPA_PLATFORM untouched."""
+    QT_QPA_PLATFORM untouched. eglfs only accepts 180/90/-90 — a literal
+    270 rotates the content without swapping the screen geometry to
+    portrait, rendering everything stretched (issue #2970) — so 270°
+    must be emitted as -90."""
     with (
         mock.patch.dict(settings, {'screen_rotation': rotation}),
         mock.patch.dict(
@@ -954,7 +962,7 @@ def test_build_webview_env_sets_eglfs_rotation(rotation: int) -> None:
         ),
     ):
         env = viewer._build_webview_env()
-    assert env['QT_QPA_EGLFS_ROTATION'] == str(rotation)
+    assert env['QT_QPA_EGLFS_ROTATION'] == expected
     # The platform string must stay a bare plugin — appending
     # ``:rotation=N`` here is exactly the no-op that broke Pi 4.
     assert env['QT_QPA_PLATFORM'] == 'eglfs'


### PR DESCRIPTION
### Issues Fixed

Follow-up to https://github.com/Screenly/Anthias/issues/2970 (and #2971): [salmanfarisvp's retest](https://github.com/Screenly/Anthias/issues/2970#issuecomment-4601449674) confirmed 0/90/180 now rotate correctly on Pi 4, but 270° (portrait inverted) renders stretched.

### Description

`QT_QPA_EGLFS_ROTATION` only accepts `180`, `90` and `-90`. A literal `270` hits the `default:` ("Invalid rotation") branch in `QEglFSScreen::geometry()`: the QOpenGLCompositor still rotates the content by 270°, but the screen geometry never swaps to portrait — the window lays out 1920x1080 landscape and gets squeezed into the portrait orientation, i.e. the stretch in the report.

- Map `270` → `-90` when composing the webview env in `_build_webview_env` (identical orientation mod 360, but takes the width/height-swap path in Qt).
- Extend the eglfs rotation test to assert the `-90` spelling for 270°.

Validated on the Pi 4 testbed by probing the live webview viewport over D-Bus at `screen_rotation=270`:

| | viewport |
|---|---|
| before (`QT_QPA_EGLFS_ROTATION=270`) | `1920x1080` (landscape layout, stretched) |
| after (`QT_QPA_EGLFS_ROTATION=-90`) | `1080x1920` (portrait, correct) |

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices. (n/a — x86 rotates via wlr-randr, code path untouched)
- [ ] I added a documentation for the changes I have made (when necessary). (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)