### PR TITLE
fix(webview): add page-load watchdog so a stalled fetch can't freeze the display

### DIFF
--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -112,6 +112,34 @@ bool isLowRamMode()
     const QByteArray value = qgetenv("ANTHIAS_LOW_RAM");
     return value == "1";
 }
+
+// Issue #2999 — page-load watchdog interval. Chromium has no overall
+// navigation timeout, so a fetch whose packets stop arriving (WiFi
+// dropout mid-load; the TCP socket stays ESTABLISHED with no FIN/RST)
+// keeps the navigation pending indefinitely. 30 s is deliberately
+// more generous than the asset-rotation cadence and the old
+// VIDEO_TIMEOUT=20 the Python side used for stalled videos: a complex
+// dashboard on a slow uplink may legitimately take 15–20 s, and a
+// too-eager watchdog would cancel loads that were about to succeed.
+// Operators can tune it via ANTHIAS_WEBPAGE_TIMEOUT_S on the viewer
+// container. Clamped so a garbage value can't disable the watchdog
+// entirely (the whole point is that there's always *some* timeout)
+// or overflow the QTimer's millisecond int.
+constexpr int kDefaultPageLoadTimeoutS = 30;
+constexpr int kMinPageLoadTimeoutS = 5;
+constexpr int kMaxPageLoadTimeoutS = 3600;
+
+int pageLoadTimeoutMs()
+{
+    bool ok = false;
+    int seconds =
+        qEnvironmentVariableIntValue("ANTHIAS_WEBPAGE_TIMEOUT_S", &ok);
+    if (!ok || seconds <= 0) {
+        seconds = kDefaultPageLoadTimeoutS;
+    }
+    return qBound(kMinPageLoadTimeoutS, seconds, kMaxPageLoadTimeoutS)
+        * 1000;
+}
 }
 
 View::View(QWidget* parent) : QWidget(parent)
@@ -189,6 +217,14 @@ View::View(QWidget* parent) : QWidget(parent)
     loadGenerationId = 0;
     reloadTimer = nullptr;
     pendingReloadIntervalS = 0;
+
+    // Issue #2999 — see the member's comment in view.h. Connected
+    // once here; startPageLoad re-arms it per attempt.
+    pageLoadWatchdog = new QTimer(this);
+    pageLoadWatchdog->setSingleShot(true);
+    pageLoadWatchdog->setInterval(pageLoadTimeoutMs());
+    connect(pageLoadWatchdog, &QTimer::timeout,
+            this, &View::handlePageLoadTimeout);
 }
 
 View::~View()
@@ -243,6 +279,13 @@ void View::loadPage(const QString &uri)
     pendingReloadIntervalS = 0;
     nextWebViewReady = false;
 
+    startPageLoad(uri, requestId);
+
+    qDebug() << "Loading web page in background web view:" << uri;
+}
+
+void View::startPageLoad(const QString &uri, quint64 requestId)
+{
     // Drop any prior loadFinished handler before stop() — a synchronous
     // loadFinished(false) emission from the previous in-flight load
     // would otherwise reach the (still-attached) handler and run with
@@ -250,9 +293,12 @@ void View::loadPage(const QString &uri)
     // detached, stop() can fire whatever it likes harmlessly.
     if (pageLoadConnection) {
         QObject::disconnect(pageLoadConnection);
+        pageLoadConnection = QMetaObject::Connection{};
     }
 
     nextWebView->stop();
+
+    pendingPageUri = uri;
 
     pageLoadConnection = connect(
         nextWebView->page(),
@@ -272,19 +318,54 @@ void View::loadPage(const QString &uri)
             }
 
             if (ok) {
+                pageLoadWatchdog->stop();
+                pendingPageUri.clear();
                 qDebug() << "Background web page loaded successfully";
                 nextWebViewReady = true;
                 switchToNextWebView();
             } else {
+                // Deliberately leave the watchdog running: when it
+                // fires, handlePageLoadTimeout re-issues this URI. A
+                // load that failed fast (DNS / connection refused
+                // while the network is down) thereby gets a paced
+                // retry, which is the only retry a single-webpage
+                // playlist will ever see — view_webpage() skips the
+                // loadPage D-Bus call when the URL hasn't changed
+                // (issue #2999).
                 qDebug() << "Background web page failed to load";
                 nextWebViewReady = false;
             }
         }
     );
 
-    nextWebView->load(QUrl(uri));
+    // (Re)arm the watchdog for this attempt — single-shot, so each
+    // retry gets a full interval.
+    pageLoadWatchdog->start();
 
-    qDebug() << "Loading web page in background web view:" << uri;
+    nextWebView->load(QUrl(uri));
+}
+
+void View::handlePageLoadTimeout()
+{
+    // Defensive: every path that cancels the pending navigation
+    // (loadImage / playVideo / a successful load) stops the watchdog
+    // and clears the URI, but if a stray timeout slips through an
+    // empty URI means there is nothing to recover.
+    if (pendingPageUri.isEmpty()) {
+        return;
+    }
+
+    qWarning() << "Webpage load did not finish within"
+               << pageLoadWatchdog->interval() / 1000
+               << "seconds — cancelling and retrying:" << pendingPageUri;
+
+    // startPageLoad stop()s the wedged navigation (cancelling its
+    // pending network I/O so stuck sockets don't pile up in
+    // Chromium's connection pool), re-issues the URI on a fresh
+    // request, and re-arms the watchdog. The generation ID is
+    // unchanged — this is still the same asset; any later asset
+    // bumps the generation and supersedes the retry's handler.
+    startPageLoad(pendingPageUri, loadGenerationId);
 }
 
 void View::loadImage(const QString &preUri)
