### PR TITLE
fix(viewer): wait for cage's Wayland socket before spawning the webview

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -404,16 +404,6 @@ BROWSER_SPAWN_INLINE_TIMEOUT_SECONDS = 10
 BROWSER_POLL_INTERVAL_SECONDS = 0.25
 # Grace period to let a SIGTERM'd webview exit before we SIGKILL it.
 BROWSER_TERMINATE_GRACE_SECONDS = 3
-# How long to wait for cage's Wayland socket before spawning the webview
-# on a Wayland board. cage exports WAYLAND_DISPLAY and creates the socket
-# before exec'ing the Python viewer, so at first launch it's already
-# there and this returns immediately; the wait matters for a respawn that
-# races a moment when the socket is briefly absent (cage restarting),
-# which otherwise has every attempt die with Qt's "Failed to create
-# wl_display (Connection refused)" and burns the whole inline budget
-# (Sentry ANTHIAS-19). Bounded so a genuinely dead compositor still falls
-# through to the existing spawn-failure handling rather than hanging.
-BROWSER_WAYLAND_SOCKET_WAIT_SECONDS = 10
 
 
 class WebviewLaunchError(RuntimeError):
@@ -464,9 +454,13 @@ def _wayland_socket_path() -> str | None:
 
     cage exports both ``XDG_RUNTIME_DIR`` and ``WAYLAND_DISPLAY`` to
     the viewer before exec'ing it; the socket lives at their join.
-    ``WAYLAND_DISPLAY`` may itself be an absolute path (rare), in
-    which case it's used verbatim. Returns ``None`` when either piece
-    is missing so the caller can skip the wait rather than guess.
+    This env signal — not ``_is_wayland_board()`` — is what gates the
+    wait: cage sets WAYLAND_DISPLAY and nothing else does, on x86,
+    arm64 AND pi5 alike, whereas ``_is_wayland_board()`` is x86-only
+    and would skip the wait on exactly the Pi 5 where ANTHIAS-19
+    fired. ``WAYLAND_DISPLAY`` may itself be an absolute path (rare),
+    used verbatim then. Returns ``None`` when either piece is missing
+    — a non-cage (linuxfb/eglfs) board with no socket to wait for.
     """
     wayland_display = getenv('WAYLAND_DISPLAY')
     if not wayland_display:
@@ -479,40 +473,34 @@ def _wayland_socket_path() -> str | None:
     return os.path.join(runtime_dir, wayland_display)
 
 
-def _wait_for_wayland_socket(
-    timeout: float = BROWSER_WAYLAND_SOCKET_WAIT_SECONDS,
-) -> None:
-    """Block until cage's Wayland socket exists, on Wayland boards.
+def _wait_for_wayland_socket(deadline: float) -> None:
+    """Block until cage's Wayland socket exists, until ``deadline``
+    (a ``monotonic()`` timestamp).
 
-    No-op on linuxfb/eglfs boards and when the env names no socket.
-    Bounded by ``timeout``: a compositor that never comes back still
-    falls through, so the spawn fails the normal way and the retry
-    loop / container restart handles it — we never hang the
-    asset_loop thread waiting on a dead cage.
+    No-op on non-cage boards (the env names no socket) and when the
+    socket is already up — the common case, returns at once.
+    ``deadline`` is the *shared* spawn-attempt budget, so this wait
+    and the D-Bus handshake wait that follows together can't exceed
+    ``startup_timeout``; a compositor that never returns falls through
+    and the spawn fails the normal way rather than hanging the
+    asset_loop thread.
     """
-    if not _is_wayland_board():
-        return
     socket_path = _wayland_socket_path()
-    if socket_path is None:
+    if socket_path is None or os.path.exists(socket_path):
         return
-    if os.path.exists(socket_path):
-        return
-    deadline = monotonic() + max(0.0, timeout)
     logging.warning(
-        'Wayland socket %s not present yet; waiting up to %gs before '
-        'spawning the webview',
+        'Wayland socket %s not present yet; waiting (within the spawn '
+        'budget) before launching the webview',
         socket_path,
-        timeout,
     )
     while monotonic() < deadline:
         if os.path.exists(socket_path):
             return
         sleep(BROWSER_POLL_INTERVAL_SECONDS)
     logging.warning(
-        'Wayland socket %s still absent after %gs; spawning anyway '
-        '(the launch will fail and retry if cage is truly down)',
+        'Wayland socket %s still absent; launching anyway (the launch '
+        'will fail and retry if cage is truly down)',
         socket_path,
-        timeout,
     )
 
 
