### PR TITLE
fix(viewer): respawn the webview when it dies mid-D-Bus call instead of crashing

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -4,6 +4,7 @@ import logging
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 from os import getenv, path
 from signal import SIGALRM, signal
 from time import monotonic, sleep
@@ -511,7 +512,7 @@ def load_browser(
     persistent failure can't freeze the asset_loop thread for minutes.
     """
     global browser, _webview_supports_set_reload_interval
-    global _last_applied_rotation
+    global _last_applied_rotation, current_browser_url
     logging.info('Loading browser...')
 
     if max_attempts is None:
@@ -568,6 +569,13 @@ def load_browser(
     # and diagnostics never see a live-looking ``browser`` while we are
     # between processes; it is reassigned on a successful spawn below.
     browser = None
+    # A freshly spawned webview displays nothing, so whatever URL the
+    # *previous* process was showing must not short-circuit the next
+    # view_image/view_webpage value comparison — otherwise a webview
+    # that crashed mid-asset respawns to a blank screen and (with an
+    # unchanged URL, e.g. a single-asset playlist) never gets the
+    # loadImage/loadPage re-sent.
+    current_browser_url = None
 
     # Retry the spawn with capped exponential backoff so a board that
     # intermittently crashes during Qt/WebEngine init self-heals on a
@@ -619,6 +627,83 @@ def load_browser(
     ) from last_error
 
 
+# D-Bus error codes that mean "the AnthiasViewer process is gone", as
+# opposed to a method-level failure from a live process. Matched by
+# substring on the exception message — the same convention as the
+# UnknownMethod handling in view_webpage — because pydbus surfaces
+# GDBus errors as GLib.GError whose .message carries the code, and the
+# test environment stubs ``gi`` so the class itself can't be imported
+# here for an isinstance check.
+#
+#   * NoReply — the peer died WHILE our call was in flight ("Message
+#     recipient disconnected from message bus without replying"). This
+#     is what the post-handshake armv7 heap-corruption crash looks
+#     like from the caller's side (Sentry 58040ab3).
+#   * ServiceUnknown / NameHasNoOwner — the peer died BEFORE the call
+#     and already released the ``anthias.viewer`` name.
+#
+# Deliberately NOT included: ``Disconnected`` (it means *our* session
+# bus connection dropped, e.g. dbus-daemon died — respawning the
+# webview can't fix that, so let it escape and have the container
+# restart bring up a whole fresh bus).
+_WEBVIEW_GONE_DBUS_ERRORS = (
+    'org.freedesktop.DBus.Error.NoReply',
+    'org.freedesktop.DBus.Error.ServiceUnknown',
+    'org.freedesktop.DBus.Error.NameHasNoOwner',
+)
+
+
+def _is_webview_gone_error(exc: Exception) -> bool:
+    message = str(exc)
+    return any(code in message for code in _WEBVIEW_GONE_DBUS_ERRORS)
+
+
+def _send_to_webview(send: Callable[[], Any]) -> None:
+    """Run a ``browser_bus`` call, respawning the webview if it died
+    mid-call.
+
+    The flaky armv7 Qt5 init crash that load_browser() retries past can
+    also strike *after* the D-Bus handshake — then the death surfaces
+    not as ``browser.is_alive() == False`` (which view_image /
+    view_webpage already handle) but as a GError raised out of the
+    in-flight ``call_sync``. Without this wrapper that exception
+    escapes main(), turning a one-process crash into a container
+    restart loop and defeating the spawn-retry machinery entirely.
+
+    On a webview-gone error: reap the dead process, respawn with the
+    short inline budget (this runs on the asset_loop thread — see the
+    budget rationale above BROWSER_SPAWN_MAX_ATTEMPTS), and retry the
+    call once. The pydbus proxy targets the well-known
+    ``anthias.viewer`` name, not the dead peer's unique name, so it
+    routes to the respawned process without being rebuilt (the same
+    assumption the rotation-bounce respawn relies on). A failure of
+    the respawn or the retried call still raises — the container
+    restart stays the last resort, it just stops being the first.
+    """
+    try:
+        send()
+        return
+    except Exception as exc:
+        if not _is_webview_gone_error(exc):
+            raise
+        logging.warning(
+            'AnthiasViewer died mid D-Bus call; respawning and retrying '
+            'once: %s',
+            exc,
+        )
+    # Reap the dead process before respawning so it has released the
+    # framebuffer and the ``anthias.viewer`` bus name (no-op if it is
+    # already fully gone; never raises).
+    if browser is not None:
+        _terminate_webview(browser)
+    load_browser(
+        max_attempts=BROWSER_SPAWN_INLINE_MAX_ATTEMPTS,
+        backoff_cap=BROWSER_SPAWN_INLINE_BACKOFF_CAP_SECONDS,
+        startup_timeout=BROWSER_SPAWN_INLINE_TIMEOUT_SECONDS,
+    )
+    send()
+
+
 def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
     """Display a webpage and arm its per-asset auto-refresh timer.
 
@@ -647,7 +732,7 @@ def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
     # str object on consecutive ticks, which a JSON-reconstructed URL
     # would defeat.
     if current_browser_url != uri:
-        browser_bus.loadPage(uri)
+        _send_to_webview(lambda: browser_bus.loadPage(uri))
         current_browser_url = uri
     # ``setReloadInterval`` is a new D-Bus method. A viewer running
     # against an older AnthiasViewer (version skew across a fleet
@@ -707,7 +792,7 @@ def view_image(uri: str) -> None:
     # pass the same str object on consecutive ticks, which a JSON-
     # reconstructed URL would defeat.
     if current_browser_url != uri:
-        browser_bus.loadImage(uri)
+        _send_to_webview(lambda: browser_bus.loadImage(uri))
         current_browser_url = uri
     logging.info('Current url is {0}'.format(current_browser_url))
 

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -466,6 +466,166 @@ def test_view_webpage_resets_interval_on_unchanged_url(
     fake_bus.setReloadInterval.assert_called_once_with(90)
 
 
+# What pydbus raises when the webview dies while a call is in flight
+# (Sentry 58040ab3 — the post-handshake armv7 heap-corruption crash)
+# and when it died before the call and released the bus name.
+_NOREPLY_ERROR = (
+    'GDBus.Error:org.freedesktop.DBus.Error.NoReply: Message recipient '
+    'disconnected from message bus without replying'
+)
+_SERVICE_UNKNOWN_ERROR = (
+    'GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name '
+    'anthias.viewer was not provided by any .service files'
+)
+
+_INLINE_BUDGET_KWARGS = {
+    'max_attempts': viewer.BROWSER_SPAWN_INLINE_MAX_ATTEMPTS,
+    'backoff_cap': viewer.BROWSER_SPAWN_INLINE_BACKOFF_CAP_SECONDS,
+    'startup_timeout': viewer.BROWSER_SPAWN_INLINE_TIMEOUT_SECONDS,
+}
+
+
+@pytest.mark.parametrize(
+    'error_message',
+    [_NOREPLY_ERROR, _SERVICE_UNKNOWN_ERROR],
+    ids=['noreply-mid-call', 'service-unknown'],
+)
+def test_view_image_respawns_webview_on_mid_call_death(
+    viewer_fixtures: _ViewerFixtures,
+    error_message: str,
+) -> None:
+    """A webview that survives the handshake but dies during the
+    ``loadImage`` D-Bus call must be reaped, respawned with the inline
+    budget, and sent the image again — not crash the viewer process
+    (Sentry 58040ab3)."""
+    uri = 'http://example.com/a.png'
+    fake_bus = mock.Mock()
+    fake_bus.loadImage.side_effect = [RuntimeError(error_message), None]
+    fake_browser = mock.Mock()
+    # Alive for view_image's liveness check, gone once
+    # _terminate_webview polls it after SIGTERM.
+    fake_browser.is_alive.side_effect = [True, False]
+    m_load_browser = mock.Mock(name='load_browser')
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'load_browser', m_load_browser),
+    ):
+        viewer_fixtures.u.view_image(uri)
+        # The retried send succeeded, so the latch must reflect it.
+        assert viewer_fixtures.u.current_browser_url == uri
+
+    assert fake_bus.loadImage.call_count == 2
+    fake_browser.terminate.assert_called_once()
+    m_load_browser.assert_called_once_with(**_INLINE_BUDGET_KWARGS)
+
+
+def test_view_webpage_respawns_webview_on_mid_call_death(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """Same recovery contract for the ``loadPage`` path — and the
+    auto-refresh timer must still be armed on the respawned process."""
+    uri = 'https://example.com'
+    fake_bus = mock.Mock()
+    fake_bus.loadPage.side_effect = [RuntimeError(_NOREPLY_ERROR), None]
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.side_effect = [True, False]
+    m_load_browser = mock.Mock(name='load_browser')
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'load_browser', m_load_browser),
+    ):
+        viewer_fixtures.u.view_webpage(uri, 30)
+        assert viewer_fixtures.u.current_browser_url == uri
+
+    assert fake_bus.loadPage.call_count == 2
+    m_load_browser.assert_called_once_with(**_INLINE_BUDGET_KWARGS)
+    fake_bus.setReloadInterval.assert_called_once_with(30)
+
+
+def test_view_image_reraises_unrelated_dbus_error(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """Method-level failures from a live webview (or a dead session
+    bus) are not respawn-worthy — they must propagate so the container
+    restart handles what a webview respawn can't fix."""
+    fake_bus = mock.Mock()
+    fake_bus.loadImage.side_effect = RuntimeError(
+        'GDBus.Error:org.freedesktop.DBus.Error.Disconnected: '
+        'The connection is closed'
+    )
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+    m_load_browser = mock.Mock(name='load_browser')
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'load_browser', m_load_browser),
+    ):
+        with pytest.raises(RuntimeError, match='Disconnected'):
+            viewer_fixtures.u.view_image('http://example.com/a.png')
+        # The failed send must not latch the URL or trigger a respawn.
+        assert viewer_fixtures.u.current_browser_url is None
+
+    m_load_browser.assert_not_called()
+    fake_browser.terminate.assert_not_called()
+
+
+def test_send_to_webview_raises_when_retry_also_fails(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """One respawn-and-retry, then give up: if the freshly spawned
+    webview dies mid-call too, the error escapes so the container
+    restart remains the last resort."""
+    send = mock.Mock(side_effect=RuntimeError(_NOREPLY_ERROR))
+    m_load_browser = mock.Mock(name='load_browser')
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser', None),
+        mock.patch.object(viewer_fixtures.u, 'load_browser', m_load_browser),
+    ):
+        with pytest.raises(RuntimeError, match='NoReply'):
+            viewer_fixtures.u._send_to_webview(send)
+
+    assert send.call_count == 2
+    m_load_browser.assert_called_once_with(**_INLINE_BUDGET_KWARGS)
+
+
+def test_load_browser_resets_current_browser_url(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """A fresh webview displays nothing, so the previous process's URL
+    must not short-circuit the next view_* value comparison — with an
+    unchanged URL (single-asset playlist) the respawned webview would
+    otherwise stay blank forever."""
+    browser_proc = viewer_fixtures.m_cmd.return_value.return_value
+    _stub_browser_stdout_chunks(
+        browser_proc,
+        [b'Anthias service start\n'],
+    )
+    browser_proc.is_alive.return_value = True
+    viewer_fixtures.p_cmd.start()
+    viewer_fixtures.p_sleep.start()
+    try:
+        with mock.patch.object(
+            viewer_fixtures.u,
+            'current_browser_url',
+            'http://example.com/stale.png',
+        ):
+            viewer_fixtures.u.load_browser()
+            assert viewer_fixtures.u.current_browser_url is None
+    finally:
+        viewer_fixtures.p_sleep.stop()
+        viewer_fixtures.p_cmd.stop()
+
+
 def test_watchdog_should_create_file_if_not_exists(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -498,7 +498,7 @@ def test_view_image_respawns_webview_on_mid_call_death(
     ``loadImage`` D-Bus call must be reaped, respawned with the inline
     budget, and sent the image again — not crash the viewer process
     (Sentry 58040ab3)."""
-    uri = 'http://example.com/a.png'
+    uri = 'https://example.com/a.png'
     fake_bus = mock.Mock()
     fake_bus.loadImage.side_effect = [RuntimeError(error_message), None]
     fake_browser = mock.Mock()
@@ -570,7 +570,7 @@ def test_view_image_reraises_unrelated_dbus_error(
         mock.patch.object(viewer_fixtures.u, 'load_browser', m_load_browser),
     ):
         with pytest.raises(RuntimeError, match='Disconnected'):
-            viewer_fixtures.u.view_image('http://example.com/a.png')
+            viewer_fixtures.u.view_image('https://example.com/a.png')
         # The failed send must not latch the URL or trigger a respawn.
         assert viewer_fixtures.u.current_browser_url is None
 
@@ -617,7 +617,7 @@ def test_load_browser_resets_current_browser_url(
         with mock.patch.object(
             viewer_fixtures.u,
             'current_browser_url',
-            'http://example.com/stale.png',
+            'https://example.com/stale.png',
         ):
             viewer_fixtures.u.load_browser()
             assert viewer_fixtures.u.current_browser_url is None


### PR DESCRIPTION
### Issues Fixed

Sentry event `58040ab3c2844b07a5d0707a77ba4122` (release 2026.6.2): `GError: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Message recipient disconnected from message bus without replying` raised from `view_image(STANDBY_SCREEN)` at viewer startup, crashing the viewer into a container restart loop.

### Description

The flaky armv7 Qt5 init crash (`malloc(): unaligned tcache chunk detected`) that `load_browser()` already retries past can also strike *after* the D-Bus handshake. In the Sentry event's breadcrumbs the webview came up on spawn attempt 3/30, then died ~0.4 s later while `loadImage` was in flight — the death surfaced as a `GError` out of `call_sync` instead of `browser.is_alive() == False`, escaped `main()`, and defeated the whole spawn-retry machinery.

- New `_send_to_webview()` wrapper around `loadImage`/`loadPage`: on a webview-gone D-Bus error (`NoReply`, `ServiceUnknown`, `NameHasNoOwner`), reap the dead process, respawn with the existing inline budget, and retry the call once. Other errors (including `Disconnected`, which means *our* session bus died) still propagate so the container restart remains the last resort.
- `load_browser()` now resets `current_browser_url`: a fresh webview displays nothing, so the previous process's URL must not short-circuit the value comparison in `view_image`/`view_webpage`. Previously a webview that crashed mid-asset with an unchanged URL (e.g. a single-asset playlist) respawned to a permanently blank screen.
- 6 new unit tests covering the respawn-and-retry path for both image and webpage assets, error-code selectivity, retry-failure propagation, and the URL reset.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
