### PR TITLE
fix(viewer): run PulseAudio so Qt 6 video plays with audio

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -94,6 +94,79 @@ mkdir -p "${XDG_RUNTIME_DIR}"
 chown viewer:video "${XDG_RUNTIME_DIR}"
 chmod 700 "${XDG_RUNTIME_DIR}"
 
+# Qt 6 boards play video through QtMultimedia (QMediaPlayer →
+# QAudioOutput), and Debian's Qt 6 Multimedia is compiled with
+# PulseAudio as its ONLY audio backend — libQt6Multimedia.so.6 links
+# libpulse and has no ALSA code. Without a running PulseAudio server
+# QMediaDevices enumerates zero audio outputs, QAudioOutput keeps a
+# null device, and every video plays silent (issue #3000). The
+# pre-#2905 mpv path talked ALSA directly and needed no sound server,
+# which is why this only bit after the QtMultimedia migration.
+#
+# Run a minimal per-container daemon as the viewer user. The config
+# is generated instead of using Debian's default.pa because the stock
+# config detects cards via module-udev-detect, which finds nothing in
+# a container without udevd (only the auto_null sink appears). One
+# module-alsa-card per /proc/asound/cards entry, loaded with
+# name=<alsa card id>, names the pulse sinks after the ALSA card
+# (e.g. alsa_output.vc4hdmi0.hdmi-stereo) — exactly the CARD=<name>
+# discriminator VideoView::resolveAlsaDevice matches the Python
+# side's get_alsa_audio_device() spec against, so the existing
+# HDMI-port auto-detection and the hdmi/local audio_output setting
+# keep working unchanged on top of pulse.
+start_pulseaudio() {
+    # Qt 5 boards (pi2/pi3) don't ship pulseaudio: GstFbdevMediaPlayer
+    # drives alsasink directly.
+    command -v pulseaudio > /dev/null || return 0
+
+    # PulseAudio keeps its state (auth cookie) under
+    # ~viewer/.config/pulse. On upgraded devices /data/.config was
+    # created by a root-running container, so pre-create the subdir
+    # and hand it to the viewer — same pattern as the /data/.anthias
+    # chown above. (The daemon refuses to start when it can't write
+    # its state dir.)
+    mkdir -p /data/.config/pulse
+    chown -Rf viewer /data/.config/pulse
+
+    pa_config=/tmp/anthias-pulse.pa
+    {
+        echo '.fail'
+        echo 'load-module module-native-protocol-unix'
+        # .nofail: a card whose profile can't open right now (e.g.
+        # the vc4hdmi of an unplugged HDMI port) must not abort
+        # daemon startup — the other cards still have to load.
+        echo '.nofail'
+        sed -n 's/^ *\([0-9][0-9]*\) \[\([^ ]*\) *\].*/\1 \2/p' \
+            /proc/asound/cards \
+            | while read -r card_index card_id; do
+                echo "load-module module-alsa-card" \
+                    "device_id=${card_index} name=${card_id}"
+            done
+        echo '.fail'
+        # Suspend idle sinks so the ALSA PCM is released between
+        # videos instead of held open by the daemon for the
+        # container's whole lifetime (same as Debian's default.pa).
+        echo 'load-module module-suspend-on-idle'
+        # Guarantee a default sink (auto_null) even when no card
+        # loaded, so clients still connect cleanly instead of
+        # erroring — same silent outcome as today, but recoverable
+        # by a container restart once audio hardware shows up.
+        echo 'load-module module-always-sink'
+    } > "$pa_config"
+
+    # --daemonize blocks until the daemon is initialised, so the
+    # socket is guaranteed to exist before AnthiasViewer's
+    # QMediaDevices first looks for a server. exit-idle-time=-1
+    # keeps the daemon alive across the long client-less gaps
+    # between videos.
+    if ! sudo --preserve-env=XDG_RUNTIME_DIR -E -u viewer \
+        pulseaudio --daemonize=yes --exit-idle-time=-1 -nF "$pa_config"; then
+        echo "start_viewer: pulseaudio failed to start —" \
+            "video will play without audio"
+    fi
+}
+start_pulseaudio
+
 # Drop empty locale env vars so they don't override defaults that the
 # container image (or downstream consumers like Python's `locale`
 # module) would otherwise inherit. docker-compose.yml.tmpl wires

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -176,10 +176,11 @@ def _log_arm64_alsa_default_once() -> None:
     except OSError as exc:
         listing = f'<could not read /proc/asound/cards: {exc}>'
     logging.info(
-        'arm64: using ALSA "default" device for HDMI audio. '
-        'If audio is silent, override via ~/.asoundrc (bind-mounted '
-        'into the viewer container — see docker-compose.yml.tmpl). '
-        'Registered ALSA cards:\n%s',
+        'arm64: using the default audio device for HDMI audio '
+        '(resolves to the PulseAudio default sink — see '
+        'start_pulseaudio in bin/start_viewer.sh). If audio is '
+        'silent, check `pactl list short sinks` in the viewer '
+        'container. Registered ALSA cards:\n%s',
         listing,
     )
 
