### PR TITLE
fix(celery): gate worker startup on applied database migrations

### DIFF
--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -10,6 +10,7 @@ import django
 import sh
 from celery import Celery, Task
 from celery.exceptions import SoftTimeLimitExceeded
+from celery.signals import worker_init
 from django.apps import apps as _django_apps
 from PIL import UnidentifiedImageError
 from tenacity import Retrying, stop_after_attempt, wait_fixed
@@ -186,6 +187,63 @@ def asset_recheck_queue_key(asset_id: str) -> str:
 def asset_recheck_lock_key(asset_id: str) -> str:
     """Task-side cooldown lock key (TTL = RECHECK_COOLDOWN_S)."""
     return f'recheck:{asset_id}:lock'
+
+
+# Poll cadence while the worker waits for the server's startup
+# ``migrate`` pass to finish (see ``wait_for_migrations`` below).
+MIGRATION_WAIT_POLL_S = 5
+
+
+def _migrations_ready() -> bool:
+    """True when the shared SQLite schema is fully migrated.
+
+    Computes the same unapplied-migration plan ``manage.py migrate
+    --check`` does. Any error getting there (``OperationalError:
+    database is locked`` while the server's dbbackup/dbrestore holds
+    the file, a missing ``django_migrations`` table on a
+    first-boot/empty DB) means the schema is not ready either, so
+    report not-ready rather than raising.
+    """
+    from django.db import connections
+    from django.db.migrations.executor import MigrationExecutor
+
+    connection = connections['default']
+    try:
+        executor = MigrationExecutor(connection)
+        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+    except Exception:
+        return False
+    finally:
+        # Don't leak the probe connection into the prefork children —
+        # SQLite handles must not be shared across fork().
+        connection.close()
+    return not plan
+
+
+@worker_init.connect
+def wait_for_migrations(**kwargs: Any) -> None:
+    """Block worker startup until the server has applied migrations.
+
+    The celery container starts in parallel with anthias-server, whose
+    start script is still running its dbbackup → migrate pass (or the
+    dbrestore fallback, which drops and re-creates every table). A
+    task replayed off the Redis broker in that window dies with
+    ``OperationalError: no such table: assets`` (Sentry ANTHIAS-1 —
+    one burst per device on every upgrade/first boot). Tasks stay
+    queued in the broker while we wait, so nothing is lost — they run
+    as soon as the schema is in place. Deliberately unbounded: a
+    worker without a database can do no useful work, and the log line
+    below keeps the wait observable.
+    """
+    waited = 0
+    while not _migrations_ready():
+        logging.warning(
+            'Database is not migrated yet; delaying celery worker '
+            'startup (%ss elapsed)',
+            waited,
+        )
+        time.sleep(MIGRATION_WAIT_POLL_S)
+        waited += MIGRATION_WAIT_POLL_S
 
 
 @celery.on_after_configure.connect

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -200,22 +200,25 @@ def _migrations_ready() -> bool:
     """True when the shared SQLite schema is fully migrated.
 
     Computes the same unapplied-migration plan ``manage.py migrate
-    --check`` does. Any error getting there (``OperationalError:
-    database is locked`` while the server's dbbackup/dbrestore holds
-    the file, a missing ``django_migrations`` table on a
-    first-boot/empty DB) means the schema is not ready either, so
-    report not-ready rather than raising. The error is still logged
-    at DEBUG so a persistent non-transient cause (bad volume mount,
-    corrupted DB file) can be identified from the device logs.
+    --check`` does. A database-side error getting there
+    (``OperationalError: database is locked`` while the server's
+    dbbackup/dbrestore holds the file, a missing
+    ``django_migrations`` table on a first-boot/empty DB) means the
+    schema is not ready either, so report not-ready rather than
+    raising; the underlying error is kept visible at DEBUG for runs
+    with ``--loglevel=debug``. Anything that is NOT a database error
+    (a programming bug in the probe itself) propagates so the worker
+    fails fast instead of waiting forever.
     """
     from django.db import connections
+    from django.db.utils import DatabaseError
     from django.db.migrations.executor import MigrationExecutor
 
     connection = connections['default']
     try:
         executor = MigrationExecutor(connection)
         plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-    except Exception:
