### PR TITLE
perf(viewer): render video via QML VideoOutput in a QQuickWidget

### DIFF
--- a/bin/test_webview_cpp.sh
+++ b/bin/test_webview_cpp.sh
@@ -31,8 +31,10 @@ make -j"$(nproc)"
 # QTEST_MAIN's generated binary exits non-zero on any test failure.
 # ``QT_QPA_PLATFORM=offscreen`` skips connecting to a real display
 # server / framebuffer — the tests don't render, they exercise
-# the QMediaPlayer / QGraphicsVideoItem API surface plus the
-# rotation transform.
-QT_QPA_PLATFORM=offscreen ./AnthiasViewerTests
+# the QMediaPlayer / VideoOutput API surface plus the option
+# plumbing. ``QT_QUICK_BACKEND=software`` keeps the QQuickWidget's
+# scene graph off the GPU so the QML scene loads on hosts whose
+# offscreen platform has no usable GL context.
+QT_QPA_PLATFORM=offscreen QT_QUICK_BACKEND=software ./AnthiasViewerTests
 
 popd >/dev/null

--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -18,11 +18,14 @@ RUN --mount=type=cache,target=/var/cache/apt,id=qt6-builder-apt-{{ artifact_boar
     apt-get install -y --no-install-recommends \
         build-essential \
         qt6-base-dev \
+        qt6-declarative-dev \
         qt6-multimedia-dev \
         qt6-webengine-dev
-# qt6-multimedia-dev: AnthiasViewer's VideoView wraps QMediaPlayer +
-# QGraphicsVideoItem (issue #2904, see
-# ``src/anthias_webview/AnthiasViewer.pro``). Qt 6.5 dropped the
+# qt6-multimedia-dev: AnthiasViewer's VideoView wraps QMediaPlayer
+# rendering into a QML ``VideoOutput`` (issue #2904, render path
+# reworked for #2967 — see ``src/anthias_webview/videoview.h``).
+# qt6-declarative-dev: the QQuickWidget that hosts the VideoOutput
+# scene (QT += quickwidgets). Qt 6.5 dropped the
 # upstream gstreamer media backend, so Debian Trixie ships only the
 # ffmpeg-backed ``libffmpegmediaplugin.so`` — decode runs through
 # libavcodec directly against the +rpt1 ``libav*`` packages pinned in
@@ -89,7 +92,7 @@ ENV QT_QPA_PLATFORM=wayland
 {% elif board == 'pi4-64' %}
 # Pi 4 switched from ``linuxfb`` to ``eglfs`` for issue #2904:
 # QtMultimedia's video pipeline needs an OpenGL context for the
-# QGraphicsVideoItem painter, and ``linuxfb`` has none. ``eglfs``
+# VideoOutput scene graph, and ``linuxfb`` has none. ``eglfs``
 # (the Qt KMS/EGL platform) gives Qt a GL context paired with
 # KMS scanout. ``QT_QPA_EGLFS_KMS_CONFIG`` pins 1080p — the V3D
 # 6.0 can't composite Chromium + the video graphics view on top

--- a/docs/board-enablement.md
+++ b/docs/board-enablement.md
@@ -131,13 +131,16 @@ userspace baseline is unaffected on every board.
 
 ### Decode path (post-#2905)
 
-Playback runs through QtMultimedia (`QMediaPlayer` + `QGraphicsVideoItem`)
-embedded in `AnthiasViewer`. Qt 6.5 dropped the upstream gstreamer media
-backend, so Debian Trixie ships only the ffmpeg-backed
-`libffmpegmediaplugin.so`, which calls libavcodec internally. The libmpv
-subprocess and the per-codec `--hwdec=` dispatch the prior viewer revisions
-relied on are both gone — Anthias no longer hand-selects a decoder. **As a
-consequence: libavcodec's default decoder choice is what runs on this board.**
+Playback runs through QtMultimedia (`QMediaPlayer` rendering into a QML
+`VideoOutput` hosted in a `QQuickWidget` — issue #2967 replaced the original
+`QGraphicsVideoItem` substrate, whose per-frame `toImage()` GPU→CPU readback
+capped presentation at 8–12 fps) embedded in `AnthiasViewer`. Qt 6.5 dropped
+the upstream gstreamer media backend, so Debian Trixie ships only the
+ffmpeg-backed `libffmpegmediaplugin.so`, which calls libavcodec internally.
+The libmpv subprocess and the per-codec `--hwdec=` dispatch the prior viewer
+revisions relied on are both gone — Anthias no longer hand-selects a decoder.
+**As a consequence: libavcodec's default decoder choice is what runs on this
+board.**
 
 ### Known hardware-decode limitation on RK3399
 

--- a/src/anthias_webview/AnthiasViewer.pro
+++ b/src/anthias_webview/AnthiasViewer.pro
@@ -12,12 +12,13 @@ CONFIG += c++17
 # ffmpeg-backed ``libffmpegmediaplugin.so``; libavcodec engages
 # the v4l2_request / v4l2_m2m decoders directly via the +rpt1
 # packages pinned in ``docker/_rpt1-ffmpeg-pin.j2`` — no
-# gstreamer plugin set needed. VideoView builds the render path
-# from ``QMediaPlayer`` → ``QGraphicsVideoItem`` so the
-# ``video-rotate`` option actually rotates the displayed frames
-# (``QVideoWidget`` has no rotation property; reviewing PR #2905
-# caught the prior ``setProperty("rotation", …)`` shortcut as a
-# silent no-op on Pi 4).
+# gstreamer plugin set needed. VideoView renders through a QML
+# ``VideoOutput`` hosted in a ``QQuickWidget`` (quickwidgets):
+# frames stay on the GPU as scene-graph textures with shader
+# YUV→RGB. The prior ``QMediaPlayer`` → ``QGraphicsVideoItem``
+# path presented at 8–12 fps because ``QVideoFrame::toImage``
+# does an RHI offscreen render + GPU→CPU readback per frame
+# (issue #2967) — see videoview.h for the full history.
 #
 # VideoView only builds against Qt 6. The Qt 5 boards (Pi 1 /
 # Pi 2 / Pi 3) route video through GstFbdevMediaPlayer on the Python side
@@ -37,9 +38,10 @@ HEADERS += \
     src/view.h
 
 greaterThan(QT_MAJOR_VERSION, 5) {
-    QT += multimedia multimediawidgets
+    QT += multimedia quickwidgets
     SOURCES += src/videoview.cpp
     HEADERS += src/videoview.h
+    RESOURCES += src/videoview.qrc
 }
 
 # Default rules for deployment.

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -5,13 +5,13 @@
 #include <QDebug>
 #include <QDir>
 #include <QFileInfo>
-#include <QGraphicsScene>
-#include <QGraphicsVideoItem>
-#include <QGraphicsView>
 #include <QMediaDevices>
 #include <QMediaMetaData>
+#include <QQmlError>
+#include <QQuickItem>
+#include <QQuickWidget>
+#include <QQuickWindow>
 #include <QRegularExpression>
-#include <QSizeF>
 #include <QVariant>
 #include <QVideoFrame>
 #include <QVideoSink>
@@ -20,38 +20,66 @@
 
 VideoView::VideoView(QWidget* parent) : QWidget(parent)
 {
-    // Black background so the surface doesn't flash white at the
-    // start of playback while libavcodec's V4L2 decoder negotiates
-    // its first capture buffer.
-    setAutoFillBackground(true);
-    QPalette pal = palette();
-    pal.setColor(QPalette::Window, Qt::black);
-    setPalette(pal);
-
     videoLayout = new QHBoxLayout(this);
     videoLayout->setContentsMargins(0, 0, 0, 0);
     videoLayout->setSpacing(0);
 
-    graphicsScene = new QGraphicsScene(this);
-    graphicsScene->setBackgroundBrush(Qt::black);
-    graphicsView = new QGraphicsView(graphicsScene, this);
-    graphicsView->setFrameShape(QFrame::NoFrame);
-    graphicsView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    graphicsView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    graphicsView->setRenderHint(QPainter::SmoothPixmapTransform);
-    graphicsView->setAlignment(Qt::AlignCenter);
-    videoLayout->addWidget(graphicsView);
+    // QML VideoOutput in a QQuickWidget: frames render through the
+    // RHI scene graph (shader YUV→RGB at composite time) instead of
+    // the QGraphicsVideoItem toImage()-readback-blit chain that
+    // capped presentation at 8–12 fps (issue #2967, see videoview.h).
+    // Black backdrop is two layers with distinct jobs: ``clearColor``
+    // covers the pre-QML-load window, the QML Rectangle provides the
+    // steady-state letterbox fill around PreserveAspectFit. (No
+    // widget-palette layer on top — the QQuickWidget fills the whole
+    // layout, so a palette would be permanently occluded.)
+    quickWidget = new QQuickWidget(this);
+    quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    quickWidget->setClearColor(Qt::black);
+    quickWidget->setSource(QUrl(QStringLiteral("qrc:/videoview.qml")));
+    if (quickWidget->status() == QQuickWidget::Error) {
+        const auto errors = quickWidget->errors();
+        for (const QQmlError& error : errors) {
+            qWarning() << "VideoView: QML load error:" << error.toString();
+        }
+    }
+    videoLayout->addWidget(quickWidget);
 
-    videoItem = new QGraphicsVideoItem;
-    // Aspect-ratio behaviour: keep the source ratio so a 16:9 clip
-    // on a 16:9 display fills the surface without stretching.
-    videoItem->setAspectRatioMode(Qt::KeepAspectRatio);
-    graphicsScene->addItem(videoItem);
+    if (quickWidget->rootObject()) {
+        videoOutputItem = quickWidget->rootObject()
+                              ->findChild<QQuickItem*>(
+                                  QStringLiteral("videoOutput"));
+    }
+    if (videoOutputItem) {
+        // VideoOutput exposes its sink as a property; resolving it
+        // here (rather than player->setVideoOutput(item)) keeps an
+        // explicit QVideoSink* around for the frame-delivery counter.
+        videoSink = qvariant_cast<QVideoSink*>(
+            videoOutputItem->property("videoSink"));
+    }
+    if (!videoOutputItem || !videoSink) {
+        // Fail hard rather than limp into decode-but-render-nowhere:
+        // a kiosk that silently black-screens every video while its
+        // logs read "playing" is the exact failure mode the VLC/mmal
+        // era shipped (docs/board-enablement.md, "rendered to
+        // nowhere"). Aborting hands the device to the existing
+        // spawn-retry / container-restart supervision, which is loud
+        // in fleet telemetry. Most likely cause on a device image:
+        // qml6-module-qtquick / qml6-module-qtmultimedia missing —
+        // the QML import fails at runtime, not the C++ link (see
+        // tools/image_builder/utils.py).
+        qFatal("VideoView: QML video scene unavailable (videoOutput "
+               "item or its videoSink missing — check the QML load "
+               "errors above and the qml6-module-qtquick / "
+               "qml6-module-qtmultimedia packages). Aborting so the "
+               "supervisor restarts the viewer instead of decoding "
+               "video to nowhere.");
+    }
 
     player = new QMediaPlayer(this);
     audioOutput = new QAudioOutput(this);
     player->setAudioOutput(audioOutput);
-    player->setVideoOutput(videoItem);
+    player->setVideoSink(videoSink);
 
     connect(player, &QMediaPlayer::playbackStateChanged,
             this, &VideoView::onPlaybackStateChanged);
@@ -62,21 +90,24 @@ VideoView::VideoView(QWidget* parent) : QWidget(parent)
 
     // Count frames delivered to the sink so SAMPLE / END_FILE lines
     // can report a "frames delivered" → "frames expected" delta.
-    // QVideoSink::videoFrameChanged fires once per displayed frame
-    // (after libavcodec / V4L2 drops happen upstream), which is the
-    // metric we care about — frames that reached the display.
-    if (videoItem->videoSink()) {
-        connect(videoItem->videoSink(), &QVideoSink::videoFrameChanged,
-                this, &VideoView::onVideoFrameDelivered);
-    }
+    // QVideoSink::videoFrameChanged fires once per decoded frame
+    // (after libavcodec / V4L2 drops happen upstream) — the
+    // decode-side rate.
+    connect(videoSink, &QVideoSink::videoFrameChanged,
+            this, &VideoView::onVideoFrameDelivered);
+
+    // Presentation-side counter. Retried from play() in case the
+    // item→window attachment ever lands later than this constructor
+    // (qrc setSource is synchronous on Qt 6.8, but a dead counter
+    // would silently report frames-rendered=0 — the inverse of the
+    // #2967 blind spot — so don't bet the diagnostic on it).
+    connectRenderCounter();
 
     openStatsLog();
 
     statsTimer = new QTimer(this);
     statsTimer->setInterval(1000);
     connect(statsTimer, &QTimer::timeout, this, &VideoView::sampleStats);
-
-    positionVideoItem();
 }
 
 VideoView::~VideoView()
@@ -122,8 +153,8 @@ void VideoView::openStatsLog()
         writeStats(
             QStringLiteral("INIT"),
             QStringLiteral(
-                "backend=qtmultimedia/ffmpeg qt=%1 "
-                "audio_default=%2")
+                "backend=qtmultimedia/ffmpeg sink=quick-videooutput "
+                "qt=%1 audio_default=%2")
                 .arg(QStringLiteral(QT_VERSION_STR),
                      QMediaDevices::defaultAudioOutput().description()));
     } else {
@@ -153,14 +184,14 @@ void VideoView::play(const QString& uri, const QVariantMap& options)
         summary << QStringLiteral("audio-device=%1").arg(alsaSpec);
     }
 
