### PR TITLE
feat(sentry): stamp the release with the build hash and tag balena deploys

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -23,7 +23,6 @@ import sentry_sdk
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.types import Event, Hint
 
-from anthias_common.utils import is_balena_app
 from anthias_common.version import get_anthias_release
 from anthias_server.settings import settings as device_settings
 
@@ -216,12 +215,26 @@ def get_board_model(model_file: str = '/proc/device-tree/model') -> str:
 sentry_sdk.set_tag('device_type', getenv('DEVICE_TYPE') or 'unknown')
 sentry_sdk.set_tag('kernel_release', platform.release())
 sentry_sdk.set_tag('kernel_machine', platform.machine())
+
+
+def is_balena_deploy() -> bool:
+    """True when running under balenaOS.
+
+    Same check as ``anthias_common.utils.is_balena_app`` (the BALENA
+    env var the balena supervisor injects), inlined rather than
+    imported: pulling anthias_common.utils into this module would
+    drag sh/requests/redis into every Django settings load, which the
+    slim environment django-stubs' mypy plugin runs under can't
+    satisfy.
+    """
+    return bool(getenv('BALENA'))
+
+
 # balena vs plain docker-compose installs differ operationally
 # (supervisor-managed restarts, no depends_on conditions, journald
 # unavailable) — segmenting by deployment kind tells the triage
-# which playbook applies. Same is_balena_app() helper the
-# reboot/shutdown tasks use (the BALENA env var balenaOS injects).
-sentry_sdk.set_tag('balena', 'true' if is_balena_app() else 'false')
+# which playbook applies.
+sentry_sdk.set_tag('balena', 'true' if is_balena_deploy() else 'false')
 _board_model = get_board_model()
 if _board_model:
     sentry_sdk.set_tag('board_model', _board_model)

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -23,6 +23,7 @@ import sentry_sdk
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.types import Event, Hint
 
+from anthias_common.utils import is_balena_app
 from anthias_common.version import get_anthias_release
 from anthias_server.settings import settings as device_settings
 
@@ -138,6 +139,31 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
 ignore_logger('celery.worker.consumer.consumer')
 ignore_logger('celery.beat')
 
