### PR TITLE
fix(server): open SQLite with WAL journaling and a busy timeout

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -259,9 +259,41 @@ else:
 # `:memory:` DB, which is what we want for unit runs.
 # .github/workflows/test-runner.yml exports ANTHIAS_INTEGRATION_TEST=1
 # only for the `pytest -m integration` step.
+# Three processes share this SQLite file across containers (uvicorn,
+# the celery worker, the viewer — they bind-mount the same
+# ~/.anthias). The stock rollback journal allows exactly one writer
+# and blocks readers while a write transaction is open, and the stock
+# busy timeout is 0 — so a celery sweep UPDATE landing while the
+# viewer reads its asset list raised ``OperationalError: database is
+# locked`` immediately instead of waiting (Sentry ANTHIAS-C/E/G).
+#
+#   * ``timeout`` — sqlite's busy handler: wait up to 20s for a lock
+#     instead of failing on the spot. Longer than any transaction
+#     Anthias runs (the writes are single-row UPDATEs; the longest
+#     holder is the startup ``migrate``/``dbbackup`` pass).
+#   * ``journal_mode=WAL`` — readers no longer block the writer and
+#     vice versa; persists in the DB file but is re-asserted each
+#     connect so restored backups / legacy DBs get upgraded too.
+#   * ``synchronous=NORMAL`` — the recommended pairing with WAL;
+#     FULL's per-commit fsync cost buys nothing extra under WAL on
+#     a power-loss-prone SD card (WAL commits are crash-safe at
+#     NORMAL; worst case is losing the very last commit).
+#   * ``transaction_mode=IMMEDIATE`` — take the write lock at
+#     transaction start so two writers queue on the busy handler
+#     instead of deadlocking mid-transaction on the read→write lock
+#     upgrade (those fail instantly, ignoring the busy timeout).
+#
+# Unit runs (pytest-django's per-worker ``:memory:`` DBs) accept the
+# same pragmas harmlessly: ``journal_mode=WAL`` is a no-op that
+# reports ``memory`` on in-memory databases.
 _db_default: dict[str, Any] = {
     'ENGINE': 'django.db.backends.sqlite3',
     'NAME': db_path,
+    'OPTIONS': {
+        'timeout': 20,
+        'init_command': ('PRAGMA journal_mode=WAL;PRAGMA synchronous=NORMAL;'),
+        'transaction_mode': 'IMMEDIATE',
+    },
 }
 if getenv('ANTHIAS_INTEGRATION_TEST') == '1':
     _db_default['TEST'] = {'NAME': db_path}

--- a/tests/test_django_db_settings.py
+++ b/tests/test_django_db_settings.py
@@ -1,0 +1,44 @@
+"""Tests for the shared SQLite connection options.
+
+Regression coverage for the fleet-wide ``OperationalError: database
+is locked`` crashes (Sentry ANTHIAS-C/E/G): uvicorn, the celery
+worker, and the viewer all open the same SQLite file from separate
+containers, so every consumer of the settings module must connect
+with a busy timeout and WAL journaling instead of the stock
+fail-immediately rollback-journal behaviour.
+"""
+
+import sqlite3
+
+from django.conf import settings
+
+
+class TestSqliteConnectionOptions:
+    def test_busy_timeout_is_set(self) -> None:
+        options = settings.DATABASES['default']['OPTIONS']
+        assert options['timeout'] == 20
+
+    def test_wal_and_synchronous_pragmas_in_init_command(self) -> None:
+        init_command = settings.DATABASES['default']['OPTIONS']['init_command']
+        assert 'PRAGMA journal_mode=WAL' in init_command
+        assert 'PRAGMA synchronous=NORMAL' in init_command
+
+    def test_transactions_start_immediate(self) -> None:
+        options = settings.DATABASES['default']['OPTIONS']
+        assert options['transaction_mode'] == 'IMMEDIATE'
+
+    def test_init_command_is_valid_sqlite(self, tmp_path) -> None:
+        # Execute the exact configured init_command against a scratch
+        # database the way Django does on connect — a typo'd pragma
+        # would otherwise only surface at service startup on-device.
+        init_command = settings.DATABASES['default']['OPTIONS']['init_command']
+        conn = sqlite3.connect(tmp_path / 'scratch.db')
+        try:
+            conn.executescript(init_command)
+            journal_mode = conn.execute('PRAGMA journal_mode').fetchone()[0]
+            synchronous = conn.execute('PRAGMA synchronous').fetchone()[0]
+        finally:
+            conn.close()
+        assert journal_mode == 'wal'
+        # NORMAL reports as 1.
+        assert synchronous == 1

--- a/tests/test_django_db_settings.py
+++ b/tests/test_django_db_settings.py
@@ -9,6 +9,7 @@ fail-immediately rollback-journal behaviour.
 """
 
 import sqlite3
+from pathlib import Path
 
 from django.conf import settings
 
@@ -27,7 +28,7 @@ class TestSqliteConnectionOptions:
         options = settings.DATABASES['default']['OPTIONS']
         assert options['transaction_mode'] == 'IMMEDIATE'
 
-    def test_init_command_is_valid_sqlite(self, tmp_path) -> None:
+    def test_init_command_is_valid_sqlite(self, tmp_path: Path) -> None:
         # Execute the exact configured init_command against a scratch
         # database the way Django does on connect — a typo'd pragma
         # would otherwise only surface at service startup on-device.


### PR DESCRIPTION
### Issues Fixed

Sentry: [ANTHIAS-C](https://anthias.sentry.io/issues/7534493975/) (`database is locked` in the viewer's `generate_asset_list`), [ANTHIAS-E](https://anthias.sentry.io/issues/7534540204/) (`reconcile_stuck_processing`), [ANTHIAS-G](https://anthias.sentry.io/issues/7534580747/) (`cleanup`).

### Description

uvicorn, the celery worker, and the viewer all open the same `~/.anthias/anthias.db` from separate containers. With the stock rollback journal and SQLite's default busy timeout of 0, any write transaction makes concurrent readers/writers fail instantly with `OperationalError: database is locked` — seen fleet-wide on 2026.6.2.

- `timeout=20` — wait for the lock instead of failing on the spot
- `journal_mode=WAL` — readers no longer block the writer and vice versa; re-asserted on every connect so restored backups/legacy DBs get upgraded too
- `synchronous=NORMAL` — the recommended WAL pairing (WAL commits are crash-safe at NORMAL)
- `transaction_mode=IMMEDIATE` — concurrent writers queue on the busy handler instead of deadlocking on the read→write lock upgrade (those fail instantly, ignoring the busy timeout)

Unit runs (pytest-django per-worker `:memory:` DBs) accept the same pragmas harmlessly.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)