### PR TITLE
fix(viewer): respawn the webview on a video-play D-Bus death, not log+stop

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -1251,6 +1251,11 @@ def setup() -> None:
     # already bound to the running AnthiasViewer; load_browser
     # would otherwise race the D-Bus name registration.
     _media_player_module.set_browser_bus(browser_bus)
+    # Give the media player the same webview-gone respawn wrapper the
+    # image/page paths use, so a video-play D-Bus call hitting a
+    # crashed webview self-heals instead of logging ERROR and leaving
+    # the screen dark (#3027 / Sentry ANTHIAS-1A).
+    _media_player_module.set_send_to_webview(_send_to_webview)
 
 
 def start_loop() -> None:

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -21,6 +21,17 @@ from anthias_server.settings import settings
 # even when only exercising GstFbdevMediaPlayer.
 _browser_bus: Any = None
 
+# Optional wrapper that runs a ``browser_bus`` call and, if the webview
+# died mid-call (a D-Bus "service gone" error), reaps + respawns it and
+# retries the call once. Injected from anthias_viewer/__init__.py
+# (``_send_to_webview``); the viewer and the media player share the same
+# AnthiasViewer process, so a video-play D-Bus call hitting a crashed
+# webview must self-heal exactly like loadImage/loadPage does (#3012),
+# rather than logging ERROR and leaving the screen dark until the next
+# rotation (Sentry ANTHIAS-1A). Left None in tests / standalone use, in
+# which case calls run directly.
+_send_to_webview: Any = None
+
 
 def set_browser_bus(bus: Any) -> None:
     """Inject the AnthiasViewer D-Bus proxy.
@@ -37,6 +48,25 @@ def set_browser_bus(bus: Any) -> None:
 
 def get_browser_bus() -> Any:
     return _browser_bus
+
+
+def set_send_to_webview(fn: Any) -> None:
+    """Inject the webview-gone-aware call wrapper (see ``_send_to_webview``
+    in anthias_viewer/__init__.py). Injected from setup() alongside
+    ``set_browser_bus``."""
+    global _send_to_webview
+    _send_to_webview = fn
+
+
+def _call_webview(send: Any) -> None:
+    """Run ``send`` through the injected respawn-on-death wrapper when
+    available, else call it directly. A webview-gone error is handled
+    (respawn + retry) inside the wrapper; anything else propagates to
+    the caller's own error handling."""
+    if _send_to_webview is not None:
+        _send_to_webview(send)
+    else:
+        send()
 
 
 def _screen_rotation() -> int:
@@ -339,7 +369,14 @@ class MPVMediaPlayer(MediaPlayer):
             return
 
         try:
-            bus.playVideo(self.uri, _marshal_dbus_options(options))
+            # Route through the respawn-on-death wrapper: a webview
+            # that crashed mid-playback is reaped + respawned and the
+            # playVideo retried, instead of logging ERROR and leaving
+            # the screen dark (Sentry ANTHIAS-1A). A non-webview-gone
+            # error still surfaces here.
+            _call_webview(
+                lambda: bus.playVideo(self.uri, _marshal_dbus_options(options))
+            )
             self._playing = True
         except Exception as exc:
             # pydbus surfaces transport / signature errors as
@@ -355,7 +392,7 @@ class MPVMediaPlayer(MediaPlayer):
         if bus is None:
             return
         try:
-            bus.stopVideo()
+            _call_webview(lambda: bus.stopVideo())
         except Exception as exc:
             logging.error('MPVMediaPlayer.stop failed: %s', exc)
 

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -996,3 +996,100 @@ def test_upload_gate_codecs_are_h264_or_hevc() -> None:
             f'in the libavcodec h264/hevc dispatch — add the '
             f'matching decoder or remove from the gate.'
         )