-    // Optional per-item rotation of the QGraphicsVideoItem. No board
+    // Optional per-item rotation of the VideoOutput item. No board
     // sends ``video-rotate`` any more: every platform now rotates the
     // whole screen (eglfs via QT_QPA_EGLFS_ROTATION on Pi 4, wlroots
-    // via wlr-randr on x86) and the video item inherits that transform,
-    // so applying it again here would double-rotate. The parse is kept
-    // as a defensive no-op (default 0 = applyRotation(0)) so an old
-    // viewer that still passes the option degrades gracefully rather
-    // than erroring on an unknown key.
+    // via wlr-randr on x86) and the Quick scene inherits that
+    // transform, so applying it again here would double-rotate. The
+    // parse is kept as a defensive no-op (default 0 = applyRotation(0))
+    // so an old viewer that still passes the option degrades
+    // gracefully rather than erroring on an unknown key.
     int rotation = 0;
     if (options.contains(QStringLiteral("video-rotate"))) {
         bool ok = false;
@@ -173,13 +204,18 @@ void VideoView::play(const QString& uri, const QVariantMap& options)
     }
     applyRotation(rotation);
 
+    // Backstop for the constructor-time connection — see
+    // connectRenderCounter().
+    connectRenderCounter();
+
     currentUri = uri;
     // playStartedAt is RESTARTED on LoadedMedia (not here) so the
     // elapsed-ms window measures real playback time, not decoder