+
+def get_sentry_release() -> str | None:
+    """CalVer release, postfixed with the build's short git hash.
+
+    The CalVer alone proved ambiguous in the field: a balena OTA
+    deploy from master ships new code while pyproject still carries
+    the last tagged version, so events from pre- and post-deploy
+    builds were indistinguishable in the 2026.6.2 audit.
+    ``GIT_SHORT_HASH`` is baked into every image by
+    tools/image_builder (the same hash the docker tag carries), which
+    pins each event to the exact build. ``+`` is semver
+    build-metadata syntax and Sentry handles it natively. Falls back
+    to the bare CalVer when the env is absent (host/dev runs), or
+    ``None`` when the version itself is unknown so Sentry doesn't
+    record a bogus '' release.
+    """
+    release = get_anthias_release()
+    if not release:
+        return None
+    git_short_hash = getenv('GIT_SHORT_HASH')
+    if git_short_hash:
+        return f'{release}+{git_short_hash}'
+    return release
+
+
 sentry_sdk.init(
     dsn=getenv('SENTRY_DSN', _default_sentry_dsn),
     before_send=_sentry_before_send,
@@ -146,12 +172,10 @@ sentry_sdk.init(
     # in Sentry. (Test runs don't send at all — see the DSN default
     # above.)
     environment=getenv('ENVIRONMENT', 'production'),
-    # CalVer release from pyproject.toml's [project].version, via the
-    # same helper the System Info page and v2 info API use (handles
-    # the `uv sync --no-install-project` Docker layout). Empty string
-    # means both sources failed — pass None so Sentry doesn't record
-    # a bogus '' release.
-    release=get_anthias_release() or None,
+    # CalVer (pyproject [project].version, via the same helper the
+    # System Info page and v2 info API use) plus the image's git
+    # short hash — see get_sentry_release above.
+    release=get_sentry_release(),
     # Request headers and user IPs are PII. Attach them only when the
     # operator hasn't opted out of analytics in anthias.conf — the
     # same knob that gates GA telemetry (see lib/telemetry.py). Crash
@@ -192,6 +216,12 @@ def get_board_model(model_file: str = '/proc/device-tree/model') -> str:
 sentry_sdk.set_tag('device_type', getenv('DEVICE_TYPE') or 'unknown')
 sentry_sdk.set_tag('kernel_release', platform.release())
 sentry_sdk.set_tag('kernel_machine', platform.machine())
+# balena vs plain docker-compose installs differ operationally
+# (supervisor-managed restarts, no depends_on conditions, journald
+# unavailable) — segmenting by deployment kind tells the triage
+# which playbook applies. Same is_balena_app() helper the
+# reboot/shutdown tasks use (the BALENA env var balenaOS injects).
+sentry_sdk.set_tag('balena', 'true' if is_balena_app() else 'false')
 _board_model = get_board_model()
 if _board_model:
     sentry_sdk.set_tag('board_model', _board_model)

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -206,13 +206,36 @@ class TestGetSentryRelease:
             assert s.get_sentry_release() is None
 
 
-def test_balena_tag_reflects_is_balena_app() -> None:
-    """The balena tag must come from the same helper the
-    reboot/shutdown tasks rely on, so the two can't disagree."""
-    import inspect
+class TestIsBalenaDeploy:
+    """The balena tag's decision logic — must match what
+    anthias_common.utils.is_balena_app derives from the BALENA env
+    var the balena supervisor injects."""
 
-    from anthias_server.django_project import settings as s
+    def test_true_under_balena(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from anthias_server.django_project import settings as s
 
-    source = inspect.getsource(s)
-    assert "set_tag('balena'" in source
-    assert 'is_balena_app()' in source
+        monkeypatch.setenv('BALENA', '1')
+        assert s.is_balena_deploy() is True
+
+    def test_false_on_compose_installs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from anthias_server.django_project import settings as s
+
+        monkeypatch.delenv('BALENA', raising=False)
+        assert s.is_balena_deploy() is False
+
+    def test_agrees_with_the_canonical_helper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The settings copy is inlined for import-weight reasons —
+        # pin it against the canonical helper so they can't drift.
+        from anthias_common.utils import is_balena_app
+        from anthias_server.django_project import settings as s
+
+        for value in (None, '1'):
+            if value is None:
+                monkeypatch.delenv('BALENA', raising=False)
+            else:
+                monkeypatch.setenv('BALENA', value)
+            assert s.is_balena_deploy() == is_balena_app()

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -10,7 +10,9 @@ and capture calls are dropped.
 """
 
 from pathlib import Path
+from unittest import mock
 
+import pytest
 import sentry_sdk
 from sentry_sdk.types import Event
 
@@ -163,3 +165,54 @@ class TestGetBoardModel:
         from anthias_server.django_project.settings import get_board_model
 
         assert get_board_model(str(tmp_path / 'missing')) == ''
+
+
+class TestGetSentryRelease:
+    """Release stamping — CalVer + the image's git short hash, so
+    pre- and post-deploy builds of the same CalVer are
+    distinguishable (the 2026.6.2 audit gap)."""
+
+    def test_appends_short_hash_when_env_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from anthias_server.django_project import settings as s
+
+        monkeypatch.setenv('GIT_SHORT_HASH', 'abc1234')
+        with mock.patch.object(
+            s, 'get_anthias_release', return_value='2026.6.2'
+        ):
+            assert s.get_sentry_release() == '2026.6.2+abc1234'
+
+    def test_bare_calver_without_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from anthias_server.django_project import settings as s
+
+        monkeypatch.delenv('GIT_SHORT_HASH', raising=False)
+        with mock.patch.object(
+            s, 'get_anthias_release', return_value='2026.6.2'
+        ):
+            assert s.get_sentry_release() == '2026.6.2'
+
+    def test_none_when_version_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No bogus '+hash'-only release when the CalVer itself is
+        # missing — Sentry should see no release at all.
+        from anthias_server.django_project import settings as s
+
+        monkeypatch.setenv('GIT_SHORT_HASH', 'abc1234')
+        with mock.patch.object(s, 'get_anthias_release', return_value=''):
+            assert s.get_sentry_release() is None
+
+
+def test_balena_tag_reflects_is_balena_app() -> None:
+    """The balena tag must come from the same helper the
+    reboot/shutdown tasks rely on, so the two can't disagree."""
+    import inspect
+
+    from anthias_server.django_project import settings as s
+
+    source = inspect.getsource(s)
+    assert "set_tag('balena'" in source
+    assert 'is_balena_app()' in source


### PR DESCRIPTION
### Issues Fixed

Closes the audit gap found after the balena deploy: every post-deploy event still reported `release: 2026.6.2` (pyproject carries the last tagged version), so old- and new-code events could only be told apart by which tags they carried.

### Description

- **Release = CalVer `+` build hash** — `GIT_SHORT_HASH` is already baked into every image by `tools/image_builder` (it's the same hash the docker tag uses), so the Sentry release becomes e.g. `2026.6.2+be63202`, pinning each event to the exact build. `+` is semver build-metadata syntax; Sentry handles it natively. Host/dev runs without the env fall back to the bare CalVer.
- **`balena: true|false` tag** — via the same `is_balena_app()` helper the reboot/shutdown tasks use. Balena and plain compose installs differ operationally (supervisor-managed restarts, no `depends_on` conditions), so triage knows which playbook applies.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)