+    except DatabaseError:
         logging.debug(
             'Migration-readiness probe failed; treating as not ready',
             exc_info=True,

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -247,17 +247,20 @@ def wait_for_migrations(**kwargs: Any) -> None:
     below keeps the wait observable.
     """
     waited = 0
+    next_log_at = 0
     while not _migrations_ready():
         # First miss logs immediately, then repeat every
         # MIGRATION_WAIT_LOG_EVERY_S — a multi-minute migrate/restore
         # on a slow SD card shouldn't drown the device log in a
-        # warning per poll.
-        if waited % MIGRATION_WAIT_LOG_EVERY_S == 0:
+        # warning per poll. Tracked as an explicit next-log threshold
+        # so the cadence holds whatever the two constants are set to.
+        if waited >= next_log_at:
             logging.warning(
                 'Database is not migrated yet; delaying celery worker '
                 'startup (%ss elapsed)',
                 waited,
             )
+            next_log_at = waited + MIGRATION_WAIT_LOG_EVERY_S
         time.sleep(MIGRATION_WAIT_POLL_S)
         waited += MIGRATION_WAIT_POLL_S
 

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -190,8 +190,10 @@ def asset_recheck_lock_key(asset_id: str) -> str:
 
 
 # Poll cadence while the worker waits for the server's startup
-# ``migrate`` pass to finish (see ``wait_for_migrations`` below).
+# ``migrate`` pass to finish, and how often a waiting worker repeats
+# its log line (see ``wait_for_migrations`` below).
 MIGRATION_WAIT_POLL_S = 5
+MIGRATION_WAIT_LOG_EVERY_S = 30
 
 
 def _migrations_ready() -> bool:
@@ -202,7 +204,9 @@ def _migrations_ready() -> bool:
     database is locked`` while the server's dbbackup/dbrestore holds
     the file, a missing ``django_migrations`` table on a
     first-boot/empty DB) means the schema is not ready either, so
-    report not-ready rather than raising.
+    report not-ready rather than raising. The error is still logged
+    at DEBUG so a persistent non-transient cause (bad volume mount,
+    corrupted DB file) can be identified from the device logs.
     """
     from django.db import connections
     from django.db.migrations.executor import MigrationExecutor
@@ -212,6 +216,10 @@ def _migrations_ready() -> bool:
         executor = MigrationExecutor(connection)
         plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
     except Exception:
+        logging.debug(
+            'Migration-readiness probe failed; treating as not ready',
+            exc_info=True,
+        )
         return False
     finally:
         # Don't leak the probe connection into the prefork children —
@@ -237,11 +245,16 @@ def wait_for_migrations(**kwargs: Any) -> None:
     """
     waited = 0
     while not _migrations_ready():
-        logging.warning(
-            'Database is not migrated yet; delaying celery worker '
-            'startup (%ss elapsed)',
-            waited,
-        )
+        # First miss logs immediately, then repeat every
+        # MIGRATION_WAIT_LOG_EVERY_S — a multi-minute migrate/restore
+        # on a slow SD card shouldn't drown the device log in a
+        # warning per poll.
+        if waited % MIGRATION_WAIT_LOG_EVERY_S == 0:
+            logging.warning(
+                'Database is not migrated yet; delaying celery worker '
+                'startup (%ss elapsed)',
+                waited,
+            )
         time.sleep(MIGRATION_WAIT_POLL_S)
         waited += MIGRATION_WAIT_POLL_S
 

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -257,7 +257,8 @@ def wait_for_migrations(**kwargs: Any) -> None:
         if waited >= next_log_at:
             logging.warning(
                 'Database is not migrated yet; delaying celery worker '
-                'startup (%ss elapsed)',
+                'startup (%ss elapsed; probe errors are logged at '
+                'DEBUG)',
                 waited,
             )
             next_log_at = waited + MIGRATION_WAIT_LOG_EVERY_S

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -1798,7 +1798,7 @@ class TestWaitForMigrations:
             mock.patch.object(
                 celery_tasks_module, '_migrations_ready', return_value=True
             ),
-            mock.patch.object(celery_tasks_module.time, 'sleep') as sleep,
+            mock.patch('anthias_server.celery_tasks.time.sleep') as sleep,
         ):
             celery_tasks_module.wait_for_migrations()
         sleep.assert_not_called()
@@ -1810,7 +1810,7 @@ class TestWaitForMigrations:
                 '_migrations_ready',
                 side_effect=[False, False, True],
             ),
-            mock.patch.object(celery_tasks_module.time, 'sleep') as sleep,
+            mock.patch('anthias_server.celery_tasks.time.sleep') as sleep,
         ):
             celery_tasks_module.wait_for_migrations()
         assert sleep.call_count == 2

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -3,6 +3,7 @@ import tempfile
 import time
 from collections.abc import Iterator
 from os import path
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -1745,3 +1746,71 @@ class TestProbeTimeLimits:
         # The finally block must have released the singleton lock so
         # the next beat tick can run.
         assert celery_tasks_module.r.get(ASSET_REVALIDATION_LOCK_KEY) is None
+
+
+class TestWaitForMigrations:
+    """Startup gate for Sentry ANTHIAS-1 — the worker must not consume
+    tasks while the server's migrate/dbrestore pass is still rewriting
+    the shared SQLite schema."""
+
+    def _patch_executor(self) -> tuple[mock.MagicMock, Any]:
+        fake_conn = mock.MagicMock()
+        connections_patch = mock.patch(
+            'django.db.connections', {'default': fake_conn}
+        )
+        executor_patch = mock.patch(
+            'django.db.migrations.executor.MigrationExecutor'
+        )
+        return fake_conn, (connections_patch, executor_patch)
+
+    def test_ready_when_plan_is_empty(self) -> None:
+        fake_conn, (connections_patch, executor_patch) = self._patch_executor()
+        with connections_patch, executor_patch as executor_cls:
+            executor_cls.return_value.migration_plan.return_value = []
+            assert celery_tasks_module._migrations_ready() is True
+        # The probe connection must not leak into the prefork children.
+        fake_conn.close.assert_called_once()
+
+    def test_not_ready_with_unapplied_migrations(self) -> None:
+        fake_conn, (connections_patch, executor_patch) = self._patch_executor()
+        with connections_patch, executor_patch as executor_cls:
+            executor_cls.return_value.migration_plan.return_value = [
+                (mock.sentinel.migration, False)
+            ]
+            assert celery_tasks_module._migrations_ready() is False
+        fake_conn.close.assert_called_once()
+
+    def test_not_ready_when_db_is_locked(self) -> None:
+        # The window that produced ANTHIAS-1: the server's
+        # dbbackup/dbrestore holds the SQLite file (or the
+        # django_migrations table is mid-recreate) and the probe
+        # raises instead of returning a plan.
+        from django.db.utils import OperationalError
+
+        fake_conn, (connections_patch, executor_patch) = self._patch_executor()
+        with connections_patch, executor_patch as executor_cls:
+            executor_cls.side_effect = OperationalError('database is locked')
+            assert celery_tasks_module._migrations_ready() is False
+        fake_conn.close.assert_called_once()
+
+    def test_worker_init_returns_immediately_when_ready(self) -> None:
+        with (
+            mock.patch.object(
+                celery_tasks_module, '_migrations_ready', return_value=True
+            ),
+            mock.patch.object(celery_tasks_module.time, 'sleep') as sleep,
+        ):
+            celery_tasks_module.wait_for_migrations()
+        sleep.assert_not_called()
+
+    def test_worker_init_blocks_until_ready(self) -> None:
+        with (
+            mock.patch.object(
+                celery_tasks_module,
+                '_migrations_ready',
+                side_effect=[False, False, True],
+            ),
+            mock.patch.object(celery_tasks_module.time, 'sleep') as sleep,
+        ):
+            celery_tasks_module.wait_for_migrations()
+        assert sleep.call_count == 2

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -1793,6 +1793,17 @@ class TestWaitForMigrations:
             assert celery_tasks_module._migrations_ready() is False
         fake_conn.close.assert_called_once()
 
+    def test_non_database_errors_fail_fast(self) -> None:
+        # A programming bug in the probe must not be mistaken for
+        # "database not ready" — that would park the worker in an
+        # infinite startup wait with no failing signal.
+        fake_conn, (connections_patch, executor_patch) = self._patch_executor()
+        with connections_patch, executor_patch as executor_cls:
+            executor_cls.side_effect = TypeError('probe bug')
+            with pytest.raises(TypeError, match='probe bug'):
+                celery_tasks_module._migrations_ready()
+        fake_conn.close.assert_called_once()
+
     def test_worker_init_returns_immediately_when_ready(self) -> None:
         with (
             mock.patch.object(


### PR DESCRIPTION
### Issues Fixed

Sentry: [ANTHIAS-1](https://anthias.sentry.io/issues/7534001787/) (`OperationalError: no such table: assets` in `normalize_video_asset` — 112 events, one burst per device on every upgrade/first boot).

### Description

The celery container boots in parallel with anthias-server, whose start script is still running its `dbbackup` → `migrate` pass (or the `dbrestore` fallback, which drops and re-creates every table). A task replayed off the Redis broker in that window dies with `no such table: assets`, and its `on_failure` cleanup then fails the same way.

- Add a `worker_init` gate that blocks the worker until the unapplied-migration plan is empty (same check as `manage.py migrate --check`)
- Probe errors (database locked while the server holds the file, missing `django_migrations` table on an empty DB) count as not-ready instead of raising
- Tasks stay queued in the broker while waiting, so nothing is lost — they run as soon as the schema is in place
- Doing this inside the worker covers every deployment topology (compose, balena, dev, test) without touching the five compose files that each spell out the worker CMD

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)