### PR TITLE
fix(celery): don't report the by-design codec rejection to Sentry

### DIFF
--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -1542,6 +1542,14 @@ def normalize_image_asset(asset_id: str) -> None:
     # Same rationale as normalize_image_asset above: a missing source
     # file is permanent and should land on on_failure right away.
     dont_autoretry_for=(FileNotFoundError,),
+    # ``UnsupportedVideoCodecError`` is the codec/resolution gate's
+    # deliberate, operator-facing rejection (Failed pill + re-encode
+    # recipe via _NormalizeAssetTask.on_failure) — an expected outcome,
+    # not a fault. Listing it in ``throws`` keeps Celery from logging it
+    # at ERROR with a traceback, and sentry-sdk's CeleryIntegration
+    # skips ``task.throws`` exceptions, so the gate stops flooding
+    # Sentry (ANTHIAS-1J, ANTHIAS-20). on_failure still runs.
+    throws=(processing.UnsupportedVideoCodecError,),
     retry_backoff=15,
     retry_backoff_max=300,
     retry_jitter=True,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1556,6 +1556,32 @@ def test_normalize_tasks_exclude_permanent_oserrors_from_autoretry() -> None:
     )
 
 
+def test_video_task_declares_codec_rejection_as_expected() -> None:
+    """The codec/resolution gate raises ``UnsupportedVideoCodecError``
+    as a deliberate, operator-facing rejection — not a fault. The video
+    task must list it in ``throws`` so Celery logs it at INFO without a
+    traceback and sentry-sdk's CeleryIntegration skips it (it returns
+    early on ``isinstance(exc, task.throws)``), keeping the gate from
+    flooding Sentry. The image task never raises it, so it must not be
+    swept into the image task's ``throws``.
+    """
+    from anthias_server.celery_tasks import (
+        normalize_image_asset,
+        normalize_video_asset,
+    )
+
+    assert processing.UnsupportedVideoCodecError in tuple(
+        getattr(normalize_video_asset, 'throws', ())
+    ), (
+        'normalize_video_asset expected throws to include '
+        'UnsupportedVideoCodecError so the by-design codec rejection '
+        'is not reported to Sentry'
+    )
+    assert processing.UnsupportedVideoCodecError not in tuple(
+        getattr(normalize_image_asset, 'throws', ())
+    )
+
+
 @pytest.mark.django_db
 def test_normalize_on_failure_writes_error_metadata(
     asset_dir: str,


### PR DESCRIPTION
## What

The upload codec/resolution gate raises `UnsupportedVideoCodecError` as a **deliberate, operator-facing rejection** — surfaced in the UI as a "Failed" pill plus a copy-pasteable ffmpeg re-encode recipe (via `_NormalizeAssetTask.on_failure`). It's an expected outcome, not a fault:

- Pi 5 has no H.264 hardware-decode block, so an H.264 upload is rejected (`Supported: hevc.`).
- An unknown arm64 board that never published a `board_subtype` can't certify any codec.

But every rejection was reaching Sentry as an unhandled Celery task error — 31+ events on `ANTHIAS-1J`, plus `ANTHIAS-20`.

## Fix

List `UnsupportedVideoCodecError` in the video task's `throws`. Celery then logs it at INFO with no traceback, and sentry-sdk's `CeleryIntegration` skips `task.throws` exceptions — its `_capture_exception` returns early on `isinstance(exc, task.throws)` (verified against the pinned `sentry-sdk==2.61.1`). `on_failure` still runs, so the operator-facing error pill + recipe are unchanged.

## Test

`test_video_task_declares_codec_rejection_as_expected` asserts the video task declares it in `throws` and the image task (which never raises it) does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)