### PR TITLE
chore(balena): standardize disk images + fleet roller on the ESR track

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -350,14 +350,34 @@ jobs:
         # regular `latest` (5.1.x is its architectural ceiling anyway).
         run: |
           set -euo pipefail
-          os_version=$(
-            balena os versions "$BALENA_IMAGE" --esr 2>/dev/null \
-              | grep -m1 '(current)' \
-              | grep -oE 'v[0-9][^ ]*' | head -1 | sed 's/^v//'
-          ) || true
-          if [ -z "${os_version:-}" ]; then
-            echo "No (current) ESR for $BALENA_IMAGE; using regular latest."
+          if [ "$BALENA_IMAGE" = "raspberry-pi2" ]; then
+            # raspberry-pi2 is the one device type with no ESR track, so
+            # it legitimately uses the regular `latest` (5.1.x ceiling).
             os_version=latest
+            echo "raspberry-pi2 has no ESR track; using regular latest."
+          else
+            # `balena os versions --esr` lists ESR builds tagged by support
+            # phase; we take the `(current)` (GA) line. Any failure to
+            # resolve it (CLI error, auth, an unexpectedly empty list) is a
+            # hard error — we must NOT silently fall back to the regular
+            # track and ship a non-ESR image. `set -e` aborts on a non-zero
+            # balena exit; the explicit check catches a clean-but-empty list.
+            # No `|| true` here: a non-zero balena exit (auth, rate limit)
+            # must abort the build via `set -e`, surfacing balena's error.
+            esr_list=$(balena os versions "$BALENA_IMAGE" --esr)
+            # `|| true` only on the parse: a missing `(current)` line trips
+            # pipefail, and we want our explicit message below, not an
+            # abrupt abort.
+            os_version=$(
+              printf '%s\n' "$esr_list" \
+                | grep -m1 '(current)' \
+                | grep -oE 'v[0-9][^ ]*' | head -1 | sed 's/^v//'
+            ) || true
+            if [ -z "$os_version" ]; then
+              echo "::error::No (current) ESR version for $BALENA_IMAGE" >&2
+              printf '%s\n' "$esr_list" >&2
+              exit 1
+            fi
           fi
           echo "Selected balenaOS version for $BALENA_IMAGE: $os_version"
           balena os download "$BALENA_IMAGE" \

--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -337,14 +337,32 @@ jobs:
           esac
 
       - name: Download OS image
-        # `--version` accepts an explicit version, a semver range,
-        # `latest`, `menu`, or `menu-esr` in balena-cli 25.x; the
-        # `default` keyword that worked under balena-cli 22.x was
-        # removed ("Version default is not available for ...").
+        # We flash the balenaOS ESR (Extended Support Release) track —
+        # its long support window suits field signage and it is balena's
+        # default-going-forward track. `balena os versions <type> --esr`
+        # lists ESR builds tagged by support phase; we take the
+        # `(current)` (GA) line. We can't use the `menu-esr` keyword that
+        # `--version` accepts in balena-cli 25.x because it is interactive
+        # only, and plain `latest` resolves to the *regular* (non-ESR)
+        # track — hence resolving the explicit ESR version here.
+        #
+        # raspberry-pi2 has no ESR track at all, so it falls back to the
+        # regular `latest` (5.1.x is its architectural ceiling anyway).
         run: |
+          set -euo pipefail
+          os_version=$(
+            balena os versions "$BALENA_IMAGE" --esr 2>/dev/null \
+              | grep -m1 '(current)' \
+              | grep -oE 'v[0-9][^ ]*' | head -1 | sed 's/^v//'
+          ) || true
+          if [ -z "${os_version:-}" ]; then
+            echo "No (current) ESR for $BALENA_IMAGE; using regular latest."
+            os_version=latest
+          fi
+          echo "Selected balenaOS version for $BALENA_IMAGE: $os_version"
           balena os download "$BALENA_IMAGE" \
             --output "$BALENA_IMAGE.img" \
-            --version latest
+            --version "$os_version"
 
       - name: Preload OS image
         run: |

