### PR TITLE
feat(sentry): tag events with device type, host kernel, and board model

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -102,7 +102,7 @@ def get_board_model(model_file: str = '/proc/device-tree/model') -> str:
     """
     try:
         with open(model_file, 'rb') as f:
-            return f.read().decode('utf-8', errors='replace').strip('\x00 \n')
+            return f.read().decode('utf-8', errors='replace').rstrip('\x00 \n')
     except OSError:
         return ''
 

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -96,12 +96,13 @@ def get_board_model(model_file: str = '/proc/device-tree/model') -> str:
 
     ``/proc/device-tree`` resolves to ``/sys/firmware/devicetree/base``,
     which Docker exposes read-only inside every container — no bind
-    mount needed. x86 hosts have no device tree, and the value is
-    NUL-terminated on the boards that do.
+    mount needed. x86 hosts have no device tree; boards that have one
+    expose the model as a NUL-terminated UTF-8 string (decoded the
+    same way device_helper's board detection does).
     """
     try:
         with open(model_file, 'rb') as f:
-            return f.read().decode('ascii', errors='replace').strip('\x00 \n')
+            return f.read().decode('utf-8', errors='replace').strip('\x00 \n')
     except OSError:
         return ''
 

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -97,12 +97,14 @@ def get_board_model(model_file: str = '/proc/device-tree/model') -> str:
     ``/proc/device-tree`` resolves to ``/sys/firmware/devicetree/base``,
     which Docker exposes read-only inside every container — no bind
     mount needed. x86 hosts have no device tree; boards that have one
-    expose the model as a NUL-terminated UTF-8 string (decoded the
-    same way device_helper's board detection does).
+    expose the model as a NUL-terminated UTF-8 string, decoded and
+    trimmed with the same idiom as device_helper's board detection.
     """
     try:
         with open(model_file, 'rb') as f:
-            return f.read().decode('utf-8', errors='replace').rstrip('\x00 \n')
+            # Kernel writes a null-terminated UTF-8 string — decode
+            # and trim exactly like device_helper's board detection.
+            return f.read().decode('utf-8', 'replace').strip('\x00 \n\t')
     except OSError:
         return ''
 

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -8,6 +8,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import platform
 import secrets
 import sys
 import zoneinfo
@@ -88,6 +89,38 @@ sentry_sdk.init(
     # https://docs.sentry.io/platforms/python/data-management/data-collected/
     send_default_pii=not device_settings['analytics_opt_out'],
 )
+
+
+def get_board_model(model_file: str = '/proc/device-tree/model') -> str:
+    """Host board model from the device tree, '' when unavailable.
+
+    ``/proc/device-tree`` resolves to ``/sys/firmware/devicetree/base``,
+    which Docker exposes read-only inside every container — no bind
+    mount needed. x86 hosts have no device tree, and the value is
+    NUL-terminated on the boards that do.
+    """
+    try:
+        with open(model_file, 'rb') as f:
+            return f.read().decode('ascii', errors='replace').strip('\x00 \n')
+    except OSError:
+        return ''
+
+
+# Board / kernel context for fleet triage. Events are sent from inside
+# a container, so Sentry's stock OS detection never sees the host —
+# which made the armv7 webview-crash cohort (ANTHIAS-D / ANTHIAS-F)
+# impossible to segment: the same Qt5/armhf viewer image behaves
+# differently under a 32-bit and a 64-bit host kernel, and nothing on
+# the event said which one the device boots. A container shares the
+# host kernel, so platform.release()/machine() report the host
+# values; DEVICE_TYPE is baked into the image at build time (pi1 /
+# pi2 / pi3 / pi3-64 / pi4-64 / x86 / ...).
+sentry_sdk.set_tag('device_type', getenv('DEVICE_TYPE') or 'unknown')
+sentry_sdk.set_tag('kernel_release', platform.release())
+sentry_sdk.set_tag('kernel_machine', platform.machine())
+_board_model = get_board_model()
+if _board_model:
+    sentry_sdk.set_tag('board_model', _board_model)
 
 
 # Quick-start development settings - unsuitable for production

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -9,6 +9,8 @@ behaviour: under pytest the client has no DSN, builds no transport,
 and capture calls are dropped.
 """
 
+from pathlib import Path
+
 import sentry_sdk
 
 
@@ -19,3 +21,25 @@ def test_sentry_does_not_send_under_pytest() -> None:
     # capture_message returns the event id when an event is queued
     # for sending; None means the event was dropped client-side.
     assert sentry_sdk.capture_message('must not be sent') is None
+
+
+class TestGetBoardModel:
+    """Board-model detection feeding the fleet-triage Sentry tags."""
+
+    def test_reads_and_strips_nul_terminated_model(
+        self, tmp_path: Path
+    ) -> None:
+        from anthias_server.django_project.settings import get_board_model
+
+        model_file = tmp_path / 'model'
+        model_file.write_bytes(b'Raspberry Pi 3 Model B Rev 1.2\x00')
+        assert (
+            get_board_model(str(model_file))
+            == 'Raspberry Pi 3 Model B Rev 1.2'
+        )
+
+    def test_returns_empty_when_no_device_tree(self, tmp_path: Path) -> None:
+        # x86 hosts have no /proc/device-tree at all.
+        from anthias_server.django_project.settings import get_board_model
+
+        assert get_board_model(str(tmp_path / 'missing')) == ''


### PR DESCRIPTION
### Issues Fixed

Supports diagnosing Sentry [ANTHIAS-D](https://anthias.sentry.io/issues/7534527444/) / [ANTHIAS-F](https://anthias.sentry.io/issues/7534554847/) (armv7 Qt5 webview init crash) — the crash cohort can't currently be segmented by board or kernel.

### Description

Events are sent from inside containers, so Sentry's stock OS detection never sees the host. While debugging the webview heap-corruption crash we found the same Qt5/armhf viewer image behaves very differently under a 32-bit vs 64-bit host kernel — and nothing on the events says which one a device boots.

- `device_type` — baked into every image at build time (`pi1`/`pi2`/`pi3`/`pi3-64`/`pi4-64`/`x86`/…)
- `kernel_release` / `kernel_machine` — containers share the host kernel, so `platform.release()`/`machine()` report host values
- `board_model` — `/proc/device-tree/model` (resolves to `/sys/firmware/devicetree/base`, readable in every container; absent on x86)

No PII: board model and kernel version are hardware/software facts, same class as the existing `release` tag.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)