### PR TITLE
fix(viewer): respawn the webview when it dies before setup's bus.get

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -1222,7 +1222,28 @@ def setup() -> None:
     load_browser()
 
     bus = pydbus.SessionBus()
-    browser_bus = bus.get('anthias.viewer', '/Anthias')
+    try:
+        browser_bus = bus.get('anthias.viewer', '/Anthias')
+    except Exception as exc:
+        # The flaky armv7 Qt5 init crash can strike in the gap between
+        # the D-Bus handshake (which made load_browser() return) and
+        # this bus.get — the name is already released again, pydbus
+        # raises ServiceUnknown, and without this handler the GError
+        # escapes main() and turns one process crash into a container
+        # restart loop (Sentry ANTHIAS-3). Same webview-gone detection
+        # and respawn-then-retry-once contract as _send_to_webview;
+        # we're still at startup, so spend the generous budget.
+        if not _is_webview_gone_error(exc):
+            raise
+        logging.warning(
+            'AnthiasViewer died between handshake and bus.get; '
+            'respawning and retrying once: %s',
+            exc,
+        )
+        if browser is not None:
+            _terminate_webview(browser)
+        load_browser()
+        browser_bus = bus.get('anthias.viewer', '/Anthias')
     # MPVMediaPlayer calls AnthiasViewer's playVideo / stopVideo
     # slots via this same proxy now that video lives in-process
     # (issue #2904). Inject after load_browser so the proxy is

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -101,6 +101,71 @@ def test_setup(viewer_fixtures: _ViewerFixtures) -> None:
         viewer_fixtures.p_loadb.stop()
 
 
+def test_setup_respawns_webview_when_busget_finds_name_gone(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """The armv7 init crash can strike between the D-Bus handshake
+    (which made load_browser() return) and setup()'s bus.get — the
+    name is released again and pydbus raises ServiceUnknown. setup()
+    must reap, respawn, and retry the bus.get instead of letting the
+    error escape main() (Sentry ANTHIAS-3)."""
+    proxy = mock.Mock(name='browser_bus_proxy')
+    fake_bus = mock.Mock()
+    fake_bus.get.side_effect = [
+        RuntimeError(
+            'GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The '
+            'name anthias.viewer was not provided by any .service files'
+        ),
+        proxy,
+    ]
+    dead_browser = mock.Mock(name='dead_browser')
+    dead_browser.is_alive.return_value = False
+
+    viewer_fixtures.p_loadb.start()
+    try:
+        with (
+            mock.patch('pydbus.SessionBus', mock.Mock(return_value=fake_bus)),
+            mock.patch.object(viewer_fixtures.u, 'browser', dead_browser),
+        ):
+            viewer_fixtures.u.setup()
+    finally:
+        viewer_fixtures.p_loadb.stop()
+
+    assert fake_bus.get.call_count == 2
+    dead_browser.terminate.assert_called_once()
+    # Once before bus.get, once for the respawn — both with the
+    # generous startup budget (no inline kwargs).
+    assert viewer_fixtures.m_loadb.call_count == 2
+    assert viewer_fixtures.m_loadb.call_args_list[1] == mock.call()
+    assert viewer_fixtures.u.browser_bus is proxy
+
+
+def test_setup_reraises_unrelated_busget_error(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """A dead session bus (Disconnected) is not respawn-worthy — the
+    container restart has to bring up a whole fresh bus."""
+    fake_bus = mock.Mock()
+    fake_bus.get.side_effect = RuntimeError(
+        'GDBus.Error:org.freedesktop.DBus.Error.Disconnected: '
+        'The connection is closed'
+    )
+
+    viewer_fixtures.p_loadb.start()
+    try:
+        with (
+            mock.patch('pydbus.SessionBus', mock.Mock(return_value=fake_bus)),
+            mock.patch.object(viewer_fixtures.u, 'browser', None),
+        ):
+            with pytest.raises(RuntimeError, match='Disconnected'):
+                viewer_fixtures.u.setup()
+    finally:
+        viewer_fixtures.p_loadb.stop()
+
+    assert fake_bus.get.call_count == 1
+    assert viewer_fixtures.m_loadb.call_count == 1
+
+
 def _stub_browser_stdout_static(
     browser_proc: mock.Mock,
     value: bytes,


### PR DESCRIPTION
### Issues Fixed

Sentry: [ANTHIAS-3](https://anthias.sentry.io/issues/7534297868/) (`GDBus.Error ServiceUnknown: The name anthias.viewer was not provided by any .service files` in `setup`).

### Description

Completes the coverage #3012 started. The flaky armv7 Qt5 init crash can also strike in the gap between the D-Bus handshake (which makes `load_browser()` return) and `setup()`'s `bus.get('anthias.viewer', ...)` — by then the name is released again, pydbus raises `ServiceUnknown`, and the GError escapes `main()`, turning one process crash into a container restart loop.

- Wrap the setup-time `bus.get` with the same webview-gone detection (`_is_webview_gone_error`) and respawn-then-retry-once contract as `_send_to_webview`
- We're still at startup with nothing on screen, so the respawn uses the generous startup budget rather than the inline one
- Unrelated D-Bus errors (e.g. `Disconnected` — our own session bus died) still propagate, since a webview respawn can't fix those

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)