### PR TITLE
fix(server): stop the GitHub update check from firing Sentry events

### DIFF
--- a/src/anthias_server/lib/github.py
+++ b/src/anthias_server/lib/github.py
@@ -50,9 +50,14 @@ def handle_github_error(
     if exc.response is not None:
         errdesc = exc.response.content
     else:
-        errdesc = 'no data'
+        errdesc = str(exc) or 'no data'
 
-    logging.error(
+    # Warning, not error: the update check is best-effort (5-minute
+    # backoff + cached-verdict fallback), and timeouts / rate limits
+    # are routine on device networks. Sentry's logging integration
+    # turns error-level logs into events, so logging these at error
+    # fires a fleet-wide Sentry event for every network blip.
+    logging.warning(
         '%s fetching %s from GitHub: %s', type(exc).__name__, action, errdesc
     )
 
@@ -84,17 +89,20 @@ def _fetch_latest_release_tag() -> str | None:
     # Trip the same 5-minute backoff for malformed bodies as for
     # transport failures. Without this, a bad JSON body or missing
     # tag_name from a 200 response would re-fire the GitHub call on
-    # every page render until upstream fixed the payload.
+    # every page render until upstream fixed the payload. Warning
+    # level for the same reason as handle_github_error — a captive
+    # portal answering 200 with an HTML body lands here, and that's
+    # an environmental condition, not an application error.
     try:
         payload = resp.json()
     except ValueError:
-        logging.error('Malformed JSON from GitHub /releases/latest')
+        logging.warning('Malformed JSON from GitHub /releases/latest')
         _set_github_error_backoff('latest release: malformed JSON')
         return None
 
     tag = payload.get('tag_name') if isinstance(payload, dict) else None
     if not isinstance(tag, str) or not tag:
-        logging.error('Missing tag_name in /releases/latest response')
+        logging.warning('Missing tag_name in /releases/latest response')
         _set_github_error_backoff('latest release: missing tag_name')
         return None
 
@@ -103,7 +111,7 @@ def _fetch_latest_release_tag() -> str | None:
     # for 24h, locking is_up_to_date() into the fallback verdict for
     # the full TTL even after upstream corrects the tag.
     if _parse_version(tag) is None:
-        logging.error('Unparseable tag_name from GitHub: %r', tag)
+        logging.warning('Unparseable tag_name from GitHub: %r', tag)
         _set_github_error_backoff('latest release: unparseable tag_name')
         return None
 
@@ -162,7 +170,7 @@ def is_up_to_date() -> bool:
 
     latest_version = _parse_version(latest_tag)
     if latest_version is None:
-        logging.error('Malformed tag_name from GitHub: %r', latest_tag)
+        logging.warning('Malformed tag_name from GitHub: %r', latest_tag)
         return _fallback_verdict(local_release)
 
     verdict = local_version >= latest_version

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -390,8 +390,8 @@ def test_handle_github_error_logs_warning_not_error(
     exc = requests_exceptions.ReadTimeout('read timed out')
     exc.response = None
     with (
-        mock.patch.object(github.logging, 'warning') as warning_mock,
-        mock.patch.object(github.logging, 'error') as error_mock,
+        mock.patch.object(logging, 'warning') as warning_mock,
+        mock.patch.object(logging, 'error') as error_mock,
     ):
         github.handle_github_error(exc, 'latest release')
     error_mock.assert_not_called()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -378,3 +378,25 @@ def test_handle_github_error_without_response(
     exc.response = None
     github.handle_github_error(exc, 'no-resp-action')
     assert redis_data['github-api-error'] == 'no-resp-action'
+
+
+def test_handle_github_error_logs_warning_not_error(
+    github_env: None,
+) -> None:
+    """The update check is best-effort and its failures are routine on
+    device networks (timeouts, rate limits). Sentry's logging
+    integration turns error-level logs into events, so logging these
+    at error fires a fleet-wide Sentry event per network blip."""
+    exc = requests_exceptions.ReadTimeout('read timed out')
+    exc.response = None
+    with (
+        mock.patch.object(github.logging, 'warning') as warning_mock,
+        mock.patch.object(github.logging, 'error') as error_mock,
+    ):
+        github.handle_github_error(exc, 'latest release')
+    error_mock.assert_not_called()
+    warning_mock.assert_called_once()
+    # The no-response branch must surface the exception detail, not a
+    # bare 'no data' (Sentry showed 'ReadTimeout … : no data', which
+    # hid the host/timeout info str(exc) carries).
+    assert warning_mock.call_args.args[3] == 'read timed out'


### PR DESCRIPTION
### Issues Fixed

Sentry event `139b36ce6ee04699cbae1c1c30be2619` (release 2026.6.2): `ReadTimeout fetching latest release from GitHub: no data` on `/splash-page/`.

### Description

Every page render calls `is_up_to_date()` via the shared page context, which fetches GitHub's `/releases/latest` with a 5s timeout. A network blip is already handled gracefully (5-minute backoff key + cached-verdict fallback), but the failure was logged at `error` level — and Sentry's logging integration turns error-level logs into events, so every flaky-network device fired a Sentry event for a non-bug.

- Downgrade the update-check failure logs (transport errors, malformed/missing/unparseable `tag_name`) to `warning` — these are environmental conditions on device networks (timeouts, rate-limited NATs, captive portals), not application errors, and the check is best-effort by design.
- Log `str(exc)` instead of the useless `no data` when the failure has no HTTP response, so the log line carries the host/timeout detail.
- Add a regression test pinning the warning level and the exception detail.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)