-    // init. Reset framesDelivered now so the very first frame
-    // count is clean.
+    // init. Reset both frame counters now so the very first counts
+    // are clean.
     playStartedAt.invalidate();
     framesDelivered = 0;
+    framesRendered = 0;
     containerFps = 0.0;
     writeStats(
         QStringLiteral("LOADFILE"),
@@ -218,10 +254,11 @@ void VideoView::stop()
             QStringLiteral("STOP"),
             QStringLiteral(
                 "uri=%1 elapsed_ms=%2 frames-delivered=%3 "
-                "position-ms=%4")
+                "frames-rendered=%4 position-ms=%5")
                 .arg(currentUri)
                 .arg(elapsedMs)
                 .arg(framesDelivered)
+                .arg(framesRendered)
                 .arg(player->position()));
     }
     player->stop();
@@ -282,10 +319,11 @@ void VideoView::onMediaStatusChanged(QMediaPlayer::MediaStatus status)
             playStartedAt.isValid() ? playStartedAt.elapsed() : -1;
         // Compare ``frames-delivered`` against the decoder-expected
         // count (container_fps × elapsed_s). The gap = frames
-        // dropped on the way to the display, the same number mpv
-        // exposed as ``frame-drop-count``. Reported with the raw
-        // delivered count so the consumer can recompute if they
-        // disagree with the fps source.
+        // dropped on the way to the sink — the same number mpv
+        // exposed as ``frame-drop-count``. ``frames-rendered`` is
+        // the presentation-side count (scene-graph renders); a
+        // rendered count far below delivered = paint-bound, the
+        // #2967 failure mode the old log could not see.
         const qreal expected =
             containerFps > 0.0 ? containerFps * (elapsedMs / 1000.0) : -1.0;
         const qint64 dropped =
@@ -296,10 +334,11 @@ void VideoView::onMediaStatusChanged(QMediaPlayer::MediaStatus status)
             QStringLiteral("END_FILE"),
             QStringLiteral(
                 "uri=%1 elapsed_ms=%2 frames-delivered=%3 "
-                "expected=%4 dropped=%5")
+                "frames-rendered=%4 expected=%5 dropped=%6")
                 .arg(currentUri)
                 .arg(elapsedMs)
                 .arg(framesDelivered)
+                .arg(framesRendered)
                 .arg(qRound(expected))
                 .arg(dropped));
         if (statsTimer) {
@@ -341,9 +380,11 @@ void VideoView::sampleStats()
     writeStats(
         QStringLiteral("SAMPLE"),
         QStringLiteral(
-            "position-ms=%1 frames-delivered=%2 expected=%3 dropped=%4")
+            "position-ms=%1 frames-delivered=%2 frames-rendered=%3 "
+            "expected=%4 dropped=%5")
             .arg(posMs)
             .arg(framesDelivered)
+            .arg(framesRendered)
             .arg(qRound(expected))
             .arg(dropped));
 }
