### PR TITLE
fix(server): keep legacy host timezones from crash-looping Django

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -10,11 +10,11 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 import secrets
 import sys
+import zoneinfo
 from os import getenv
 from pathlib import Path
 from typing import Any
 
-import pytz
 import sentry_sdk
 
 from anthias_common.version import get_anthias_release
@@ -297,12 +297,37 @@ USE_I18N = True
 
 USE_TZ = True
 
-try:
-    with open('/etc/timezone', 'r') as f:
-        TIME_ZONE = f.read().strip()
-        pytz.timezone(TIME_ZONE)  # Checks if the timezone is valid.
-except (pytz.exceptions.UnknownTimeZoneError, FileNotFoundError):
-    TIME_ZONE = 'UTC'
+
+def get_host_time_zone(
+    timezone_file: str = '/etc/timezone',
+    zoneinfo_root: Path = Path('/usr/share/zoneinfo'),
+) -> str:
+    """Read the host's /etc/timezone, falling back to UTC.
+
+    /etc/timezone is bind-mounted from the host, so its value is
+    whatever the host distro wrote there. Validate it the same way
+    Django does in django.conf.Settings.__init__ — a zoneinfo lookup
+    PLUS the /usr/share/zoneinfo file check. Validating with a bundled
+    database alone (the old pytz check) is not enough: it accepts
+    names like `US/Central` that the image's tzdata may not ship on
+    disk, and Django then raises ValueError at startup, crash-looping
+    every Django process on the device.
+    """
+    try:
+        with open(timezone_file, 'r') as f:
+            time_zone = f.read().strip()
+        zoneinfo.ZoneInfo(time_zone)
+        if (
+            zoneinfo_root.exists()
+            and not zoneinfo_root.joinpath(*time_zone.split('/')).exists()
+        ):
+            raise zoneinfo.ZoneInfoNotFoundError(time_zone)
+        return time_zone
+    except (OSError, ValueError, zoneinfo.ZoneInfoNotFoundError):
+        return 'UTC'
+
+
+TIME_ZONE = get_host_time_zone()
 
 
 # Static files (CSS, JavaScript, Images)

--- a/tests/test_django_timezone.py
+++ b/tests/test_django_timezone.py
@@ -1,0 +1,93 @@
+"""Tests for the host-timezone validation in the Django settings.
+
+Regression coverage for the `US/Central` crash-loop: the host's
+/etc/timezone can carry a legacy alias that the zoneinfo database
+knows but the image's /usr/share/zoneinfo doesn't ship as a file
+(trixie moved legacy aliases into tzdata-legacy). Django validates
+TIME_ZONE against the on-disk tree, so the settings module must
+apply the same check and fall back to UTC instead of letting Django
+raise ValueError at startup.
+"""
+
+from pathlib import Path
+
+from anthias_server.django_project.settings import get_host_time_zone
+
+
+def _write_timezone(tmp_path: Path, value: str) -> str:
+    timezone_file = tmp_path / 'etc-timezone'
+    timezone_file.write_text(value)
+    return str(timezone_file)
+
+
+def _zoneinfo_root(tmp_path: Path, *zone_files: str) -> Path:
+    root = tmp_path / 'zoneinfo'
+    for zone in zone_files:
+        zone_path = root.joinpath(*zone.split('/'))
+        zone_path.parent.mkdir(parents=True, exist_ok=True)
+        zone_path.touch()
+    root.mkdir(exist_ok=True)
+    return root
+
+
+class TestGetHostTimeZone:
+    def test_valid_zone_present_on_disk(self, tmp_path: Path) -> None:
+        assert (
+            get_host_time_zone(
+                timezone_file=_write_timezone(tmp_path, 'America/Chicago\n'),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago'),
+            )
+            == 'America/Chicago'
+        )
+
+    def test_zone_known_to_zoneinfo_but_missing_on_disk(
+        self, tmp_path: Path
+    ) -> None:
+        # The Sentry crash: `US/Central` resolves via the tzdata
+        # package, but the on-disk tree (Django's source of truth)
+        # lacks the legacy alias.
+        assert (
+            get_host_time_zone(
+                timezone_file=_write_timezone(tmp_path, 'US/Central\n'),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago'),
+            )
+            == 'UTC'
+        )
+
+    def test_unknown_zone_name(self, tmp_path: Path) -> None:
+        assert (
+            get_host_time_zone(
+                timezone_file=_write_timezone(tmp_path, 'Not/AZone\n'),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago'),
+            )
+            == 'UTC'
+        )
+
+    def test_empty_timezone_file(self, tmp_path: Path) -> None:
+        assert (
+            get_host_time_zone(
+                timezone_file=_write_timezone(tmp_path, '\n'),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago'),
+            )
+            == 'UTC'
+        )
+
+    def test_missing_timezone_file(self, tmp_path: Path) -> None:
+        assert (
+            get_host_time_zone(
+                timezone_file=str(tmp_path / 'does-not-exist'),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago'),
+            )
+            == 'UTC'
+        )
+
+    def test_no_zoneinfo_root_skips_disk_check(self, tmp_path: Path) -> None:
+        # Mirrors Django: when /usr/share/zoneinfo is absent the disk
+        # check is skipped and the zoneinfo lookup alone decides.
+        assert (
+            get_host_time_zone(
+                timezone_file=_write_timezone(tmp_path, 'America/Chicago\n'),
+                zoneinfo_root=tmp_path / 'no-such-zoneinfo',
+            )
+            == 'America/Chicago'
+        )

--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -96,6 +96,13 @@ def build_image(
         'python-is-python3',
         'sudo',
         'sqlite3',
+        # The host's /etc/timezone is bind-mounted into the
+        # containers, and hosts in the wild still use legacy aliases
+        # like `US/Central`. Trixie moved those out of tzdata into
+        # tzdata-legacy; without it Django's startup check against
+        # /usr/share/zoneinfo rejects the host's timezone and the
+        # device would fall back to UTC.
+        'tzdata-legacy',
     ]
 
     # The 32-bit Pi boards (pi2, pi3) link against Broadcom's legacy


### PR DESCRIPTION
### Issues Fixed

Fixes a production crash-loop reported via Sentry: `ValueError: Incorrect timezone setting: US/Central`, raised at startup by every Django process (`migrate`, server, celery) on devices whose host `/etc/timezone` contains a legacy alias.

### Description

The host's `/etc/timezone` is bind-mounted into the containers. The old settings validation used pytz, whose bundled database accepts legacy aliases like `US/Central` — but Django validates `TIME_ZONE` against `/usr/share/zoneinfo` on disk, and Debian trixie moved the legacy aliases out of `tzdata` into `tzdata-legacy`. pytz said valid, Django said invalid, and the device crash-looped.

Two-part fix:

- **`settings.py`**: validate the host timezone exactly the way Django does (`zoneinfo` lookup **plus** the on-disk `/usr/share/zoneinfo` check) and fall back to `UTC` on any failure, so no `/etc/timezone` value can ever crash-loop the device again.
- **Base image**: install `tzdata-legacy`, so hosts that legitimately use legacy aliases keep their actual local time instead of silently dropping to UTC.

Verified on a freshly built x86 server image: with `/etc/timezone` = `US/Central`, Django now starts with `TIME_ZONE: US/Central` and local time `CDT -0500`; with a garbage value it falls back to `UTC`. Regression tests added in `tests/test_django_timezone.py`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)