### PR TITLE
fix(docker): pull the BuildKit frontend via mirror.gcr.io

### DIFF
--- a/docker/Dockerfile.redis.j2
+++ b/docker/Dockerfile.redis.j2
@@ -1,4 +1,4 @@
-# syntax=mirror.gcr.io/docker/dockerfile:1.4
+# syntax=mirror.gcr.io/docker/dockerfile:1.24
 # vim: ft=dockerfile
 
 FROM {{ base_image }}:{{ base_image_tag }}

--- a/docker/Dockerfile.redis.j2
+++ b/docker/Dockerfile.redis.j2
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=mirror.gcr.io/docker/dockerfile:1.4
 # vim: ft=dockerfile
 
 FROM {{ base_image }}:{{ base_image_tag }}

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -1,4 +1,4 @@
-# syntax=mirror.gcr.io/docker/dockerfile:1.4
+# syntax=mirror.gcr.io/docker/dockerfile:1.24
 # vim: ft=dockerfile
 {% if environment == 'production' %}
 {# bun ships no 32-bit binaries at all — its release artifacts cover

--- a/docker/Dockerfile.server.j2
+++ b/docker/Dockerfile.server.j2
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=mirror.gcr.io/docker/dockerfile:1.4
 # vim: ft=dockerfile
 {% if environment == 'production' %}
 {# bun ships no 32-bit binaries at all — its release artifacts cover

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=mirror.gcr.io/docker/dockerfile:1.4
 # vim: ft=dockerfile
 {% include 'uv-builder.j2' %}
 

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -20,7 +20,7 @@
 #     git checkout 2ca65fc7b74444edd51d5803a2c1e05a801a6023 && \
 #     ./configure --disable-x86asm && make -j$(nproc) --quiet
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 {% if apt_dependencies %}
 {% if disable_cache_mounts %}

--- a/docker/Dockerfile.test.j2
+++ b/docker/Dockerfile.test.j2
@@ -1,4 +1,4 @@
-# syntax=mirror.gcr.io/docker/dockerfile:1.4
+# syntax=mirror.gcr.io/docker/dockerfile:1.24
 # vim: ft=dockerfile
 {% include 'uv-builder.j2' %}
 

--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=mirror.gcr.io/docker/dockerfile:1.4
 # vim: ft=dockerfile
 {% include 'uv-builder.j2' %}
 

--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -1,4 +1,4 @@
-# syntax=mirror.gcr.io/docker/dockerfile:1.4
+# syntax=mirror.gcr.io/docker/dockerfile:1.24
 # vim: ft=dockerfile
 {% include 'uv-builder.j2' %}
 


### PR DESCRIPTION
### Issues Fixed

CI builds intermittently fail with `failed to resolve source metadata for docker.io/docker/dockerfile:1.4 … i/o timeout` (e.g. the Generate OpenAPI Schema run on the Sentry PR) because the `# syntax=` directive still pulls the BuildKit frontend from Docker Hub.

### Description

Two changes to the `# syntax=` directive in the four Dockerfile templates (server, viewer, redis, test):

1. **Pull via `mirror.gcr.io`** — this was the last Docker Hub pull in the build pipeline (base images already use `mirror.gcr.io/library/debian`; bun/uv come from ghcr.io). Verified the mirror serves the same multi-arch manifest list.
2. **Bump the frontend pin 1.4 → 1.24** — 1.4 is from May 2022; this picks up four years of frontend bugfixes while keeping the minor-pin convention. No template uses syntax newer than `--mount=type=cache`.

Validated by building the rendered redis image locally against `mirror.gcr.io/docker/dockerfile:1.24`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)