### PR TITLE
fix(server): log GitHub release-check failures at warning, not error

### DIFF
--- a/src/anthias_server/lib/github.py
+++ b/src/anthias_server/lib/github.py
@@ -52,7 +52,13 @@ def handle_github_error(
     else:
         errdesc = 'no data'
 
-    logging.error(
+    # Warning, not error: a signage device that can't reach
+    # api.github.com (offline installs, locked-down networks, GitHub
+    # outages, rate limits) is a routine condition the caller already
+    # degrades through gracefully — backoff above, cached verdict
+    # fallback in is_up_to_date(). An ERROR-level log would land in
+    # Sentry on every offline device (ANTHIAS-8).
+    logging.warning(
         '%s fetching %s from GitHub: %s', type(exc).__name__, action, errdesc
     )
 
@@ -88,13 +94,13 @@ def _fetch_latest_release_tag() -> str | None:
     try:
         payload = resp.json()
     except ValueError:
-        logging.error('Malformed JSON from GitHub /releases/latest')
+        logging.warning('Malformed JSON from GitHub /releases/latest')
         _set_github_error_backoff('latest release: malformed JSON')
         return None
 
     tag = payload.get('tag_name') if isinstance(payload, dict) else None
     if not isinstance(tag, str) or not tag:
-        logging.error('Missing tag_name in /releases/latest response')
+        logging.warning('Missing tag_name in /releases/latest response')
         _set_github_error_backoff('latest release: missing tag_name')
         return None
 
@@ -103,7 +109,7 @@ def _fetch_latest_release_tag() -> str | None:
     # for 24h, locking is_up_to_date() into the fallback verdict for
     # the full TTL even after upstream corrects the tag.
     if _parse_version(tag) is None:
-        logging.error('Unparseable tag_name from GitHub: %r', tag)
+        logging.warning('Unparseable tag_name from GitHub: %r', tag)
         _set_github_error_backoff('latest release: unparseable tag_name')
         return None
 
@@ -162,7 +168,7 @@ def is_up_to_date() -> bool:
 
     latest_version = _parse_version(latest_tag)
     if latest_version is None:
-        logging.error('Malformed tag_name from GitHub: %r', latest_tag)
+        logging.warning('Malformed tag_name from GitHub: %r', latest_tag)
         return _fallback_verdict(local_release)
 
     verdict = local_version >= latest_version

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -390,21 +390,37 @@ def test_handle_github_error_logs_at_warning_not_error(
     exc = requests_exceptions.ConnectionError()
     exc.response = None
     with (
-        mock.patch.object(github.logging, 'warning') as warning_mock,
-        mock.patch.object(github.logging, 'error') as error_mock,
+        mock.patch('anthias_server.lib.github.logging.warning') as m_warning,
+        mock.patch('anthias_server.lib.github.logging.error') as m_error,
     ):
         github.handle_github_error(exc, 'latest release')
-    warning_mock.assert_called_once()
-    error_mock.assert_not_called()
+    m_warning.assert_called_once()
+    m_error.assert_not_called()
 
 
 def test_github_module_never_logs_at_error_level() -> None:
     """Every failure path in this module is degraded through
     gracefully (backoff + cached verdict), so none of it belongs at
-    ERROR level. Pin that by source inspection so a future path
-    doesn't quietly reintroduce Sentry noise."""
+    ERROR level or above — that's what the Sentry logging integration
+    turns into an event (ANTHIAS-8). Pin that with an AST walk over
+    the module's actual logging calls, so comments/docstrings can't
+    false-positive and renamed-but-still-ERROR calls can't slip by.
+    """
+    import ast
     import inspect
 
-    source = inspect.getsource(github)
-    assert 'logging.error' not in source
-    assert 'logging.exception' not in source
+    tree = ast.parse(inspect.getsource(github))
+    error_level_calls = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in ('error', 'exception', 'critical')
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == 'logging'
+    ]
+    assert not error_level_calls, (
+        f'ERROR-level logging calls found in lib/github.py at lines '
+        f'{error_level_calls} — these become Sentry events on every '
+        f'offline device'
+    )

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -403,7 +403,8 @@ def test_github_module_never_logs_at_error_level() -> None:
     gracefully (backoff + cached verdict), so none of it belongs at
     ERROR level or above — that's what the Sentry logging integration
     turns into an event (ANTHIAS-8). Pin that with an AST walk over
-    the module's direct ``logging.error/exception/critical`` calls,
+    the module's direct ``logging.error/exception/critical/fatal``
+    calls,
     so comments and docstrings can't false-positive the check. (The
     module logs via the root ``logging`` module only; a named-logger
     refactor would need this test updated.)
@@ -417,7 +418,7 @@ def test_github_module_never_logs_at_error_level() -> None:
         for node in ast.walk(tree)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
-        and node.func.attr in ('error', 'exception', 'critical')
+        and node.func.attr in ('error', 'exception', 'critical', 'fatal')
         and isinstance(node.func.value, ast.Name)
         and node.func.value.id == 'logging'
     ]

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -381,7 +381,7 @@ def test_handle_github_error_without_response(
 
 
 def test_handle_github_error_logs_at_warning_not_error(
-    github_env: None, redis_data: dict[str, str]
+    github_env: None,
 ) -> None:
     """An unreachable api.github.com is a routine condition on a
     signage device (offline installs, locked-down networks) — it must
@@ -403,8 +403,10 @@ def test_github_module_never_logs_at_error_level() -> None:
     gracefully (backoff + cached verdict), so none of it belongs at
     ERROR level or above — that's what the Sentry logging integration
     turns into an event (ANTHIAS-8). Pin that with an AST walk over
-    the module's actual logging calls, so comments/docstrings can't
-    false-positive and renamed-but-still-ERROR calls can't slip by.
+    the module's direct ``logging.error/exception/critical`` calls,
+    so comments and docstrings can't false-positive the check. (The
+    module logs via the root ``logging`` module only; a named-logger
+    refactor would need this test updated.)
     """
     import ast
     import inspect

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -378,3 +378,33 @@ def test_handle_github_error_without_response(
     exc.response = None
     github.handle_github_error(exc, 'no-resp-action')
     assert redis_data['github-api-error'] == 'no-resp-action'
+
+
+def test_handle_github_error_logs_at_warning_not_error(
+    github_env: None, redis_data: dict[str, str]
+) -> None:
+    """An unreachable api.github.com is a routine condition on a
+    signage device (offline installs, locked-down networks) — it must
+    not log at ERROR, which would land in Sentry on every offline
+    device (ANTHIAS-8)."""
+    exc = requests_exceptions.ConnectionError()
+    exc.response = None
+    with (
+        mock.patch.object(github.logging, 'warning') as warning_mock,
+        mock.patch.object(github.logging, 'error') as error_mock,
+    ):
+        github.handle_github_error(exc, 'latest release')
+    warning_mock.assert_called_once()
+    error_mock.assert_not_called()
+
+
+def test_github_module_never_logs_at_error_level() -> None:
+    """Every failure path in this module is degraded through
+    gracefully (backoff + cached verdict), so none of it belongs at
+    ERROR level. Pin that by source inspection so a future path
+    doesn't quietly reintroduce Sentry noise."""
+    import inspect
+
+    source = inspect.getsource(github)
+    assert 'logging.error' not in source
+    assert 'logging.exception' not in source


### PR DESCRIPTION
### Issues Fixed

Sentry: [ANTHIAS-8](https://anthias.sentry.io/issues/7534440162/) (`ConnectionError fetching latest release from GitHub: no data` on `/splash-page/`).

### Description

A signage device that can't reach `api.github.com` — offline installs, locked-down networks, GitHub outages, rate limits — is a routine condition, and the update check already degrades through it gracefully (5-minute error backoff, cached last verdict in `is_up_to_date()`). But the failure paths logged at ERROR, which the Sentry logging integration turns into an event, so every offline device reported on each splash-page render.

- Downgrade every failure path in `lib/github.py` (transport errors, malformed/missing/unparseable `tag_name`) to WARNING
- Add a regression test pinning the module as ERROR-free, plus a behavioural test on `handle_github_error`

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)