@@ -351,6 +392,33 @@ void VideoView::sampleStats()
 void VideoView::onVideoFrameDelivered()
 {
     ++framesDelivered;
+}
+
+void VideoView::onSceneRendered()
+{
+    ++framesRendered;
+}
+
+void VideoView::connectRenderCounter()
+{
+    // Count scene-graph renders — the presentation-side rate. The
+    // Quick scene re-renders only on damage, and during playback the
+    // VideoOutput frame updates are the damage, so renders/s ≈
+    // frames actually composited to the screen. This is the counter
+    // whose absence let #2967's 8 fps presentation ship while the
+    // sink-side log read "dropped≈0". Idempotent: no-op once the
+    // connection is made (constructor normally succeeds; play()
+    // retries as a backstop against late item→window attachment).
+    if (renderCounterConnection || !videoOutputItem) {
+        return;
+    }
+    QQuickWindow* window = videoOutputItem->window();
+    if (!window) {
+        return;
+    }
+    renderCounterConnection =
+        connect(window, &QQuickWindow::afterRendering,
+                this, &VideoView::onSceneRendered);
 }
 
 QAudioDevice VideoView::resolveAlsaDevice(const QString& alsaSpec) const
@@ -421,52 +489,15 @@ void VideoView::applyRotation(int angle)
         normalised = 0;
     }
     currentRotation = normalised;
-    if (!videoItem) {
+    if (!videoOutputItem) {
         return;
     }
-    // ``QGraphicsItem::setRotation`` rotates around the item's
-    // transformOrigin (we set this in positionVideoItem). Unlike
-    // the prior ``QVideoWidget::setProperty("rotation", …)`` this
-    // is actually consumed by the painter, so the operator sees
-    // a rotated video instead of an unrotated one.
-    videoItem->setRotation(currentRotation);
-    positionVideoItem();
-}
-
-void VideoView::positionVideoItem()
-{
-    if (!videoItem || !graphicsView || !graphicsScene) {
-        return;
-    }
-    const QSizeF viewport(graphicsView->viewport()->width(),
-                          graphicsView->viewport()->height());
-    if (viewport.isEmpty()) {
-        return;
-    }
-    // 90/270 rotations swap the bounding box, so the item's native
-    // size becomes the viewport's height × width (rotated). 0/180
-    // use the viewport directly. The QGraphicsVideoItem then maps
-    // the source frame into this size, honouring the
-    // KeepAspectRatio mode.
-    QSizeF itemSize = viewport;
-    if (currentRotation == 90 || currentRotation == 270) {
-        itemSize.transpose();
-    }
-    videoItem->setSize(itemSize);
-    // Centre the item in the scene so setRotation rotates around
-    // the visible mid-point.
-    const QRectF bounds(QPointF(0, 0), itemSize);
-    videoItem->setTransformOriginPoint(bounds.center());
-    videoItem->setPos(
-        (viewport.width() - itemSize.width()) / 2.0,
-        (viewport.height() - itemSize.height()) / 2.0);
-    graphicsScene->setSceneRect(0, 0, viewport.width(), viewport.height());
-}
-
-void VideoView::resizeEvent(QResizeEvent* event)
-{
-    QWidget::resizeEvent(event);
-    positionVideoItem();
+    // VideoOutput consumes ``orientation`` natively (it exists for
+    // camera-orientation use): the scene graph rotates the frames
+    // and swaps the fit box for 90/270 — no manual transform-origin
+    // or viewport-transpose bookkeeping like the QGraphicsVideoItem
+    // era needed.
+    videoOutputItem->setProperty("orientation", normalised);
 }
 
 void VideoView::writeStats(const QString& kind, const QString& detail)

--- a/src/anthias_webview/src/videoview.h
+++ b/src/anthias_webview/src/videoview.h
@@ -13,9 +13,8 @@
 #include <QWidget>
 
 class QAudioOutput;
-class QGraphicsScene;
-class QGraphicsVideoItem;
-class QGraphicsView;
+class QQuickItem;
+class QQuickWidget;
 class QVideoSink;
 
 // VideoView owns the Qt 6 multimedia playback pipeline for the Qt6
@@ -40,18 +39,26 @@ class QVideoSink;
 // on Pi 5, rkvdec on Rock Pi 4) without any per-codec dispatch
 // from the application.
 //
-// QGraphicsView + QGraphicsScene + QGraphicsVideoItem is the
-// rendering substrate (not QVideoWidget). The graphics-item path
-// is what lets ``video-rotate`` actually rotate the displayed
-// frames — ``QGraphicsItem::setRotation`` is honoured by the
-// painter, whereas QVideoWidget has no rotation property and a
-// dynamic property attached via ``setProperty`` is read by
-// nothing (review of PR #2905 caught this as a silent Pi 4
-// regression for any operator whose Settings page screen_rotation
-// was non-zero). All three boards run the same path so the
-// transformation is testable in CI; the cage boards still inherit
-// rotation from wlr-randr at the compositor level and so ignore
-// the option dict's ``video-rotate`` value.
+// The rendering substrate is a QML ``VideoOutput`` hosted in a
+// ``QQuickWidget`` (issue #2967). The previous substrate —
+// ``QGraphicsVideoItem`` on a default (raster) ``QGraphicsView``
+// viewport — hardware-decoded perfectly but presented at 8–12 fps:
+// every frame went ``QVideoFrame::toImage()`` → ``qImageFromVideoFrame``
+// (an RHI offscreen render **plus GPU→CPU readback**), then a
+// smooth-scaled CPU raster blit into the widget backing store,
+// which eglfs/wayland re-uploaded to the GPU to composite. Two
+// GPU/CPU crossings per frame saturated the GUI thread (~80% on
+// Pi 4) while ``playback-stats.log`` — which counts sink
+// deliveries, not paints — still read "dropped≈0". VideoOutput's
+// frames stay on the GPU: the scene graph samples the decoded
+// planes as textures and converts YUV→RGB in a fragment shader at
+// composite time. QQuickWidget renders through QQuickRenderControl
+// into an FBO inside the app's single native window — the same
+// machinery QWebEngineView already uses here, so it is proven on
+// eglfs (single-native-window constraint) and proven to inherit
+// QT_QPA_EGLFS_ROTATION / wlr-randr whole-screen rotation (#2971).
+// A ``QVideoWidget`` would NOT satisfy the eglfs constraint: it
+// wraps a ``QVideoWindow`` — a second native window.
 //
 // The MainWindow D-Bus surface (``playVideo`` / ``stopVideo`` /
 // ``videoEnded``) and the Python option-dict contract are