--- a/bin/balena_fleet_maintenance.py
+++ b/bin/balena_fleet_maintenance.py
@@ -156,7 +156,7 @@ def current_esr_version(device_type: str) -> str | None:
         return None
     for line in out.splitlines():
         if '(current)' in line:
-            token = line.strip().split()[0].lstrip('v')
+            token: str = line.strip().split()[0].lstrip('v')
             if token[:1].isdigit():
                 return token
     return None

--- a/bin/balena_fleet_maintenance.py
+++ b/bin/balena_fleet_maintenance.py
@@ -5,7 +5,16 @@ A lot of field devices were flashed from pre-#2098 images that pinned them
 to the downloaded release, and many sit on years-old balenaOS / supervisor
 versions. This rolls them forward in tranches: per device it unpins the
 release (so it tracks the fleet's latest stable) and starts a host OS update
-to the latest balenaOS (which also carries the matching supervisor).
+to the target balenaOS (which also carries the matching supervisor).
+
+The default target is the (current)/GA balenaOS **ESR** version per device
+type — the same track our disk images flash (see the ESR resolution in
+.github/workflows/build-balena-disk-image.yaml). ESR is reachable by HUP from
+the old classic-track lines; devices already on the ESR/CalVer track or on
+regular 7.x are skipped (no HUP path), and recent 6.x that only reach a newer
+ESR than the GA target are skipped fault-tolerantly. Use `--track regular`
+or an explicit `--os-version` to override. raspberrypi2 has no ESR track and
+falls back to regular `latest`.
 
 It is deliberately cautious:
 
@@ -137,6 +146,50 @@ def latest_os_version(device_type: str) -> str | None:
     return versions[0]
 
 
+def current_esr_version(device_type: str) -> str | None:
+    """The GA '(current)'-tagged balenaOS ESR version for a device type,
+    e.g. '2025.7.0'. Returns None when the device type has no ESR track
+    (e.g. raspberrypi2) or the lookup fails — callers fall back to
+    latest_os_version()."""
+    ok, out, _ = run_balena(['os', 'versions', device_type, '--esr'])
+    if not ok:
+        return None
+    for line in out.splitlines():
+        if '(current)' in line:
+            token = line.strip().split()[0].lstrip('v')
+            if token[:1].isdigit():
+                return token
+    return None
+
+
+def is_calver(version: str) -> bool:
+    """True for the CalVer ESR scheme (2024.x and up), False for the
+    classic semver regular track (2.x .. 7.x). The two share an integer
+    namespace at the major position, so parse_os_version() alone can't tell
+    them apart — this guard does."""
+    return parse_os_version(version)[0] >= 2000
+
+
+def unreachable_for_target(current: str, target: str) -> bool:
+    """Cheap, conservative pre-filter for devices that balena's HUP matrix
+    will not move to *target*, so we can skip them without a per-device API
+    round-trip (the bulk device list has tens of thousands of rows).
+
+    Only consulted for an ESR target. ESR is reachable by HUP from the old
+    classic-track lines (2.x .. ~6.1) but NOT from devices already on the
+    CalVer/ESR track (they are at or ahead of target) nor from regular 7.x.
+    Some recent 6.x (6.5+, 6.10+) also only reach a *newer* ESR than a GA
+    target; those are left as candidates and handled fault-tolerantly (one
+    logged 'no path' skip) rather than hard-coding a fuzzy 6.x cutoff."""
+    if not is_calver(target):
+        return False
+    if is_calver(current):
+        return True  # already on the ESR/CalVer track (at or ahead)
+    if parse_os_version(current)[0] >= 7:
+        return True  # regular 7.x has no HUP path onto ESR
+    return False
+
+
 @dataclass
 class Device:
     uuid: str
@@ -205,6 +258,7 @@ def select_tranche(
         and d.uuid not in done
         and (include_offline or d.is_online)
         and normalize_os(d.os_version) != target_os
+        and not unreachable_for_target(d.os_version, target_os)
     ]
     if order == 'oldest':
         eligible.sort(key=lambda d: parse_os_version(d.os_version))
@@ -286,7 +340,16 @@ def main() -> int:
     ap.add_argument(
         '--os-version',
         default=None,
-        help='target balenaOS version (default: latest per device type)',
+        help='explicit target balenaOS version; overrides --track',
+    )
+    ap.add_argument(
+        '--track',
+        choices=['esr', 'regular'],
+        default='esr',
+        help='which balenaOS track to target when --os-version is not '
+        'given: esr = the (current)/GA ESR (default), regular = newest '
+        'regular release. Device types without an ESR track (raspberrypi2) '
+        'fall back to regular automatically.',
     )
     ap.add_argument(
         '--order',
@@ -354,7 +417,18 @@ def main() -> int:
         if device_type is None:
             print(f'\n# {fleet}: unknown fleet, skipping', file=sys.stderr)
             continue
-        target_os = args.os_version or latest_os_version(device_type)
+        if args.os_version:
+            target_os = args.os_version
+        elif args.track == 'esr':
+            target_os = current_esr_version(device_type)
+            if not target_os:
+                target_os = latest_os_version(device_type)
+                print(
+                    f'\n# {fleet}: no ESR track for {device_type}, '
+                    f'falling back to regular latest'
+                )
+        else:
+            target_os = latest_os_version(device_type)
         if not target_os:
             print(
                 f'\n# {fleet}: cannot resolve target OS, skipping',

--- a/tests/test_balena_fleet_maintenance.py
+++ b/tests/test_balena_fleet_maintenance.py
@@ -19,6 +19,7 @@ _SCRIPT = (
 _spec = importlib.util.spec_from_file_location(
     'balena_fleet_maintenance', _SCRIPT
 )
+assert _spec is not None and _spec.loader is not None
 fm = importlib.util.module_from_spec(_spec)
 # Register before exec so @dataclass can resolve the module by name.
 sys.modules[_spec.name] = fm
@@ -38,7 +39,7 @@ _spec.loader.exec_module(fm)
         ('balenaOS 2.113.4', False),
     ],
 )
-def test_is_calver(version, expected):
+def test_is_calver(version: str, expected: bool) -> None:
     assert fm.is_calver(version) is expected
 
 
@@ -46,7 +47,7 @@ def test_is_calver(version, expected):
     'current',
     ['balenaOS 2.113.4', '5.1.54', '5.3.22', '6.0.36', '6.1.24+rev2'],
 )
-def test_old_classic_lines_can_reach_esr(current):
+def test_old_classic_lines_can_reach_esr(current: str) -> None:
     # The genuinely old (2.x .. 6.1) lines are valid HUP sources for ESR.
     assert fm.unreachable_for_target(current, '2025.7.0') is False
 
@@ -55,16 +56,16 @@ def test_old_classic_lines_can_reach_esr(current):
     'current',
     ['2026.1.0', 'balenaOS 2026.1.0', '2025.7.0'],
 )
