### PR TITLE
fix(viewer): default x86 audio fallback to ALSA 'default'

### DIFF
--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -247,7 +247,16 @@ def get_alsa_audio_device() -> str:
         elif device_type in ['pi1', 'pi2', 'pi3']:
             return 'sysdefault:CARD=vc4hdmi'
         else:
-            return 'sysdefault:CARD=HID'
+            # x86 fallback: ALSA card names vary across Intel / AMD /
+            # Nvidia HDA chipsets, so there's no portable per-SoC name
+            # to hard-code (the old 'sysdefault:CARD=HID' matched no
+            # real card on standard HDA setups). Defer to the `default`
+            # device — which VideoView::resolveAlsaDevice resolves to
+            # the PulseAudio default sink (x86 is a Qt 6 board and
+            # Debian's Qt 6 Multimedia only has a PulseAudio backend;
+            # the daemon is started by start_viewer.sh). Mirrors the
+            # ARM64 path above.
+            return 'default'
 
 
 class MediaPlayer:

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -341,12 +341,15 @@ def test_hdmi_on_pi1_pi2_pi3_uses_vc4hdmi(
         assert get_alsa_audio_device() == 'sysdefault:CARD=vc4hdmi'
 
 
-def test_hdmi_on_x86_falls_back_to_hid(alsa_settings: Any) -> None:
+def test_hdmi_on_x86_uses_alsa_default(alsa_settings: Any) -> None:
+    # No portable per-SoC ALSA card name across Intel / AMD / Nvidia
+    # HDA chipsets, so x86 defers to `default`, which the C++ side
+    # resolves to the PulseAudio default sink.
     alsa_settings.__getitem__.return_value = 'hdmi'
     with patch(
         'anthias_viewer.media_player.get_device_type', return_value='x86'
     ):
-        assert get_alsa_audio_device() == 'sysdefault:CARD=HID'
+        assert get_alsa_audio_device() == 'default'
 
 
 class _FakeDirEntry:


### PR DESCRIPTION
Supersedes #2927 (original work by @Xzzz, attribution preserved in the commit), rebased onto current `master` and fixed up to pass CI.

## Problem
On x86, `get_alsa_audio_device()` returned `sysdefault:CARD=HID` as the fallback, which matches no real ALSA card on standard Intel/AMD/Nvidia HDA chipsets, leaving operators with no working audio.

## Fix
Defer to the `default` device instead. This mirrors the ARM64 branch directly above, which already returns `'default'` for the same reason (heterogeneous SoCs, no portable per-SoC card name).

On x86 — a Qt 6 board — `VideoView::resolveAlsaDevice` resolves `default` to the **PulseAudio default sink**, since Debian's Qt 6 Multimedia only has a PulseAudio backend and the daemon is started by `start_viewer.sh`. (This is why the rationale differs from the original PR, which predated the PulseAudio migration in #3001 and described raw `~/.asoundrc` routing.)

## Changes vs the original PR
- Updated the inline comment to reflect the PulseAudio resolution path rather than raw `~/.asoundrc`.
- Updated `test_hdmi_on_x86_falls_back_to_hid` → `test_hdmi_on_x86_uses_alsa_default`, asserting `'default'`. The original PR touched only `media_player.py`, so it would have failed this test (added later in #2811).

## Verification
- `uv run ruff check` + `ruff format --check`: clean
- `uv run pytest tests/test_media_player.py -m "not integration"`: 79 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)