@@ -193,13 +194,13 @@ def get_alsa_audio_device() -> str:
     # through to the Pi-name dispatch when we're actually on a Pi.
     if os.environ.get('DEVICE_TYPE') in ARM64_DEVICE_TYPES:
         # No portable per-SoC HDMI card name across Rockchip /
-        # Allwinner / Amlogic, so defer to ALSA's `default` device.
-        # Operators with a non-standard HDMI sink can override via
-        # ~/.asoundrc (already bind-mounted into the viewer container
-        # — see docker-compose.yml.tmpl). Log the chosen ALSA card
-        # at INFO once per process so a silent-HDMI report carries
-        # enough breadcrumbs to debug from journalctl alone (the
-        # `aplay -l` enumeration also lands in the same log).
+        # Allwinner / Amlogic, so defer to the `default` device —
+        # which VideoView::resolveAlsaDevice resolves to the
+        # PulseAudio default sink (the daemon start_viewer.sh runs;
+        # Debian's Qt 6 Multimedia only has a PulseAudio backend).
+        # Log the chosen device at INFO once per process so a
+        # silent-HDMI report carries enough breadcrumbs to debug
+        # from journalctl alone.
         _log_arm64_alsa_default_once()
         return 'default'
 

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -283,9 +283,22 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
         # gstreamer plugin set needed. VLC is deliberately not
         # installed because MediaPlayerProxy never routes Qt6
         # boards to it.
+        # pulseaudio: Debian's Qt 6 Multimedia is compiled with
+        # PulseAudio as its ONLY audio backend — libQt6Multimedia.so.6
+        # links libpulse and contains no libasound/ALSA code at all —
+        # so without a running PulseAudio server QMediaDevices
+        # enumerates zero audio outputs, QAudioOutput holds a null
+        # device, and every video plays silent (issue #3000; the
+        # pre-#2905 mpv path talked ALSA directly and needed no sound
+        # server). bin/start_viewer.sh starts a minimal per-container
+        # daemon as the viewer user. pulseaudio-utils ships pactl so
+        # a silent-audio field report can be debugged from a shell
+        # (list sinks / sink-inputs) without modifying the image.
         viewer_extra_apt_dependencies.extend(
             [
                 'libqt6multimedia6',
+                'pulseaudio',
+                'pulseaudio-utils',
                 'qml6-module-qtmultimedia',
                 'qml6-module-qtquick',
                 'qt6-base-dev',


### PR DESCRIPTION
### Issues Fixed

Fixes #3000

### Description

Debian's Qt 6 Multimedia is compiled with **PulseAudio as its only audio backend** — `libQt6Multimedia.so.6` links `libpulse` and contains no ALSA code. The viewer container runs no sound server, so `QMediaDevices` enumerates zero audio outputs, `QAudioOutput` keeps a null device, and every video on a Qt 6 board (pi4-64, pi5, x86, arm64) plays silent. The pre-#2905 mpv path talked ALSA directly and needed no sound server, which is why audio regressed with the QtMultimedia migration.

- Ship `pulseaudio` (+ `pulseaudio-utils` for field debugging via `pactl`) in the Qt 6 viewer images.
- `start_viewer.sh` starts a minimal per-container daemon as the `viewer` user. The config is generated (the stock `default.pa` detects cards via `module-udev-detect`, which finds nothing in a container without udevd): one `module-alsa-card` per `/proc/asound/cards` entry, loaded with `name=<alsa card id>`, so pulse sink names embed the ALSA card name (`alsa_output.vc4hdmi0.hdmi-stereo`). That's exactly the `CARD=<name>` discriminator `VideoView::resolveAlsaDevice` matches against, so the existing HDMI-port auto-detection and the hdmi/local `audio_output` setting keep working unchanged.
- Qt 5 boards (pi2/pi3) are untouched — `GstFbdevMediaPlayer` drives `alsasink` directly and their images don't ship pulseaudio.

Validated on a physical Pi 4 running the pi4-64 image built from this branch: the stats log `INIT` line reports `audio_default=vc4-hdmi-0 Digital Stereo (HDMI)` (previously empty), the `vc4hdmi0` PCM reaches `RUNNING` with 48 kHz IEC958 samples flowing during video playback, the AnthiasViewer stream attaches to `alsa_output.vc4hdmi0.hdmi-stereo`, and `module-suspend-on-idle` releases the PCM between clips.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)