### PR TITLE
fix(viewer): fix two startup warnings surfaced by the log cleanup

### DIFF
--- a/bin/migrate_legacy_paths.sh
+++ b/bin/migrate_legacy_paths.sh
@@ -36,8 +36,12 @@
 set -euo pipefail
 
 # Resolve the user's home dir without trusting $HOME (this script may be
-# invoked under sudo).
-USER_HOME="${USER_HOME:-/home/${USER}}"
+# invoked under sudo). $USER is unset when run inside the viewer
+# container (DATA mode, via migrate_in_container_paths.sh), so fall back
+# to `id -un` rather than letting `set -u` abort the whole migration on
+# an unbound $USER. USER_HOME is only actually used in HOST mode; in
+# DATA mode it just needs to resolve without erroring.
+USER_HOME="${USER_HOME:-/home/${USER:-$(id -un)}}"
 
 # HOST mode (no arg) operates on $USER_HOME and additionally does the repo
 # rename + sudoers cleanup. DATA mode (explicit base dir) does only the

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -11,7 +11,12 @@ int main(int argc, char *argv[])
     QApplication::setOverrideCursor(QCursor(Qt::BlankCursor));
 
     MainWindow *window = new MainWindow();
-    window->show();
+    // Show fullscreen exactly once, here, after the window is fully
+    // constructed. Previously the MainWindow ctor also called
+    // showFullScreen(), so the window was shown twice — under
+    // cage/wayland that double-commit triggered wlroots' "A configure
+    // is scheduled for an uninitialized xdg_surface" warning at startup.
+    window->showFullScreen();
 
     QDBusConnection connection = QDBusConnection::sessionBus();
 

--- a/src/anthias_webview/src/mainwindow.cpp
+++ b/src/anthias_webview/src/mainwindow.cpp
@@ -16,8 +16,9 @@ MainWindow::MainWindow() : QMainWindow()
     // the existing slots).
     connect(view, &View::videoEnded, this, &MainWindow::videoEnded);
 #endif
-
-    showFullScreen();
+    // NOTE: the window is shown (showFullScreen) by main() after
+    // construction, not here — showing in both places double-committed
+    // the surface and tripped a wlroots xdg_surface warning under cage.
 }
 
 void MainWindow::loadPage(const QString &uri)


### PR DESCRIPTION
### Issues Fixed

Two pre-existing viewer startup warnings that became visible once the debug-logging firehose was removed (#2977).

### Description

**1. `migrate_legacy_paths.sh` aborts on unbound `$USER` in-container.** The script runs `set -euo pipefail`, and `USER_HOME="${USER_HOME:-/home/${USER}}"` references a bare `$USER`. In the viewer container (DATA mode, invoked via `migrate_in_container_paths.sh`) `$USER` is unset, so `set -u` aborts the script at that line — which on a legacy (screenly→anthias) device would skip the in-container migration entirely. Now falls back to `id -un` (`${USER:-$(id -un)}`) so it resolves without erroring. `USER_HOME` is only actually used in HOST mode; in DATA mode it just needs to not blow up.

**2. `AnthiasViewer` shows its window twice.** The `MainWindow` ctor called `showFullScreen()` and `main()` then called `window->show()`. Under cage/wayland (pi5/x86/arm64) that double surface-commit tripped wlroots' `A configure is scheduled for an uninitialized xdg_surface` warning at startup. The window is now shown exactly once, via `showFullScreen()` in `main()` after construction.

Both are warning/robustness fixes — no behavior change to normal playback.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] Unit tests / lint unaffected (shell + C++ webview only; `bash -n` clean).
- [ ] End-to-end Pi test — the C++ change needs a webview rebuild; I'll confirm the wlroots warning is gone on the pi5 testbed once the image builds.
- [x] x86 — same cage/wayland path as pi5; covered by the show-once fix.
- [ ] Documentation — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
