### PR TITLE
fix(sentry): stop reporting transient redis blips and client disconnects

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,8 @@ services:
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - ENVIRONMENT=development
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     restart: always
     volumes:
       - anthias-data:/data
@@ -33,7 +34,7 @@ services:
       anthias-server:
         condition: service_started
       redis:
-        condition: service_started
+        condition: service_healthy
     command: >
       nice -n 19 ionice -c 3
       celery -A anthias_server.celery_tasks.celery worker -B -n worker@anthias
@@ -51,6 +52,12 @@ services:
   redis:
     platform: "linux/amd64"
     image: mirror.gcr.io/library/redis:alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
 volumes:
     anthias-data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -52,7 +52,7 @@ services:
       anthias-test:
         condition: service_started
       redis:
-        condition: service_started
+        condition: service_healthy
     environment: *test_env
     restart: always
     volumes:
@@ -61,6 +61,12 @@ services:
 
   redis:
     image: mirror.gcr.io/library/redis:alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
 volumes:
   anthias-data:

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -15,8 +15,16 @@ services:
       - LISTEN=0.0.0.0
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
+    # Gate startup on redis actually answering PING (see the
+    # healthcheck on the redis service below) — plain service_started
+    # only orders container creation, so uvicorn's first Channels /
+    # Celery touch could still race a redis that hadn't finished
+    # loading its RDB. NOTE: docker-compose only; the balena
+    # supervisor doesn't support depends_on conditions, so fleet
+    # devices rely on each consumer's own reconnect logic instead.
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     devices:
       - "/dev/vchiq:/dev/vchiq"
     restart: always
@@ -39,8 +47,15 @@ services:
       context: .
       dockerfile: docker/Dockerfile.viewer
     mem_limit: ${VIEWER_MEMORY_LIMIT_KB}k
+    # redis: the viewer subscribes to the anthias.viewer pub/sub
+    # channel and publishes the display resolution; wait for a PING
+    # so neither hits "connection refused" at boot. (compose-only —
+    # see the note on anthias-server's depends_on.)
     depends_on:
-      - anthias-server
+      anthias-server:
+        condition: service_started
+      redis:
+        condition: service_healthy
     environment:
       - HOME=/data
       - PORT=8080
@@ -122,9 +137,14 @@ services:
       nice -n 19 ionice -c 3
       celery -A anthias_server.celery_tasks.celery worker -B -n worker@anthias
       --loglevel=info --scheduler celery.beat.Scheduler
+    # redis is both the broker and the beat heartbeat; gate on a PING
+    # so the worker doesn't burn its first connection retries during
+    # compose startup. (compose-only — see anthias-server's note.)
     depends_on:
-      - anthias-server
-      - redis
+      anthias-server:
+        condition: service_started
+      redis:
+        condition: service_healthy
     environment:
       - HOME=/data
       - CELERY_BROKER_URL=redis://redis:6379/0
@@ -152,6 +172,16 @@ services:
       dockerfile: docker/Dockerfile.redis
     ports:
       - 127.0.0.1:6379:6379
+    # Lets the depends_on conditions above hold service startup until
+    # redis actually answers, covering the RDB-load window after a
+    # restart on a slow SD card. start_period keeps the early probes
+    # from counting against the retry budget.
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
     restart: always
     volumes:
       - redis-data:/var/lib/redis

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -121,13 +121,16 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
     return event
 
 
-# celery's consumer logs every broker reconnect attempt at ERROR
-# ("consumer: Cannot connect to redis://..., Trying again in 6.00
-# seconds") while it retries on its own — same expected-transient
-# rationale as the before_send filter above, but it arrives as a log
-# message rather than an exception, so it has to be silenced at the
-# logger. (Sentry ANTHIAS-K.)
+# celery's consumer and the embedded beat scheduler both log every
+# broker reconnect attempt at ERROR ("consumer: Cannot connect to
+# redis://..., Trying again in 6.00 seconds" / "beat: Connection
+# error: ..., Trying again in 2.0 seconds") while they retry on
+# their own — same expected-transient rationale as the before_send
+# filter above, but these arrive as log messages rather than
+# exceptions, so they have to be silenced at the logger.
+# (Sentry ANTHIAS-K and ANTHIAS-P.)
 ignore_logger('celery.worker.consumer.consumer')