@@ -71,12 +78,11 @@ public:
     //   * ``audio-device`` — ALSA device name (the same string the
     //     mpv era used; QAudioDevice consumes the ``CARD=<name>``
     //     portion).
-    //   * ``video-rotate`` — int as string (0/90/180/270), Pi 4 only
-    //     (cage / wayland boards inherit rotation from wlr-randr).
-    //     Applied to the QGraphicsVideoItem so the painter rotates
-    //     the visible frames; the rotated bounding box is mapped
-    //     back to the viewport so a 90° rotation of 1920x1080 fits
-    //     inside the 1080-tall surface without clipping.
+    //   * ``video-rotate`` — int as string (0/90/180/270). Defensive
+    //     no-op: no board sends it any more (every platform rotates
+    //     the whole screen at the compositor / QPA layer). Applied
+    //     to the VideoOutput item's ``orientation`` property so an
+    //     old caller still gets rotated frames instead of an error.
     //
     // ``hwdec`` / ``vd-lavc-threads`` / ``video-sync`` from the
     // libmpv option set are deliberately ignored — libavcodec
@@ -88,9 +94,6 @@ public:
     // the next ``play()`` is a cheap setSource + play, not a
     // pipeline rebuild.
     void stop();
-
-protected:
-    void resizeEvent(QResizeEvent* event) override;
 
 signals:
     // Fires on ``QMediaPlayer::EndOfMedia``. Re-emitted by
@@ -112,10 +115,28 @@ private slots:
     // Counts frames delivered to QVideoSink so the SAMPLE / END_FILE
     // log lines can compare ``actually displayed`` against
     // ``decoder-expected`` and report a dropped-frame estimate.
-    // ``videoFrameChanged`` fires per display tick on the
-    // QGraphicsVideoItem's underlying sink; counting those is the
-    // most direct measurement QtMultimedia exposes.
+    // ``videoFrameChanged`` fires once per frame the pipeline hands
+    // to the sink — i.e. the *decode-side* rate.
     void onVideoFrameDelivered();
+
+    // Counts scene-graph render passes
+    // (``QQuickWindow::afterRendering``). The Quick scene only
+    // re-renders on damage, and during video playback the
+    // VideoOutput's frame updates are the damage — so this is the
+    // *presentation-side* rate. Issue #2967 existed precisely
+    // because the stats log had no such counter: sink deliveries
+    // read "dropped≈0" while ~70% of frames never reached the
+    // screen. SAMPLE / END_FILE now log both ends of the pipe.
+    void onSceneRendered();
+
+private:
+    // Wire onSceneRendered to the VideoOutput item's QQuickWindow.
+    // Idempotent; called from the constructor and re-tried from
+    // play() so a hypothetical late item→window attachment can't
+    // leave the presentation counter permanently at 0 (which would
+    // read as a total presentation failure — the inverse of the
+    // #2967 blind spot).
+    void connectRenderCounter();
 
 private:
     // Resolve an ALSA device name (``alsa/sysdefault:CARD=vc4hdmi0``,
@@ -130,10 +151,12 @@ private:
     // boards; this routine extracts ``CARD=`` and matches that
     // segment specifically).
     QAudioDevice resolveAlsaDevice(const QString& alsaSpec) const;
-    // Apply (or clear) the rotation on the QGraphicsVideoItem and
-    // resize the viewport so the rotated frame fills the surface
-    // without clipping. ``angle`` is normalised to {0, 90, 180, 270};
-    // anything else snaps to 0.
+    // Apply (or clear) the rotation on the VideoOutput item's
+    // ``orientation`` property. ``angle`` is normalised to
+    // {0, 90, 180, 270}; anything else snaps to 0. VideoOutput
+    // handles the 90/270 bounding-box swap itself (the property
+    // exists for camera-orientation use), so there is no manual
+    // transform-origin / transpose bookkeeping here.
     void applyRotation(int angle);
     // Append ``ISO-8601 KIND detail`` to
     // ``/data/.anthias/playback-stats.log``. Renamed from the
@@ -149,20 +172,27 @@ private:
     // called per-line — the cost-per-line stays an append + flush.
     void openStatsLog();
 
-    // Rotation is applied around the centre so 90/270 swap the
-    // bounding box around the same on-screen midpoint as 0/180.
-    void positionVideoItem();
-
     QMediaPlayer* player = nullptr;
     QAudioOutput* audioOutput = nullptr;
-    QGraphicsView* graphicsView = nullptr;
-    QGraphicsScene* graphicsScene = nullptr;
-    QGraphicsVideoItem* videoItem = nullptr;
+    QQuickWidget* quickWidget = nullptr;
+    // The QML VideoOutput item (owned by the QQuickWidget's root
+    // object) and its sink. Both are guaranteed non-null past the
+    // constructor: a failed QML load (missing qml6-module-* runtime
+    // packages) is a qFatal there, because decode-but-render-nowhere
+    // is a silent black screen on a kiosk while crash-respawn is
+    // loud and supervised.
+    QQuickItem* videoOutputItem = nullptr;
+    QVideoSink* videoSink = nullptr;
     QHBoxLayout* videoLayout = nullptr;
+    QMetaObject::Connection renderCounterConnection;
     int currentRotation = 0;
 
-    // Stats state. Same shape as the libmpv version so log
-    // consumers don't have to change schemas. ``playStartedAt`` is
+    // Stats state. Extends the libmpv-era line shape with a
+    // ``frames-rendered=`` field (the presentation-side counter
+    // #2967 was missing); all fields are key=value tagged, so
+    // consumers must key on field names, not positions —
+    // positional parsers of STOP/SAMPLE/END_FILE lines break on
+    // this revision. ``playStartedAt`` is
     // restarted on ``LoadedMedia`` (not in play()) so the elapsed
     // window measures real playback wall-clock, not decoder init —
     // review of #2905 flagged that the init delay inflated drop