@@ -525,12 +513,18 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
     handshake or fails to emit it within ``startup_timeout``. The matched
     string must stay in lockstep with ``qInfo() << "Anthias service
     start"`` in src/anthias_webview/src/main.cpp.
+
+    ``startup_timeout`` is the total budget for the attempt: on a cage
+    board one shared deadline covers both the wait for the Wayland
+    socket and the handshake, so the socket wait can't pile on top of
+    ``startup_timeout``.
     """
-    # On Wayland boards, don't race cage's socket — a spawn before it
-    # exists dies instantly with "Failed to create wl_display" and
+    deadline = monotonic() + startup_timeout
+    # On cage boards, don't race the Wayland socket — a spawn before
+    # it exists dies instantly with "Failed to create wl_display" and
     # wastes a retry attempt (Sentry ANTHIAS-19). No-op elsewhere and
     # when the socket is already up (the common case).
-    _wait_for_wayland_socket()
+    _wait_for_wayland_socket(deadline)
     try:
         # _bg_exc=False: with the default (True), sh re-raises the exit
         # error (e.g. SignalException_SIGABRT on a Qt init crash, or
@@ -550,7 +544,9 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
             f'AnthiasViewer binary not found: {exc}'
         ) from exc
 
-    deadline = monotonic() + startup_timeout
+    # Reuse the same ``deadline`` the Wayland-socket wait above shares,
+    # so the whole attempt — socket wait plus handshake — is bounded by
+    # ``startup_timeout`` rather than the two stacking.
     while monotonic() < deadline:
         if BROWSER_HANDSHAKE_LINE in candidate.process.stdout.decode(
             'utf-8', errors='replace'

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -404,6 +404,16 @@ BROWSER_SPAWN_INLINE_TIMEOUT_SECONDS = 10
 BROWSER_POLL_INTERVAL_SECONDS = 0.25
 # Grace period to let a SIGTERM'd webview exit before we SIGKILL it.
 BROWSER_TERMINATE_GRACE_SECONDS = 3
+# How long to wait for cage's Wayland socket before spawning the webview
+# on a Wayland board. cage exports WAYLAND_DISPLAY and creates the socket
+# before exec'ing the Python viewer, so at first launch it's already
+# there and this returns immediately; the wait matters for a respawn that
+# races a moment when the socket is briefly absent (cage restarting),
+# which otherwise has every attempt die with Qt's "Failed to create
+# wl_display (Connection refused)" and burns the whole inline budget
+# (Sentry ANTHIAS-19). Bounded so a genuinely dead compositor still falls
+# through to the existing spawn-failure handling rather than hanging.
+BROWSER_WAYLAND_SOCKET_WAIT_SECONDS = 10
 
 
 class WebviewLaunchError(RuntimeError):
@@ -448,6 +458,64 @@ def _terminate_webview(proc: Any) -> None:
         logging.debug('Could not SIGKILL AnthiasViewer', exc_info=True)
 
 
+def _wayland_socket_path() -> str | None:
+    """Path to cage's Wayland socket, or ``None`` if the env doesn't
+    name one.
+
+    cage exports both ``XDG_RUNTIME_DIR`` and ``WAYLAND_DISPLAY`` to
+    the viewer before exec'ing it; the socket lives at their join.
+    ``WAYLAND_DISPLAY`` may itself be an absolute path (rare), in
+    which case it's used verbatim. Returns ``None`` when either piece
+    is missing so the caller can skip the wait rather than guess.
+    """
+    wayland_display = getenv('WAYLAND_DISPLAY')
+    if not wayland_display:
+        return None
+    if os.path.isabs(wayland_display):
+        return wayland_display
+    runtime_dir = getenv('XDG_RUNTIME_DIR')
+    if not runtime_dir:
+        return None
+    return os.path.join(runtime_dir, wayland_display)
+
+
+def _wait_for_wayland_socket(
+    timeout: float = BROWSER_WAYLAND_SOCKET_WAIT_SECONDS,
+) -> None:
+    """Block until cage's Wayland socket exists, on Wayland boards.
+
+    No-op on linuxfb/eglfs boards and when the env names no socket.
+    Bounded by ``timeout``: a compositor that never comes back still
+    falls through, so the spawn fails the normal way and the retry
+    loop / container restart handles it — we never hang the
+    asset_loop thread waiting on a dead cage.
+    """
+    if not _is_wayland_board():
+        return
+    socket_path = _wayland_socket_path()
+    if socket_path is None:
+        return
+    if os.path.exists(socket_path):
+        return
+    deadline = monotonic() + max(0.0, timeout)
+    logging.warning(
+        'Wayland socket %s not present yet; waiting up to %gs before '
+        'spawning the webview',
+        socket_path,
+        timeout,
+    )
+    while monotonic() < deadline:
+        if os.path.exists(socket_path):
+            return
+        sleep(BROWSER_POLL_INTERVAL_SECONDS)
+    logging.warning(
+        'Wayland socket %s still absent after %gs; spawning anyway '
+        '(the launch will fail and retry if cage is truly down)',
+        socket_path,
+        timeout,
+    )
+
+
 def _spawn_webview_once(startup_timeout: float) -> Any:
     """Spawn AnthiasViewer once and block until it registers on D-Bus.
 
