### PR TITLE
chore(release): bump to 2026.06.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.06.0",
+  "version": "2026.06.1",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.06.0"
+version = "2026.06.1"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.6.0"
+version = "2026.6.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
### Description

CalVer bump for the next release: still June 2026, so micro increments 0 → 1. Bumps `package.json`, `pyproject.toml`, and `uv.lock` (via `uv lock`), same as the 2026.06.0 bump (#2965).

Ships everything merged since v2026.06.0:

- QML VideoOutput presentation path (#2975)
- pi2/pi3 GStreamer HW video pipeline replacing VLC (#2972)
- x86 `WLR_DRM_NO_ATOMIC=1` display-freeze fix (#2978)
- Pi 4 eglfs rotation (#2971) and 270° portrait-inverted fix (#2973)
- armv7 viewer spawn retry (#2969), Writeback-connector headless guard (#2968)
- viewer log cleanups (#2977, #2979)

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)