@@ -173,6 +203,7 @@ private:
     QString currentUri;
     QElapsedTimer playStartedAt;
     qint64 framesDelivered = 0;
+    qint64 framesRendered = 0;
     qreal containerFps = 0.0;
 
     // Cap on /data/.anthias/playback-stats.log size. 8 MB ≈ a full

--- a/src/anthias_webview/src/videoview.qml
+++ b/src/anthias_webview/src/videoview.qml
@@ -1,0 +1,26 @@
+import QtQuick
+import QtMultimedia
+
+// VideoView's scene: a single VideoOutput on a black backdrop.
+// VideoOutput is the only public Qt 6 video item whose frames render
+// through the RHI scene graph (YUV→RGB happens in a fragment shader
+// at composite time) — no QVideoFrame::toImage() GPU→CPU readback,
+// no raster blit. Issue #2967 measured the prior
+// QGraphicsVideoItem-on-raster-viewport path at 8–12 presented fps
+// on Pi 4/Pi 5 with a saturated GUI thread; this path keeps every
+// frame on the GPU.
+//
+// ``orientation`` is driven from C++ (VideoView::applyRotation) for
+// the legacy ``video-rotate`` option — a defensive no-op in
+// production since every platform now rotates the whole screen at
+// the compositor / QPA layer.
+Rectangle {
+    color: "black"
+
+    VideoOutput {
+        id: videoOutput
+        objectName: "videoOutput"
+        anchors.fill: parent
+        fillMode: VideoOutput.PreserveAspectFit
+    }
+}

--- a/src/anthias_webview/src/videoview.qrc
+++ b/src/anthias_webview/src/videoview.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>videoview.qml</file>
+    </qresource>
+</RCC>

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -174,7 +174,7 @@ View::View(QWidget* parent) : QWidget(parent)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // QtMultimedia-backed video surface. Created hidden — only
     // made visible when ``playVideo`` fires. The QMediaPlayer +
-    // QGraphicsVideoItem live for the lifetime of this widget so
+    // QML VideoOutput live for the lifetime of this widget so
     // repeated plays don't pay pipeline-rebuild cost on every
     // asset. Qt 5 boards (Pi 1 / Pi 2 / Pi 3) skip this — video plays via
     // GstFbdevMediaPlayer painting straight to the framebuffer.

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -27,10 +27,11 @@ public:
     void setReloadInterval(int seconds);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // Hands the URI + option dict to VideoView (QtMultimedia
-    // QMediaPlayer + QGraphicsVideoItem) and switches visibility
-    // so the video surface is on top of the QWebEngineView pair /
-    // image canvas. Pauses background URL loads so a parked
-    // QWebEngineView doesn't keep streaming while video plays.
+    // QMediaPlayer rendering into a QML VideoOutput) and switches
+    // visibility so the video surface is on top of the
+    // QWebEngineView pair / image canvas. Pauses background URL
+    // loads so a parked QWebEngineView doesn't keep streaming while
+    // video plays.
     //
     // Qt 5 boards (Pi 1 / Pi 2 / Pi 3) route video through GstFbdevMediaPlayer
     // painting straight to the framebuffer (see
@@ -76,7 +77,7 @@ private:
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // QtMultimedia-backed video widget (issue #2904). Sibling of
     // the web / image widgets — visibility is toggled rather than
-    // re-parented so the QMediaPlayer + QGraphicsVideoItem survive
+    // re-parented so the QMediaPlayer + Quick scene survive
     // across plays (no pipeline rebuild per asset).
     VideoView* videoView;
 #endif

--- a/src/anthias_webview/tests/test_videoview.cpp
+++ b/src/anthias_webview/tests/test_videoview.cpp
@@ -1,33 +1,38 @@
 // QtTest unit tests for VideoView's QtMultimedia pipeline
-// (issue #2904). The tests instantiate VideoView with no display
-// (``QT_QPA_PLATFORM=offscreen``) and assert on the publicly
-// observable behaviour:
+// (issue #2904, render path reworked for #2967). The tests
+// instantiate VideoView with no display
+// (``QT_QPA_PLATFORM=offscreen`` + ``QT_QUICK_BACKEND=software``)
+// and assert on the publicly observable behaviour:
 //
-//   * Construction succeeds and the inner QMediaPlayer exists.
+//   * Construction succeeds, the inner QMediaPlayer exists, and the
+//     QML scene loads with a usable VideoOutput item wired to the
+//     player's video sink.
 //   * ``play()`` updates source / playback state without throwing.
 //   * ``stop()`` is idempotent (callable before and after play).
 //   * Options dict keys are accepted forgivingly (no crash on
 //     unknown / empty option values).
 //   * The audio device resolver falls back to the system default
 //     when a typo'd ALSA spec doesn't match anything.
-//   * ``video-rotate`` actually rotates the QGraphicsVideoItem.
+//   * ``video-rotate`` lands on the VideoOutput item's
+//     ``orientation`` property (the value the scene graph consumes).
 //
 // Real-device validation handles the ffmpeg pipeline end-to-end
-// (decoder engagement + drop counts via
+// (decoder engagement + delivered/rendered counts via
 // /data/.anthias/playback-stats.log on the BBB test bed).
-// QtMultimedia's pipeline doesn't fully
-// initialise under the offscreen platform because there's no
-// rendering surface to upload frames into, so we don't try to play
-// media — just exercise the API surface plus the rotation transform.
+// QtMultimedia's pipeline doesn't fully initialise under the
+// offscreen platform because there's no rendering surface to
+// composite into, so we don't try to play media — just exercise the
+// API surface plus the option plumbing.
 
 #include <QCoreApplication>
-#include <QGraphicsScene>
-#include <QGraphicsVideoItem>
 #include <QMediaPlayer>
+#include <QQuickItem>
+#include <QQuickWidget>
 #include <QSignalSpy>
 #include <QTest>
 #include <QUrl>
 #include <QVariantMap>
+#include <QVideoSink>
 
 #include "videoview.h"
 
@@ -38,15 +43,37 @@ class TestVideoView : public QObject
 
 private slots:
     // Smoke test: constructing VideoView creates the QMediaPlayer