-def test_calver_devices_are_at_or_ahead_of_esr_target(current):
+def test_calver_devices_are_at_or_ahead_of_esr_target(current: str) -> None:
     # Already on the ESR/CalVer track -> no downward/sideways HUP path.
     assert fm.unreachable_for_target(current, '2025.7.0') is True
 
 
-def test_regular_seven_cannot_reach_esr():
+def test_regular_seven_cannot_reach_esr() -> None:
     assert fm.unreachable_for_target('7.2.0', '2025.7.0') is True
 
 
-def test_no_filter_for_regular_target():
+def test_no_filter_for_regular_target() -> None:
     # raspberrypi2 falls back to a regular target; the ESR pre-filter must
     # not suppress an otherwise-eligible device there.
     assert fm.unreachable_for_target('5.1.54', '5.1.20') is False

--- a/tests/test_balena_fleet_maintenance.py
+++ b/tests/test_balena_fleet_maintenance.py
@@ -1,0 +1,71 @@
+"""Unit tests for the balenaOS track logic in bin/balena_fleet_maintenance.py.
+
+The roller targets the ESR track by default; these cover the CalVer-vs-semver
+discrimination and the HUP-reachability pre-filter that decides which devices
+are even candidates for an ESR target.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / 'bin'
+    / 'balena_fleet_maintenance.py'
+)
+_spec = importlib.util.spec_from_file_location(
+    'balena_fleet_maintenance', _SCRIPT
+)
+fm = importlib.util.module_from_spec(_spec)
+# Register before exec so @dataclass can resolve the module by name.
+sys.modules[_spec.name] = fm
+_spec.loader.exec_module(fm)
+
+
+@pytest.mark.parametrize(
+    'version,expected',
+    [
+        ('2024.1.0', True),
+        ('2025.7.0', True),
+        ('2026.1.0', True),
+        ('balenaOS 2026.1.0', True),
+        ('7.2.0', False),
+        ('6.12.3+rev4', False),
+        ('5.1.54', False),
+        ('balenaOS 2.113.4', False),
+    ],
+)
+def test_is_calver(version, expected):
+    assert fm.is_calver(version) is expected
+
+
+@pytest.mark.parametrize(
+    'current',
+    ['balenaOS 2.113.4', '5.1.54', '5.3.22', '6.0.36', '6.1.24+rev2'],
+)
+def test_old_classic_lines_can_reach_esr(current):
+    # The genuinely old (2.x .. 6.1) lines are valid HUP sources for ESR.
+    assert fm.unreachable_for_target(current, '2025.7.0') is False
+
+
+@pytest.mark.parametrize(
+    'current',
+    ['2026.1.0', 'balenaOS 2026.1.0', '2025.7.0'],
+)
+def test_calver_devices_are_at_or_ahead_of_esr_target(current):
+    # Already on the ESR/CalVer track -> no downward/sideways HUP path.
+    assert fm.unreachable_for_target(current, '2025.7.0') is True
+
+
+def test_regular_seven_cannot_reach_esr():
+    assert fm.unreachable_for_target('7.2.0', '2025.7.0') is True
+
+
+def test_no_filter_for_regular_target():
+    # raspberrypi2 falls back to a regular target; the ESR pre-filter must
+    # not suppress an otherwise-eligible device there.
+    assert fm.unreachable_for_target('5.1.54', '5.1.20') is False
+    assert fm.unreachable_for_target('2.113.4', '5.1.20') is False


### PR DESCRIPTION
## Description

balenaOS ships two parallel tracks — **regular** (latest `7.2.0`) and **ESR** (Extended Support Release, CalVer e.g. `2025.7.0`). ESR's long support window suits field signage and is balena's default-going-forward track, so we standardize the fleet **and** our disk images on it.

This surfaced during a fleet OS/supervisor audit: our disk image build was doing `balena os download --version latest`, which silently resolves to the **regular** track, while the fleet roller also defaulted to regular. So newly-flashed devices were landing on regular `7.2.0`, not ESR.

### Changes

- **`build-balena-disk-image.yaml`** — resolve the `(current)`/GA ESR version per device type from `balena os versions --esr` and flash that, instead of `--version latest`. `menu-esr` can't be used in CI (interactive only), hence the explicit resolve. `raspberrypi2` has no ESR track, so it falls back to regular `latest` (5.1.x is its architectural ceiling anyway).
- **`bin/balena_fleet_maintenance.py`** — default the HUP target to the `(current)` ESR via a new `--track esr|regular` (esr default; `--os-version` still overrides). Adds a conservative reachability pre-filter: devices already on the ESR/CalVer track, or on regular `7.x` — which balena's HUP matrix won't move onto an ESR target — are skipped without a per-device API round-trip, rather than attempted and failed.
- **Tests** — unit coverage for the CalVer-vs-semver discrimination and the reachability filter.

### Notes / track topology

The two tracks are mutually unreachable at their tops (verified via the SDK's `getSupportedOsUpdateVersions`):

- Legacy `2.x` / `5.x` / `6.0`–`6.1` **can** HUP to ESR — this is the EOL-risk population the roller targets.
- Devices already on ESR `2026.1.0` (the newer `next` ESR) are *ahead* of GA `2025.7.0` and converge when GA advances.
- Regular `6.10`/`6.12`/`7.x` reach ESR only by reflash; they age out as devices are re-imaged from this updated build.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)