### PR TITLE
fix(server): survive unreadable static files instead of crash-looping

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -338,7 +338,11 @@ if getenv('ANTHIAS_SERVICE') != 'viewer':
 # closing bracket where S4502 actually raises its issue.
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
+    # Fault-tolerant subclass of whitenoise's middleware: its startup
+    # scan of STATIC_ROOT survives unreadable entries (a corrupted SD
+    # card raising EUCLEAN bricked a device into a uvicorn crash-loop
+    # — Sentry ANTHIAS-Y). See anthias_server/lib/whitenoise.py.
+    'anthias_server.lib.whitenoise.ResilientWhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'anthias_server.lib.csrf.SameHostOriginCsrfMiddleware',

--- a/src/anthias_server/lib/whitenoise.py
+++ b/src/anthias_server/lib/whitenoise.py
@@ -1,0 +1,81 @@
+"""Fault-tolerant WhiteNoise middleware.
+
+WhiteNoise scans STATIC_ROOT once at startup (``autorefresh=False``
+in production). Stock behaviour lets any ``OSError`` from that scan
+propagate, which takes uvicorn down during ASGI import — observed in
+the field as ``OSError: [Errno 117] Structure needs cleaning`` when a
+balena OTA rewrote the staticfiles image layer onto a device with
+corrupted ext4 metadata (Sentry ANTHIAS-Y, 400+ events from one
+crash-looping device).
+
+A signage appliance must degrade, not brick: one unreadable admin
+vendor file is not worth losing the API, the WebSocket endpoint, and
+the asset server. Skip what the filesystem refuses to serve, keep
+everything else, and emit a single ERROR log per startup so the
+storage fault still lands in Sentry exactly once per boot — loud
+enough to act on, quiet enough not to flood.
+"""
+
+import logging
+import os
+from collections.abc import Iterator
+
+from whitenoise.middleware import WhiteNoiseMiddleware
+
+_SKIP_LOG_EXAMPLES = 3
+
+
+class ResilientWhiteNoiseMiddleware(WhiteNoiseMiddleware):
+    """WhiteNoise whose startup scan survives unreadable entries.
+
+    Mirrors ``whitenoise.base.WhiteNoise.update_files_dictionary`` /
+    ``scantree`` (whitenoise 6.x — both are stable one-screen
+    helpers) with per-entry ``OSError`` tolerance added. Everything
+    else — response serving, headers, compression handling — is
+    inherited untouched.
+    """
+
+    def update_files_dictionary(self, root: str, prefix: str) -> None:
+        skipped: list[tuple[str, OSError]] = []
+        stat_cache = dict(self._scantree_tolerant(root, skipped))
+        for path in stat_cache:
+            relative_path = path[len(root) :]
+            relative_url = relative_path.replace('\\', '/')
+            url = prefix + relative_url
+            self.add_file_to_dictionary(url, path, stat_cache=stat_cache)
+        if skipped:
+            examples = '; '.join(
+                f'{path}: {exc}' for path, exc in skipped[:_SKIP_LOG_EXAMPLES]
+            )
+            logging.error(
+                'Skipped %d unreadable static file(s)/dir(s) under %s — '
+                'the filesystem reported errors (%s). The device storage '
+                'likely needs attention (fsck/reflash); serving the '
+                'remaining static files.',
+                len(skipped),
+                root,
+                examples,
+            )
+
+    @classmethod
+    def _scantree_tolerant(
+        cls,
+        root: str,
+        skipped: list[tuple[str, OSError]],
+    ) -> Iterator[tuple[str, os.stat_result]]:
+        """``whitenoise.base.scantree``, but a directory that can't be
+        listed or an entry that can't be stat'd is recorded in
+        ``skipped`` instead of aborting the whole scan."""
+        try:
+            entries = list(os.scandir(root))
+        except OSError as exc:
+            skipped.append((root, exc))
+            return
+        for entry in entries:
+            try:
+                if entry.is_dir():
+                    yield from cls._scantree_tolerant(entry.path, skipped)
+                else:
+                    yield entry.path, entry.stat()
+            except OSError as exc:
+                skipped.append((entry.path, exc))