+
+
+# ---------------------------------------------------------------------------
+# Webview-gone respawn routing (#3027 / Sentry ANTHIAS-1A)
+# ---------------------------------------------------------------------------
+
+
+class TestPlayRoutesThroughWebviewWrapper:
+    """play()/stop() must run their D-Bus calls through the injected
+    webview-gone wrapper so a crashed webview is respawned + retried,
+    not logged at ERROR with the screen left dark."""
+
+    def test_play_uses_injected_wrapper(self, mpv: _MPVFixtures) -> None:
+        # A wrapper that just invokes the call (the happy path) — play
+        # must go through it rather than touching the bus directly.
+        calls: list[str] = []
+
+        def wrapper(send: Any) -> None:
+            calls.append('wrapped')
+            send()
+
+        with patch.object(media_player_module, '_send_to_webview', wrapper):
+            mpv.player.uri = 'https://example.com/v.mp4'
+            mpv.player.play()
+
+        assert calls == ['wrapped']
+        mpv.mock_bus.playVideo.assert_called_once()
+        assert mpv.player.is_playing() is True
+
+    def test_stop_uses_injected_wrapper(self, mpv: _MPVFixtures) -> None:
+        calls: list[str] = []
+
+        def wrapper(send: Any) -> None:
+            calls.append('wrapped')
+            send()
+
+        with patch.object(media_player_module, '_send_to_webview', wrapper):
+            mpv.player.stop()
+
+        assert calls == ['wrapped']
+        mpv.mock_bus.stopVideo.assert_called_once()
+
+    def test_play_recovers_when_wrapper_respawns(
+        self, mpv: _MPVFixtures
+    ) -> None:
+        # Simulate the real wrapper: first send hits a webview-gone
+        # error, the wrapper respawns and the retried send succeeds.
+        attempts = {'n': 0}
+
+        def respawning_wrapper(send: Any) -> None:
+            attempts['n'] += 1
+            mpv.mock_bus.playVideo.side_effect = [
+                RuntimeError('NoReply'),
+                None,
+            ]
+            # The production wrapper retries send() once after respawn;
+            # emulate that here so the second call lands.
+            try:
+                send()
+            except RuntimeError:
+                send()
+
+        with patch.object(
+            media_player_module, '_send_to_webview', respawning_wrapper
+        ):
+            mpv.player.uri = 'https://example.com/v.mp4'
+            mpv.player.play()
+
+        assert mpv.mock_bus.playVideo.call_count == 2
+        assert mpv.player.is_playing() is True
+
+    def test_play_clears_state_when_wrapper_reraises(
+        self, mpv: _MPVFixtures
+    ) -> None:
+        # A non-webview-gone error propagates out of the wrapper; play
+        # must log + clear _playing so it doesn't think a video is up.
+        def reraising_wrapper(send: Any) -> None:
+            raise RuntimeError('Disconnected')
+
+        with patch.object(
+            media_player_module, '_send_to_webview', reraising_wrapper
+        ):
+            mpv.player.uri = 'https://example.com/v.mp4'
+            mpv.player.play()
+
+        assert mpv.player.is_playing() is False
+
+    def test_direct_call_when_no_wrapper_injected(
+        self, mpv: _MPVFixtures
+    ) -> None:
+        # Standalone / test use (no injection): calls run directly, so
+        # the prior behaviour is preserved.
+        assert media_player_module._send_to_webview is None
+        mpv.player.uri = 'https://example.com/v.mp4'
+        mpv.player.play()
+        mpv.mock_bus.playVideo.assert_called_once()
+        assert mpv.player.is_playing() is True


### PR DESCRIPTION
### Issues Fixed

Fixes #3027 / Sentry [ANTHIAS-1A](https://anthias.sentry.io/issues/7535261322/) — `MPVMediaPlayer.play failed: GDBus.Error NoReply: Message recipient disconnected`.

### Description

`media_player.py`'s `play()`/`stop()` called `bus.playVideo`/`bus.stopVideo` directly and, on any exception, logged at ERROR and returned. When the webview died mid-call this is the exact webview-gone `NoReply` that `_send_to_webview` (#3012) already self-heals for `view_image`/`view_webpage` — but the media-player path was never routed through it, so a transient webview crash during playback (1) fired a Sentry event for a self-healing condition and (2) left video dead until the next asset rotation respawned the webview.

- Route `play`/`stop` through the injected `_send_to_webview` wrapper: reap + respawn + retry once on a webview-gone D-Bus error
- Injected via `set_send_to_webview()` in `setup()`, right next to the existing `set_browser_bus()` — keeps the respawn logic (and its global state) in `__init__.py` and avoids a circular import (`__init__` already imports `media_player`)
- Non-webview-gone errors still propagate to `play`/`stop`'s existing log-and-clear-`_playing` handling; with no wrapper injected (standalone/tests) calls run directly, so prior behaviour is preserved

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)