### PR TITLE
fix(redis): persist data to the mounted volume so device identity survives recreation

### DIFF
--- a/docker/Dockerfile.redis.j2
+++ b/docker/Dockerfile.redis.j2
@@ -44,5 +44,7 @@ CMD ["redis-server", \
      "--protected-mode", "no", \
      "--dir", "/var/lib/redis", \
      "--appendonly", "yes", \
-     "--save", "3600 1 300 100 60 10000"]
+     "--save", "3600 1", \
+     "--save", "300 100", \
+     "--save", "60 10000"]
 

--- a/docker/Dockerfile.redis.j2
+++ b/docker/Dockerfile.redis.j2
@@ -16,10 +16,33 @@ ENV GIT_HASH={{ git_hash }}
 ENV GIT_SHORT_HASH={{ git_short_hash }}
 ENV GIT_BRANCH={{ git_branch }}
 
-RUN sed -i 's/^bind.*/bind 0.0.0.0/g' /etc/redis/redis.conf
-RUN sed -i 's/^protected-mode.*/protected-mode no/g' /etc/redis/redis.conf
-
 {% include 'labels.j2' %}
 
-CMD ["redis-server", "--protected-mode", "no"]
+# redis-server is started with explicit flags rather than the distro's
+# /etc/redis/redis.conf so behaviour is deterministic regardless of the
+# base image's packaged defaults, and so we control exactly where data
+# lands.
+#
+# Persistence matters: the device's telemetry identity (the `device_id`
+# used as the GA4 client_id) and its 24h telemetry cooldown live only in
+# Redis. The redis-data volume is mounted at /var/lib/redis in both the
+# non-balena (docker-compose.yml.tmpl) and balena
+# (docker-compose.balena.yml.tmpl) deployments, but the previous CMD
+# loaded no config, so `dir` defaulted to the process CWD (/) and the
+# RDB snapshot was written to the container's ephemeral writable layer —
+# never the volume. Every container recreation (a version deploy, image
+# update, or `compose down`) therefore wiped the device_id, and GA
+# counted the same physical device as a brand-new one on every upgrade.
+#
+# --dir pins data onto the mounted volume; --appendonly yes persists the
+# (rare) device_id write within ~1s via the AOF (default fsync everysec),
+# which RDB save points alone wouldn't catch if the container is recreated
+# inside a save window; the RDB save points are kept as a belt-and-braces
+# snapshot. --protected-mode no preserves the existing cross-container
+# access (other services connect over the `redis` service network).
+CMD ["redis-server", \
+     "--protected-mode", "no", \
+     "--dir", "/var/lib/redis", \
+     "--appendonly", "yes", \
+     "--save", "3600 1 300 100 60 10000"]
 


### PR DESCRIPTION
## Problem

The `redis-data` volume mounted at `/var/lib/redis` (in both `docker-compose.yml.tmpl` and `docker-compose.balena.yml.tmpl`) was effectively unused: `docker/Dockerfile.redis.j2` launched `redis-server --protected-mode no` **without a config file**, so Redis used the default `dir "."` (= the process CWD, `/`, since there's no `WORKDIR`). RDB/AOF data landed on the container's **ephemeral writable layer**, not the volume.

Consequence: every container recreation — a version deploy (tag bump → pull → up), image update, or `compose down` — wiped Redis. That includes the telemetry **`device_id`** (used as the GA4 Measurement Protocol `client_id`) and its 24h cooldown, both of which live only in Redis. So Google Analytics counted the same physical device as a brand-new device on every upgrade — inflating device counts.

Corroborating evidence the config was dead: the old `sed` edits to `/etc/redis/redis.conf` (`bind`, `protected-mode`) were no-ops, and `--protected-mode no` had to be re-passed on the CLI precisely because the conf was never loaded.

## Fix

Start `redis-server` with explicit, deterministic flags:

```dockerfile
CMD ["redis-server", \
     "--protected-mode", "no", \
     "--dir", "/var/lib/redis", \
     "--appendonly", "yes", \
     "--save", "3600 1 300 100 60 10000"]
```

- `--dir /var/lib/redis` pins data onto the mounted volume.
- `--appendonly yes` persists the (rare) `device_id` write within ~1s via the AOF (default `appendfsync everysec`) — RDB save points alone wouldn't catch a recreation that happens inside a save window.
- RDB save points kept as a belt-and-braces snapshot.
- `--protected-mode no` preserves existing cross-container access.
- Dropped the two dead `sed` lines (the conf they edited is never loaded).

## Covers both deployments

One shared `anthias-redis` image. Both prod compose files already mount `redis-data:/var/lib/redis`; named volumes persist across container recreation (docker-compose) and across OTA releases (balena). No compose changes needed.

## Verification

Built the image and ran the recreation scenario:

- `config get dir` → `/var/lib/redis`, `config get appendonly` → `yes`
- AOF (`appendonlydir/`) written **to the volume**
- Set `device_id` + `telemetry-cooldown`, **destroyed the container, started a fresh one on the same volume** → both keys survived

## Note

Existing devices will see a **one-time** `device_id` reset when they first upgrade to this image (their current value is on the soon-to-be-discarded ephemeral layer), then it's stable from then on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)