+ignore_logger('celery.beat')
 
 sentry_sdk.init(
     dsn=getenv('SENTRY_DSN', _default_sentry_dsn),

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -21,6 +21,7 @@ from typing import Any
 import redis.exceptions
 import sentry_sdk
 from sentry_sdk.integrations.logging import ignore_logger
+from sentry_sdk.types import Event, Hint
 
 from anthias_common.version import get_anthias_release
 from anthias_server.settings import settings as device_settings
@@ -89,9 +90,7 @@ def _exception_chain(exc: BaseException | None) -> Iterator[BaseException]:
         exc = exc.__cause__ or exc.__context__
 
 
-def _sentry_before_send(
-    event: dict[str, Any], hint: dict[str, Any]
-) -> dict[str, Any] | None:
+def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
     """Drop events that report expected transient states, not bugs.
 
     Two classes of noise, both observed fleet-wide on day one:

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -8,15 +8,19 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import asyncio
 import platform
 import secrets
 import sys
 import zoneinfo
+from collections.abc import Iterator
 from os import getenv
 from pathlib import Path
 from typing import Any
 
+import redis.exceptions
 import sentry_sdk
+from sentry_sdk.integrations.logging import ignore_logger
 
 from anthias_common.version import get_anthias_release
 from anthias_server.settings import settings as device_settings
@@ -68,8 +72,67 @@ _default_sentry_dsn = (
         '@o4511522371534848.ingest.us.sentry.io/4511522375794688'
     )
 )
+
+
+def _exception_chain(exc: BaseException | None) -> Iterator[BaseException]:
+    """Walk ``exc`` and everything it was raised from.
+
+    Wrappers matter here: channels-redis and kombu re-raise the
+    underlying ``redis.exceptions.ConnectionError`` wrapped in their
+    own types, so the transient-noise check below has to look at the
+    whole ``__cause__``/``__context__`` chain, not just the head.
+    """
+    seen: set[int] = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        yield exc
+        exc = exc.__cause__ or exc.__context__
+
+
+def _sentry_before_send(
+    event: dict[str, Any], hint: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Drop events that report expected transient states, not bugs.
+
+    Two classes of noise, both observed fleet-wide on day one:
+
+      * ``redis.exceptions.ConnectionError`` (and subclasses, plus
+        anything raised from one) — redis restarts after its
+        container recycles or before its DNS name resolves during
+        compose startup. Every consumer already self-heals: celery's
+        consumer reconnects with backoff, the viewer's reporter loop
+        retries on its next tick, and Channels re-establishes on the
+        next WebSocket frame. A *persistent* redis outage still
+        surfaces — the device stops working and the watchdog restart
+        loop is visible in balena — but a 5-second blip is not worth
+        an event per process (Sentry ANTHIAS-M / ANTHIAS-K /
+        ANTHIAS-H / ANTHIAS-J).
+      * ``asyncio.CancelledError`` — an HTTP client hanging up
+        mid-request under ASGI; Django/uvicorn cancel the handler by
+        design (Sentry ANTHIAS-N).
+    """
+    exc_info = hint.get('exc_info')
+    if not exc_info:
+        return event
+    for exc in _exception_chain(exc_info[1]):
+        if isinstance(exc, asyncio.CancelledError):
+            return None
+        if isinstance(exc, redis.exceptions.ConnectionError):
+            return None
+    return event
+
+
+# celery's consumer logs every broker reconnect attempt at ERROR
+# ("consumer: Cannot connect to redis://..., Trying again in 6.00
+# seconds") while it retries on its own — same expected-transient
+# rationale as the before_send filter above, but it arrives as a log
+# message rather than an exception, so it has to be silenced at the
+# logger. (Sentry ANTHIAS-K.)
+ignore_logger('celery.worker.consumer.consumer')
+
 sentry_sdk.init(
     dsn=getenv('SENTRY_DSN', _default_sentry_dsn),
+    before_send=_sentry_before_send,
     # Same value the DEBUG flag below keys off: 'development', 'test',
     # or 'production' (the default) — lets dev events be filtered out
     # in Sentry. (Test runs don't send at all — see the DSN default

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -87,7 +87,13 @@ def _exception_chain(exc: BaseException | None) -> Iterator[BaseException]:
     while exc is not None and id(exc) not in seen:
         seen.add(id(exc))
         yield exc
-        exc = exc.__cause__ or exc.__context__
+        # Mirror traceback rendering: an explicit ``raise ... from
+        # None`` sets __suppress_context__, meaning the author
+        # deliberately detached the causal chain — don't let a
+        # suppressed redis error hide the wrapper exception.
+        exc = exc.__cause__ or (
+            None if exc.__suppress_context__ else exc.__context__
+        )
 
 
 def _sentry_before_send(event: Event, hint: Hint) -> Event | None:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import django
 import pydbus
+import redis.exceptions
 import requests
 import sh as sh
 
@@ -1269,6 +1270,36 @@ DISPLAY_RESOLUTION_INTERVAL_S = 60
 DISPLAY_RESOLUTION_TTL_S = 180
 
 
+def _publish_display_resolution_once() -> None:
+    """One reporter tick — detect the resolution and write it to Redis.
+
+    Never raises: the reporter thread must survive any single failed
+    tick and try again on the next one.
+    """
+    try:
+        value = detect_screen_resolution()
+        if value:
+            r.set(
+                DISPLAY_RESOLUTION_KEY,
+                value,
+                ex=DISPLAY_RESOLUTION_TTL_S,
+            )
+    except redis.exceptions.ConnectionError as exc:
+        # Redis being briefly unreachable (container recycle, compose
+        # startup before its DNS name resolves) is an expected state,
+        # not a crash — the next tick retries and the key's TTL
+        # semantics already make the System Info card fall back
+        # gracefully. Warning, not exception: an ERROR-level log with
+        # a traceback would land in Sentry (ANTHIAS-M / ANTHIAS-H).
+        logging.warning(
+            'publish_display_resolution skipped, redis unreachable '
+            '(will retry): %s',
+            exc,
+        )
+    except Exception:
+        logging.exception('publish_display_resolution failed')
+
+
 def _publish_display_resolution_loop() -> None:
     """Background reporter — write the active display resolution to
     Redis on a 1-minute cadence with a 3-minute TTL.
@@ -1282,16 +1313,7 @@ def _publish_display_resolution_loop() -> None:
 
     def tick() -> None:
         while True:
-            try:
-                value = detect_screen_resolution()
-                if value:
-                    r.set(
-                        DISPLAY_RESOLUTION_KEY,
-                        value,
-                        ex=DISPLAY_RESOLUTION_TTL_S,
-                    )
-            except Exception:
-                logging.exception('publish_display_resolution failed')
+            _publish_display_resolution_once()
             sleep(DISPLAY_RESOLUTION_INTERVAL_S)
 
     t = threading.Thread(

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -107,6 +107,9 @@ class TestBeforeSendTransientNoise:
     def test_celery_reconnect_logger_is_ignored(self) -> None:
         # celery's consumer retries broker connections on its own but
         # logs each attempt at ERROR; the logger is silenced at init.
+        # The ignore_logger call happens at settings-module import —
+        # import it explicitly so this test passes in isolation too.
+        import anthias_server.django_project.settings  # noqa: F401
         from sentry_sdk.integrations.logging import _IGNORED_LOGGERS
 
         assert 'celery.worker.consumer.consumer' in _IGNORED_LOGGERS

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -77,6 +77,31 @@ class TestBeforeSendTransientNoise:
             }
         assert _sentry_before_send({'event_id': 'x'}, hint) is None
 
+    def test_keeps_wrapper_when_context_is_suppressed(self) -> None:
+        # ``raise ... from None`` detaches the causal chain — a redis
+        # error that merely *preceded* the wrapper must not drop it.
+        import redis.exceptions
+
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        try:
+            try:
+                raise redis.exceptions.ConnectionError('refused')
+            except redis.exceptions.ConnectionError:
+                raise RuntimeError('a real bug') from None
+        except RuntimeError as wrapper:
+            hint = {
+                'exc_info': (
+                    type(wrapper),
+                    wrapper,
+                    wrapper.__traceback__,
+                )
+            }
+        event: Event = {'event_id': 'x'}
+        assert _sentry_before_send(event, hint) == event
+
     def test_drops_cancelled_error(self) -> None:
         import asyncio
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -113,6 +113,9 @@ class TestBeforeSendTransientNoise:
         from sentry_sdk.integrations.logging import _IGNORED_LOGGERS
 
         assert 'celery.worker.consumer.consumer' in _IGNORED_LOGGERS
+        # The embedded beat scheduler retries broker connections the
+        # same way and logs each attempt at ERROR too.
+        assert 'celery.beat' in _IGNORED_LOGGERS
 
 
 class TestGetBoardModel:
@@ -135,3 +138,4 @@ class TestGetBoardModel:
         from anthias_server.django_project.settings import get_board_model
 
         assert get_board_model(str(tmp_path / 'missing')) == ''
+

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -163,4 +163,3 @@ class TestGetBoardModel:
         from anthias_server.django_project.settings import get_board_model
 
         assert get_board_model(str(tmp_path / 'missing')) == ''
-

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -23,6 +23,93 @@ def test_sentry_does_not_send_under_pytest() -> None:
     assert sentry_sdk.capture_message('must not be sent') is None
 
 
+class TestBeforeSendTransientNoise:
+    """The before_send hook must drop expected transient states
+    (redis restarting, an HTTP client hanging up) and nothing else.
+    Regression coverage for Sentry ANTHIAS-M / ANTHIAS-K / ANTHIAS-H /
+    ANTHIAS-J (redis blips) and ANTHIAS-N (client disconnect)."""
+
+    @staticmethod
+    def _hint_for(exc: BaseException) -> dict:
+        try:
+            raise exc
+        except BaseException as caught:  # noqa: BLE001 — CancelledError
+            return {'exc_info': (type(caught), caught, caught.__traceback__)}
+
+    def test_drops_redis_connection_error(self) -> None:
+        import redis.exceptions
+
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        hint = self._hint_for(
+            redis.exceptions.ConnectionError(
+                'Error 111 connecting to redis:6379. Connection refused.'
+            )
+        )
+        assert _sentry_before_send({'event_id': 'x'}, hint) is None
+
+    def test_drops_wrapped_redis_connection_error(self) -> None:
+        # channels-redis / kombu re-raise the underlying redis error
+        # wrapped in their own exception types — the chain has to be
+        # walked, not just the head.
+        import redis.exceptions
+
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        try:
+            try:
+                raise redis.exceptions.ConnectionError('refused')
+            except redis.exceptions.ConnectionError as inner:
+                raise RuntimeError('channel layer send failed') from inner
+        except RuntimeError as wrapper:
+            hint = {
+                'exc_info': (
+                    type(wrapper),
+                    wrapper,
+                    wrapper.__traceback__,
+                )
+            }
+        assert _sentry_before_send({'event_id': 'x'}, hint) is None
+
+    def test_drops_cancelled_error(self) -> None:
+        import asyncio
+
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        hint = self._hint_for(asyncio.CancelledError())
+        assert _sentry_before_send({'event_id': 'x'}, hint) is None
+
+    def test_keeps_ordinary_exceptions(self) -> None:
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        event = {'event_id': 'x'}
+        hint = self._hint_for(ValueError('a real bug'))
+        assert _sentry_before_send(event, hint) is event
+
+    def test_keeps_events_without_exc_info(self) -> None:
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        event = {'event_id': 'x'}
+        assert _sentry_before_send(event, {}) is event
+
+    def test_celery_reconnect_logger_is_ignored(self) -> None:
+        # celery's consumer retries broker connections on its own but
+        # logs each attempt at ERROR; the logger is silenced at init.
+        from sentry_sdk.integrations.logging import _IGNORED_LOGGERS
+
+        assert 'celery.worker.consumer.consumer' in _IGNORED_LOGGERS
+
+
 class TestGetBoardModel:
     """Board-model detection feeding the fleet-triage Sentry tags."""
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -12,6 +12,7 @@ and capture calls are dropped.
 from pathlib import Path
 
 import sentry_sdk
+from sentry_sdk.types import Event
 
 
 def test_sentry_does_not_send_under_pytest() -> None:
@@ -30,11 +31,12 @@ class TestBeforeSendTransientNoise:
     ANTHIAS-J (redis blips) and ANTHIAS-N (client disconnect)."""
 
     @staticmethod
-    def _hint_for(exc: BaseException) -> dict:
-        try:
-            raise exc
-        except BaseException as caught:  # noqa: BLE001 — CancelledError
-            return {'exc_info': (type(caught), caught, caught.__traceback__)}
+    def _hint_for(exc: BaseException) -> dict[str, object]:
+        # Build the exc_info triple directly instead of raise/except —
+        # before_send only inspects exc_info[1] and its
+        # __cause__/__context__ chain, and not catching BaseException
+        # keeps Sonar S5754 happy.
+        return {'exc_info': (type(exc), exc, None)}
 
     def test_drops_redis_connection_error(self) -> None:
         import redis.exceptions
@@ -90,17 +92,17 @@ class TestBeforeSendTransientNoise:
             _sentry_before_send,
         )
 
-        event = {'event_id': 'x'}
+        event: Event = {'event_id': 'x'}
         hint = self._hint_for(ValueError('a real bug'))
-        assert _sentry_before_send(event, hint) is event
+        assert _sentry_before_send(event, hint) == event
 
     def test_keeps_events_without_exc_info(self) -> None:
         from anthias_server.django_project.settings import (
             _sentry_before_send,
         )
 
-        event = {'event_id': 'x'}
-        assert _sentry_before_send(event, {}) is event
+        event: Event = {'event_id': 'x'}
+        assert _sentry_before_send(event, {}) == event
 
     def test_celery_reconnect_logger_is_ignored(self) -> None:
         # celery's consumer retries broker connections on its own but

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1668,7 +1668,7 @@ class TestPublishDisplayResolutionOnce:
             viewer._publish_display_resolution_once()
         assert any(
             record.levelno == logging.WARNING
-            and 'redis unreachable' in record.message
+            and 'redis unreachable' in record.getMessage()
             for record in caplog.records
         )
         assert all(record.levelno < logging.ERROR for record in caplog.records)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1649,6 +1649,18 @@ class TestPublishDisplayResolutionOnce:
     """The reporter tick must treat a redis blip as a retryable state
     (warning), not a crash (Sentry ANTHIAS-M / ANTHIAS-H)."""
 
+    @pytest.fixture(autouse=True)
+    def _enable_logging(self) -> Iterator[None]:
+        # This module calls logging.disable(logging.CRITICAL) at
+        # import time, which would make the caplog assertions below
+        # vacuous (no records ever emitted). Lift the disable for
+        # these tests and restore it afterwards.
+        logging.disable(logging.NOTSET)
+        try:
+            yield
+        finally:
+            logging.disable(logging.CRITICAL)
+
     def test_redis_down_logs_warning_not_error(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1643,3 +1643,62 @@ def test_handle_reload_linuxfb_idempotent_under_repeat(
     fake_browser.terminate.assert_not_called()
     skip.set.assert_called_once()
     assert viewer._rotation_bounce_pending is True
+
+
+class TestPublishDisplayResolutionOnce:
+    """The reporter tick must treat a redis blip as a retryable state
+    (warning), not a crash (Sentry ANTHIAS-M / ANTHIAS-H)."""
+
+    def test_redis_down_logs_warning_not_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import redis.exceptions
+
+        with (
+            mock.patch.object(
+                viewer, 'detect_screen_resolution', return_value='1920x1080'
+            ),
+            mock.patch.object(
+                viewer.r,
+                'set',
+                side_effect=redis.exceptions.ConnectionError('refused'),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            viewer._publish_display_resolution_once()
+        assert any(
+            record.levelno == logging.WARNING
+            and 'redis unreachable' in record.message
+            for record in caplog.records
+        )
+        assert all(record.levelno < logging.ERROR for record in caplog.records)
+
+    def test_other_failures_still_log_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with (
+            mock.patch.object(
+                viewer,
+                'detect_screen_resolution',
+                side_effect=RuntimeError('boom'),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            viewer._publish_display_resolution_once()
+        assert any(
+            record.levelno == logging.ERROR for record in caplog.records
+        )
+
+    def test_writes_resolution_with_ttl(self) -> None:
+        with (
+            mock.patch.object(
+                viewer, 'detect_screen_resolution', return_value='1280x720'
+            ),
+            mock.patch.object(viewer.r, 'set') as set_mock,
+        ):
+            viewer._publish_display_resolution_once()
+        set_mock.assert_called_once_with(
+            viewer.DISPLAY_RESOLUTION_KEY,
+            '1280x720',
+            ex=viewer.DISPLAY_RESOLUTION_TTL_S,
+        )


### PR DESCRIPTION
### Issues Fixed

Sentry: [ANTHIAS-M](https://anthias.sentry.io/issues/7534699071/) / [ANTHIAS-H](https://anthias.sentry.io/issues/7534605276/) (viewer resolution reporter, redis refused / DNS not yet resolvable), [ANTHIAS-K](https://anthias.sentry.io/issues/7534698885/) (celery consumer reconnect log), [ANTHIAS-J](https://anthias.sentry.io/issues/7534613775/) (ASGI redis connection reset), [ANTHIAS-N](https://anthias.sentry.io/issues/7534704829/) (`CancelledError` on client disconnect), [ANTHIAS-P](https://anthias.sentry.io/issues/7534806426/) (celery beat reconnect log).

### Description

**Two layers, per review feedback:**

1. **Orchestration (root cause for startup ordering):** redis now has a `redis-cli ping` healthcheck, and `anthias-server` / `anthias-viewer` / `anthias-celery` are gated on `condition: service_healthy` in the prod template, dev, and test composes. Bare `service_started` only orders container *creation*, so consumers could race a redis still loading its RDB.
2. **Sentry-side handling for what compose can't gate:** the balena supervisor doesn't support `depends_on` conditions (fleet devices get no ordering guarantee), and nothing gates a redis container recycling *mid-life* (OOM, upgrade) — long-running services will always see a window of `ConnectionError` then. Every consumer already self-heals, so those windows are filtered rather than reported.

Redis being briefly unreachable (its container recycling, or compose startup before the `redis` DNS name resolves) is an expected state on a signage device, and every consumer already self-heals — celery's consumer reconnects with backoff, the viewer's reporter retries on its next tick, Channels re-establishes on the next WebSocket frame. Same for an HTTP client hanging up mid-request under ASGI: Django/uvicorn cancel the handler by design. Neither is a code bug, but together they produced 6 noise events per redis blip / disconnect.

- `before_send` hook drops events whose exception chain (walking `__cause__`/`__context__`, since channels-redis/kombu wrap the underlying error) contains `redis.exceptions.ConnectionError` or `asyncio.CancelledError`
- `ignore_logger('celery.worker.consumer.consumer')` — the reconnect retry arrives as an ERROR log line, not an exception
- The viewer's resolution reporter now logs a redis blip at WARNING (retry next tick) instead of ERROR-with-traceback; tick body extracted into a testable helper

A *persistent* redis outage still surfaces — the device visibly stops working and the restart loop shows in balena — but a 5-second blip no longer fans out into Sentry issues.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