@@ -458,6 +526,11 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
     string must stay in lockstep with ``qInfo() << "Anthias service
     start"`` in src/anthias_webview/src/main.cpp.
     """
+    # On Wayland boards, don't race cage's socket — a spawn before it
+    # exists dies instantly with "Failed to create wl_display" and
+    # wastes a retry attempt (Sentry ANTHIAS-19). No-op elsewhere and
+    # when the socket is already up (the common case).
+    _wait_for_wayland_socket()
     try:
         # _bg_exc=False: with the default (True), sh re-raises the exit
         # error (e.g. SignalException_SIGABRT on a Qt init crash, or

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1714,3 +1714,112 @@ class TestPublishDisplayResolutionOnce:
             '1280x720',
             ex=viewer.DISPLAY_RESOLUTION_TTL_S,
         )
+
+
+# ---------------------------------------------------------------------------
+# Wayland socket wait (Sentry ANTHIAS-19)
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForWaylandSocket:
+    """The webview spawn must not race cage's Wayland socket on a
+    Wayland board — a spawn before the socket exists dies with
+    'Failed to create wl_display' and wastes a retry attempt."""
+
+    def test_no_op_on_non_wayland_board(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: False)
+        slept = mock.Mock()
+        monkeypatch.setattr(viewer, 'sleep', slept)
+        # Even with no socket env set, a linuxfb/eglfs board returns
+        # immediately without polling.
+        viewer._wait_for_wayland_socket(timeout=5)
+        slept.assert_not_called()
+
+    def test_returns_immediately_when_socket_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: True)
+        monkeypatch.setenv('XDG_RUNTIME_DIR', str(tmp_path))
+        monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-1')
+        (tmp_path / 'wayland-1').write_text('')
+        slept = mock.Mock()
+        monkeypatch.setattr(viewer, 'sleep', slept)
+        viewer._wait_for_wayland_socket(timeout=5)
+        slept.assert_not_called()
+
+    def test_waits_then_proceeds_when_socket_appears(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: True)
+        monkeypatch.setenv('XDG_RUNTIME_DIR', str(tmp_path))
+        monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-1')
+        socket = tmp_path / 'wayland-1'
+
+        # The socket shows up after the second poll.
+        calls = {'n': 0}
+
+        def fake_sleep(_seconds: float) -> None:
+            calls['n'] += 1
+            if calls['n'] >= 2:
+                socket.write_text('')
+
+        monkeypatch.setattr(viewer, 'sleep', fake_sleep)
+        viewer._wait_for_wayland_socket(timeout=5)
+        assert socket.exists()
+        assert calls['n'] >= 2
+
+    def test_bounded_when_socket_never_appears(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        # A dead compositor must not hang the asset_loop thread — the
+        # wait falls through after the timeout and lets the spawn fail
+        # the normal way.
+        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: True)
+        monkeypatch.setenv('XDG_RUNTIME_DIR', str(tmp_path))
+        monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-1')
+        monkeypatch.setattr(viewer, 'sleep', lambda _s: None)
+        # Returns (doesn't raise / hang) even though the socket is absent.
+        viewer._wait_for_wayland_socket(timeout=1)
+        assert not (tmp_path / 'wayland-1').exists()
+
+    def test_skips_when_env_incomplete(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: True)
+        monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
+        slept = mock.Mock()
+        monkeypatch.setattr(viewer, 'sleep', slept)
+        viewer._wait_for_wayland_socket(timeout=5)
+        slept.assert_not_called()
+
+    def test_spawn_waits_for_socket_before_launching(
+        self, viewer_fixtures: _ViewerFixtures
+    ) -> None:
+        # _spawn_webview_once must call the wait before it shells out,
+        # so a respawn never races cage. Make the spawn fail fast (a
+        # missing binary is the cheapest terminal error) and assert
+        # the wait ran first.
+        order: list[str] = []
+
+        def fake_wait() -> None:
+            order.append('wait')
+
+        def fake_command(*args: Any, **kwargs: Any) -> Any:
+            order.append('spawn')
+            raise viewer_fixtures.u.sh.CommandNotFound('AnthiasViewer')
+
+        with (
+            mock.patch.object(
+                viewer_fixtures.u,
+                '_wait_for_wayland_socket',
+                side_effect=fake_wait,
+            ),
+            mock.patch.object(
+                viewer_fixtures.u.sh, 'Command', side_effect=fake_command
+            ),
+            pytest.raises(viewer_fixtures.u.WebviewBinaryMissingError),
+        ):
+            viewer_fixtures.u._spawn_webview_once(1)
+        assert order == ['wait', 'spawn']

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -4,7 +4,7 @@
 import logging
 import os
 from collections.abc import Iterator
-from time import sleep
+from time import monotonic, sleep
 from typing import Any
 from unittest import mock
 
@@ -1722,37 +1722,60 @@ class TestPublishDisplayResolutionOnce:
 
 
 class TestWaitForWaylandSocket:
-    """The webview spawn must not race cage's Wayland socket on a
-    Wayland board — a spawn before the socket exists dies with
-    'Failed to create wl_display' and wastes a retry attempt."""
+    """The webview spawn must not race cage's Wayland socket — a spawn
+    before the socket exists dies with 'Failed to create wl_display'
+    and wastes a retry attempt (Sentry ANTHIAS-19). The gate is the
+    WAYLAND_DISPLAY env cage exports, NOT _is_wayland_board() (which is
+    x86-only and would skip the Pi 5 where this actually fired)."""
 
-    def test_no_op_on_non_wayland_board(
+    def test_no_op_when_no_socket_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: False)
+        # linuxfb/eglfs board: cage never ran, so WAYLAND_DISPLAY is
+        # unset and the wait returns immediately without polling.
+        monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
         slept = mock.Mock()
         monkeypatch.setattr(viewer, 'sleep', slept)
-        # Even with no socket env set, a linuxfb/eglfs board returns
-        # immediately without polling.
-        viewer._wait_for_wayland_socket(timeout=5)
+        viewer._wait_for_wayland_socket(monotonic() + 5)
         slept.assert_not_called()
 
     def test_returns_immediately_when_socket_present(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
-        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: True)
         monkeypatch.setenv('XDG_RUNTIME_DIR', str(tmp_path))
         monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-1')
         (tmp_path / 'wayland-1').write_text('')
         slept = mock.Mock()
         monkeypatch.setattr(viewer, 'sleep', slept)
-        viewer._wait_for_wayland_socket(timeout=5)
+        viewer._wait_for_wayland_socket(monotonic() + 5)
         slept.assert_not_called()
+
+    def test_fires_on_pi5_via_env_not_board_helper(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Any,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # The regression Copilot flagged: _is_wayland_board() returns
+        # False for pi5, so gating on it would skip the wait on exactly
+        # the board ANTHIAS-19 came from. With DEVICE_TYPE=pi5 the wait
+        # must still engage (driven by WAYLAND_DISPLAY), proven by the
+        # 'not present yet' warning firing for an absent socket.
+        monkeypatch.setenv('DEVICE_TYPE', 'pi5')
+        assert viewer._is_wayland_board() is False
+        monkeypatch.setenv('XDG_RUNTIME_DIR', str(tmp_path))
+        monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-1')
+        monkeypatch.setattr(viewer, 'sleep', lambda _s: None)
+        with caplog.at_level(logging.WARNING):
+            # Deadline already passed: the loop body is skipped, but the
+            # pre-loop "not present yet" warning still fires iff the wait
+            # was entered (i.e. not board-skipped).
+            viewer._wait_for_wayland_socket(monotonic() - 1)
+        assert any('not present yet' in r.getMessage() for r in caplog.records)
 
     def test_waits_then_proceeds_when_socket_appears(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
-        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: True)
         monkeypatch.setenv('XDG_RUNTIME_DIR', str(tmp_path))
         monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-1')
         socket = tmp_path / 'wayland-1'
@@ -1766,32 +1789,33 @@ class TestWaitForWaylandSocket:
                 socket.write_text('')
 
         monkeypatch.setattr(viewer, 'sleep', fake_sleep)
-        viewer._wait_for_wayland_socket(timeout=5)
+        viewer._wait_for_wayland_socket(monotonic() + 100)
         assert socket.exists()
         assert calls['n'] >= 2
 
     def test_bounded_when_socket_never_appears(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
-        # A dead compositor must not hang the asset_loop thread — the
-        # wait falls through after the timeout and lets the spawn fail
-        # the normal way.
-        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: True)
+        # A dead compositor must not hang the asset_loop thread — once
+        # the shared deadline passes the wait falls through and lets the
+        # spawn fail the normal way.
         monkeypatch.setenv('XDG_RUNTIME_DIR', str(tmp_path))
         monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-1')
         monkeypatch.setattr(viewer, 'sleep', lambda _s: None)
-        # Returns (doesn't raise / hang) even though the socket is absent.
-        viewer._wait_for_wayland_socket(timeout=1)
+        # Deadline already in the past → returns at once, no hang.
+        viewer._wait_for_wayland_socket(monotonic() - 1)
         assert not (tmp_path / 'wayland-1').exists()
 
-    def test_skips_when_env_incomplete(
+    def test_skips_when_runtime_dir_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(viewer, '_is_wayland_board', lambda: True)
-        monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
+        # WAYLAND_DISPLAY set but XDG_RUNTIME_DIR absent → no socket
+        # path can be formed, so skip rather than guess.
+        monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-1')
+        monkeypatch.delenv('XDG_RUNTIME_DIR', raising=False)
         slept = mock.Mock()
         monkeypatch.setattr(viewer, 'sleep', slept)
-        viewer._wait_for_wayland_socket(timeout=5)
+        viewer._wait_for_wayland_socket(monotonic() + 5)
         slept.assert_not_called()
 
     def test_spawn_waits_for_socket_before_launching(
@@ -1803,7 +1827,7 @@ class TestWaitForWaylandSocket:
         # the wait ran first.
         order: list[str] = []
 
-        def fake_wait() -> None:
+        def fake_wait(_deadline: float) -> None:
             order.append('wait')
 
         def fake_command(*args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
### Issues Fixed

Fixes #3024 / Sentry [ANTHIAS-19](https://anthias.sentry.io/issues/7535229911/) — Pi 5 webview respawn lost the race with cage's Wayland socket (`Failed to create wl_display (Connection refused)`).

### Description

On Wayland boards (x86 / arm64 / pi5) cage exports `WAYLAND_DISPLAY` and creates the socket before exec'ing the Python viewer, so the *first* spawn is fine. But a **respawn** mid-playback (via `_send_to_webview` / `load_browser`) can land in a moment where the socket is briefly absent — cage restarting — and then every attempt inside the short inline budget dies instantly with `Failed to create wl_display`, surfacing as a `WebviewLaunchError` that escalates to a container restart.

This is the Wayland sibling of the `/dev/fb0` (linuxfb) and connector-status (eglfs) waits `start_viewer.sh` already does — but those run once at container start, not on a respawn, so the wait has to live where the spawn does.

- `_wait_for_wayland_socket()` blocks up to 10s for `$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY`, called at the top of `_spawn_webview_once`
- No-op on non-Wayland boards, when the env names no socket, and (common case) when the socket already exists — returns immediately
- Bounded: a genuinely dead compositor falls through after the timeout so the existing spawn-failure handling / container restart still applies — never hangs the asset_loop thread

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)