--- a/src/anthias_server/lib/whitenoise.py
+++ b/src/anthias_server/lib/whitenoise.py
@@ -76,15 +76,18 @@ class ResilientWhiteNoiseMiddleware(WhiteNoiseMiddleware):
         listed or an entry that can't be stat'd is recorded in
         ``skipped`` instead of aborting the whole scan."""
         try:
-            entries = list(os.scandir(root))
+            scandir = os.scandir(root)
         except OSError as exc:
             skipped.append((root, exc))
             return
-        for entry in entries:
-            try:
-                if entry.is_dir():
-                    yield from cls._scantree_tolerant(entry.path, skipped)
-                else:
-                    yield entry.path, entry.stat()
-            except OSError as exc:
-                skipped.append((entry.path, exc))
+        # Close the directory FD promptly even on a large/deep tree —
+        # the recursion below can hold many open otherwise.
+        with scandir:
+            for entry in scandir:
+                try:
+                    if entry.is_dir():
+                        yield from cls._scantree_tolerant(entry.path, skipped)
+                    else:
+                        yield entry.path, entry.stat()
+                except OSError as exc:
+                    skipped.append((entry.path, exc))

--- a/src/anthias_server/lib/whitenoise.py
+++ b/src/anthias_server/lib/whitenoise.py
@@ -22,6 +22,8 @@ from collections.abc import Iterator
 
 from whitenoise.middleware import WhiteNoiseMiddleware
 
+logger = logging.getLogger(__name__)
+
 _SKIP_LOG_EXAMPLES = 3
 
 
@@ -36,10 +38,17 @@ class ResilientWhiteNoiseMiddleware(WhiteNoiseMiddleware):
     """
 
     def update_files_dictionary(self, root: str, prefix: str) -> None:
+        # Stock whitenoise computes the URL as ``prefix +
+        # path[len(root):]`` and relies on its caller having appended
+        # a trailing separator to ``root``. Don't depend on that:
+        # normalise here so a ``root`` without the trailing sep can't
+        # yield a ``/static//css/app.css`` double-slash URL that then
+        # fails to match incoming requests.
+        root_with_sep = os.path.join(root, '')
         skipped: list[tuple[str, OSError]] = []
-        stat_cache = dict(self._scantree_tolerant(root, skipped))
+        stat_cache = dict(self._scantree_tolerant(root_with_sep, skipped))
         for path in stat_cache:
-            relative_path = path[len(root) :]
+            relative_path = path[len(root_with_sep) :]
             relative_url = relative_path.replace('\\', '/')
             url = prefix + relative_url
             self.add_file_to_dictionary(url, path, stat_cache=stat_cache)
@@ -47,7 +56,7 @@ class ResilientWhiteNoiseMiddleware(WhiteNoiseMiddleware):
             examples = '; '.join(
                 f'{path}: {exc}' for path, exc in skipped[:_SKIP_LOG_EXAMPLES]
             )
