### PR TITLE
fix(celery): catch the asset-probe timeout instead of hard-killing the worker

### DIFF
--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -1088,17 +1088,11 @@ def revalidate_asset_urls() -> None:
             try:
                 reachable = _check_asset_reachability(asset)
             except SoftTimeLimitExceeded:
-                # Out of budget for the whole sweep — abort cleanly
-                # (the ``finally`` below releases the lock; rows
-                # updated so far keep their fresh state) instead of
-                # letting the hard limit SIGKILL the pool child. The
-                # next beat tick starts over.
-                logging.warning(
-                    'revalidate_asset_urls: sweep exceeded %ss; '
-                    'aborting until the next beat tick',
-                    ASSET_REVALIDATION_SOFT_TIME_LIMIT_S,
-                )
-                return
+                # Out of budget for the whole sweep — handled by the
+                # outer except below. Re-raise past the blanket
+                # Exception arm that would otherwise swallow it and
+                # keep the sweep running into the hard limit.
+                raise
             except Exception:
                 # url_fails should swallow its own exceptions, but a
                 # surprise from sh/requests shouldn't kill the whole sweep.
@@ -1111,6 +1105,19 @@ def revalidate_asset_urls() -> None:
                 is_reachable=reachable,
                 last_reachability_check=timezone.now(),
             )
+    except SoftTimeLimitExceeded:
+        # The soft signal is delivered asynchronously, so it can fire
+        # anywhere in the loop — during a probe or during the DB
+        # update — which is why the whole sweep body is covered, not
+        # just _check_asset_reachability. Abort cleanly (the
+        # ``finally`` below releases the lock; rows updated so far
+        # keep their fresh state) instead of letting the hard limit
+        # SIGKILL the pool child. The next beat tick starts over.
+        logging.warning(
+            'revalidate_asset_urls: sweep exceeded %ss; '
+            'aborting until the next beat tick',
+            ASSET_REVALIDATION_SOFT_TIME_LIMIT_S,
+        )
     finally:
         # Compare-and-delete: only release if the lock still holds
         # *our* token. If the TTL expired and someone else acquired
@@ -1346,30 +1353,43 @@ def revalidate_asset_url(asset_id: str) -> None:
     ):
         return
 
+    # The soft-limit signal is delivered asynchronously, so the outer
+    # try covers the DB update as well as the probe — a delivery
+    # landing between the probe returning and the UPDATE committing
+    # must not escape as a task failure (that's the SIGKILL-adjacent
+    # noise this task's limits exist to avoid).
     try:
-        reachable = _check_asset_reachability(asset)
+        try:
+            reachable = _check_asset_reachability(asset)
+        except SoftTimeLimitExceeded:
+            # A probe that can't finish inside the soft budget gets
+            # the same verdict url_fails gives an HTTP timeout:
+            # unreachable. Recording the verdict (rather than
+            # bailing) keeps the viewer's _asset_is_displayable in
+            # sync with reality and the cooldown lock prevents an
+            # immediate re-probe storm.
+            logging.warning(
+                'revalidate_asset_url: probe for %s exceeded %ss; '
+                'marking unreachable',
+                asset_id,
+                ASSET_RECHECK_SOFT_TIME_LIMIT_S,
+            )
+            reachable = False
+        except Exception:
+            logging.exception(
+                'revalidate_asset_url: probe crashed for %s', asset_id
+            )
+            return
+        Asset.objects.filter(asset_id=asset_id).update(
+            is_reachable=reachable,
+            last_reachability_check=timezone.now(),
+        )
     except SoftTimeLimitExceeded:
-        # A probe that can't finish inside the soft budget gets the
-        # same verdict url_fails gives an HTTP timeout: unreachable.
-        # Recording the verdict (rather than bailing) keeps the
-        # viewer's _asset_is_displayable in sync with reality and the
-        # cooldown lock prevents an immediate re-probe storm.
         logging.warning(
-            'revalidate_asset_url: probe for %s exceeded %ss; '
-            'marking unreachable',
+            'revalidate_asset_url: soft time limit hit while '
+            'finalising the probe for %s; giving up this recheck',
             asset_id,
-            ASSET_RECHECK_SOFT_TIME_LIMIT_S,
         )