-    // + QGraphicsVideoItem pair and the stats logger initialises
-    // (writes an ``INIT`` line on hosts where ``/data/.anthias`` is
-    // writeable — the test host typically has no such directory, in
-    // which case the warning fires and statsStream stays null; both
-    // states are acceptable).
+    // and loads the QML scene with the VideoOutput item present.
+    // The stats logger initialises too (writes an ``INIT`` line on
+    // hosts where ``/data/.anthias`` is writeable — the test host
+    // typically has no such directory, in which case the warning
+    // fires and statsStream stays null; both states are acceptable).
     void constructorBuildsPlayer()
     {
         VideoView view;
         QVERIFY(view.findChild<QMediaPlayer*>() != nullptr);
+        QVERIFY2(findVideoOutput(view) != nullptr,
+                 "VideoOutput item missing — videoview.qml failed to "
+                 "load (missing qml6-module-qtquick / "
+                 "qml6-module-qtmultimedia on this host?)");
+    }
+
+    // The player must render into the VideoOutput's sink — that's
+    // the whole point of the #2967 rework. Guard against a silent
+    // regression where the QML loads but the sink wiring is dropped
+    // (video would decode to nowhere, exactly the failure mode the
+    // VLC/mmal era shipped for years).
+    void playerUsesVideoOutputSink()
+    {
+        VideoView view;
+        QMediaPlayer* player = view.findChild<QMediaPlayer*>();
+        QQuickItem* item = findVideoOutput(view);
+        QVERIFY(player != nullptr);
+        QVERIFY(item != nullptr);
+        QVERIFY(player->videoSink() != nullptr);
+        QCOMPARE(
+            player->videoSink(),
+            qvariant_cast<QVideoSink*>(item->property("videoSink")));
     }
 
     // ``stop()`` must be callable on a freshly-built VideoView
@@ -87,33 +114,29 @@ private slots:
         QVERIFY(true);
     }
 
-    // ``video-rotate`` must actually rotate the QGraphicsVideoItem
-    // (not just be stored as a dynamic property — that's what the
-    // prior QVideoWidget code did, which the PR #2905 review
-    // flagged as a silent Pi 4 regression). Assert on
-    // ``QGraphicsItem::rotation()``, the value the painter reads
-    // to apply the transform. Both ``str`` and ``int`` are tested
-    // because pydbus may marshal the option either way depending
-    // on caller — the C++ side normalises via ``QVariant::toInt``.
-    void playRotatesVideoItem()
+    // ``video-rotate`` must land on the VideoOutput item's
+    // ``orientation`` property — the value the scene graph actually
+    // consumes when rotating frames (the QGraphicsVideoItem era
+    // asserted ``QGraphicsItem::rotation()`` for the same reason:
+    // a stored-but-unconsumed dynamic property was PR #2905's silent
+    // Pi 4 regression). Both ``str`` and ``int`` are tested because
+    // pydbus may marshal the option either way depending on caller —
+    // the C++ side normalises via ``QVariant::toInt``.
+    void playRotatesVideoOutput()
     {
         for (int angle : {0, 90, 180, 270}) {
             for (const QVariant& asWire :
                  {QVariant(QString::number(angle)), QVariant(angle)}) {
                 VideoView view;
-                // Force a non-zero geometry so positionVideoItem
-                // can size the item; default 640x480 is fine but
-                // 1080p makes the transform-origin maths match
-                // production.
                 view.resize(1920, 1080);
                 QVariantMap options;
                 options["video-rotate"] = asWire;
                 view.play(QStringLiteral("file:///nonexistent.mp4"),
                           options);
-                QGraphicsVideoItem* item = findVideoItem(view);
+                QQuickItem* item = findVideoOutput(view);
                 QVERIFY2(item != nullptr,
-                         "QGraphicsVideoItem missing from scene");
-                QCOMPARE(qRound(item->rotation()), angle);
+                         "VideoOutput item missing from QML scene");
+                QCOMPARE(item->property("orientation").toInt(), angle);
                 view.stop();
             }
         }
@@ -129,31 +152,25 @@ private slots:
         QVariantMap options;
         options["video-rotate"] = QStringLiteral("45");
         view.play(QStringLiteral("file:///nonexistent.mp4"), options);
-        QGraphicsVideoItem* item = findVideoItem(view);
+        QQuickItem* item = findVideoOutput(view);
         QVERIFY(item != nullptr);
-        QCOMPARE(qRound(item->rotation()), 0);
+        QCOMPARE(item->property("orientation").toInt(), 0);
         view.stop();
     }
 
 private:
-    // QGraphicsVideoItem is a QGraphicsObject attached to the
-    // scene, not a child QObject of the widget tree, so
-    // ``findChild`` won't reach it. Recover it via the scene's
-    // items() list — VideoView's scene is the only QGraphicsScene
-    // parented to the widget.
-    QGraphicsVideoItem* findVideoItem(const QWidget& view) const
+    // The VideoOutput is a QQuickItem inside the QQuickWidget's QML
+    // scene, not a child QObject of the widget tree, so a plain
+    // ``findChild`` on the VideoView won't reach it — go through the
+    // QQuickWidget's root object.
+    QQuickItem* findVideoOutput(const QWidget& view) const
     {
-        const QList<QGraphicsScene*> scenes =
-            view.findChildren<QGraphicsScene*>();
-        if (scenes.isEmpty()) {
+        QQuickWidget* quick = view.findChild<QQuickWidget*>();
+        if (!quick || !quick->rootObject()) {
             return nullptr;
         }
-        for (QGraphicsItem* sceneItem : scenes.first()->items()) {
-            if (sceneItem->type() == QGraphicsVideoItem::Type) {
-                return static_cast<QGraphicsVideoItem*>(sceneItem);
-            }
-        }
-        return nullptr;
+        return quick->rootObject()->findChild<QQuickItem*>(
+            QStringLiteral("videoOutput"));
     }
 };
 

--- a/src/anthias_webview/tests/tests.pro
+++ b/src/anthias_webview/tests/tests.pro
@@ -1,23 +1,26 @@
 # QtTest-based unit tests for AnthiasViewer's QtMultimedia
 # pipeline (issue #2904). Built and run via bin/test_webview_cpp.sh
