### PR TITLE
fix(sentry): silence celery redis-backend reconnect-retry log

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -137,16 +137,18 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
     return event
 
 
-# celery's consumer and the embedded beat scheduler both log every
-# broker reconnect attempt at ERROR ("consumer: Cannot connect to
-# redis://..., Trying again in 6.00 seconds" / "beat: Connection
-# error: ..., Trying again in 2.0 seconds") while they retry on
-# their own — same expected-transient rationale as the before_send
-# filter above, but these arrive as log messages rather than
-# exceptions, so they have to be silenced at the logger.
-# (Sentry ANTHIAS-K and ANTHIAS-P.)
+# celery's consumer, the embedded beat scheduler, and the redis
+# result backend all log every broker/backend reconnect attempt at
+# ERROR ("consumer: Cannot connect to redis://..., Trying again in
+# 6.00 seconds" / "beat: Connection error: ..., Trying again in 2.0
+# seconds" / "Connection to Redis lost: Retry (4/20) in 1.00
+# second.") while they retry on their own — same expected-transient
+# rationale as the before_send filter above, but these arrive as log
+# messages rather than exceptions, so they have to be silenced at the
+# logger. (Sentry ANTHIAS-K / ANTHIAS-P / ANTHIAS-2E.)
 ignore_logger('celery.worker.consumer.consumer')
 ignore_logger('celery.beat')
+ignore_logger('celery.backends.redis')
 
 
 def get_sentry_release() -> str | None:

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -163,6 +163,10 @@ class TestBeforeSendTransientNoise:
         # The embedded beat scheduler retries broker connections the
         # same way and logs each attempt at ERROR too.
         assert 'celery.beat' in _IGNORED_LOGGERS
+        # The redis result backend logs its own reconnect retries
+        # ("Connection to Redis lost: Retry (4/20)") at ERROR
+        # (Sentry ANTHIAS-2E).
+        assert 'celery.backends.redis' in _IGNORED_LOGGERS
 
 
 class TestGetBoardModel:


### PR DESCRIPTION
### Issues Fixed

Sentry [ANTHIAS-2E](https://anthias.sentry.io/issues/7537668650/) — `Connection to Redis lost: Retry (4/20) in 1.00 second.` from the `celery.backends.redis` logger.

### Description

Same transient-redis noise as the consumer/beat reconnect logs already ignored (#3018/#3028), but emitted by celery's **redis result backend** when it retries a dropped backend connection on its own. It arrives as an ERROR-level log message (not an exception), so the `before_send` exception filter doesn't see it — it has to be silenced at the logger.

- `ignore_logger('celery.backends.redis')`, alongside the existing `celery.worker.consumer.consumer` / `celery.beat` entries
- Extend the ignored-logger regression test

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)