-        reachable = False
-    except Exception:
-        logging.exception(
-            'revalidate_asset_url: probe crashed for %s', asset_id
-        )
-        return
-    Asset.objects.filter(asset_id=asset_id).update(
-        is_reachable=reachable,
-        last_reachability_check=timezone.now(),
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -9,6 +9,7 @@ from typing import Any
 import django
 import sh
 from celery import Celery, Task
+from celery.exceptions import SoftTimeLimitExceeded
 from django.apps import apps as _django_apps
 from PIL import UnidentifiedImageError
 from tenacity import Retrying, stop_after_attempt, wait_fixed
@@ -111,12 +112,35 @@ RECONCILE_STUCK_LOCK_KEY = 'celery:reconcile_stuck_processing:lock'
 # back-to-back ffprobe runs (each up to 15s wall-clock under url_fails).
 RECHECK_COOLDOWN_S = 60
 
+# Time budget for a single on-demand probe. A legitimate worst case
+# under url_fails comfortably exceeds the previous 30s hard limit: a
+# hanging getaddrinfo against a broken resolver (no timeout knob
+# exists for it), then an HTTP HEAD (10s) plus the GET fallback
+# (10s). Tripping the *hard* limit SIGKILLs the pool child, which
+# Sentry reported as three separate issues per occurrence — the
+# "Hard time limit exceeded" error, the TimeLimitExceeded raise, and
+# the "ForkPoolWorker exited with signal 9" billiard log (ANTHIAS-A /
+# ANTHIAS-9 / ANTHIAS-B). The soft limit raises
+# ``SoftTimeLimitExceeded`` *inside* the task instead, which the task
+# records as an ordinary failed probe; the hard limit stays as the
+# backstop for a probe stuck in C code where the soft signal can't be
+# delivered.
+ASSET_RECHECK_SOFT_TIME_LIMIT_S = 60
+ASSET_RECHECK_TIME_LIMIT_S = 90
+
 # Hard ceiling on how long a single sweep is allowed to run. Set above
 # the periodic interval so a sweep that's running long doesn't get
 # guillotined while the next beat tick races to start a new one — the
 # Redis lock below is the primary overlap guard, the time_limit just
 # bounds pathological cases (broken DNS resolver, a stuck ffprobe).
 ASSET_REVALIDATION_TIME_LIMIT_S = 60 * 30
+
+# Soft companion to the sweep's hard limit: raise
+# ``SoftTimeLimitExceeded`` inside the loop a minute early so the
+# sweep can abort cleanly (release its lock, keep the rows updated so
+# far) instead of being SIGKILLed by the hard limit — the same
+# kill-versus-catch rationale as the on-demand probe limits above.
+ASSET_REVALIDATION_SOFT_TIME_LIMIT_S = ASSET_REVALIDATION_TIME_LIMIT_S - 60
 
 # Redis key for the sweep singleton lock. Whoever sets it first runs
 # the sweep; later beat ticks observe the key and exit. The TTL matches
@@ -1002,7 +1026,10 @@ def _check_asset_reachability(asset: Asset) -> bool:
     return not url_fails(uri)
 
 
-@celery.task(time_limit=ASSET_REVALIDATION_TIME_LIMIT_S)
+@celery.task(
+    time_limit=ASSET_REVALIDATION_TIME_LIMIT_S,
+    soft_time_limit=ASSET_REVALIDATION_SOFT_TIME_LIMIT_S,
+)
 def revalidate_asset_urls() -> None:
     """Refresh ``Asset.is_reachable`` for every enabled asset.
 
@@ -1060,6 +1087,18 @@ def revalidate_asset_urls() -> None:
                 continue
             try:
                 reachable = _check_asset_reachability(asset)
+            except SoftTimeLimitExceeded:
+                # Out of budget for the whole sweep — abort cleanly
+                # (the ``finally`` below releases the lock; rows
+                # updated so far keep their fresh state) instead of
+                # letting the hard limit SIGKILL the pool child. The
+                # next beat tick starts over.
+                logging.warning(
+                    'revalidate_asset_urls: sweep exceeded %ss; '
+                    'aborting until the next beat tick',
+                    ASSET_REVALIDATION_SOFT_TIME_LIMIT_S,
+                )
+                return
             except Exception:
                 # url_fails should swallow its own exceptions, but a
                 # surprise from sh/requests shouldn't kill the whole sweep.
@@ -1255,7 +1294,10 @@ def reconcile_stuck_processing() -> None:
         r.eval(_LOCK_RELEASE_LUA, 1, RECONCILE_STUCK_LOCK_KEY, token)
 
 
-@celery.task(time_limit=30)
+@celery.task(
+    time_limit=ASSET_RECHECK_TIME_LIMIT_S,
+    soft_time_limit=ASSET_RECHECK_SOFT_TIME_LIMIT_S,
+)
 def revalidate_asset_url(asset_id: str) -> None:
     """On-demand probe for a single asset.
 
@@ -1306,6 +1348,19 @@ def revalidate_asset_url(asset_id: str) -> None:
 
     try:
         reachable = _check_asset_reachability(asset)
+    except SoftTimeLimitExceeded:
+        # A probe that can't finish inside the soft budget gets the
+        # same verdict url_fails gives an HTTP timeout: unreachable.
+        # Recording the verdict (rather than bailing) keeps the
+        # viewer's _asset_is_displayable in sync with reality and the
+        # cooldown lock prevents an immediate re-probe storm.
+        logging.warning(
+            'revalidate_asset_url: probe for %s exceeded %ss; '
+            'marking unreachable',
+            asset_id,
+            ASSET_RECHECK_SOFT_TIME_LIMIT_S,
+        )
+        reachable = False
     except Exception:
         logging.exception(
             'revalidate_asset_url: probe crashed for %s', asset_id

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -1670,3 +1670,78 @@ def test_reconcile_lock_released_after_clean_run(
         reconcile_stuck_processing.apply()
 
     assert celery_tasks_module.r.get(RECONCILE_STUCK_LOCK_KEY) is None
+
+
+# ---------------------------------------------------------------------------
+# Soft time limits (Sentry ANTHIAS-A / ANTHIAS-9 / ANTHIAS-B)
+# ---------------------------------------------------------------------------
+
+
+class TestProbeTimeLimits:
+    """A probe that outlives its budget must be caught via the soft
+    limit and recorded as a failed probe — tripping the hard limit
+    SIGKILLs the pool child instead."""
+
+    def test_recheck_task_has_soft_limit_headroom(self) -> None:
+        assert (
+            revalidate_asset_url.soft_time_limit
+            == celery_tasks_module.ASSET_RECHECK_SOFT_TIME_LIMIT_S
+        )
+        assert (
+            revalidate_asset_url.time_limit
+            == celery_tasks_module.ASSET_RECHECK_TIME_LIMIT_S
+        )
+        # The soft limit must fire with room to spare before the
+        # SIGKILL backstop, and must cover the documented worst-case
+        # legitimate probe (HEAD 10s + GET 10s + DNS stall).
+        assert (
+            revalidate_asset_url.soft_time_limit
+            < revalidate_asset_url.time_limit
+        )
+        assert revalidate_asset_url.soft_time_limit >= 30
+
+    def test_sweep_task_has_soft_limit_headroom(self) -> None:
+        assert (
+            revalidate_asset_urls.soft_time_limit
+            == celery_tasks_module.ASSET_REVALIDATION_SOFT_TIME_LIMIT_S
+        )
+        assert (
+            revalidate_asset_urls.soft_time_limit
+            < revalidate_asset_urls.time_limit
+        )
+
+    @pytest.mark.django_db
+    def test_recheck_soft_limit_marks_unreachable(
+        self, eager_celery_recheck: None
+    ) -> None:
+        from celery.exceptions import SoftTimeLimitExceeded
+
+        asset = _make_recheck_asset(is_reachable=True)
+        assert asset.last_reachability_check is None
+        with mock.patch(
+            'anthias_server.celery_tasks.url_fails',
+            side_effect=SoftTimeLimitExceeded,
+        ):
+            revalidate_asset_url.apply(args=('a1',))
+        refreshed = Asset.objects.get(asset_id='a1')
+        assert refreshed.is_reachable is False
+        assert refreshed.last_reachability_check is not None
+
+    @pytest.mark.django_db
+    def test_sweep_soft_limit_aborts_and_releases_lock(
+        self, eager_celery: None
+    ) -> None:
+        from celery.exceptions import SoftTimeLimitExceeded
+
+        _make_revalidation_asset()
+        with mock.patch(
+            'anthias_server.celery_tasks.url_fails',
+            side_effect=SoftTimeLimitExceeded,
+        ):
+            result = revalidate_asset_urls.apply()
+        # Caught inside the task — no exception propagates (an
+        # uncaught one would mean the SIGKILL path in production).
+        assert result.successful()
+        # The finally block must have released the singleton lock so
+        # the next beat tick can run.
+        assert celery_tasks_module.r.get(ASSET_REVALIDATION_LOCK_KEY) is None

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -1694,21 +1694,20 @@ class TestProbeTimeLimits:
         # The soft limit must fire with room to spare before the
         # SIGKILL backstop, and must cover the documented worst-case
         # legitimate probe (HEAD 10s + GET 10s + DNS stall).
-        assert (
-            revalidate_asset_url.soft_time_limit
-            < revalidate_asset_url.time_limit
-        )
-        assert revalidate_asset_url.soft_time_limit >= 30
+        soft = revalidate_asset_url.soft_time_limit
+        hard = revalidate_asset_url.time_limit
+        assert soft is not None
+        assert hard is not None
+        assert soft < hard
+        assert soft >= 30
 
     def test_sweep_task_has_soft_limit_headroom(self) -> None:
-        assert (
-            revalidate_asset_urls.soft_time_limit
-            == celery_tasks_module.ASSET_REVALIDATION_SOFT_TIME_LIMIT_S
-        )
-        assert (
-            revalidate_asset_urls.soft_time_limit
-            < revalidate_asset_urls.time_limit
-        )
+        soft = revalidate_asset_urls.soft_time_limit
+        hard = revalidate_asset_urls.time_limit
+        assert soft == celery_tasks_module.ASSET_REVALIDATION_SOFT_TIME_LIMIT_S
+        assert soft is not None
+        assert hard is not None
+        assert soft < hard
 
     @pytest.mark.django_db
     def test_recheck_soft_limit_marks_unreachable(
@@ -1739,8 +1738,9 @@ class TestProbeTimeLimits:
             side_effect=SoftTimeLimitExceeded,
         ):
             result = revalidate_asset_urls.apply()
-        # Caught inside the task — no exception propagates (an
-        # uncaught one would mean the SIGKILL path in production).
+        # Caught inside the task — no exception propagates, so the
+        # sweep ends as a clean success instead of a task failure
+        # that error monitoring would report.
         assert result.successful()
         # The finally block must have released the singleton lock so
         # the next beat tick can run.


### PR DESCRIPTION
### Issues Fixed

Sentry: [ANTHIAS-A](https://anthias.sentry.io/issues/7534479539/) (`Hard time limit (30s) exceeded for revalidate_asset_url`), [ANTHIAS-9](https://anthias.sentry.io/issues/7534479528/) (`TimeLimitExceeded`), [ANTHIAS-B](https://anthias.sentry.io/issues/7534479773/) (`ForkPoolWorker exited with signal 9 (SIGKILL)`) — all three are the same hard-kill.

### Description

`revalidate_asset_url`'s 30s **hard** time limit was reachable by a legitimately slow probe: `url_fails` can burn a hanging `getaddrinfo` against a broken resolver (no timeout knob exists for it), then an HTTP HEAD (10s) plus the GET fallback (10s). Tripping the hard limit SIGKILLs the pool child, which surfaces as three separate Sentry issues per occurrence.

- `soft_time_limit=60` / `time_limit=90` on the on-demand probe — the soft limit raises `SoftTimeLimitExceeded` *inside* the task, which now records the same verdict an HTTP timeout gets (unreachable, `last_reachability_check` stamped) instead of dying
- The periodic sweep gets the same treatment: it aborts cleanly one minute before its 30-min hard limit, releasing its Redis singleton lock so the next beat tick starts fresh
- The hard limits stay as the backstop for a probe stuck in C code where the soft signal can't be delivered

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)