-# inside a container or on a host with Qt 6 (qt6-multimedia-dev).
-# Not wired into the main viewer Docker image; the production
-# Dockerfile only builds AnthiasViewer.pro (no test sources or
-# test runner are shipped to devices).
+# inside a container or on a host with Qt 6 (qt6-multimedia-dev +
+# qt6-declarative-dev). Not wired into the main viewer Docker image;
+# the production Dockerfile only builds AnthiasViewer.pro (no test
+# sources or test runner are shipped to devices).
 
 TEMPLATE = app
 TARGET = AnthiasViewerTests
 
-QT += core gui testlib widgets multimedia multimediawidgets dbus
+QT += core gui testlib widgets multimedia quick quickwidgets dbus
 CONFIG += c++17 console testcase
 
 # Re-use the production sources verbatim — tests instantiate
 # VideoView directly. ``main.cpp`` is excluded because QTEST_MAIN
-# provides its own entry point.
+# provides its own entry point. The qrc carries the QML scene
+# (videoview.qml) the production widget loads.
 SOURCES += \
     ../src/videoview.cpp \
     test_videoview.cpp
 
 HEADERS += ../src/videoview.h
+
+RESOURCES += ../src/videoview.qrc
 
 INCLUDEPATH += ../src

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -259,9 +259,21 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
 
     if is_qt6:
         # Shared Qt 6 runtime for every Qt6 board (pi4-64, pi5, x86,
-        # arm64). VideoView uses QMediaPlayer + QVideoWidget from
-        # qt6-multimedia. Qt 6.8 dropped its gstreamer backend
-        # upstream (only ``libffmpegmediaplugin.so`` ships in
+        # arm64). VideoView plays through QMediaPlayer into a QML
+        # ``VideoOutput`` hosted in a QQuickWidget (issue #2967:
+        # frames stay on the GPU as scene-graph textures — the prior
+        # QGraphicsVideoItem raster path presented at 8–12 fps).
+        # That needs the declarative runtime (QQuickWidget links
+        # libQt6QuickWidgets, pulled by qt6-declarative-dev) plus the
+        # two QML *plugin* modules the scene imports at runtime —
+        # qml6-module-qtquick (Rectangle et al.) and
+        # qml6-module-qtmultimedia (VideoOutput). The QML modules
+        # are runtime-only plugins: the build succeeds without them
+        # and the viewer then black-screens with "module not
+        # installed" QML errors in the container log, so they must
+        # ship in the image even though nothing links them.
+        # Qt 6.8 dropped its gstreamer backend upstream (only
+        # ``libffmpegmediaplugin.so`` ships in
         # ``/usr/lib/.../qt6/plugins/multimedia/``); decode goes
         # through libavcodec directly. The +rpt1 ``ffmpeg`` /
         # ``libav*`` packages pinned in _rpt1-ffmpeg-pin.j2 carry
@@ -274,8 +286,10 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
         viewer_extra_apt_dependencies.extend(
             [
                 'libqt6multimedia6',
-                'libqt6multimediawidgets6',
+                'qml6-module-qtmultimedia',
+                'qml6-module-qtquick',
                 'qt6-base-dev',
+                'qt6-declarative-dev',
                 'qt6-image-formats-plugins',
                 'qt6-multimedia-dev',
                 'qt6-webengine-dev',

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -272,7 +272,7 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
         # and the viewer then black-screens with "module not
         # installed" QML errors in the container log, so they must
         # ship in the image even though nothing links them.
-        # Qt 6.8 dropped its gstreamer backend upstream (only
+        # Qt 6.5 dropped its gstreamer backend upstream (only
         # ``libffmpegmediaplugin.so`` ships in
         # ``/usr/lib/.../qt6/plugins/multimedia/``); decode goes
         # through libavcodec directly. The +rpt1 ``ffmpeg`` /


### PR DESCRIPTION
### Issues Fixed

- Fixes #2967

### Description

HW decode was never the problem on the Qt6 boards — presentation was. The `QGraphicsVideoItem`-on-raster-`QGraphicsView` substrate ran every frame through `QVideoFrame::toImage()` (an RHI offscreen render **plus GPU→CPU readback**), then a smooth-scaled CPU blit into the backing store, capping presentation at 8.3 fps on Pi 4 / 10–12 fps on Pi 5 while the sink-side stats read "dropped≈0".

This PR renders through a QML `VideoOutput` hosted in a `QQuickWidget`: frames stay on the GPU as scene-graph textures with shader YUV→RGB, composited via the same `QQuickRenderControl` FBO machinery `QWebEngineView` already uses — so it satisfies eglfs's single-native-window constraint (a `QVideoWidget` would not: it wraps a second native `QVideoWindow`).

Measured on the testbeds (1080p30, DRM vblank tracepoints):

| | Pi 4 (eglfs) | Pi 5 (cage/wayland) |
|---|---|---|
| Presented fps | 8.3 → **30.0** | 11.7 → **26.6** (30 Hz output) |
| Total viewer CPU | ~115% → **64%** | ~155% → **13%** (HEVC HW) / 175% → **35%** (H.264 SW) |

Also:
- `playback-stats.log` now logs `frames-rendered` (scene-graph renders, the presentation-side rate) next to `frames-delivered` — the missing counter that let this regression ship unnoticed. Fields are key=value; positional parsers of SAMPLE/END_FILE/STOP lines break on this revision.
- QML-scene-unavailable is now a `qFatal` (supervised crash-respawn) instead of silently decoding video to nowhere.
- Rotation re-validated on-device: `QT_QPA_EGLFS_ROTATION=90` rotates the Quick-composited window (viewport probe 1080x1920) with video still at full rate.
- Qt6 viewer images gain `qt6-declarative-dev` + `qml6-module-qtquick` + `qml6-module-qtmultimedia`; `multimediawidgets` is dropped.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

> x86/arm64 share the validated Pi 5 path (cage/wayland + Quick scene graph) but have not been live-tested; the x86 testbed has failing storage. Worth a check on real x86 hardware before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)