### PR TITLE
chore(viewer): drop the always-on Qt debug logging from the image

### DIFF
--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -121,11 +121,6 @@ COPY docker/eglfs-kms-pi4.json /etc/anthias/eglfs-kms.json
 ENV QT_QPA_PLATFORM=linuxfb
 {% endif %}
 
-# Turn on debug logging for now
-#ENV QT_LOGGING_RULES=qt.qpa.*=true
-ENV QT_LOGGING_RULES=*.debug=true
-ENV QT_QPA_DEBUG=1
-
 ENV GIT_HASH={{ git_hash }}
 ENV GIT_SHORT_HASH={{ git_short_hash }}
 ENV GIT_BRANCH={{ git_branch }}


### PR DESCRIPTION
### Issues Fixed

Fleet observability: the viewer image ships unconditional Qt debug logging, which floods the device logs and makes them unreadable.

### Description

Drop `QT_LOGGING_RULES=*.debug=true` and `QT_QPA_DEBUG=1` from `docker/Dockerfile.viewer.j2` (and the stale "Turn on debug logging for now" comment + commented-out `qt.qpa.*` rule).

These were a temporary bring-up aid ("for now", introduced in #2060, Nov 2024) that was never reverted — emitted **unconditionally, on every board, in production**. On a real device that's ~20+ Qt scenegraph / `sh`-chunk lines per second, which **saturates balena's 1000-line log buffer in ~35 seconds** and buries every application-level event (asset changes, errors, crashes). Observed directly while validating a live pi4 (`stormy-sun`): the entire 800-line log window covered only ~35s and contained zero application events under the debug spam.

No functional change to playback — only removes the firehose of `qt.*` debug output, restoring usable `balena logs`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes (no code paths touched — Dockerfile `ENV`-only change).
- [ ] End-to-end Pi test — N/A (removes debug `ENV`s only; no behavior change beyond log volume).
- [x] x86 — same template, debug `ENV`s removed for all boards.
- [ ] Documentation — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
