### PR TITLE
fix(test): give the test-stack celery worker the test environment

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,7 +14,14 @@ services:
     build: &test_build
       context: .
       dockerfile: docker/Dockerfile.test
-    environment:
+    # Shared with anthias-celery via the anchor: the worker MUST see
+    # the same ENVIRONMENT/ANTHIAS_TEST_DB_PATH as the server. Without
+    # ENVIRONMENT=test, settings.py takes the production branch on the
+    # worker — it reads the (empty) /data/.anthias/anthias.db instead
+    # of the test DB ("no such table: assets" on every task) and, with
+    # no DSN override, ships those errors to the production Sentry
+    # project tagged environment=production.
+    environment: &test_env
       - HOME=/data
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
@@ -46,10 +53,7 @@ services:
         condition: service_started
       redis:
         condition: service_started
-    environment:
-      - HOME=/data
-      - CELERY_BROKER_URL=redis://redis:6379/0
-      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+    environment: *test_env
     restart: always
     volumes:
       - .:/usr/src/app

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -606,10 +606,29 @@ def test_add_asset_via_video_upload(reset_assets: None, page: Page) -> None:
     assert asset is not None
     assert asset.name == 'Video'
     assert asset.mimetype == 'video'
-    # Video uploads land with the placeholder default_duration while
-    # probe_video_duration runs ffprobe out-of-band on Celery.
-    assert asset.duration == settings['default_duration']
-    assert asset.is_processing is True
+    # Video uploads land with the placeholder default_duration and
+    # is_processing=True, then normalize_video_asset ffprobes the
+    # file out-of-band on Celery. Wait for the worker's terminal
+    # write instead of asserting the transient placeholder — racing
+    # the worker either way is flaky, and the wait doubles as the
+    # regression guard for the worker reading the wrong DB (it used
+    # to die with "no such table: assets", leaving the row stuck on
+    # "Processing" forever).
+    _wait_db(
+        lambda: Asset.objects.filter(is_processing=False).count() == 1,
+        timeout=30.0,
+        description='video normalisation reached terminal state',
+    )
+    asset = Asset.objects.first()
+    assert asset is not None
+    # ffprobe-d duration of tests/assets/asset.mov (5.57 s, floored),
+    # committed by the worker on both the accept and reject paths.
+    assert asset.duration == 5
+    # The test container sets no DEVICE_TYPE → empty HW-decode set →
+    # the mpeg4 source is rejected by the codec gate: on_failure
+    # writes the operator-facing error and disables the row.
+    assert asset.is_enabled is False
+    assert (asset.metadata or {}).get('error_message')
 
 
 @pytest.mark.integration

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -621,7 +621,7 @@ def test_add_asset_via_video_upload(reset_assets: None, page: Page) -> None:
     )
     asset = Asset.objects.first()
     assert asset is not None
-    # ffprobe-d duration of tests/assets/asset.mov (5.57 s, floored),
+    # ffprobe'd duration of tests/assets/asset.mov (5.57 s, floored),
     # committed by the worker on both the accept and reject paths.
     assert asset.duration == 5
     # The test container sets no DEVICE_TYPE → empty HW-decode set →


### PR DESCRIPTION
### Issues Fixed

Sentry event `b84d0dcc49b241cba4c85d9f79981589` (release 2026.6.2): `OperationalError: no such table: assets` in `normalize_video_asset`, surfaced as "normalize on_failure cleanup failed". The task baggage carried `sentry-environment=test` while the event itself was tagged `production` — a test-stack task executed by a worker that thought it was in production.

### Description

The `anthias-celery` service in `docker-compose.test.yml` was missing `ENVIRONMENT=test` and `ANTHIAS_TEST_DB_PATH`, so the worker's `settings.py` took the production branch:

- It read the empty, auto-created `/data/.anthias/anthias.db` instead of the test DB at `/data/.anthias/test.db`, failing every dispatched task (and the `on_failure` cleanup) with `no such table: assets`.
- It fell back to the default production Sentry DSN with `environment=production`, leaking test-run errors into the production Sentry project.

Fix: share the `environment:` block between `anthias-test` and `anthias-celery` via a YAML anchor (same pattern the file already uses for `build:`), so the two services cannot drift again. Verified with `docker compose -f docker-compose.test.yml config` that both services resolve identical environments.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices. (N/A — test-infra-only change, no shipped code affected.)
- [ ] I have tested my changes for x86 devices. (N/A — test-infra-only change, no shipped code affected.)
- [ ] I added a documentation for the changes I have made (when necessary). (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)