### PR TITLE
fix(viewer): default WLR_DRM_NO_ATOMIC=1 on x86 so EBUSY can't freeze the display

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -428,6 +428,31 @@ case "$DEVICE_TYPE" in
     export LIBSEAT_BACKEND=builtin
     export WLR_LIBINPUT_NO_DEVICES=1
 
+    # x86 (Intel i915 in particular) can wedge cage's display pipeline
+    # under heavy QtWebEngine GPU load (issue #2976): wlroots 0.18's
+    # non-blocking atomic page-flip commit gets EBUSY from the kernel
+    # while the previous commit is still fence-blocked behind the web
+    # render, and the trixie cage 0.2 / wlroots 0.18 failure path
+    # doesn't always recover — the screen freezes on the last frame
+    # until the container restarts, even though the viewer keeps
+    # cycling assets. The legacy KMS interface (drmModePageFlip) has
+    # no shallow-queue EBUSY semantics, so it tolerates GPU fence
+    # backpressure; a single-output kiosk uses none of the atomic
+    # extras (VRR, overlay planes, multi-output modeset queueing).
+    # WLR_DRM_NO_MODIFIERS pairs with it: the same trixie wlroots
+    # 0.18.2 + i915 stack has a second documented freeze in the
+    # modifier-fallback swapchain realloc (Debian bug 1112158), and
+    # legacy flips reject scan-out buffers whose modifiers change
+    # between frames — modifier-less allocation keeps the legacy path
+    # maximally reliable. ${VAR:-1} keeps both user-overridable via a
+    # compose override (wlroots parses 0 as false). Scoped to x86:
+    # arm64/pi5 run vc4/rockchip where atomic is the well-exercised
+    # path and no freeze has been observed.
+    if [ "$DEVICE_TYPE" = 'x86' ]; then
+        export WLR_DRM_NO_ATOMIC="${WLR_DRM_NO_ATOMIC:-1}"
+        export WLR_DRM_NO_MODIFIERS="${WLR_DRM_NO_MODIFIERS:-1}"
+    fi
+
     # cage default `-m extend` spans all enumerated DRM outputs,
     # including ones that are physically disconnected — so a Pi user
     # who plugs into the second micro-HDMI port (HDMI-A-2 instead of


### PR DESCRIPTION
### Issues Fixed

Fixes #2976

### Description

On x86 (Intel i915 in particular), heavy QtWebEngine GPU load can wedge cage's display pipeline: wlroots 0.18's non-blocking atomic page-flip commit gets `EBUSY` from the kernel while the previous commit is still fence-blocked behind the web render, and the trixie cage 0.2 / wlroots 0.18.2 failure path doesn't always recover. The screen freezes on the last frame until the container restarts, even though the viewer keeps cycling assets.

This defaults `WLR_DRM_NO_ATOMIC=1` and `WLR_DRM_NO_MODIFIERS=1` in `bin/start_viewer.sh` for x86 only:

- The legacy KMS interface (`drmModePageFlip`) has no shallow-queue `EBUSY` semantics, so it tolerates GPU fence backpressure. A single-output kiosk uses none of the atomic extras (VRR, overlay-plane offload, multi-output modeset queueing). The same workaround is in wide use across the wlroots ecosystem (sway/labwc) with no reported drawbacks.
- `WLR_DRM_NO_MODIFIERS=1` pairs with it: the identical trixie wlroots 0.18.2 + i915 stack has a second documented freeze in the modifier-fallback swapchain realloc (Debian bug 1112158), and wlroots' legacy flips reject scan-out buffers whose modifiers change between frames — modifier-less allocation keeps the legacy path maximally reliable. This is also the exact combination the reporter soak-tested on the failing hardware.
- Both are `${VAR:-1}` defaults, so a compose override can set either back to `0` (wlroots parses `0` as false).
- Scoped to x86: arm64/pi5 run vc4/rockchip where atomic is the well-exercised path and no freeze has been observed. Both env vars remain supported in wlroots 0.19, so this survives the next Debian cycle.

Lands in the image via `start_viewer.sh`, covering both the curl-installer and balena deployments.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)