### PR TITLE
feat(sentry): add Sentry error tracking to the Django services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ server = [
     "PyYAML==6.0.2",
     "redis==7.4.0",
     "requests==2.33.1",
+    "sentry-sdk==2.61.1",
     "tenacity==9.1.4",
     "sh==2.2.2",
     "urllib3==2.7.0",
@@ -89,6 +90,7 @@ viewer = [
     "pytz==2026.2",
     "redis==7.4.0",
     "requests==2.33.1",
+    "sentry-sdk==2.61.1",
     "tenacity==9.1.4",
     "sh==2.2.2",
     "urllib3==2.7.0",
@@ -147,6 +149,7 @@ mypy = [
     # ignored, mirroring the cec / pydbus / sh pattern.
     "Pillow==12.2.0",
     "pytz==2026.2",
+    "sentry-sdk==2.61.1",
     "whitenoise==6.12.0",
 ]
 

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -38,18 +38,41 @@ except ModuleNotFoundError as exc:
 # Repo root: src/anthias_server/django_project/settings.py → up 3 to repo root.
 BASE_DIR = Path(__file__).resolve().parents[3]
 
+# Detect "running under tests" without depending solely on the
+# ENVIRONMENT env var. The root conftest.py sets ENVIRONMENT=test via
+# os.environ.setdefault, but pytest-django's plugin-time settings load
+# can fire before that conftest executes — leaving getenv() blank and
+# this module pointed at the production /data path on local pytest
+# runs. Detect pytest itself by inspecting argv (covers `pytest ...`,
+# `python -m pytest ...`, and `uv run pytest ...`) so the test branch
+# is taken regardless of import order. Used by both the Sentry DSN
+# default here and the DATABASES test branch further down.
+_running_under_pytest = any('pytest' in (a or '') for a in sys.argv)
+
 # Operators can point crash reporting at their own Sentry project by
 # setting SENTRY_DSN, or disable it entirely by setting it to an
 # empty string (sentry_sdk treats a falsy DSN as "don't send").
-sentry_sdk.init(
-    dsn=getenv(
-        'SENTRY_DSN',
+#
+# Test runs default to the empty DSN: the unit suite is built to run
+# with no external network dependencies (conftest.py force-mocks
+# Redis for the same reason), and exceptions raised on purpose by
+# failing tests must not land in the production Sentry project. An
+# explicit SENTRY_DSN still wins so the integration stack can opt in
+# deliberately.
+_default_sentry_dsn = (
+    ''
+    if getenv('ENVIRONMENT') == 'test' or _running_under_pytest
+    else (
         'https://da18c7bdab65c9adc4afcd311f5b6f09'
-        '@o4511522371534848.ingest.us.sentry.io/4511522375794688',
-    ),
+        '@o4511522371534848.ingest.us.sentry.io/4511522375794688'
+    )
+)
+sentry_sdk.init(
+    dsn=getenv('SENTRY_DSN', _default_sentry_dsn),
     # Same value the DEBUG flag below keys off: 'development', 'test',
-    # or 'production' (the default) — lets dev/CI events be filtered
-    # out in Sentry without suppressing them at the source.
+    # or 'production' (the default) — lets dev events be filtered out
+    # in Sentry. (Test runs don't send at all — see the DSN default
+    # above.)
     environment=getenv('ENVIRONMENT', 'production'),
     # CalVer release from pyproject.toml's [project].version, via the
     # same helper the System Info page and v2 info API use (handles
@@ -206,16 +229,6 @@ CHANNEL_LAYERS = {
 
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
-#
-# Detect "running under tests" without depending solely on the
-# ENVIRONMENT env var. The root conftest.py sets ENVIRONMENT=test via
-# os.environ.setdefault, but pytest-django's plugin-time settings load
-# can fire before that conftest executes — leaving getenv() blank and
-# this module pointed at the production /data path on local pytest
-# runs. Detect pytest itself by inspecting argv (covers `pytest ...`,
-# `python -m pytest ...`, and `uv run pytest ...`) so the test branch
-# is taken regardless of import order.
-_running_under_pytest = any('pytest' in (a or '') for a in sys.argv)
 
 # In test mode the DB path defaults to a repo-local file so the suite
 # runs without Docker / without writable `/data`. CI containers can

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from typing import Any
 
 import pytz
+import sentry_sdk
 
+from anthias_common.version import get_anthias_release
 from anthias_server.settings import settings as device_settings
 
 # django_stubs_ext.monkeypatch() makes Django generic classes
@@ -35,6 +37,34 @@ except ModuleNotFoundError as exc:
 
 # Repo root: src/anthias_server/django_project/settings.py → up 3 to repo root.
 BASE_DIR = Path(__file__).resolve().parents[3]
+
+# Operators can point crash reporting at their own Sentry project by
+# setting SENTRY_DSN, or disable it entirely by setting it to an
+# empty string (sentry_sdk treats a falsy DSN as "don't send").
+sentry_sdk.init(
+    dsn=getenv(
+        'SENTRY_DSN',
+        'https://da18c7bdab65c9adc4afcd311f5b6f09'
+        '@o4511522371534848.ingest.us.sentry.io/4511522375794688',
+    ),
+    # Same value the DEBUG flag below keys off: 'development', 'test',
+    # or 'production' (the default) — lets dev/CI events be filtered
+    # out in Sentry without suppressing them at the source.
+    environment=getenv('ENVIRONMENT', 'production'),
+    # CalVer release from pyproject.toml's [project].version, via the
+    # same helper the System Info page and v2 info API use (handles
+    # the `uv sync --no-install-project` Docker layout). Empty string
+    # means both sources failed — pass None so Sentry doesn't record
+    # a bogus '' release.
+    release=get_anthias_release() or None,
+    # Request headers and user IPs are PII. Attach them only when the
+    # operator hasn't opted out of analytics in anthias.conf — the
+    # same knob that gates GA telemetry (see lib/telemetry.py). Crash
+    # events themselves still flow; this gates only the PII
+    # enrichment. See
+    # https://docs.sentry.io/platforms/python/data-management/data-collected/
+    send_default_pii=not device_settings['analytics_opt_out'],
+)
 
 
 # Quick-start development settings - unsuitable for production

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,21 @@
+"""Regression guard for the Sentry test-mode gate in settings.py.
+
+The unit suite must run with no external network dependencies
+(conftest.py force-mocks Redis for the same reason), and exceptions
+raised on purpose by failing tests must never reach the production
+Sentry project. settings.py defaults the DSN to '' whenever
+ENVIRONMENT=test or pytest is detected on argv — this test pins that
+behaviour: under pytest the client has no DSN, builds no transport,
+and capture calls are dropped.
+"""
+
+import sentry_sdk
+
+
+def test_sentry_does_not_send_under_pytest() -> None:
+    client = sentry_sdk.get_client()
+    assert not client.dsn
+    assert client.transport is None
+    # capture_message returns the event id when an event is queued
+    # for sending; None means the event was dropped client-side.
+    assert sentry_sdk.capture_message('must not be sent') is None

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,7 @@ mypy = [
     { name = "pytz" },
     { name = "requests" },
     { name = "ruff" },
+    { name = "sentry-sdk" },
     { name = "tenacity" },
     { name = "types-gunicorn" },
     { name = "types-netifaces" },
@@ -191,6 +192,7 @@ server = [
     { name = "pyyaml" },
     { name = "redis" },
     { name = "requests" },
+    { name = "sentry-sdk" },
     { name = "sh" },
     { name = "tenacity" },
     { name = "urllib3" },
@@ -228,6 +230,7 @@ test = [
     { name = "pyyaml" },
     { name = "redis" },
     { name = "requests" },
+    { name = "sentry-sdk" },
     { name = "sh" },
     { name = "tenacity" },
     { name = "time-machine" },
@@ -247,6 +250,7 @@ viewer = [
     { name = "pytz" },
     { name = "redis" },
     { name = "requests" },
+    { name = "sentry-sdk" },
     { name = "sh" },
     { name = "tenacity" },
     { name = "urllib3" },
@@ -324,6 +328,7 @@ mypy = [
     { name = "pytz", specifier = "==2026.2" },
     { name = "requests", specifier = "==2.33.1" },
     { name = "ruff", specifier = "==0.14.10" },
+    { name = "sentry-sdk", specifier = "==2.61.1" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "types-gunicorn", specifier = "==26.0.0.20260518" },
     { name = "types-netifaces", specifier = "==0.11.0.20260408" },
@@ -356,6 +361,7 @@ server = [
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "redis", specifier = "==7.4.0" },
     { name = "requests", specifier = "==2.33.1" },
+    { name = "sentry-sdk", specifier = "==2.61.1" },
     { name = "sh", specifier = "==2.2.2" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "urllib3", specifier = "==2.7.0" },
@@ -393,6 +399,7 @@ test = [
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "redis", specifier = "==7.4.0" },
     { name = "requests", specifier = "==2.33.1" },
+    { name = "sentry-sdk", specifier = "==2.61.1" },
     { name = "sh", specifier = "==2.2.2" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "time-machine", specifier = "==3.2.0" },
@@ -412,6 +419,7 @@ viewer = [
     { name = "pytz", specifier = "==2026.2" },
     { name = "redis", specifier = "==7.4.0" },
     { name = "requests", specifier = "==2.33.1" },
+    { name = "sentry-sdk", specifier = "==2.61.1" },
     { name = "sh", specifier = "==2.2.2" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "urllib3", specifier = "==2.7.0" },
@@ -2053,6 +2061,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
     { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
     { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.61.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/3b/4bc6b348bbd331daa14d4babe9f2b99bc854f4da41560eefb9488d78481d/sentry_sdk-2.61.1.tar.gz", hash = "sha256:9c6adccb3feefa9ba032c8d295ca477575c2f11896046a2b0ad686c47c4af555", size = 459429, upload-time = "2026-06-01T07:24:18.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/54/c9218db183846e08efaf68534889ef42e499dde432778881104a42f7071b/sentry_sdk-2.61.1-py3-none-any.whl", hash = "sha256:fa36eaf4b8ad708f718500d4bdcc1532637526a22beb874d88cbc0a46458b5ae", size = 483735, upload-time = "2026-06-01T07:24:17.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Issues Fixed

Not associated with an issue — adds crash reporting so fleet-wide errors surface in Sentry instead of only in device logs.

### Description

Adds `sentry-sdk` (2.61.1) and initialises it in the shared Django settings module, so **anthias-server**, **anthias-celery**, and **anthias-viewer** all report crashes (each service loads this module at boot via `DJANGO_SETTINGS_MODULE` + `django.setup()`).

- **`SENTRY_DSN` env override** — operators can point crash reporting at their own Sentry project, or set it to an empty string to disable sending entirely (verified: empty DSN → no transport, events dropped).
- **`environment=`** mirrors the `ENVIRONMENT` env var (`production` default), so dev/CI events are filterable in Sentry.
- **`release=`** comes from `pyproject.toml`'s `[project].version` via the existing `get_anthias_release()` helper (handles the `uv sync --no-install-project` image layout).
- **PII is gated** on the existing `analytics_opt_out` knob in `anthias.conf` — the same one that gates GA telemetry. Opted-out devices still report crashes, just without request headers / IPs / user data.

The dependency is added to the `server` and `viewer` groups, plus the `mypy` group (that CI job imports settings through the django-stubs plugin).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)