### PR TITLE
fix(build): ship libwebpdemux2 so pi3 Pillow can save WebP

### DIFF
--- a/tools/image_builder/__main__.py
+++ b/tools/image_builder/__main__.py
@@ -87,6 +87,23 @@ def build_image(
         # the conversion) both inherit it. Inert on the viewer
         # process; harmless to ship there too.
         'libheif1',
+        # Runtime libs for Pillow's WebP support (the normalisation
+        # pipeline saves every converted image as lossless WebP).
+        # On 32-bit Pi (armv7) there's no Pillow wheel, so it's built
+        # from source against libwebp-dev and dynamically links the
+        # whole webp family at runtime — libwebp7, libwebpmux3 *and*
+        # libwebpdemux2 (Pillow's _webp uses WebPAnimDecoder). ffmpeg
+        # pulls libwebp7 + libwebpmux3 transitively but NOT
+        # libwebpdemux2, so without it `import PIL._webp` fails, the
+        # WebP plugin registers no save handler, and the conversion
+        # dies with `KeyError: 'WEBP'` (Sentry ANTHIAS-1Y, pi3). List
+        # all three explicitly so the pipeline never depends on
+        # ffmpeg's transitive graph. The 64-bit wheel bundles its own
+        # webp libs, so these are inert there — same harmless-on-all-
+        # boards rationale as libheif1 above.
+        'libwebp7',
+        'libwebpdemux2',
+        'libwebpmux3',
         'lsb-release',
         'procps',
         'psmisc',


### PR DESCRIPTION
## What

The upload image-normalisation pipeline converts HEIC/HEIF/TIFF/etc. to **lossless WebP** via Pillow. On **32-bit Pi (armv7)** there's no Pillow wheel, so it's compiled from source against `libwebp-dev` and dynamically links the whole webp family at runtime.

The runtime image only carried `libwebp7` + `libwebpmux3` (both transitive deps of `ffmpeg`'s `libavcodec`) — but **not `libwebpdemux2`**, which nothing else pulls. Without it, `import PIL._webp` can't resolve `libwebpdemux.so.2`, the WebP plugin registers no save handler, and the conversion dies with `KeyError: 'WEBP'` (Sentry **ANTHIAS-1Y**, 11 events, all `pi3`).

## Fix

Add `libwebp7` / `libwebpdemux2` / `libwebpmux3` to the runtime `base_apt_dependencies` explicitly so the pipeline never depends on ffmpeg's transitive graph — same rationale as the `libheif1` entry beside them. Inert on 64-bit boards (their Pillow wheel bundles its own webp libs), so listed unconditionally for simplicity, matching `libheif1`.

## Verification

On `debian:trixie`, a from-source `Pillow==12.2.0` `_webp.so` links:

```
libwebp.so.7    libwebpmux.so.3    libwebpdemux.so.2    libsharpyuv.so.0
```

Installing only `ffmpeg` + `libheif1` (runtime parity) leaves **`libwebpdemux2` absent** while the other three are present — exactly the failure signature. Generated `Dockerfile.server` for `pi3` now installs all three at runtime alongside `libheif1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)