### PR TITLE
chore(release): bump to 2026.06.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.06.2",
+  "version": "2026.06.3",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.06.2"
+version = "2026.06.3"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.6.2"
+version = "2026.6.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
### Issues Fixed

Unblocks the Sentry board. Every build since 2026.6.2 has reported the **same base release version** `2026.6.2` (only the `+<git-hash>` build-metadata differed), so `resolvedInNextRelease` could never take effect — Sentry kept reopening fixed issues on the next event. Concrete evidence from this morning's sweep, ANTHIAS-9's release spread:

```
2026.6.2 (34)  ·  2026.6.2+fe942a5 (31)  ·  2026.6.2+871401c (18)  ·  2026.6.2+eb1baa6 (2)
```

All the same base version → no "next release" boundary. Bumping to **2026.06.3** creates one, so the fixes already deployed actually clear and future resolves stick.

### Description

Mechanical CalVer bump (mirrors #3009): `pyproject.toml`, `package.json`, `uv.lock`. No code change.

This ships the crash/noise fixes merged since 2026.6.2 — SQLite WAL + busy timeout (#3015), celery migration-gate (#3016) and asset-probe soft limits (#3017), transient-redis/`CancelledError` Sentry filtering + redis healthcheck (#3018/#3028), GitHub update-check log level (#3019), webview respawn on D-Bus death at setup/mid-play (#3020/#3031), resilient static-file scan (#3026), Wayland-socket wait (#3030), and the Sentry release/board-triage tags (#3021/#3025).

**Note:** merging this is just the version bump. Publishing the GitHub release + OTA deploy to the fleets remains a separate, deliberate step (per the usual release sequencing). Recommend merging #3032 (display_power `DataError`) and #3036 (celery redis-backend log noise) first so they ride the same release.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)