@@ -319,6 +400,10 @@ void View::loadImage(const QString &preUri)
         QObject::disconnect(pageLoadConnection);
         pageLoadConnection = QMetaObject::Connection{};
     }
+    // ...and its watchdog, so a stale timeout doesn't retry a webpage
+    // the playlist has rotated away from (issue #2999).
+    pageLoadWatchdog->stop();
+    pendingPageUri.clear();
     // Webpage auto-refresh only applies while a webpage is on screen;
     // killing the timer (and clearing the pending interval) here keeps
     // a stale reload from firing into the (now hidden) QWebEngineView
@@ -487,6 +572,8 @@ void View::playVideo(const QString &uri, const QVariantMap &options)
         QObject::disconnect(pageLoadConnection);
         pageLoadConnection = QMetaObject::Connection{};
     }
+    pageLoadWatchdog->stop();
+    pendingPageUri.clear();
     stopReloadTimer();
     pendingReloadIntervalS = 0;
     webView1->stop();

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -59,6 +59,18 @@ private:
     void loadAsStaticImage(const QByteArray& data);
     void setupAnimation();
     void switchToNextWebView();
+    // Issues a (re)load of ``uri`` into nextWebView: detaches any
+    // stale loadFinished handler, cancels the in-flight navigation,
+    // attaches a fresh one-shot handler tagged with ``requestId``,
+    // and (re)arms the page-load watchdog. Called by loadPage for
+    // the initial attempt and by handlePageLoadTimeout for retries.
+    void startPageLoad(const QString &uri, quint64 requestId);
+    // Issue #2999 — runs when a webpage navigation has neither
+    // finished nor been superseded within the watchdog interval
+    // (e.g. stalled mid-fetch by a network dropout). Cancels the
+    // wedged load and retries the same URI so the device self-heals
+    // once connectivity returns.
+    void handlePageLoadTimeout();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // Hides VideoView and re-enables the web/image surface. Called
     // by loadPage / loadImage so a switch from video back to a web
@@ -93,6 +105,27 @@ private:
     // we can drop it before issuing stop() on the next loadPage and
     // avoid a synchronous loadFinished(false) racing into a stale slot.
     QMetaObject::Connection pageLoadConnection;
+
+    // Issue #2999 — page-load watchdog. QtWebEngine has no built-in
+    // navigation timeout: a fetch interrupted mid-flight (WiFi AP
+    // drop, no FIN/RST) leaves the request pending forever, so
+    // loadFinished never fires, the dual-view swap never happens and
+    // the screen freezes on the previous asset until the container is
+    // restarted. Single-shot; armed by startPageLoad, stopped on a
+    // successful load and by every path that cancels the pending
+    // navigation (loadImage / playVideo). On timeout — or after a
+    // *failed* load, where the handler deliberately leaves it running
+    // as a delayed-retry tick — handlePageLoadTimeout stops the wedged
+    // navigation and re-issues the same URI. The retry matters: the
+    // viewer's view_webpage() only sends loadPage when the URL
+    // *changes*, so with a single-webpage playlist no further D-Bus
+    // call would ever arrive to unwedge a stalled load.
+    QTimer* pageLoadWatchdog;
+
+    // URI of the loadPage navigation currently in flight (empty when
+    // none). Read by handlePageLoadTimeout to retry; cleared whenever
+    // the pending navigation is cancelled in favor of an image/video.
+    QString pendingPageUri;
 
     // Per-asset auto-refresh timer. When non-null and active, fires
     // currentWebView->reload() every ``pendingReloadIntervalS`` seconds.


### PR DESCRIPTION
### Issues Fixed

Fixes #2999

### Description

QtWebEngine has no overall navigation timeout. A webpage fetch interrupted mid-flight (WiFi AP dropout — the TCP socket stays ESTABLISHED, no FIN/RST ever arrives) keeps the navigation pending forever: `loadFinished` never fires, the dual-view swap never happens, and the screen freezes on the previous asset until the container is restarted. The Python scheduler keeps cycling normally (`loadPage` is fire-and-forget D-Bus), which is exactly the symptom set reported in the issue. Worse, `view_webpage()` only re-sends `loadPage` when the URL *changes*, so a single-webpage playlist can never recover even after connectivity returns.

This adds the missing safety net on the C++ side, analogous to the old `VIDEO_TIMEOUT` for stalled videos:

- A single-shot page-load watchdog armed per load attempt (default 30 s; tunable via `ANTHIAS_WEBPAGE_TIMEOUT_S` on the viewer container, clamped to 5–3600 s).
- On timeout it `stop()`s the wedged navigation — cancelling the pending network I/O so dead sockets don't accumulate in Chromium's connection pool — and retries the same URI on a fresh request.
- Fast failures (DNS / connection refused while the network is down) reuse the watchdog as a paced retry tick, so single-webpage playlists self-heal too.
- The watchdog is disarmed by every path that supersedes the pending load (successful swap, `loadImage`, `playVideo`); the existing generation-ID guard keeps stale retries from racing newer assets.

**Repro/validation** (x86 viewer image on the dev host, webview built from this branch, offscreen QPA, driven over D-Bus like the real viewer; tarpit HTTP server hangs the first `/stall-once` fetch mid-body and serves it normally on retry):

- Unpatched: stalled load shows no `loadFinished` for 90 s+, screen frozen on previous asset, no recovery path.
- Patched (10 s watchdog for the test): `Webpage load did not finish within 10 seconds — cancelling and retrying` → retry succeeds → `Switching to next web view`, with **no further D-Bus traffic**; healthy pages never trip the watchdog; rotating to an image disarms it (no stale retry).

Also verified the Qt5 (armv7) path still builds: `tools.image_builder --build-target pi2 --service viewer` succeeds and the resulting binary contains the watchdog. Existing webview QtTest suite passes 9/9.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)