-            logging.error(
+            logger.error(
                 'Skipped %d unreadable static file(s)/dir(s) under %s — '
                 'the filesystem reported errors (%s). The device storage '
                 'likely needs attention (fsck/reflash); serving the '

--- a/stubs/whitenoise-stubs/middleware.pyi
+++ b/stubs/whitenoise-stubs/middleware.pyi
@@ -13,7 +13,7 @@ class WhiteNoiseMiddleware:
 
     def __init__(
         self,
-        get_response: Callable[[HttpRequest], HttpResponseBase | None],
+        get_response: Callable[[HttpRequest], HttpResponseBase],
         settings: Any = ...,
     ) -> None: ...
     def __call__(self, request: HttpRequest) -> HttpResponseBase: ...

--- a/stubs/whitenoise-stubs/middleware.pyi
+++ b/stubs/whitenoise-stubs/middleware.pyi
@@ -1,0 +1,26 @@
+# Minimal stub covering only what
+# anthias_server/lib/whitenoise.py subclasses and touches — same
+# pattern as channels-stubs / redis-stubs (a future upstream py.typed
+# release should replace this).
+import os
+from collections.abc import Callable
+from typing import Any
+
+from django.http import HttpRequest, HttpResponseBase
+
+class WhiteNoiseMiddleware:
+    files: dict[str, Any]
+
+    def __init__(
+        self,
+        get_response: Callable[[HttpRequest], HttpResponseBase | None],
+        settings: Any = ...,
+    ) -> None: ...
+    def __call__(self, request: HttpRequest) -> HttpResponseBase: ...
+    def update_files_dictionary(self, root: str, prefix: str) -> None: ...
+    def add_file_to_dictionary(
+        self,
+        url: str,
+        path: str,
+        stat_cache: dict[str, os.stat_result] | None = ...,
+    ) -> None: ...

--- a/stubs/whitenoise-stubs/py.typed
+++ b/stubs/whitenoise-stubs/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/tests/test_whitenoise_resilient.py
+++ b/tests/test_whitenoise_resilient.py
@@ -10,10 +10,12 @@ device over one unreadable Django-admin vendor file.
 import logging
 import os
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 import pytest
 from django.conf import settings
+from django.http import HttpResponse
 
 from anthias_server.lib.whitenoise import ResilientWhiteNoiseMiddleware
 
@@ -23,6 +25,24 @@ def _make_tree(root: Path) -> None:
     (root / 'css' / 'app.css').write_text('body{}')
     (root / 'js').mkdir()
     (root / 'js' / 'app.js').write_text('//')
+
+
+class _ScandirCM:
+    """Context-manager iterable matching ``os.scandir``'s protocol,
+    so fakes that hand back a custom entry list still work with the
+    production ``with os.scandir(...) as it:`` usage."""
+
+    def __init__(self, entries: list[Any]) -> None:
+        self._entries = entries
+
+    def __enter__(self) -> 'list[Any]':
+        return self._entries
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def __iter__(self) -> Any:
+        return iter(self._entries)
 
 
 class TestScantreeTolerant:
@@ -89,8 +109,9 @@ class TestScantreeTolerant:
                     raise OSError(117, 'Structure needs cleaning', self.path)
                 return self._entry.stat()
 
-        def fake_scandir(path: str) -> list[_Entry]:
-            return [_Entry(e) for e in real_scandir(path)]
+        def fake_scandir(path: str) -> _ScandirCM:
+            with real_scandir(path) as it:
+                return _ScandirCM([_Entry(e) for e in it])
 
         skipped: list[tuple[str, OSError]] = []
         with mock.patch(
@@ -106,14 +127,17 @@ class TestScantreeTolerant:
 
 
 class TestMiddlewareDegradesGracefully:
-    def _middleware(self, root: Path) -> ResilientWhiteNoiseMiddleware:
-        # Instantiate against a scratch STATIC_ROOT the way Django's
-        # handler does at startup; autorefresh off = the one-shot
-        # scan that crashed in the field.
-        with mock.patch.object(settings, 'STATIC_ROOT', str(root)):
-            return ResilientWhiteNoiseMiddleware(
-                get_response=lambda request: None
-            )
+    def _middleware(self) -> ResilientWhiteNoiseMiddleware:
+        # Construct without scanning (the test settings enable
+        # WHITENOISE_AUTOREFRESH under DEBUG, so __init__ doesn't scan
+        # STATIC_ROOT), then drive the overridden scan directly — that
+        # keeps the test pinned to our code rather than to whichever
+        # startup path the active DEBUG/autorefresh config takes. The
+        # get_response returns a real HttpResponse per Django's
+        # middleware contract.
+        return ResilientWhiteNoiseMiddleware(
+            get_response=lambda request: HttpResponse()
+        )
 
     def test_survives_corrupted_subtree_and_serves_the_rest(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -122,22 +146,23 @@ class TestMiddlewareDegradesGracefully:
         bad_dir = str(tmp_path / 'js')
         real_scandir = os.scandir
 
-        def fake_scandir(path: str):  # type: ignore[no-untyped-def]
+        def fake_scandir(path: str) -> Any:
             if str(path) == bad_dir:
                 raise OSError(117, 'Structure needs cleaning', path)
             return real_scandir(path)
 
+        middleware = self._middleware()
         with (
             mock.patch(
                 'anthias_server.lib.whitenoise.os.scandir', fake_scandir
             ),
             caplog.at_level(logging.ERROR),
         ):
-            middleware = self._middleware(tmp_path)
+            middleware.update_files_dictionary(str(tmp_path), '/static/')
 
-        # No exception escaped, the healthy file is served under
-        # its canonical /static/ URL (no double-slash from a root
-        # without a trailing separator)...
+        # No exception escaped, the healthy file is served under its
+        # canonical /static/ URL (no double-slash from a root without
+        # a trailing separator)...
         assert '/static/css/app.css' in middleware.files
         # ...and exactly one ERROR records the storage fault.
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
@@ -149,9 +174,11 @@ class TestMiddlewareDegradesGracefully:
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         _make_tree(tmp_path)
+        middleware = self._middleware()
         with caplog.at_level(logging.ERROR):
-            middleware = self._middleware(tmp_path)
-        assert any('app.css' in url for url in middleware.files)
+            middleware.update_files_dictionary(str(tmp_path), '/static/')
+        assert '/static/css/app.css' in middleware.files
+        assert '/static/js/app.js' in middleware.files
         assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
 
 

--- a/tests/test_whitenoise_resilient.py
+++ b/tests/test_whitenoise_resilient.py
@@ -1,0 +1,163 @@
+"""Tests for the fault-tolerant WhiteNoise startup scan.
+
+Regression coverage for Sentry ANTHIAS-Y: a balena OTA rewrote the
+staticfiles layer onto a device with corrupted ext4 metadata, the
+stock WhiteNoise scan raised ``OSError: [Errno 117] Structure needs
+cleaning`` at ASGI import, and uvicorn crash-looped — bricking the
+device over one unreadable Django-admin vendor file.
+"""
+
+import logging
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from django.conf import settings
+
+from anthias_server.lib.whitenoise import ResilientWhiteNoiseMiddleware
+
+
+def _make_tree(root: Path) -> None:
+    (root / 'css').mkdir(parents=True)
+    (root / 'css' / 'app.css').write_text('body{}')
+    (root / 'js').mkdir()
+    (root / 'js' / 'app.js').write_text('//')
+
+
+class TestScantreeTolerant:
+    def test_yields_all_entries_on_healthy_tree(self, tmp_path: Path) -> None:
+        _make_tree(tmp_path)
+        skipped: list[tuple[str, OSError]] = []
+        found = dict(
+            ResilientWhiteNoiseMiddleware._scantree_tolerant(
+                str(tmp_path), skipped
+            )
+        )
+        assert skipped == []
+        assert {os.path.basename(p) for p in found} == {
+            'app.css',
+            'app.js',
+        }
+
+    def test_unlistable_directory_is_skipped_not_fatal(
+        self, tmp_path: Path
+    ) -> None:
+        _make_tree(tmp_path)
+        bad_dir = str(tmp_path / 'js')
+        real_scandir = os.scandir
+
+        def fake_scandir(path: str):  # type: ignore[no-untyped-def]
+            if str(path) == bad_dir:
+                raise OSError(117, 'Structure needs cleaning', path)
+            return real_scandir(path)
+
+        skipped: list[tuple[str, OSError]] = []
+        with mock.patch(
+            'anthias_server.lib.whitenoise.os.scandir', fake_scandir
+        ):
+            found = dict(
+                ResilientWhiteNoiseMiddleware._scantree_tolerant(
+                    str(tmp_path), skipped
+                )
+            )
+        # The css file survives; the corrupted dir is recorded.
+        assert {os.path.basename(p) for p in found} == {'app.css'}
+        assert len(skipped) == 1
+        assert skipped[0][0] == bad_dir
+        assert skipped[0][1].errno == 117
+
+    def test_unstattable_entry_is_skipped_not_fatal(
+        self, tmp_path: Path
+    ) -> None:
+        # The exact ANTHIAS-Y shape: scandir lists the entry but the
+        # corrupted inode fails on stat().
+        _make_tree(tmp_path)
+        bad_file = str(tmp_path / 'js' / 'app.js')
+        real_scandir = os.scandir
+
+        class _Entry:
+            def __init__(self, entry: os.DirEntry[str]) -> None:
+                self._entry = entry
+                self.path = entry.path
+
+            def is_dir(self) -> bool:
+                return self._entry.is_dir()
+
+            def stat(self) -> os.stat_result:
+                if self.path == bad_file:
+                    raise OSError(117, 'Structure needs cleaning', self.path)
+                return self._entry.stat()
+
+        def fake_scandir(path: str) -> list[_Entry]:
+            return [_Entry(e) for e in real_scandir(path)]
+
+        skipped: list[tuple[str, OSError]] = []
+        with mock.patch(
+            'anthias_server.lib.whitenoise.os.scandir', fake_scandir
+        ):
+            found = dict(
+                ResilientWhiteNoiseMiddleware._scantree_tolerant(
+                    str(tmp_path), skipped
+                )
+            )
+        assert {os.path.basename(p) for p in found} == {'app.css'}
+        assert [p for p, _ in skipped] == [bad_file]
+
+
+class TestMiddlewareDegradesGracefully:
+    def _middleware(self, root: Path) -> ResilientWhiteNoiseMiddleware:
+        # Instantiate against a scratch STATIC_ROOT the way Django's
+        # handler does at startup; autorefresh off = the one-shot
+        # scan that crashed in the field.
+        with mock.patch.object(settings, 'STATIC_ROOT', str(root)):
+            return ResilientWhiteNoiseMiddleware(
+                get_response=lambda request: None
+            )
+
+    def test_survives_corrupted_subtree_and_serves_the_rest(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _make_tree(tmp_path)
+        bad_dir = str(tmp_path / 'js')
+        real_scandir = os.scandir
+
+        def fake_scandir(path: str):  # type: ignore[no-untyped-def]
+            if str(path) == bad_dir:
+                raise OSError(117, 'Structure needs cleaning', path)
+            return real_scandir(path)
+
+        with (
+            mock.patch(
+                'anthias_server.lib.whitenoise.os.scandir', fake_scandir
+            ),
+            caplog.at_level(logging.ERROR),
+        ):
+            middleware = self._middleware(tmp_path)
+
+        # No exception escaped, the healthy file is served...
+        assert any('app.css' in url for url in middleware.files)
+        # ...and exactly one ERROR records the storage fault.
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert 'Structure needs cleaning' in errors[0].getMessage()
+        assert 'storage' in errors[0].getMessage()
+
+    def test_no_error_log_on_healthy_tree(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _make_tree(tmp_path)
+        with caplog.at_level(logging.ERROR):
+            middleware = self._middleware(tmp_path)
+        assert any('app.css' in url for url in middleware.files)
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+def test_settings_use_the_resilient_middleware() -> None:
+    assert (
+        'anthias_server.lib.whitenoise.ResilientWhiteNoiseMiddleware'
+        in settings.MIDDLEWARE
+    )
+    assert 'whitenoise.middleware.WhiteNoiseMiddleware' not in (
+        settings.MIDDLEWARE
+    )

--- a/tests/test_whitenoise_resilient.py
+++ b/tests/test_whitenoise_resilient.py
@@ -135,8 +135,10 @@ class TestMiddlewareDegradesGracefully:
         ):
             middleware = self._middleware(tmp_path)
 
-        # No exception escaped, the healthy file is served...
-        assert any('app.css' in url for url in middleware.files)
+        # No exception escaped, the healthy file is served under
+        # its canonical /static/ URL (no double-slash from a root
+        # without a trailing separator)...
+        assert '/static/css/app.css' in middleware.files
         # ...and exactly one ERROR records the storage fault.
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert len(errors) == 1


### PR DESCRIPTION
### Issues Fixed

Sentry [ANTHIAS-Y](https://anthias.sentry.io/issues/7535130055/) — `OSError: [Errno 117] Structure needs cleaning` in WhiteNoise's startup scan; 400+ events from a single crash-looping pi3.

### Description

Timeline correlation confirmed this *surfaced* with the `2026.6.2+rev1` OTA (fleet release 14:26 UTC → first event 15:40 UTC): the deploy rewrote the staticfiles image layer onto a device whose ext4 metadata is corrupted, and the first read of `admin/js/vendor/select2/i18n/gl.js` returned EUCLEAN. The file is stock Django-admin vendor JS — the corruption is the device's storage, not the release's code.

The failure *mode* is ours though: stock WhiteNoise lets the scan exception propagate out of ASGI import, so one unreadable vendor file kills uvicorn entirely — no API, no WebSocket, no asset serving. A signage appliance should degrade, not brick.

- `ResilientWhiteNoiseMiddleware` mirrors whitenoise 6.x's `update_files_dictionary`/`scantree` (both stable one-screen helpers) with per-entry `OSError` tolerance
- Skipped entries are collected and logged as **one ERROR per startup** (with up to 3 example paths) — the storage fault still lands in Sentry once per boot, actionable without flooding
- Minimal `stubs/whitenoise-stubs/` (same pattern as channels-stubs) so the subclass passes strict mypy

The affected device itself still needs ops attention (fsck/reflash) — event geo says Jonzac, France.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)