### PR TITLE
fix(server): surface the exception detail in GitHub update-check warnings

### DIFF
--- a/src/anthias_server/lib/github.py
+++ b/src/anthias_server/lib/github.py
@@ -50,7 +50,9 @@ def handle_github_error(
     if exc.response is not None:
         errdesc = exc.response.content
     else:
-        errdesc = 'no data'
+        # Surface the exception detail — a bare 'no data' hid the
+        # host/timeout info str(exc) carries (e.g. 'read timed out').
+        errdesc = str(exc) or 'no data'
 
     # Warning, not error: a signage device that can't reach
     # api.github.com (offline installs, locked-down networks, GitHub

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -427,3 +427,17 @@ def test_github_module_never_logs_at_error_level() -> None:
         f'{error_level_calls} — these become Sentry events on every '
         f'offline device'
     )
+
+
+def test_handle_github_error_surfaces_exception_detail(
+    github_env: None,
+) -> None:
+    """The no-response branch must log the exception detail, not a
+    bare 'no data' — Sentry previously showed 'ConnectionError
+    fetching latest release from GitHub: no data', hiding the
+    host/timeout info that str(exc) carries."""
+    exc = requests_exceptions.ReadTimeout('read timed out')
+    exc.response = None
+    with mock.patch('anthias_server.lib.github.logging.warning') as m_warning:
+        github.handle_github_error(exc, 'latest release')
+    assert m_warning.call_args.args[3] == 'read timed out'


### PR DESCRIPTION
### Issues Fixed

Follow-up to [ANTHIAS-8](https://anthias.sentry.io/issues/7534440162/) / #3019; ports the one improvement from #3014 that #3019 didn't carry.

### Description

`handle_github_error`'s no-response branch logged a literal `no data`, which is what made the original Sentry title ("ConnectionError fetching latest release from GitHub: no data") unactionable. Use `str(exc) or 'no data'` so the warning carries the host/timeout detail.

The rest of #3014 (the warning-level downgrade) already shipped in #3019, so #3014 can be closed.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)