### PR TITLE
fix(viewer): silence sh's monitor-thread crash report on webview exit

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -457,8 +457,18 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
     start"`` in src/anthias_webview/src/main.cpp.
     """
     try:
+        # _bg_exc=False: with the default (True), sh re-raises the exit
+        # error (e.g. SignalException_SIGABRT on a Qt init crash, or
+        # SIGTERM from our own _terminate_webview) inside its daemon
+        # monitor thread, where nothing can catch it — Sentry then
+        # reports an unhandled error for a failure the handshake watch
+        # below already detects and the caller's retry loop already
+        # handles. We never call .wait(), so no exception is deferred.
         candidate = sh.Command('AnthiasViewer')(
-            _bg=True, _err_to_out=True, _env=_build_webview_env()
+            _bg=True,
+            _bg_exc=False,
+            _err_to_out=True,
+            _env=_build_webview_env(),
         )
     except sh.CommandNotFound as exc:
         raise WebviewBinaryMissingError(

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -143,6 +143,14 @@ def test_load_browser(viewer_fixtures: _ViewerFixtures) -> None:
         viewer_fixtures.p_sleep.stop()
         viewer_fixtures.p_cmd.stop()
     viewer_fixtures.m_cmd.assert_called_once_with('AnthiasViewer')
+    # _bg_exc must stay False: with sh's default (True), a webview crash
+    # (or our own SIGTERM on teardown) re-raises the exit error inside
+    # sh's daemon monitor thread, where nothing can catch it — every
+    # crash the retry loop already handles would still surface as an
+    # unhandled-in-thread error in Sentry.
+    launch_kwargs = viewer_fixtures.m_cmd.return_value.call_args.kwargs
+    assert launch_kwargs['_bg'] is True
+    assert launch_kwargs['_bg_exc'] is False
 
 
 def test_spawn_webview_once_raises_on_early_exit(


### PR DESCRIPTION
### Issues Fixed

Sentry event `0c37023f9c8541a6a8ec6bc7b3cbf092` (release 2026.6.2): every AnthiasViewer crash — and even our own SIGTERM during teardown — surfaced as an unhandled `SignalException_SIGABRT` from `sh`'s daemon monitor thread, despite the failure already being detected and retried by `load_browser()`.

### Description

`sh`'s default `_bg_exc=True` re-raises the child's exit error inside the library's own background thread, where nothing can catch it; Sentry's threading integration then reports it as `handled: no`. The spawn in `_spawn_webview_once` now passes `_bg_exc=False` — safe because the handle is only used via `is_alive()` / `process.stdout` / `terminate()`, never `.wait()`, so failure detection stays with the existing D-Bus handshake watch and retry loop.

Verified at runtime: with `_bg_exc=False` a SIGABRT'd child produces zero unhandled thread exceptions while `is_alive()` still flips to `False`. A regression assertion in `test_load_browser` locks the kwargs in.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)