### PR TITLE
fix(celery): store display_power in redis as a string, not a bool

### DIFF
--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -290,7 +290,16 @@ def setup_periodic_tasks(sender: Any, **kwargs: Any) -> None:
 
 @celery.task(time_limit=30)
 def get_display_power() -> None:
-    r.set('display_power', diagnostics.get_display_power())
+    # diagnostics.get_display_power() returns ``str | bool`` (bool for
+    # a clean CEC True/False, str for the error fallbacks). redis-py
+    # refuses a bool — ``DataError: Invalid input of type: 'bool'`` —
+    # so every successful power query crashed this task and left the
+    # key unset (Sentry ANTHIAS-2C). Coerce to str: the v2 System Info
+    # API exposes ``display_power`` as ``string | null`` and just
+    # passes the value through, so 'True'/'False'/'CEC error' all fit
+    # — and the on/off state now actually populates instead of only
+    # the error cases ever landing.
+    r.set('display_power', str(diagnostics.get_display_power()))
     r.expire('display_power', 3600)
 
 

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -165,19 +165,38 @@ def test_cleanup_returns_when_assetdir_missing() -> None:
         settings['assetdir'] = original
 
 
-def test_get_display_power_writes_redis() -> None:
-    """The Celery task wraps diagnostics.get_display_power and persists."""
+@pytest.mark.parametrize(
+    'cec_value, expected',
+    [
+        (True, 'True'),
+        (False, 'False'),
+        ('CEC error', 'CEC error'),
+    ],
+)
+def test_get_display_power_writes_redis_as_str(
+    cec_value: object, expected: str
+) -> None:
+    """The Celery task persists the CEC power state to redis as a str.
+
+    diagnostics.get_display_power() returns ``str | bool``; redis-py
+    raises ``DataError: Invalid input of type: 'bool'`` on a bool, so
+    a clean CEC True/False used to crash the task (Sentry ANTHIAS-2C).
+    The value must reach redis already coerced to a string.
+    """
     fake_redis = mock.MagicMock()
     with (
         mock.patch.object(celery_tasks_module, 'r', fake_redis),
         mock.patch(
             'anthias_server.celery_tasks.diagnostics.get_display_power',
-            return_value=True,
+            return_value=cec_value,
         ),
     ):
         get_display_power.apply()
 
-    fake_redis.set.assert_called_once_with('display_power', True)
+    fake_redis.set.assert_called_once_with('display_power', expected)
+    # No bool ever reaches redis — guards against the DataError.
+    written = fake_redis.set.call_args.args[1]
+    assert isinstance(written, str)
     fake_redis.expire.assert_called_once_with('display_power', 3600)
 
 


### PR DESCRIPTION
### Issues Fixed

Sentry [ANTHIAS-2C](https://anthias.sentry.io/issues/7536962172/) — `DataError: Invalid input of type: 'bool'` in `get_display_power` (32 events on the current `2026.6.2+fe942a5` build).

### Description

`diagnostics.get_display_power()` returns `str | bool` — a real bool for a clean CEC `True`/`False`, a string for the error fallbacks. `redis-py` refuses a bool (`DataError: Invalid input of type: 'bool'. Convert to a bytes, str, int or float first.`), so **every successful CEC power query crashed the task** and left the `display_power` key unset; only the error-string cases ever stored. The v2 System Info API exposes `display_power` as `string | null` and just passes the value through.

- `r.set('display_power', str(diagnostics.get_display_power()))` — `'True'`/`'False'`/`'CEC error'` all satisfy the API schema, and the on/off state now actually populates
- The existing test asserted the buggy bool write (the `MagicMock` redis accepted what real redis rejects); rewritten to assert str coercion across `True`/`False`/error with an `isinstance(str)` guard

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)