### PR TITLE
feat(server): add bulk asset management (enable/disable/edit/delete)

### DIFF
--- a/src/anthias_server/app/helpers.py
+++ b/src/anthias_server/app/helpers.py
@@ -116,7 +116,7 @@ def remove_default_assets() -> None:
             asset.delete()
 
 
-def delete_asset_with_file(asset: Asset) -> None:
+def delete_asset_with_file(asset: Asset, *, nudge_viewer: bool = True) -> None:
     """Delete an ``Asset`` row, remove its on-disk file (if owned), and
     nudge the viewer to advance past it.
 
@@ -132,6 +132,10 @@ def delete_asset_with_file(asset: Asset) -> None:
     and a stray file is eventually cleaned up by the periodic
     ``cleanup()`` orphan sweep — letting an unlink error block the DB
     delete would leave the operator unable to remove the row at all.
+
+    ``nudge_viewer=False`` skips the per-row viewer reload so a bulk
+    delete can fire a single reload after the whole batch instead of
+    spamming the pub/sub channel once per asset (#3046).
     """
     if asset.uri and asset.uri.startswith(settings['assetdir']):
         try:
@@ -147,4 +151,5 @@ def delete_asset_with_file(asset: Asset) -> None:
     # screen instead of finishing its remaining ``duration`` (#2430).
     # The viewer's reload handler checks whether the currently-shown
     # asset is still active and advances if not.
-    ViewerPublisher.get_instance().send_to_viewer('reload')
+    if nudge_viewer:
+        ViewerPublisher.get_instance().send_to_viewer('reload')

--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -477,23 +477,34 @@ label { text-align: left; }
       &[data-no-label]::before { display: none; }
     }
 
-    // Home rows: 2-column grid. Name spans both, schedule + duration
-    // share row 2, toggle + actions share row 3. Right-aligned cells
-    // align their labels to match.
+    // Home rows: 2-column grid. The select checkbox (child 1) is
+    // lifted out of flow into the top-left corner; name (child 2)
+    // spans both columns, schedule + duration share row 2, toggle +
+    // actions share row 3. Right-aligned cells align their labels to
+    // match.
     tbody tr[data-asset-id] {
       display: grid;
       grid-template-columns: 1fr auto;
       gap: var(--space-2) var(--space-3);
+      position: relative;
+      padding-left: 1.9rem;
 
-      td:nth-child(1) { grid-column: 1 / -1; }
-      td:nth-child(2) { grid-column: 1 / 2; }
-      td:nth-child(3) {
+      td.asset-select-col {
+        position: absolute;
+        left: 0;
+        top: var(--space-3);
+        padding: 0;
+        &::before { display: none; }
+      }
+      td:nth-child(2) { grid-column: 1 / -1; }
+      td:nth-child(3) { grid-column: 1 / 2; }
+      td:nth-child(4) {
         grid-column: 2 / 3;
         text-align: right;
         &::before { text-align: right; }
       }
-      td:nth-child(4) { grid-column: 1 / 2; align-self: center; }
-      td:nth-child(5) {
+      td:nth-child(5) { grid-column: 1 / 2; align-self: center; }
+      td:nth-child(6) {
         grid-column: 2 / 3;
         align-self: center;
         &::before { text-align: right; }
@@ -504,6 +515,39 @@ label { text-align: left; }
 
     tbody tr:hover td { background: transparent; }
   }
+}
+
+// Bulk-selection chrome (#3046): the leading checkbox column, the
+// per-section select-all in the surface header, and the selected-row
+// highlight. The checkbox itself reuses .app-check-input from the
+// forms section; .asset-select is just the clickable hit-area wrapper.
+.asset-select-col {
+  width: 2.75rem;
+  text-align: center;
+}
+
+.asset-select {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin: 0;
+
+  .app-check-input { margin: 0; cursor: pointer; }
+}
+
+.surface__header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.asset-table tbody tr.is-selected td {
+  background: var(--color-accent-wash);
+}
+.asset-table tbody tr.is-selected:hover td {
+  background: var(--color-accent-wash);
 }
 
 .asset-cell-name {
@@ -1202,6 +1246,16 @@ label { text-align: left; }
     background-color: var(--color-link);
     border-color: var(--color-link);
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m4 8.5 3 3 5-7'/%3e%3c/svg%3e");
+    background-size: 0.85rem 0.85rem;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+  // Partial selection (the section select-all when only some rows are
+  // ticked). Mirrors :checked but draws a dash instead of a tick.
+  &:indeterminate {
+    background-color: var(--color-link);
+    border-color: var(--color-link);
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-width='3' d='M4 8h8'/%3e%3c/svg%3e");
     background-size: 0.85rem 0.85rem;
     background-position: center;
     background-repeat: no-repeat;
@@ -2335,3 +2389,85 @@ body.auth-body {
   align-items: center;
   text-decoration: none;
 }
+
+// -----------------------------------------------------------------------------
+// Bulk asset actions (#3046)
+// -----------------------------------------------------------------------------
+// Floating bar pinned to the bottom of the viewport while a selection
+// is active. Sits below the modal overlays (z 1050+) so the bulk-edit
+// and bulk-delete dialogs render over it. The inner card carries the
+// dark elevated look the navbar/footer use so it stands clear of the
+// page surfaces.
+.bulk-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: var(--space-5);
+  z-index: 1040;
+  display: flex;
+  justify-content: center;
+  padding-inline: var(--space-4);
+  pointer-events: none;
+}
+.bulk-bar__inner {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 720px;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-on-dark);
+  border: 1px solid var(--color-border-on-dark);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-lg);
+}
+.bulk-bar__count {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.9rem;
+  white-space: nowrap;
+  i { font-size: 1.1rem; opacity: 0.85; }
+  strong { font-variant-numeric: tabular-nums; }
+}
+.bulk-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.bulk-bar__clear {
+  color: var(--color-text-on-dark);
+  background: transparent;
+  border-color: var(--color-border-on-dark);
+}
+
+@media (max-width: 640px) {
+  .bulk-bar__inner {
+    flex-direction: column;
+    align-items: stretch;
+    border-radius: var(--radius-lg);
+  }
+  .bulk-bar__actions { justify-content: center; }
+}
+
+// Bulk-edit modal: each schedule field group is a card whose body is
+// only revealed once its "Change …" toggle is on. The is-on class
+// lifts the card so the active groups read as the ones being written.
+.bulk-field {
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--t-fast), background var(--t-fast);
+
+  &.is-on {
+    border-color: var(--color-accent-edge);
+    background: var(--color-accent-wash);
+  }
+}
+.bulk-field__toggle { cursor: pointer; }

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -12,6 +12,7 @@ declare global {
     flatpickr: typeof flatpickrLib
     homeApp: () => HomeAppData
     fallbackCopyToClipboard: (text: string) => boolean
+    bulkSucceeded: (event: Event) => boolean
   }
 }
 
@@ -75,7 +76,7 @@ interface HomeAppData {
   clearSelection(): void
   openBulkEdit(): void
   closeBulkEdit(): void
-  isSuccessResponse(event: Event): boolean
+  onBulkDone(event: Event): void
 }
 
 // 'ok'       — file accepted and the asset row was created.
@@ -311,25 +312,19 @@ function homeApp(): HomeAppData {
     closeBulkEdit() {
       this.bulkEditOpen = false
     },
-    // A bulk endpoint returns 200 even when it refuses the input (bad
-    // date, partial time window, blank duration, "nothing to change")
-    // and just rides an error/info toast back on the HX-Trigger header.
-    // So a bare event.detail.successful (2xx) isn't enough to decide
-    // whether to clear the selection / close the modal — that would
-    // wipe the operator's work when nothing was applied. Treat it as a
-    // success only on a 2xx whose toast is absent or kind 'success'.
-    isSuccessResponse(event) {
-      const detail = (event as CustomEvent<{ successful?: boolean; xhr?: XMLHttpRequest }>).detail
-      if (!detail?.successful || !detail.xhr) return false
-      const header = detail.xhr.getResponseHeader('HX-Trigger')
-      if (!header) return true
-      try {
-        const kind = (JSON.parse(header) as { toast?: { kind?: string } })
-          ?.toast?.kind
-        return kind === undefined || kind === 'success'
-      } catch {
-        return true
-      }
+    // Bridged from the bulk forms' hx-on::after-request via a global
+    // window 'bulk-done' CustomEvent (hx-on runs in global scope and
+    // can't reach Alpine methods — same dispatch-to-window bridge the
+    // Add modal uses for 'asset-saved'). Only fires on a real success
+    // (window.bulkSucceeded gates it), so a rejected edit leaves the
+    // selection and modal intact. detail flags say which modal to close.
+    onBulkDone(event) {
+      const detail =
+        (event as CustomEvent<{ closeDelete?: boolean; closeEdit?: boolean }>)
+          .detail || {}
+      this.clearSelection()
+      if (detail.closeDelete) this.bulkDeleteOpen = false
+      if (detail.closeEdit) this.closeBulkEdit()
     },
 
     // Multi-file upload (issue #3045). The server's assets_upload
@@ -694,6 +689,30 @@ function fallbackCopyToClipboard(text: string): boolean {
   return ok
 }
 window.fallbackCopyToClipboard = fallbackCopyToClipboard
+
+// Did a bulk request actually succeed? The bulk endpoints return 200
+// even when they refuse the input (bad date, partial window, blank
+// duration, "nothing to change", empty/stale selection) and just ride
+// an error/info toast on the HX-Trigger header. The bulk forms call
+// this from hx-on::after-request — which runs in GLOBAL scope, not
+// Alpine's — so it lives on window rather than as a component method.
+// True only on a 2xx whose toast is absent or kind 'success'.
+function bulkSucceeded(event: Event): boolean {
+  const detail = (
+    event as CustomEvent<{ successful?: boolean; xhr?: XMLHttpRequest }>
+  ).detail
+  if (!detail?.successful || !detail.xhr) return false
+  const header = detail.xhr.getResponseHeader('HX-Trigger')
+  if (!header) return true
+  try {
+    const kind = (JSON.parse(header) as { toast?: { kind?: string } })?.toast
+      ?.kind
+    return kind === undefined || kind === 'success'
+  } catch {
+    return true
+  }
+}
+window.bulkSucceeded = bulkSucceeded
 
 window.homeApp = homeApp
 

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -37,6 +37,8 @@ interface ToastStoreLike {
   push(kind: 'success' | 'error' | 'info', message: string): number
 }
 
+type SectionKey = 'active' | 'inactive'
+
 interface HomeAppData {
   mode: 'add' | 'edit' | null
   editAsset: AssetEdit | null
@@ -46,6 +48,11 @@ interface HomeAppData {
   uploadState: UploadState
   uploadProgress: number
   uploadFileName: string
+  // Bulk selection / actions (#3046)
+  selectedIds: string[]
+  visibleIds: Record<SectionKey, string[]>
+  bulkEditOpen: boolean
+  bulkDeleteOpen: boolean
   init(): void
   openAdd(): void
   openEdit(asset: AssetEdit): void
@@ -57,6 +64,16 @@ interface HomeAppData {
   onUploadStart(): void
   onUploadProgress(ev: CustomEvent<ProgressEvent>): void
   onUploadDone(ev: CustomEvent<{ successful: boolean; xhr: XMLHttpRequest }>): void
+  // Bulk selection helpers
+  isSelected(id: string): boolean
+  toggleSelect(id: string): void
+  setVisible(section: SectionKey, ids: string[]): void
+  sectionAllSelected(section: SectionKey): boolean
+  sectionSomeSelected(section: SectionKey): boolean
+  toggleSection(section: SectionKey, checked: boolean): void
+  clearSelection(): void
+  openBulkEdit(): void
+  closeBulkEdit(): void
 }
 
 const DATE_FMT_MAP: Record<string, string> = {
@@ -97,6 +114,10 @@ function homeApp(): HomeAppData {
     uploadState: null,
     uploadProgress: 0,
     uploadFileName: '',
+    selectedIds: [],
+    visibleIds: { active: [], inactive: [] },
+    bulkEditOpen: false,
+    bulkDeleteOpen: false,
 
     init(this: HomeAppData & { $watch: (k: string, cb: () => void) => void }) {
       // Re-bind Flatpickr every time the edit modal opens. The
@@ -105,6 +126,11 @@ function homeApp(): HomeAppData {
       // (after Alpine has actually inserted the form into the DOM)
       // before querying for inputs.
       this.$watch('editAsset', () =>
+        requestAnimationFrame(() => this.bindFlatpickr()),
+      )
+      // The bulk-edit modal reuses the same .js-flatpickr-* inputs and
+      // is also gated behind an x-if, so bind on open the same way.
+      this.$watch('bulkEditOpen', () =>
         requestAnimationFrame(() => this.bindFlatpickr()),
       )
     },
@@ -206,6 +232,62 @@ function homeApp(): HomeAppData {
     closePreview() {
       this.previewAsset = null
     },
+
+    // --- Bulk selection (#3046) ---------------------------------------
+    // selectedIds is the source of truth; row checkboxes bind their
+    // :checked to isSelected() so the selection survives the table's
+    // 5s HTMX swap (the swapped rows re-evaluate against this state).
+    isSelected(id) {
+      return this.selectedIds.includes(id)
+    },
+    toggleSelect(id) {
+      if (this.selectedIds.includes(id)) {
+        this.selectedIds = this.selectedIds.filter((x) => x !== id)
+      } else {
+        this.selectedIds = [...this.selectedIds, id]
+      }
+    },
+    // Called from each rendered table partial (x-init re-fires after
+    // every swap) so Alpine always knows the ids currently on screen.
+    // Prune the selection to what's still visible — a row deleted out
+    // from under us (or by another browser) shouldn't linger selected.
+    setVisible(section, ids) {
+      this.visibleIds[section] = ids
+      const all = new Set([
+        ...this.visibleIds.active,
+        ...this.visibleIds.inactive,
+      ])
+      this.selectedIds = this.selectedIds.filter((id) => all.has(id))
+    },
+    sectionAllSelected(section) {
+      const ids = this.visibleIds[section]
+      return ids.length > 0 && ids.every((id) => this.selectedIds.includes(id))
+    },
+    sectionSomeSelected(section) {
+      const ids = this.visibleIds[section]
+      const n = ids.filter((id) => this.selectedIds.includes(id)).length
+      return n > 0 && n < ids.length
+    },
+    toggleSection(section, checked) {
+      const ids = this.visibleIds[section]
+      if (checked) {
+        const merged = new Set([...this.selectedIds, ...ids])
+        this.selectedIds = [...merged]
+      } else {
+        const drop = new Set(ids)
+        this.selectedIds = this.selectedIds.filter((id) => !drop.has(id))
+      }
+    },
+    clearSelection() {
+      this.selectedIds = []
+    },
+    openBulkEdit() {
+      this.bulkEditOpen = true
+    },
+    closeBulkEdit() {
+      this.bulkEditOpen = false
+    },
+
     onUploadStart() {
       this.uploadState = 'sending'
       this.uploadProgress = 0

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -75,6 +75,7 @@ interface HomeAppData {
   clearSelection(): void
   openBulkEdit(): void
   closeBulkEdit(): void
+  isSuccessResponse(event: Event): boolean
 }
 
 // 'ok'       — file accepted and the asset row was created.
@@ -275,13 +276,20 @@ function homeApp(): HomeAppData {
       const all = new Set([...activeIds, ...inactiveIds])
       this.selectedIds = this.selectedIds.filter((id) => all.has(id))
     },
+    // Build a Set for membership so these stay O(visible + selected)
+    // rather than O(visible × selected) — a selection of thousands (the
+    // point of bulk editing) would otherwise lag on every reactive
+    // re-evaluation.
     sectionAllSelected(section) {
       const ids = this.visibleIds[section]
-      return ids.length > 0 && ids.every((id) => this.selectedIds.includes(id))
+      if (!ids.length) return false
+      const sel = new Set(this.selectedIds)
+      return ids.every((id) => sel.has(id))
     },
     sectionSomeSelected(section) {
       const ids = this.visibleIds[section]
-      const n = ids.filter((id) => this.selectedIds.includes(id)).length
+      const sel = new Set(this.selectedIds)
+      const n = ids.reduce((acc, id) => acc + (sel.has(id) ? 1 : 0), 0)
       return n > 0 && n < ids.length
     },
     toggleSection(section, checked) {
@@ -302,6 +310,26 @@ function homeApp(): HomeAppData {
     },
     closeBulkEdit() {
       this.bulkEditOpen = false
+    },
+    // A bulk endpoint returns 200 even when it refuses the input (bad
+    // date, partial time window, blank duration, "nothing to change")
+    // and just rides an error/info toast back on the HX-Trigger header.
+    // So a bare event.detail.successful (2xx) isn't enough to decide
+    // whether to clear the selection / close the modal — that would
+    // wipe the operator's work when nothing was applied. Treat it as a
+    // success only on a 2xx whose toast is absent or kind 'success'.
+    isSuccessResponse(event) {
+      const detail = (event as CustomEvent<{ successful?: boolean; xhr?: XMLHttpRequest }>).detail
+      if (!detail?.successful || !detail.xhr) return false
+      const header = detail.xhr.getResponseHeader('HX-Trigger')
+      if (!header) return true
+      try {
+        const kind = (JSON.parse(header) as { toast?: { kind?: string } })
+          ?.toast?.kind
+        return kind === undefined || kind === 'success'
+      } catch {
+        return true
+      }
     },
 
     // Multi-file upload (issue #3045). The server's assets_upload

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -67,7 +67,7 @@ interface HomeAppData {
   // Bulk selection helpers
   isSelected(id: string): boolean
   toggleSelect(id: string): void
-  setVisible(section: SectionKey, ids: string[]): void
+  syncVisibleIds(activeIds: string[], inactiveIds: string[]): void
   sectionAllSelected(section: SectionKey): boolean
   sectionSomeSelected(section: SectionKey): boolean
   toggleSection(section: SectionKey, checked: boolean): void
@@ -247,16 +247,17 @@ function homeApp(): HomeAppData {
         this.selectedIds = [...this.selectedIds, id]
       }
     },
-    // Called from each rendered table partial (x-init re-fires after
-    // every swap) so Alpine always knows the ids currently on screen.
-    // Prune the selection to what's still visible — a row deleted out
-    // from under us (or by another browser) shouldn't linger selected.
-    setVisible(section, ids) {
-      this.visibleIds[section] = ids
-      const all = new Set([
-        ...this.visibleIds.active,
-        ...this.visibleIds.inactive,
-      ])
+    // Called once from each rendered table partial (x-init re-fires
+    // after every swap) so Alpine always knows the ids currently on
+    // screen. Both sections are passed together and pruning happens
+    // once against their union — pruning per-section would drop the
+    // selection for a row that moved between sections (e.g. an enabled
+    // asset just disabled), because the other section's list would
+    // still be stale at that moment.
+    syncVisibleIds(activeIds, inactiveIds) {
+      this.visibleIds.active = activeIds
+      this.visibleIds.inactive = inactiveIds
+      const all = new Set([...activeIds, ...inactiveIds])
       this.selectedIds = this.selectedIds.filter((id) => all.has(id))
     },
     sectionAllSelected(section) {

--- a/src/anthias_server/app/templates/_asset_row.html
+++ b/src/anthias_server/app/templates/_asset_row.html
@@ -1,6 +1,14 @@
 {% load asset_filters %}
 {% with pills=asset|schedule_pills %}
-<tr data-asset-id="{{ asset.asset_id }}" data-processing="{{ asset.is_processing|yesno:'true,false' }}" data-name="{{ asset.name|default:''|escape }}" data-duration="{{ asset.duration|default:0 }}">
+<tr data-asset-id="{{ asset.asset_id }}" data-processing="{{ asset.is_processing|yesno:'true,false' }}" data-name="{{ asset.name|default:''|escape }}" data-duration="{{ asset.duration|default:0 }}" :class="isSelected('{{ asset.asset_id }}') && 'is-selected'">
+  <td class="asset-select-col" data-label="Select" data-no-label>
+    <label class="asset-select">
+      <input type="checkbox" class="app-check-input js-row-select"
+        :checked="isSelected('{{ asset.asset_id }}')"
+        @change="toggleSelect('{{ asset.asset_id }}')"
+        aria-label="Select {{ asset.name|default:'asset'|escape }}">
+    </label>
+  </td>
   <td data-label="Name" data-no-label>
     <div class="asset-cell-name">
       {% if is_active %}<i class="ti ti-grip-vertical drag-handle" title="Drag to reorder"></i>{% endif %}

--- a/src/anthias_server/app/templates/_asset_table.html
+++ b/src/anthias_server/app/templates/_asset_table.html
@@ -13,9 +13,26 @@
   data-order-url="{% url 'anthias_app:assets_order' %}"
   class="flex flex-col gap-4"
 >
+  {% comment %} Republish the on-screen asset ids to the homeApp Alpine
+     scope after every swap (x-init re-fires when this element is
+     re-inserted). Drives the bulk select-all state + prunes a
+     selection of rows that have since disappeared. {% endcomment %}
+  <div x-init="setVisible('active', {{ active_assets|asset_ids }}); setVisible('inactive', {{ inactive_assets|asset_ids }})" hidden></div>
+
   <section id="active-assets-section" class="surface surface--active">
     <header class="surface__header">
-      <h2><i class="ti ti-toggle-right mr-2"></i>Enabled</h2>
+      <div class="surface__header-left">
+        {% if active_assets %}
+        <label class="asset-select asset-select--all" title="Select all enabled">
+          <input type="checkbox" class="app-check-input"
+            :checked="sectionAllSelected('active')"
+            @change="toggleSection('active', $event.target.checked)"
+            x-effect="$el.indeterminate = sectionSomeSelected('active')"
+            aria-label="Select all enabled assets">
+        </label>
+        {% endif %}
+        <h2><i class="ti ti-toggle-right mr-2"></i>Enabled</h2>
+      </div>
       <span class="surface__count">{{ active_assets|length }} item{{ active_assets|length|pluralize }}</span>
     </header>
 
@@ -23,6 +40,7 @@
     <table class="asset-table">
       <thead>
         <tr>
+          <th scope="col" class="asset-select-col"><span class="sr-only">Select</span></th>
           <th scope="col">Name</th>
           <th scope="col" style="width: 28%">Schedule window</th>
           <th scope="col" style="width: 10%">Duration</th>
@@ -43,7 +61,18 @@
 
   <section id="inactive-assets-section" class="surface">
     <header class="surface__header">
-      <h2><i class="ti ti-player-pause mr-2"></i>Inactive</h2>
+      <div class="surface__header-left">
+        {% if inactive_assets %}
+        <label class="asset-select asset-select--all" title="Select all inactive">
+          <input type="checkbox" class="app-check-input"
+            :checked="sectionAllSelected('inactive')"
+            @change="toggleSection('inactive', $event.target.checked)"
+            x-effect="$el.indeterminate = sectionSomeSelected('inactive')"
+            aria-label="Select all inactive assets">
+        </label>
+        {% endif %}
+        <h2><i class="ti ti-player-pause mr-2"></i>Inactive</h2>
+      </div>
       <span class="surface__count">{{ inactive_assets|length }} item{{ inactive_assets|length|pluralize }}</span>
     </header>
 
@@ -51,6 +80,7 @@
     <table class="asset-table">
       <thead>
         <tr>
+          <th scope="col" class="asset-select-col"><span class="sr-only">Select</span></th>
           <th scope="col">Name</th>
           <th scope="col" style="width: 28%">Schedule window</th>
           <th scope="col" style="width: 10%">Duration</th>

--- a/src/anthias_server/app/templates/_asset_table.html
+++ b/src/anthias_server/app/templates/_asset_table.html
@@ -17,7 +17,7 @@
      scope after every swap (x-init re-fires when this element is
      re-inserted). Drives the bulk select-all state + prunes a
      selection of rows that have since disappeared. {% endcomment %}
-  <div x-init="setVisible('active', {{ active_assets|asset_ids }}); setVisible('inactive', {{ inactive_assets|asset_ids }})" hidden></div>
+  <div x-init="syncVisibleIds({{ active_assets|asset_ids }}, {{ inactive_assets|asset_ids }})" hidden></div>
 
   <section id="active-assets-section" class="surface surface--active">
     <header class="surface__header">

--- a/src/anthias_server/app/templates/_bulk_action_bar.html
+++ b/src/anthias_server/app/templates/_bulk_action_bar.html
@@ -29,7 +29,7 @@
         hx-post="{% url 'anthias_app:assets_bulk_action' %}"
         hx-target="#asset-table"
         hx-swap="outerHTML"
-        hx-on::after-request="if (isSuccessResponse(event)) clearSelection()"
+        hx-on::after-request="if (window.bulkSucceeded(event)) window.dispatchEvent(new CustomEvent('bulk-done'))"
         class="inline m-0"
       >
         {% csrf_token %}
@@ -46,7 +46,7 @@
         hx-post="{% url 'anthias_app:assets_bulk_action' %}"
         hx-target="#asset-table"
         hx-swap="outerHTML"
-        hx-on::after-request="if (isSuccessResponse(event)) clearSelection()"
+        hx-on::after-request="if (window.bulkSucceeded(event)) window.dispatchEvent(new CustomEvent('bulk-done'))"
         class="inline m-0"
       >
         {% csrf_token %}
@@ -105,7 +105,7 @@
         hx-post="{% url 'anthias_app:assets_bulk_action' %}"
         hx-target="#asset-table"
         hx-swap="outerHTML"
-        hx-on::after-request="if (isSuccessResponse(event)) { clearSelection(); bulkDeleteOpen = false; }"
+        hx-on::after-request="if (window.bulkSucceeded(event)) window.dispatchEvent(new CustomEvent('bulk-done', {detail: {closeDelete: true}}))"
         class="inline m-0"
       >
         {% csrf_token %}

--- a/src/anthias_server/app/templates/_bulk_action_bar.html
+++ b/src/anthias_server/app/templates/_bulk_action_bar.html
@@ -29,7 +29,7 @@
         hx-post="{% url 'anthias_app:assets_bulk_action' %}"
         hx-target="#asset-table"
         hx-swap="outerHTML"
-        hx-on::after-request="if (event.detail.successful) clearSelection()"
+        hx-on::after-request="if (isSuccessResponse(event)) clearSelection()"
         class="inline m-0"
       >
         {% csrf_token %}
@@ -46,7 +46,7 @@
         hx-post="{% url 'anthias_app:assets_bulk_action' %}"
         hx-target="#asset-table"
         hx-swap="outerHTML"
-        hx-on::after-request="if (event.detail.successful) clearSelection()"
+        hx-on::after-request="if (isSuccessResponse(event)) clearSelection()"
         class="inline m-0"
       >
         {% csrf_token %}
@@ -105,7 +105,7 @@
         hx-post="{% url 'anthias_app:assets_bulk_action' %}"
         hx-target="#asset-table"
         hx-swap="outerHTML"
-        hx-on::after-request="if (event.detail.successful) { clearSelection(); bulkDeleteOpen = false; }"
+        hx-on::after-request="if (isSuccessResponse(event)) { clearSelection(); bulkDeleteOpen = false; }"
         class="inline m-0"
       >
         {% csrf_token %}

--- a/src/anthias_server/app/templates/_bulk_action_bar.html
+++ b/src/anthias_server/app/templates/_bulk_action_bar.html
@@ -1,0 +1,120 @@
+{% comment %} Floating bulk-action bar (#3046). Shown whenever one or
+   more rows are selected (selectedIds is the homeApp Alpine state).
+   Enable / Disable / Delete each POST the comma-joined selection to
+   assets_bulk_action and swap the table partial back; Edit opens the
+   bulk-edit modal. selectedIds is read at submit time via the hidden
+   ``ids`` input's :value binding, so it always reflects the live
+   selection. On a successful action the selection is cleared.
+{% endcomment %}
+<div
+  class="bulk-bar"
+  x-show="selectedIds.length"
+  x-cloak
+  x-transition.opacity
+  role="region"
+  aria-label="Bulk actions"
+>
+  <div class="bulk-bar__inner">
+    <div class="bulk-bar__count">
+      <i class="ti ti-checkbox"></i>
+      <span><strong x-text="selectedIds.length"></strong>
+        <span x-text="selectedIds.length === 1 ? 'asset' : 'assets'"></span>
+        selected</span>
+    </div>
+
+    <div class="bulk-bar__actions">
+      <form
+        method="post"
+        action="{% url 'anthias_app:assets_bulk_action' %}"
+        hx-post="{% url 'anthias_app:assets_bulk_action' %}"
+        hx-target="#asset-table"
+        hx-swap="outerHTML"
+        hx-on::after-request="if (event.detail.successful) clearSelection()"
+        class="inline m-0"
+      >
+        {% csrf_token %}
+        <input type="hidden" name="action" value="enable">
+        <input type="hidden" name="ids" :value="selectedIds.join(',')">
+        <button type="submit" class="app-btn app-btn-light app-btn-pill">
+          <i class="ti ti-toggle-right"></i><span>Enable</span>
+        </button>
+      </form>
+
+      <form
+        method="post"
+        action="{% url 'anthias_app:assets_bulk_action' %}"
+        hx-post="{% url 'anthias_app:assets_bulk_action' %}"
+        hx-target="#asset-table"
+        hx-swap="outerHTML"
+        hx-on::after-request="if (event.detail.successful) clearSelection()"
+        class="inline m-0"
+      >
+        {% csrf_token %}
+        <input type="hidden" name="action" value="disable">
+        <input type="hidden" name="ids" :value="selectedIds.join(',')">
+        <button type="submit" class="app-btn app-btn-light app-btn-pill">
+          <i class="ti ti-player-pause"></i><span>Disable</span>
+        </button>
+      </form>
+
+      <button type="button" class="app-btn app-btn-light app-btn-pill" @click="openBulkEdit()">
+        <i class="ti ti-pencil"></i><span>Edit</span>
+      </button>
+
+      <button type="button" class="app-btn app-btn-danger app-btn-pill" @click="bulkDeleteOpen = true">
+        <i class="ti ti-trash"></i><span>Delete</span>
+      </button>
+
+      <button type="button" class="app-btn app-btn-icon bulk-bar__clear" @click="clearSelection()" title="Clear selection" aria-label="Clear selection">
+        <i class="ti ti-x"></i>
+      </button>
+    </div>
+  </div>
+</div>
+
+{% comment %} Bulk delete confirmation — mirrors the single-asset
+   delete prompt in home.html. {% endcomment %}
+<div
+  x-show="bulkDeleteOpen"
+  x-cloak
+  class="modal-overlay"
+  style="z-index: 1060"
+  @keydown.escape.window="bulkDeleteOpen = false"
+  @click.self="bulkDeleteOpen = false"
+>
+  <div class="modal-card modal-card--sm">
+    <div class="modal-card__header">
+      <h2>Delete selected assets?</h2>
+      <button type="button" class="modal-card__close" @click="bulkDeleteOpen = false" aria-label="Close">
+        <i class="ti ti-x"></i>
+      </button>
+    </div>
+    <div class="modal-card__body">
+      <p class="m-0">
+        You're about to delete
+        <strong><span x-text="selectedIds.length"></span>
+          <span x-text="selectedIds.length === 1 ? 'asset' : 'assets'"></span></strong>.
+        This action cannot be undone.
+      </p>
+    </div>
+    <div class="modal-card__footer">
+      <button type="button" class="app-btn app-btn-link" @click="bulkDeleteOpen = false">Cancel</button>
+      <form
+        method="post"
+        action="{% url 'anthias_app:assets_bulk_action' %}"
+        hx-post="{% url 'anthias_app:assets_bulk_action' %}"
+        hx-target="#asset-table"
+        hx-swap="outerHTML"
+        hx-on::after-request="if (event.detail.successful) { clearSelection(); bulkDeleteOpen = false; }"
+        class="inline m-0"
+      >
+        {% csrf_token %}
+        <input type="hidden" name="action" value="delete">
+        <input type="hidden" name="ids" :value="selectedIds.join(',')">
+        <button type="submit" class="app-btn app-btn-danger confirm-bulk-delete">
+          <i class="ti ti-trash"></i><span>Delete</span>
+        </button>
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/anthias_server/app/templates/_bulk_edit_modal.html
+++ b/src/anthias_server/app/templates/_bulk_edit_modal.html
@@ -72,7 +72,7 @@
             </label>
             <div class="mt-3" x-show="applyDuration" x-cloak>
               <div class="app-floating">
-                <input type="number" class="app-input" id="bulk-duration" name="duration" min="0" step="1" value="10" required :disabled="!applyDuration">
+                <input type="number" class="app-input" id="bulk-duration" name="duration" min="0" step="1" placeholder="e.g. 10" required :disabled="!applyDuration">
                 <label for="bulk-duration">Duration (seconds)</label>
               </div>
               <p class="modal-section__hint mt-2 mb-0">

--- a/src/anthias_server/app/templates/_bulk_edit_modal.html
+++ b/src/anthias_server/app/templates/_bulk_edit_modal.html
@@ -35,7 +35,7 @@
         hx-post="{% url 'anthias_app:assets_bulk_update' %}"
         hx-target="#asset-table"
         hx-swap="outerHTML"
-        hx-on::after-request="if (event.detail.successful) { clearSelection(); closeBulkEdit(); }"
+        hx-on::after-request="if (isSuccessResponse(event)) { clearSelection(); closeBulkEdit(); }"
         x-data="{ applyDates: false, applyDuration: false, applyTime: false, applyDays: false }"
       >
         {% csrf_token %}

--- a/src/anthias_server/app/templates/_bulk_edit_modal.html
+++ b/src/anthias_server/app/templates/_bulk_edit_modal.html
@@ -35,7 +35,7 @@
         hx-post="{% url 'anthias_app:assets_bulk_update' %}"
         hx-target="#asset-table"
         hx-swap="outerHTML"
-        hx-on::after-request="if (isSuccessResponse(event)) { clearSelection(); closeBulkEdit(); }"
+        hx-on::after-request="if (window.bulkSucceeded(event)) window.dispatchEvent(new CustomEvent('bulk-done', {detail: {closeEdit: true}}))"
         x-data="{ applyDates: false, applyDuration: false, applyTime: false, applyDays: false }"
       >
         {% csrf_token %}

--- a/src/anthias_server/app/templates/_bulk_edit_modal.html
+++ b/src/anthias_server/app/templates/_bulk_edit_modal.html
@@ -72,7 +72,7 @@
             </label>
             <div class="mt-3" x-show="applyDuration" x-cloak>
               <div class="app-floating">
-                <input type="number" class="app-input" id="bulk-duration" name="duration" min="0" step="1" value="10" :disabled="!applyDuration">
+                <input type="number" class="app-input" id="bulk-duration" name="duration" min="0" step="1" value="10" required :disabled="!applyDuration">
                 <label for="bulk-duration">Duration (seconds)</label>
               </div>
               <p class="modal-section__hint mt-2 mb-0">

--- a/src/anthias_server/app/templates/_bulk_edit_modal.html
+++ b/src/anthias_server/app/templates/_bulk_edit_modal.html
@@ -1,0 +1,137 @@
+{% comment %} Bulk-edit modal (#3046). Applies common schedule fields
+   to every selected asset at once. Each field group is opt-in via a
+   "Change …" toggle: only ticked groups are POSTed (their inputs are
+   disabled — and so omitted — until the toggle is on) and the matching
+   apply_* flag tells assets_bulk_update which groups to write. This
+   keeps an operator from silently overwriting fields they didn't mean
+   to touch across the whole selection.
+
+   Reuses the .js-flatpickr-datetime / .js-flatpickr-time inputs so
+   home.ts bindFlatpickr() (re-run on the bulkEditOpen watch) wires the
+   same date/time pickers the per-asset edit modal uses.
+{% endcomment %}
+<div
+  x-show="bulkEditOpen"
+  x-cloak
+  class="modal-overlay"
+  @keydown.escape.window="closeBulkEdit()"
+  @click.self="closeBulkEdit()"
+>
+  <div class="modal-card">
+    <div class="modal-card__header">
+      <h2>Edit
+        <span x-text="selectedIds.length"></span>
+        <span x-text="selectedIds.length === 1 ? 'asset' : 'assets'"></span>
+      </h2>
+      <button type="button" class="modal-card__close" @click="closeBulkEdit()" aria-label="Close">
+        <i class="ti ti-x"></i>
+      </button>
+    </div>
+
+    <template x-if="bulkEditOpen">
+      <form
+        method="post"
+        action="{% url 'anthias_app:assets_bulk_update' %}"
+        hx-post="{% url 'anthias_app:assets_bulk_update' %}"
+        hx-target="#asset-table"
+        hx-swap="outerHTML"
+        hx-on::after-request="if (event.detail.successful) { clearSelection(); closeBulkEdit(); }"
+        x-data="{ applyDates: false, applyDuration: false, applyTime: false, applyDays: false }"
+      >
+        {% csrf_token %}
+        <input type="hidden" name="ids" :value="selectedIds.join(',')">
+        <div class="modal-card__body">
+          <p class="modal-section__hint mt-0">
+            Tick a field to change it on every selected asset. Unticked
+            fields are left as they are.
+          </p>
+
+          {# ---- Availability dates ---- #}
+          <section class="bulk-field" :class="applyDates && 'is-on'">
+            <label class="app-check app-switch bulk-field__toggle m-0">
+              <input type="checkbox" class="app-check-input" name="apply_dates" value="true" x-model="applyDates">
+              <span class="app-check-label ml-2">Start &amp; end dates</span>
+            </label>
+            <div class="app-form-grid mt-3" x-show="applyDates" x-cloak>
+              <div class="app-floating">
+                <input type="text" class="app-input js-flatpickr-datetime" id="bulk-start" name="start_date" :disabled="!applyDates" autocomplete="off">
+                <label for="bulk-start">Start</label>
+              </div>
+              <div class="app-floating">
+                <input type="text" class="app-input js-flatpickr-datetime" id="bulk-end" name="end_date" :disabled="!applyDates" autocomplete="off">
+                <label for="bulk-end">End</label>
+              </div>
+            </div>
+          </section>
+
+          {# ---- Duration ---- #}
+          <section class="bulk-field" :class="applyDuration && 'is-on'">
+            <label class="app-check app-switch bulk-field__toggle m-0">
+              <input type="checkbox" class="app-check-input" name="apply_duration" value="true" x-model="applyDuration">
+              <span class="app-check-label ml-2">Duration</span>
+            </label>
+            <div class="mt-3" x-show="applyDuration" x-cloak>
+              <div class="app-floating">
+                <input type="number" class="app-input" id="bulk-duration" name="duration" min="0" step="1" value="10" :disabled="!applyDuration">
+                <label for="bulk-duration">Duration (seconds)</label>
+              </div>
+              <p class="modal-section__hint mt-2 mb-0">
+                Video assets keep their measured length — duration only
+                applies to images and web pages.
+              </p>
+            </div>
+          </section>
+
+          {# ---- Time-of-day window ---- #}
+          <section class="bulk-field" :class="applyTime && 'is-on'">
+            <label class="app-check app-switch bulk-field__toggle m-0">
+              <input type="checkbox" class="app-check-input" name="apply_time" value="true" x-model="applyTime">
+              <span class="app-check-label ml-2">Play from / until times</span>
+            </label>
+            <div class="mt-3" x-show="applyTime" x-cloak>
+              <div class="app-form-grid">
+                <div class="app-floating">
+                  <input type="text" class="app-input js-flatpickr-time" id="bulk-play-from" name="play_time_from" :disabled="!applyTime" autocomplete="off">
+                  <label for="bulk-play-from">Play from</label>
+                </div>
+                <div class="app-floating">
+                  <input type="text" class="app-input js-flatpickr-time" id="bulk-play-to" name="play_time_to" :disabled="!applyTime" autocomplete="off">
+                  <label for="bulk-play-to">Play until</label>
+                </div>
+              </div>
+              <p class="modal-section__hint mt-2 mb-0">
+                Leave both empty to clear the time window (play all day).
+              </p>
+            </div>
+          </section>
+
+          {# ---- Weekdays ---- #}
+          <section class="bulk-field" :class="applyDays && 'is-on'">
+            <label class="app-check app-switch bulk-field__toggle m-0">
+              <input type="checkbox" class="app-check-input" name="apply_days" value="true" x-model="applyDays">
+              <span class="app-check-label ml-2">Days of week</span>
+            </label>
+            <div class="mt-3" x-show="applyDays" x-cloak>
+              <div class="weekday-picker">
+                <template x-for="d in [{n:1,l:'Mon'},{n:2,l:'Tue'},{n:3,l:'Wed'},{n:4,l:'Thu'},{n:5,l:'Fri'},{n:6,l:'Sat'},{n:7,l:'Sun'}]" :key="d.n">
+                  <label class="weekday">
+                    <input type="checkbox" name="play_days" :value="d.n" checked :disabled="!applyDays">
+                    <span x-text="d.l"></span>
+                  </label>
+                </template>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div class="modal-card__footer">
+          <button type="button" class="app-btn app-btn-link" @click="closeBulkEdit()">Cancel</button>
+          <button type="submit" class="app-btn app-btn-primary"
+            :disabled="!(applyDates || applyDuration || applyTime || applyDays)">
+            <i class="ti ti-check"></i><span>Apply to selected</span>
+          </button>
+        </div>
+      </form>
+    </template>
+  </div>
+</div>

--- a/src/anthias_server/app/templates/home.html
+++ b/src/anthias_server/app/templates/home.html
@@ -39,9 +39,17 @@
 
   {% include "_asset_table.html" %}
 
+  {% comment %} _asset_modal stays the first .modal-card in the DOM —
+     the add-asset layering integration test grabs .modal-card.first.
+     The bulk modals/bar (which also carry a .modal-card) are included
+     after it so that assumption holds. {% endcomment %}
   {% include "_asset_modal.html" %}
 
   {% include "_preview_modal.html" %}
+
+  {% include "_bulk_action_bar.html" %}
+
+  {% include "_bulk_edit_modal.html" %}
 
   {% comment %} Delete confirmation overlay — shared shell with the reboot/shutdown
      prompt on /settings (.modal-overlay + .modal-card pattern). {% endcomment %}

--- a/src/anthias_server/app/templates/home.html
+++ b/src/anthias_server/app/templates/home.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block main %}
-<div class="app-container" x-data="homeApp()" @asset-saved.window="closeModal()">
+<div class="app-container" x-data="homeApp()" @asset-saved.window="closeModal()" @bulk-done.window="onBulkDone($event)">
   <div class="page-header-bar">
     <div class="page-header-bar__title">
       <h1 class="page-header">Schedule Overview</h1>

--- a/src/anthias_server/app/templatetags/asset_filters.py
+++ b/src/anthias_server/app/templatetags/asset_filters.py
@@ -188,25 +188,25 @@ def to_json(value: Any) -> SafeString:
 
 
 @register.filter
-def asset_ids(assets: Any) -> SafeString:
+def asset_ids(assets: Any) -> str:
     """Render a list of assets as a JSON array of their asset_ids.
 
     Inlined into the asset-table partial's ``x-init`` so Alpine knows
     which rows are on screen after every HTMX swap (drives the bulk
-    select-all + selection pruning, #3046). asset_id is a hex/underscore
-    token, but route it through json.dumps + the same escape pass
-    ``to_json`` uses so the literal stays valid inside the attribute
-    regardless of what a row carries.
+    select-all + selection pruning, #3046).
+
+    Unlike ``to_json`` (which mark_safe's its output because it's
+    embedded in a *single*-quoted Alpine attribute and hand-escapes the
+    apostrophe), this value lands in a *double*-quoted ``x-init="…"``
+    attribute. The JSON's own ``"`` would prematurely close that
+    attribute, so we deliberately return a plain ``str`` and let
+    Django's template autoescaping HTML-encode ``"``/``&``/``<``/``>``
+    to entities — the browser decodes them back to valid JSON before
+    Alpine evaluates the expression. Returning a SafeString here would
+    suppress that escaping and break the markup.
     """
     ids = [getattr(a, 'asset_id', '') for a in (assets or [])]
-    encoded = json.dumps(ids, separators=(',', ':'))
-    safe = (
-        encoded.replace('&', '\\u0026')
-        .replace("'", '\\u0027')
-        .replace('<', '\\u003c')
-        .replace('>', '\\u003e')
-    )
-    return mark_safe(safe)
+    return json.dumps(ids, separators=(',', ':'))
 
 
 @register.filter

--- a/src/anthias_server/app/templatetags/asset_filters.py
+++ b/src/anthias_server/app/templatetags/asset_filters.py
@@ -188,6 +188,28 @@ def to_json(value: Any) -> SafeString:
 
 
 @register.filter
+def asset_ids(assets: Any) -> SafeString:
+    """Render a list of assets as a JSON array of their asset_ids.
+
+    Inlined into the asset-table partial's ``x-init`` so Alpine knows
+    which rows are on screen after every HTMX swap (drives the bulk
+    select-all + selection pruning, #3046). asset_id is a hex/underscore
+    token, but route it through json.dumps + the same escape pass
+    ``to_json`` uses so the literal stays valid inside the attribute
+    regardless of what a row carries.
+    """
+    ids = [getattr(a, 'asset_id', '') for a in (assets or [])]
+    encoded = json.dumps(ids, separators=(',', ':'))
+    safe = (
+        encoded.replace('&', '\\u0026')
+        .replace("'", '\\u0027')
+        .replace('<', '\\u003c')
+        .replace('>', '\\u003e')
+    )
+    return mark_safe(safe)
+
+
+@register.filter
 def schedule_window(asset: Any) -> dict[str, str]:
     """Return a structured descriptor for the asset's start/end window.
 

--- a/src/anthias_server/app/urls.py
+++ b/src/anthias_server/app/urls.py
@@ -48,6 +48,16 @@ urlpatterns = [
     path('assets/upload/', views.assets_upload, name='assets_upload'),
     path('assets/order/', views.assets_order, name='assets_order'),
     path(
+        'assets/bulk/action/',
+        views.assets_bulk_action,
+        name='assets_bulk_action',
+    ),
+    path(
+        'assets/bulk/update/',
+        views.assets_bulk_update,
+        name='assets_bulk_update',
+    ),
+    path(
         'assets/control/<str:command>/',
         views.assets_control,
         name='assets_control',

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -946,7 +946,11 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
     if duration_assets:
         Asset.objects.bulk_update(duration_assets, ['duration'])
     ViewerPublisher.get_instance().send_to_viewer('reload')
-    count = len(assets)
+    # Report only the rows actually written. Shared fields touch every
+    # selected asset, but a duration-only edit skips videos — so a mixed
+    # selection there updated just the non-video subset, and the toast
+    # shouldn't claim the videos were changed.
+    count = len(assets) if changed_fields else len(duration_assets)
     return _asset_table_response(
         request,
         toast=('success', f'{count} asset{_pluralize(count)} updated'),

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -730,8 +730,20 @@ def assets_bulk_action(request: HttpRequest) -> HttpResponse:
 
     action = request.POST.get('action', '')
     ids = _bulk_ids(request)
-    if action not in ('enable', 'disable', 'delete') or not ids:
-        return _asset_table_response(request)
+    # Toast on the degenerate cases instead of a silent no-toast 2xx —
+    # the client's success gate treats the latter as success and would
+    # clear the selection (e.g. an empty POST racing a table swap, or a
+    # stale/typoed action value).
+    if action not in ('enable', 'disable', 'delete'):
+        return _asset_table_response(
+            request,
+            toast=('error', 'Unknown bulk action'),
+        )
+    if not ids:
+        return _asset_table_response(
+            request,
+            toast=('info', 'No assets selected'),
+        )
 
     if action == 'delete':
         from anthias_server.app.helpers import delete_asset_with_file
@@ -802,8 +814,9 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
     ids = _bulk_ids(request)
     if not ids:
         return _asset_table_response(request)
-    assets = list(Asset.objects.filter(asset_id__in=ids))
-    if not assets:
+    base_qs = Asset.objects.filter(asset_id__in=ids)
+    matched = base_qs.count()
+    if not matched:
         # Non-empty ids that match nothing (e.g. a stale selection after
         # another operator deleted the rows). Toast so the client's
         # success gate keeps the selection / leaves the modal open
@@ -919,64 +932,58 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
             sorted(set(parsed_days)) or [1, 2, 3, 4, 5, 6, 7]
         )
 
-    # --- Mutate every selected asset in memory, then write them with
-    # bulk_update() (Asset has no custom save()/signals). A large
-    # selection — the whole point of bulk editing — would otherwise fire
-    # one UPDATE per row. We track exactly which columns were touched so
-    # bulk_update only writes those.
-    #
-    # ``duration`` is handled on its own list, NOT folded into the
-    # shared field set: it's only written for non-video assets (video
-    # duration is owned by the probe task), and including the column in
-    # an all-rows bulk_update would write every video's *stale in-memory*
-    # duration back, racing with a concurrent probe_video_duration
-    # UPDATE. Splitting it keeps that "never touch video duration"
-    # guarantee (Copilot review of #3048).
-    changed_fields: set[str] = set()
-    duration_assets: list[Asset] = []
-    for asset in assets:
-        if apply_dates:
-            if new_start is not None:
-                asset.start_date = new_start
-                changed_fields.add('start_date')
-            if new_end is not None:
-                asset.end_date = new_end
-                changed_fields.add('end_date')
-        if apply_duration and asset.mimetype != 'video':
-            asset.duration = new_duration
-            duration_assets.append(asset)
-        if apply_time:
-            if clear_time:
-                asset.play_time_from = None
-                asset.play_time_to = None
-            else:
-                asset.play_time_from = new_time_from
-                asset.play_time_to = new_time_to
-            changed_fields.update(('play_time_from', 'play_time_to'))
-        if apply_days and new_play_days is not None:
-            asset.play_days = new_play_days
-            changed_fields.add('play_days')
+    # The new values are uniform across the whole selection, so apply
+    # them with plain queryset update()s — one UPDATE per affected
+    # column-group — instead of loading every row and building the big
+    # CASE statement bulk_update() would (Copilot review of #3048).
+    # Duration goes through a separate update that excludes videos, so a
+    # video row's probe-owned duration is never touched.
+    shared: dict[str, object] = {}
+    if apply_dates:
+        if new_start is not None:
+            shared['start_date'] = new_start
+        if new_end is not None:
+            shared['end_date'] = new_end
+    if apply_time:
+        shared['play_time_from'] = None if clear_time else new_time_from
+        shared['play_time_to'] = None if clear_time else new_time_to
+    if apply_days and new_play_days is not None:
+        shared['play_days'] = new_play_days
 
-    # Nothing actually changed (e.g. apply_dates ticked but both date
-    # fields left blank, or a duration-only edit on an all-video
-    # selection). bulk_update() rejects an empty field list, so short-
-    # circuit with the same "nothing to change" toast.
-    if not changed_fields and not duration_assets:
+    if not shared and not apply_duration:
+        # e.g. apply_dates ticked but both date fields left blank.
         return _asset_table_response(
             request,
             toast=('info', 'Nothing to change — pick a field to edit'),
         )
 
-    if changed_fields:
-        Asset.objects.bulk_update(assets, sorted(changed_fields))
-    if duration_assets:
-        Asset.objects.bulk_update(duration_assets, ['duration'])
+    # Count the rows actually affected from matched-rows count()s rather
+    # than update()'s return value (which reports rows *changed* on some
+    # backends — re-applying an identical value would otherwise read as
+    # zero). Shared fields touch every matched row; duration touches
+    # only the non-video subset.
+    if shared:
+        base_qs.update(**shared)
+    nonvideo_count = 0
+    if apply_duration:
+        nonvideo_qs = base_qs.exclude(mimetype='video')
+        nonvideo_count = nonvideo_qs.count()
+        if nonvideo_count:
+            nonvideo_qs.update(duration=new_duration)
+
+    count = matched if shared else nonvideo_count
+    if not count:
+        # Duration-only edit on an all-video selection — nothing the
+        # duration rule allows us to change.
+        return _asset_table_response(
+            request,
+            toast=(
+                'info',
+                'Duration applies to images and web pages only '
+                '— nothing changed',
+            ),
+        )
     ViewerPublisher.get_instance().send_to_viewer('reload')
-    # Report only the rows actually written. Shared fields touch every
-    # selected asset, but a duration-only edit skips videos — so a mixed
-    # selection there updated just the non-video subset, and the toast
-    # shouldn't claim the videos were changed.
-    count = len(assets) if changed_fields else len(duration_assets)
     return _asset_table_response(
         request,
         toast=('success', f'{count} asset{_pluralize(count)} updated'),

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -696,6 +696,213 @@ def assets_order(request: HttpRequest) -> HttpResponse:
     return _asset_table_response(request)
 
 
+def _bulk_ids(request: HttpRequest) -> list[str]:
+    """Pull the comma-separated asset_id list the bulk-action bar POSTs.
+
+    Same wire shape as ``assets_order`` ('ids' = "a,b,c"); empty
+    segments are dropped so a trailing comma or an empty field yields
+    [].
+    """
+    return [i for i in request.POST.get('ids', '').split(',') if i]
+
+
+def _pluralize(count: int, suffix: str = 's') -> str:
+    return '' if count == 1 else suffix
+
+
+@authorized
+@require_http_methods(['POST'])
+def assets_bulk_action(request: HttpRequest) -> HttpResponse:
+    """Enable / disable / delete a set of assets in one request.
+
+    Backs the home-page bulk-action bar. ``action`` is one of
+    enable/disable/delete and ``ids`` is the comma-separated selection.
+    A single table partial + viewer reload covers the whole batch
+    rather than one round-trip per row, which is the painful workaround
+    this feature replaces (#3046).
+    """
+    from anthias_server.app.models import Asset
+
+    action = request.POST.get('action', '')
+    ids = _bulk_ids(request)
+    if action not in ('enable', 'disable', 'delete') or not ids:
+        return _asset_table_response(request)
+
+    assets = list(Asset.objects.filter(asset_id__in=ids))
+    if not assets:
+        return _asset_table_response(request)
+
+    if action == 'delete':
+        from anthias_server.app.helpers import delete_asset_with_file
+
+        for asset in assets:
+            # delete_asset_with_file nudges the viewer per row; the
+            # redundant reloads are cheap and keep the shared helper
+            # the single source of truth for file cleanup (#2908).
+            delete_asset_with_file(asset)
+        count = len(assets)
+        return _asset_table_response(
+            request,
+            toast=(
+                'success',
+                f'{count} asset{_pluralize(count)} deleted',
+            ),
+        )
+
+    enabled = action == 'enable'
+    for asset in assets:
+        asset.is_enabled = enabled
+        asset.save()
+    ViewerPublisher.get_instance().send_to_viewer('reload')
+    count = len(assets)
+    verb = 'enabled' if enabled else 'disabled'
+    return _asset_table_response(
+        request,
+        toast=('success', f'{count} asset{_pluralize(count)} {verb}'),
+    )
+
+
+@authorized
+@require_http_methods(['POST'])
+def assets_bulk_update(request: HttpRequest) -> HttpResponse:
+    """Apply common schedule fields to a set of assets at once.
+
+    Mirrors the per-asset ``assets_update`` parsing for dates,
+    duration, time-of-day, and weekday filters, but each group is
+    opt-in via an ``apply_*`` flag so an operator only overwrites the
+    fields they ticked — an unticked group is left untouched on every
+    selected asset. Everything is parsed before any row is mutated so a
+    bad date/time toasts without leaving a half-applied batch (#3046).
+    """
+    import json as _json
+
+    from anthias_server.app.models import Asset
+
+    ids = _bulk_ids(request)
+    if not ids:
+        return _asset_table_response(request)
+    assets = list(Asset.objects.filter(asset_id__in=ids))
+    if not assets:
+        return _asset_table_response(request)
+
+    apply_dates = request.POST.get('apply_dates') == 'true'
+    apply_duration = request.POST.get('apply_duration') == 'true'
+    apply_time = request.POST.get('apply_time') == 'true'
+    apply_days = request.POST.get('apply_days') == 'true'
+
+    if not (apply_dates or apply_duration or apply_time or apply_days):
+        return _asset_table_response(
+            request,
+            toast=('info', 'Nothing to change — pick a field to edit'),
+        )
+
+    # --- Parse everything up-front; toast on the first bad value ---
+    new_start: datetime | None = None
+    new_end: datetime | None = None
+    if apply_dates:
+        start = request.POST.get('start_date')
+        end = request.POST.get('end_date')
+        try:
+            if start:
+                new_start = _parse_local_datetime(start)
+            if end:
+                new_end = _parse_local_datetime(end)
+        except ValueError:
+            return _asset_table_response(
+                request,
+                toast=(
+                    'error',
+                    'Could not read the start/end date — nothing changed',
+                ),
+            )
+
+    new_duration: int | None = None
+    if apply_duration:
+        try:
+            new_duration = int(request.POST.get('duration') or 0)
+        except (TypeError, ValueError):
+            return _asset_table_response(
+                request,
+                toast=('error', 'Duration must be a number — nothing changed'),
+            )
+
+    new_time_from: time | None = None
+    new_time_to: time | None = None
+    clear_time = False
+    if apply_time:
+        play_from = (request.POST.get('play_time_from') or '').strip()
+        play_to = (request.POST.get('play_time_to') or '').strip()
+        if play_from and play_to:
+            try:
+                new_time_from = _parse_local_time(play_from)
+                new_time_to = _parse_local_time(play_to)
+            except ValueError:
+                return _asset_table_response(
+                    request,
+                    toast=(
+                        'error',
+                        'Could not read the play from/until times '
+                        '— nothing changed',
+                    ),
+                )
+        elif play_from or play_to:
+            return _asset_table_response(
+                request,
+                toast=(
+                    'error',
+                    'Set both play from and until times, or clear both '
+                    '— nothing changed',
+                ),
+            )
+        else:
+            # Both empty with the toggle on means "remove the window".
+            clear_time = True
+
+    new_play_days: str | None = None
+    if apply_days:
+        parsed_days: list[int] = []
+        for d in request.POST.getlist('play_days'):
+            try:
+                n = int(d)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= n <= 7:
+                parsed_days.append(n)
+        new_play_days = _json.dumps(
+            sorted(set(parsed_days)) or [1, 2, 3, 4, 5, 6, 7]
+        )
+
+    # --- Apply to every selected asset ---
+    for asset in assets:
+        if apply_dates:
+            if new_start is not None:
+                asset.start_date = new_start
+            if new_end is not None:
+                asset.end_date = new_end
+        # Video duration stays owned by the probe task — same guard the
+        # per-asset edit form applies — so a bulk duration change never
+        # clobbers a probed length back to a fixed value.
+        if apply_duration and asset.mimetype != 'video':
+            asset.duration = new_duration
+        if apply_time:
+            if clear_time:
+                asset.play_time_from = None
+                asset.play_time_to = None
+            else:
+                asset.play_time_from = new_time_from
+                asset.play_time_to = new_time_to
+        if apply_days and new_play_days is not None:
+            asset.play_days = new_play_days
+        asset.save()
+
+    ViewerPublisher.get_instance().send_to_viewer('reload')
+    count = len(assets)
+    return _asset_table_response(
+        request,
+        toast=('success', f'{count} asset{_pluralize(count)} updated'),
+    )
+
+
 def _safe_redirect_uri(uri: str) -> str | None:
     """Defang asset.uri before handing it to redirect().
 

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -804,7 +804,15 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
         return _asset_table_response(request)
     assets = list(Asset.objects.filter(asset_id__in=ids))
     if not assets:
-        return _asset_table_response(request)
+        # Non-empty ids that match nothing (e.g. a stale selection after
+        # another operator deleted the rows). Toast so the client's
+        # success gate keeps the selection / leaves the modal open
+        # rather than treating a silent no-toast 2xx as success — same
+        # contract as the enable/disable path.
+        return _asset_table_response(
+            request,
+            toast=('info', 'No matching assets selected'),
+        )
 
     apply_dates = request.POST.get('apply_dates') == 'true'
     apply_duration = request.POST.get('apply_duration') == 'true'

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -702,11 +702,13 @@ def assets_order(request: HttpRequest) -> HttpResponse:
 def _bulk_ids(request: HttpRequest) -> list[str]:
     """Pull the comma-separated asset_id list the bulk-action bar POSTs.
 
-    Same wire shape as ``assets_order`` ('ids' = "a,b,c"); empty
-    segments are dropped so a trailing comma or an empty field yields
-    [].
+    Same wire shape as ``assets_order`` ('ids' = "a,b,c"). Each segment
+    is stripped and empty ones dropped, so a trailing comma, an empty
+    field, or a hand-built ``"a, b"`` (with spaces) still resolves to
+    clean ids rather than silently failing to match a row.
     """
-    return [i for i in request.POST.get('ids', '').split(',') if i]
+    parts = (i.strip() for i in request.POST.get('ids', '').split(','))
+    return [i for i in parts if i]
 
 
 def _pluralize(count: int, suffix: str = 's') -> str:
@@ -736,7 +738,10 @@ def assets_bulk_action(request: HttpRequest) -> HttpResponse:
 
         assets = list(Asset.objects.filter(asset_id__in=ids))
         if not assets:
-            return _asset_table_response(request)
+            return _asset_table_response(
+                request,
+                toast=('info', 'No matching assets to delete'),
+            )
         for asset in assets:
             # Suppress the per-row viewer reload — a large batch would
             # otherwise spam the pub/sub channel with one 'reload' per
@@ -754,12 +759,22 @@ def assets_bulk_action(request: HttpRequest) -> HttpResponse:
 
     # Enable/disable have no model signals, so collapse to a single
     # queryset UPDATE (one DB write regardless of selection size) plus
-    # one viewer reload. ``update()`` returns the affected row count,
-    # which doubles as the toast count and the empty-selection guard.
+    # one viewer reload. Count is taken from a separate matched-rows
+    # count(), NOT update()'s return value: some backends (and SQLite in
+    # some builds) report rows *changed*, so bulk-enabling already-
+    # enabled assets could return 0 even though the selection was valid.
+    # We want the count of rows the selection actually addressed.
     enabled = action == 'enable'
-    count = Asset.objects.filter(asset_id__in=ids).update(is_enabled=enabled)
+    qs = Asset.objects.filter(asset_id__in=ids)
+    count = qs.count()
     if not count:
-        return _asset_table_response(request)
+        # A genuinely empty match (stale ids) — toast so the client's
+        # success gate keeps the selection and the operator sees why.
+        return _asset_table_response(
+            request,
+            toast=('info', 'No matching assets selected'),
+        )
+    qs.update(is_enabled=enabled)
     ViewerPublisher.get_instance().send_to_viewer('reload')
     verb = 'enabled' if enabled else 'disabled'
     return _asset_table_response(

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -893,18 +893,26 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
             sorted(set(parsed_days)) or [1, 2, 3, 4, 5, 6, 7]
         )
 
-    # --- Apply to every selected asset ---
+    # --- Mutate every selected asset in memory, then write them all in
+    # one bulk_update() (Asset has no custom save()/signals). A large
+    # selection — the whole point of bulk editing — would otherwise fire
+    # one UPDATE per row. We track exactly which columns were touched so
+    # bulk_update only writes those.
+    changed_fields: set[str] = set()
     for asset in assets:
         if apply_dates:
             if new_start is not None:
                 asset.start_date = new_start
+                changed_fields.add('start_date')
             if new_end is not None:
                 asset.end_date = new_end
+                changed_fields.add('end_date')
         # Video duration stays owned by the probe task — same guard the
         # per-asset edit form applies — so a bulk duration change never
         # clobbers a probed length back to a fixed value.
         if apply_duration and asset.mimetype != 'video':
             asset.duration = new_duration
+            changed_fields.add('duration')
         if apply_time:
             if clear_time:
                 asset.play_time_from = None
@@ -912,10 +920,22 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
             else:
                 asset.play_time_from = new_time_from
                 asset.play_time_to = new_time_to
+            changed_fields.update(('play_time_from', 'play_time_to'))
         if apply_days and new_play_days is not None:
             asset.play_days = new_play_days
-        asset.save()
+            changed_fields.add('play_days')
 
+    # Nothing actually changed (e.g. apply_dates ticked but both date
+    # fields left blank, or a duration-only edit on an all-video
+    # selection). bulk_update() rejects an empty field list, so short-
+    # circuit with the same "nothing to change" toast.
+    if not changed_fields:
+        return _asset_table_response(
+            request,
+            toast=('info', 'Nothing to change — pick a field to edit'),
+        )
+
+    Asset.objects.bulk_update(assets, sorted(changed_fields))
     ViewerPublisher.get_instance().send_to_viewer('reload')
     count = len(assets)
     return _asset_table_response(

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -893,12 +893,21 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
             sorted(set(parsed_days)) or [1, 2, 3, 4, 5, 6, 7]
         )
 
-    # --- Mutate every selected asset in memory, then write them all in
-    # one bulk_update() (Asset has no custom save()/signals). A large
+    # --- Mutate every selected asset in memory, then write them with
+    # bulk_update() (Asset has no custom save()/signals). A large
     # selection — the whole point of bulk editing — would otherwise fire
     # one UPDATE per row. We track exactly which columns were touched so
     # bulk_update only writes those.
+    #
+    # ``duration`` is handled on its own list, NOT folded into the
+    # shared field set: it's only written for non-video assets (video
+    # duration is owned by the probe task), and including the column in
+    # an all-rows bulk_update would write every video's *stale in-memory*
+    # duration back, racing with a concurrent probe_video_duration
+    # UPDATE. Splitting it keeps that "never touch video duration"
+    # guarantee (Copilot review of #3048).
     changed_fields: set[str] = set()
+    duration_assets: list[Asset] = []
     for asset in assets:
         if apply_dates:
             if new_start is not None:
@@ -907,12 +916,9 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
             if new_end is not None:
                 asset.end_date = new_end
                 changed_fields.add('end_date')
-        # Video duration stays owned by the probe task — same guard the
-        # per-asset edit form applies — so a bulk duration change never
-        # clobbers a probed length back to a fixed value.
         if apply_duration and asset.mimetype != 'video':
             asset.duration = new_duration
-            changed_fields.add('duration')
+            duration_assets.append(asset)
         if apply_time:
             if clear_time:
                 asset.play_time_from = None
@@ -929,13 +935,16 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
     # fields left blank, or a duration-only edit on an all-video
     # selection). bulk_update() rejects an empty field list, so short-
     # circuit with the same "nothing to change" toast.
-    if not changed_fields:
+    if not changed_fields and not duration_assets:
         return _asset_table_response(
             request,
             toast=('info', 'Nothing to change — pick a field to edit'),
         )
 
-    Asset.objects.bulk_update(assets, sorted(changed_fields))
+    if changed_fields:
+        Asset.objects.bulk_update(assets, sorted(changed_fields))
+    if duration_assets:
+        Asset.objects.bulk_update(duration_assets, ['duration'])
     ViewerPublisher.get_instance().send_to_viewer('reload')
     count = len(assets)
     return _asset_table_response(

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -728,18 +728,18 @@ def assets_bulk_action(request: HttpRequest) -> HttpResponse:
     if action not in ('enable', 'disable', 'delete') or not ids:
         return _asset_table_response(request)
 
-    assets = list(Asset.objects.filter(asset_id__in=ids))
-    if not assets:
-        return _asset_table_response(request)
-
     if action == 'delete':
         from anthias_server.app.helpers import delete_asset_with_file
 
+        assets = list(Asset.objects.filter(asset_id__in=ids))
+        if not assets:
+            return _asset_table_response(request)
         for asset in assets:
-            # delete_asset_with_file nudges the viewer per row; the
-            # redundant reloads are cheap and keep the shared helper
-            # the single source of truth for file cleanup (#2908).
-            delete_asset_with_file(asset)
+            # Suppress the per-row viewer reload — a large batch would
+            # otherwise spam the pub/sub channel with one 'reload' per
+            # asset — and send a single reload after the batch instead.
+            delete_asset_with_file(asset, nudge_viewer=False)
+        ViewerPublisher.get_instance().send_to_viewer('reload')
         count = len(assets)
         return _asset_table_response(
             request,
@@ -749,12 +749,15 @@ def assets_bulk_action(request: HttpRequest) -> HttpResponse:
             ),
         )
 
+    # Enable/disable have no model signals, so collapse to a single
+    # queryset UPDATE (one DB write regardless of selection size) plus
+    # one viewer reload. ``update()`` returns the affected row count,
+    # which doubles as the toast count and the empty-selection guard.
     enabled = action == 'enable'
-    for asset in assets:
-        asset.is_enabled = enabled
-        asset.save()
+    count = Asset.objects.filter(asset_id__in=ids).update(is_enabled=enabled)
+    if not count:
+        return _asset_table_response(request)
     ViewerPublisher.get_instance().send_to_viewer('reload')
-    count = len(assets)
     verb = 'enabled' if enabled else 'disabled'
     return _asset_table_response(
         request,
@@ -818,12 +821,30 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
 
     new_duration: int | None = None
     if apply_duration:
+        # A blank field must NOT silently clobber every selected asset's
+        # duration to 0 (the per-asset edit form preserves the existing
+        # value on blank; bulk has no single "existing" to fall back to,
+        # so require a value instead). Toast and change nothing.
+        raw_duration = (request.POST.get('duration') or '').strip()
+        if not raw_duration:
+            return _asset_table_response(
+                request,
+                toast=('error', 'Enter a duration — nothing changed'),
+            )
         try:
-            new_duration = int(request.POST.get('duration') or 0)
+            new_duration = int(raw_duration)
         except (TypeError, ValueError):
             return _asset_table_response(
                 request,
                 toast=('error', 'Duration must be a number — nothing changed'),
+            )
+        if new_duration < 0:
+            return _asset_table_response(
+                request,
+                toast=(
+                    'error',
+                    'Duration must be zero or more — nothing changed',
+                ),
             )
 
     new_time_from: time | None = None

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -813,7 +813,13 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
 
     ids = _bulk_ids(request)
     if not ids:
-        return _asset_table_response(request)
+        # Empty selection (e.g. a submit racing a table swap). Toast so
+        # the client's success gate keeps the modal open rather than
+        # treating the silent 2xx as success — mirrors assets_bulk_action.
+        return _asset_table_response(
+            request,
+            toast=('info', 'No assets selected'),
+        )
     base_qs = Asset.objects.filter(asset_id__in=ids)
     matched = base_qs.count()
     if not matched:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1231,9 +1231,12 @@ def test_toggle_enables_asset(reset_assets: None, page: Page) -> None:
     ).to_be_visible()
     _disable_asset_poll(page)
 
+    # Target the activity toggle specifically — rows now also carry a
+    # bulk-select checkbox (#3046), so a bare input[type=checkbox] is
+    # ambiguous.
     page.locator(
         f'tr[data-asset-id="{asset_disabled["asset_id"]}"] '
-        f'input[type="checkbox"]'
+        f'.activity-toggle input[type="checkbox"]'
     ).click()
 
     _wait_db(
@@ -1255,9 +1258,12 @@ def test_toggle_disables_asset(reset_assets: None, page: Page) -> None:
     ).to_be_visible()
     _disable_asset_poll(page)
 
+    # Target the activity toggle specifically — rows now also carry a
+    # bulk-select checkbox (#3046), so a bare input[type=checkbox] is
+    # ambiguous.
     page.locator(
         f'tr[data-asset-id="{asset_active["asset_id"]}"] '
-        f'input[type="checkbox"]'
+        f'.activity-toggle input[type="checkbox"]'
     ).click()
 
     _wait_db(

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1169,6 +1169,31 @@ def test_assets_bulk_update_duration_skips_video(
 
 
 @pytest.mark.django_db
+def test_assets_bulk_update_blank_duration_does_not_clobber(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """apply_duration on with a blank duration must NOT zero out every
+    asset — it toasts and changes nothing (Copilot review of #3048).
+    """
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_duration': 'true',
+                'duration': '',
+            },
+        )
+    assert response.status_code in (200, 302)
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.duration == 10
+
+
+@pytest.mark.django_db
 def test_assets_bulk_update_time_window(
     client: Client, bulk_assets: list[Asset]
 ) -> None:
@@ -1326,6 +1351,25 @@ def test_asset_table_renders_selection_controls(
     body = response.content.decode()
     assert 'js-row-select' in body
     assert "sectionAllSelected('active')" in body
+
+
+@pytest.mark.django_db
+def test_asset_ids_json_is_html_escaped_in_x_init(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """Regression for the Copilot review of #3048: the asset_ids JSON
+    is inlined into a double-quoted x-init="…" attribute, so its own
+    double quotes MUST be entity-escaped (Django autoescaping) — a raw
+    `["id"]` would close the attribute early and break the markup.
+    """
+    response = client.get(reverse('anthias_app:assets_table'))
+    body = response.content.decode()
+    # The ids land entity-escaped inside the setVisible() call …
+    assert 'setVisible(' in body
+    assert '&quot;' in body
+    # … and the raw, attribute-breaking form must not appear.
+    assert 'setVisible(&#x27;active&#x27;, ["' not in body
+    assert "setVisible('active', [\"" not in body
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1194,6 +1194,33 @@ def test_assets_bulk_update_blank_duration_does_not_clobber(
 
 
 @pytest.mark.django_db
+def test_assets_bulk_update_duration_only_count_excludes_videos(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """A duration-only edit on a mixed selection (2 webpages + 1 video)
+    skips the video, so the success toast must report 2 updated, not 3
+    (Copilot review of #3048). Read the count off the HX-Trigger toast.
+    """
+    import json as _json
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_duration': 'true',
+                'duration': '42',
+            },
+            HTTP_HX_REQUEST='true',
+        )
+    trigger = _json.loads(response['HX-Trigger'])
+    assert trigger['toast']['message'] == '2 assets updated'
+
+
+@pytest.mark.django_db
 def test_assets_bulk_update_never_writes_video_duration_column(
     client: Client, bulk_assets: list[Asset]
 ) -> None:
@@ -1458,12 +1485,12 @@ def test_asset_ids_json_is_html_escaped_in_x_init(
     """
     response = client.get(reverse('anthias_app:assets_table'))
     body = response.content.decode()
-    # The ids land entity-escaped inside the setVisible() call …
-    assert 'setVisible(' in body
+    # The ids land entity-escaped inside the syncVisibleIds() call …
+    assert 'syncVisibleIds(' in body
     assert '&quot;' in body
     # … and the raw, attribute-breaking form must not appear.
-    assert 'setVisible(&#x27;active&#x27;, ["' not in body
-    assert "setVisible('active', [\"" not in body
+    assert 'syncVisibleIds([&quot;' in body or 'syncVisibleIds([])' in body
+    assert 'syncVisibleIds(["' not in body
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1114,6 +1114,84 @@ def test_assets_bulk_action_empty_ids_is_noop(
 
 
 @pytest.mark.django_db
+def test_assets_bulk_action_trims_whitespace_in_ids(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """A hand-built ``"a, b"`` CSV (spaces after commas) must still
+    match every row — _bulk_ids strips each segment (Copilot review of
+    #3048).
+    """
+    for a in bulk_assets:
+        a.is_enabled = False
+        a.save()
+    spaced = ', '.join(a.asset_id for a in bulk_assets)
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_action'),
+            data={'action': 'enable', 'ids': spaced},
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.is_enabled is True
+
+
+@pytest.mark.django_db
+def test_assets_bulk_action_enable_already_enabled_reports_match_count(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """Re-enabling already-enabled assets must report the matched count,
+    not 0 — the count comes from a matched-rows count(), not update()'s
+    changed-rows return, which can be 0 on some backends (Copilot review
+    of #3048). A 0 with no toast would also make the client treat it as
+    success and clear the selection.
+    """
+    import json as _json
+
+    # bulk_assets are created is_enabled=True; enable them again.
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_action'),
+            data={
+                'action': 'enable',
+                'ids': _bulk_ids_csv(bulk_assets),
+            },
+            HTTP_HX_REQUEST='true',
+        )
+    trigger = _json.loads(response['HX-Trigger'])
+    assert trigger['toast'] == {
+        'kind': 'success',
+        'message': '3 assets enabled',
+    }
+
+
+@pytest.mark.django_db
+def test_assets_bulk_action_no_matching_ids_keeps_selection(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """Stale ids that match nothing return an info toast (not a silent
+    no-toast 2xx) so the client's success gate keeps the selection."""
+    import json as _json
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_action'),
+            data={'action': 'enable', 'ids': 'no-such-id,also-missing'},
+            HTTP_HX_REQUEST='true',
+        )
+    trigger = _json.loads(response['HX-Trigger'])
+    assert trigger['toast']['kind'] == 'info'
+
+
+@pytest.mark.django_db
 def test_assets_bulk_update_dates(
     client: Client, bulk_assets: list[Asset]
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1194,6 +1194,46 @@ def test_assets_bulk_update_blank_duration_does_not_clobber(
 
 
 @pytest.mark.django_db
+def test_assets_bulk_update_never_writes_video_duration_column(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """The duration bulk_update must exclude video rows entirely (not
+    just write the same value back) so it can't race with / clobber the
+    probe_video_duration task's UPDATE (Copilot review of #3048). Spy on
+    bulk_update and assert no video object is ever in a call that writes
+    the duration column.
+    """
+    calls: list[tuple[list[Asset], list[str]]] = []
+    real_bulk_update = Asset.objects.bulk_update
+
+    def spy(objs: Any, fields: Any, *a: Any, **k: Any) -> Any:
+        objs = list(objs)
+        calls.append((objs, list(fields)))
+        return real_bulk_update(objs, fields, *a, **k)
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        with mock.patch.object(Asset.objects, 'bulk_update', side_effect=spy):
+            client.post(
+                reverse('anthias_app:assets_bulk_update'),
+                data={
+                    'ids': _bulk_ids_csv(bulk_assets),
+                    'apply_duration': 'true',
+                    'duration': '42',
+                },
+            )
+
+    duration_writes = [objs for objs, fields in calls if 'duration' in fields]
+    assert duration_writes, 'expected a duration bulk_update'
+    for objs in duration_writes:
+        assert all(a.mimetype != 'video' for a in objs), (
+            'a video asset was included in the duration write'
+        )
+
+
+@pytest.mark.django_db
 def test_assets_bulk_update_issues_single_update_query(
     client: Client,
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1194,6 +1194,60 @@ def test_assets_bulk_update_blank_duration_does_not_clobber(
 
 
 @pytest.mark.django_db
+def test_assets_bulk_update_issues_single_update_query(
+    client: Client,
+) -> None:
+    """Bulk update must write the whole selection in one UPDATE, not one
+    per row (Copilot review of #3048) — proven by counting UPDATE
+    statements against a 5-asset selection.
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    now = timezone.now()
+    ids = []
+    for i in range(5):
+        a = Asset.objects.create(
+            name=f'q{i}',
+            uri=f'https://q{i}.example',
+            mimetype='webpage',
+            duration=10,
+            is_enabled=True,
+            is_processing=False,
+            play_order=i,
+            start_date=now,
+            end_date=now + timedelta(days=30),
+        )
+        ids.append(a.asset_id)
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        with CaptureQueriesContext(connection) as ctx:
+            client.post(
+                reverse('anthias_app:assets_bulk_update'),
+                data={
+                    'ids': ','.join(ids),
+                    'apply_duration': 'true',
+                    'duration': '55',
+                },
+            )
+
+    updates = [
+        q['sql']
+        for q in ctx.captured_queries
+        if q['sql'].lstrip().upper().startswith('UPDATE "ASSETS"')
+    ]
+    assert len(updates) == 1, (
+        f'expected exactly 1 UPDATE for the batch, got {len(updates)}:\n'
+        + '\n'.join(updates)
+    )
+    for a_id in ids:
+        assert Asset.objects.get(asset_id=a_id).duration == 55
+
+
+@pytest.mark.django_db
 def test_assets_bulk_update_time_window(
     client: Client, bulk_assets: list[Asset]
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1325,43 +1325,39 @@ def test_assets_bulk_update_duration_only_count_excludes_videos(
 
 
 @pytest.mark.django_db
-def test_assets_bulk_update_never_writes_video_duration_column(
+def test_assets_bulk_update_never_writes_video_duration(
     client: Client, bulk_assets: list[Asset]
 ) -> None:
-    """The duration bulk_update must exclude video rows entirely (not
-    just write the same value back) so it can't race with / clobber the
-    probe_video_duration task's UPDATE (Copilot review of #3048). Spy on
-    bulk_update and assert no video object is ever in a call that writes
-    the duration column.
+    """The duration update must exclude video rows at the SQL level so
+    it can't race with / clobber the probe_video_duration task. Set the
+    video's stored duration to a sentinel and confirm a bulk duration
+    edit leaves it untouched while the webpages change (Copilot review
+    of #3048).
     """
-    calls: list[tuple[list[Asset], list[str]]] = []
-    real_bulk_update = Asset.objects.bulk_update
-
-    def spy(objs: Any, fields: Any, *a: Any, **k: Any) -> Any:
-        objs = list(objs)
-        calls.append((objs, list(fields)))
-        return real_bulk_update(objs, fields, *a, **k)
+    webpage_one, webpage_two, video = bulk_assets
+    # Simulate the probe having written a duration on the video; the
+    # bulk edit must not overwrite it.
+    Asset.objects.filter(asset_id=video.asset_id).update(duration=123)
 
     with mock.patch(
         'anthias_server.settings.ViewerPublisher.send_to_viewer',
         return_value=None,
     ):
-        with mock.patch.object(Asset.objects, 'bulk_update', side_effect=spy):
-            client.post(
-                reverse('anthias_app:assets_bulk_update'),
-                data={
-                    'ids': _bulk_ids_csv(bulk_assets),
-                    'apply_duration': 'true',
-                    'duration': '42',
-                },
-            )
-
-    duration_writes = [objs for objs, fields in calls if 'duration' in fields]
-    assert duration_writes, 'expected a duration bulk_update'
-    for objs in duration_writes:
-        assert all(a.mimetype != 'video' for a in objs), (
-            'a video asset was included in the duration write'
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_duration': 'true',
+                'duration': '42',
+            },
         )
+
+    video.refresh_from_db()
+    webpage_one.refresh_from_db()
+    webpage_two.refresh_from_db()
+    assert video.duration == 123, 'video duration was clobbered'
+    assert webpage_one.duration == 42
+    assert webpage_two.duration == 42
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1192,6 +1192,32 @@ def test_assets_bulk_action_no_matching_ids_keeps_selection(
 
 
 @pytest.mark.django_db
+def test_assets_bulk_update_unmatched_ids_keeps_selection(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """bulk_update with non-empty but unmatched ids returns an info
+    toast (not a silent no-toast 2xx) so the client keeps the selection
+    and the modal stays open (Copilot review of #3048)."""
+    import json as _json
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': 'no-such-id,also-missing',
+                'apply_duration': 'true',
+                'duration': '42',
+            },
+            HTTP_HX_REQUEST='true',
+        )
+    trigger = _json.loads(response['HX-Trigger'])
+    assert trigger['toast']['kind'] == 'info'
+
+
+@pytest.mark.django_db
 def test_assets_bulk_update_dates(
     client: Client, bulk_assets: list[Asset]
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -973,6 +973,361 @@ def test_assets_update_missing_id_is_no_op(client: Client) -> None:
     assert response.status_code in (200, 302)
 
 
+# ---------------------------------------------------------------------------
+# Bulk asset actions (#3046)
+
+
+@pytest.fixture
+def bulk_assets() -> list[Asset]:
+    """Three assets — two webpages and one video — for bulk tests."""
+    now = timezone.now()
+    common = {
+        'duration': 10,
+        'is_enabled': True,
+        'is_processing': False,
+        'start_date': now,
+        'end_date': now + timedelta(days=30),
+    }
+    return [
+        Asset.objects.create(
+            name='one',
+            uri='https://a.example',
+            mimetype='webpage',
+            play_order=0,
+            **common,
+        ),
+        Asset.objects.create(
+            name='two',
+            uri='https://b.example',
+            mimetype='webpage',
+            play_order=1,
+            **common,
+        ),
+        Asset.objects.create(
+            name='vid',
+            uri='https://c.example/v.mp4',
+            mimetype='video',
+            play_order=2,
+            **common,
+        ),
+    ]
+
+
+def _bulk_ids_csv(assets: list[Asset]) -> str:
+    return ','.join(a.asset_id for a in assets)
+
+
+@pytest.mark.django_db
+def test_assets_bulk_action_disable(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_action'),
+            data={
+                'action': 'disable',
+                'ids': _bulk_ids_csv(bulk_assets),
+            },
+        )
+    assert response.status_code in (200, 302)
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.is_enabled is False
+
+
+@pytest.mark.django_db
+def test_assets_bulk_action_enable_only_selected(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """Only the ids in the POST flip — an unselected row is untouched."""
+    for a in bulk_assets:
+        a.is_enabled = False
+        a.save()
+    selected = bulk_assets[:2]
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_action'),
+            data={'action': 'enable', 'ids': _bulk_ids_csv(selected)},
+        )
+    bulk_assets[0].refresh_from_db()
+    bulk_assets[1].refresh_from_db()
+    bulk_assets[2].refresh_from_db()
+    assert bulk_assets[0].is_enabled is True
+    assert bulk_assets[1].is_enabled is True
+    assert bulk_assets[2].is_enabled is False
+
+
+@pytest.mark.django_db
+def test_assets_bulk_action_delete(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_action'),
+            data={'action': 'delete', 'ids': _bulk_ids_csv(bulk_assets)},
+        )
+    assert Asset.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_assets_bulk_action_invalid_action_is_noop(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_action'),
+            data={'action': 'frobnicate', 'ids': _bulk_ids_csv(bulk_assets)},
+        )
+    assert response.status_code in (200, 302)
+    assert Asset.objects.count() == 3
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.is_enabled is True
+
+
+@pytest.mark.django_db
+def test_assets_bulk_action_empty_ids_is_noop(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_action'),
+            data={'action': 'delete', 'ids': ''},
+        )
+    assert response.status_code in (200, 302)
+    assert Asset.objects.count() == 3
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_dates(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_dates': 'true',
+                'start_date': '01/02/2030 09:00 AM',
+                'end_date': '01/03/2030 09:00 AM',
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.start_date is not None
+        assert (a.start_date.year, a.start_date.month, a.start_date.day) == (
+            2030,
+            1,
+            2,
+        )
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_duration_skips_video(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """Duration is applied to images/webpages but never videos — the
+    video's duration is owned by the probe task (mirrors assets_update).
+    """
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_duration': 'true',
+                'duration': '42',
+            },
+        )
+    webpage_one, webpage_two, video = bulk_assets
+    webpage_one.refresh_from_db()
+    webpage_two.refresh_from_db()
+    video.refresh_from_db()
+    assert webpage_one.duration == 42
+    assert webpage_two.duration == 42
+    assert video.duration == 10
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_time_window(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_time': 'true',
+                'play_time_from': '09:00',
+                'play_time_to': '17:00',
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.play_time_from == time(9, 0)
+        assert a.play_time_to == time(17, 0)
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_clears_time_window(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """apply_time on with both fields empty removes the window."""
+    for a in bulk_assets:
+        a.play_time_from = time(9, 0)
+        a.play_time_to = time(17, 0)
+        a.save()
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_time': 'true',
+                'play_time_from': '',
+                'play_time_to': '',
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.play_time_from is None
+        assert a.play_time_to is None
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_partial_time_window_toasts(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """Only one endpoint set — reject and leave everything untouched."""
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_time': 'true',
+                'play_time_from': '09:00',
+                'play_time_to': '',
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.play_time_from is None
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_days(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_days': 'true',
+                'play_days': ['1', '3', '5'],
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.get_play_days() == [1, 3, 5]
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_no_flags_is_noop(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    original = [a.start_date for a in bulk_assets]
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'start_date': '01/02/2030 09:00 AM',
+            },
+        )
+    assert response.status_code in (200, 302)
+    for a, start in zip(bulk_assets, original):
+        a.refresh_from_db()
+        assert a.start_date == start
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_invalid_date_toasts_and_keeps_values(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    original = [a.start_date for a in bulk_assets]
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_dates': 'true',
+                'start_date': 'not-a-date',
+            },
+        )
+    assert response.status_code in (200, 302)
+    for a, start in zip(bulk_assets, original):
+        a.refresh_from_db()
+        assert a.start_date == start
+
+
+@pytest.mark.django_db
+def test_asset_ids_filter_emits_json_array(bulk_assets: list[Asset]) -> None:
+    from anthias_server.app.templatetags.asset_filters import asset_ids
+
+    rendered = str(asset_ids(bulk_assets))
+    assert rendered.startswith('[') and rendered.endswith(']')
+    for a in bulk_assets:
+        assert a.asset_id in rendered
+
+
+@pytest.mark.django_db
+def test_asset_table_renders_selection_controls(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    response = client.get(reverse('anthias_app:assets_table'))
+    body = response.content.decode()
+    assert 'js-row-select' in body
+    assert "sectionAllSelected('active')" in body
+
+
 @pytest.mark.django_db
 def test_asset_table_partial_via_htmx_header(
     client: Client, asset: Asset

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1575,6 +1575,27 @@ def test_asset_table_renders_selection_controls(
 
 
 @pytest.mark.django_db
+def test_bulk_forms_use_global_event_bridge_not_alpine_methods(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """hx-on::after-request runs in global JS scope, so the bulk forms
+    must NOT call Alpine component methods there (that throws
+    ReferenceError and the selection never clears). They go through the
+    window.bulkSucceeded() gate + a 'bulk-done' window event that Alpine
+    handles via @bulk-done.window (Copilot review of #3048).
+    """
+    body = client.get(reverse('anthias_app:home')).content.decode()
+    assert 'window.bulkSucceeded(event)' in body
+    assert '@bulk-done.window="onBulkDone($event)"' in body
+    # The old, broken forms called Alpine methods straight from hx-on.
+    assert 'hx-on::after-request="if (isSuccessResponse(' not in body
+    assert (
+        'hx-on::after-request="if (event.detail.successful) clearSelection'
+        not in body
+    )
+
+
+@pytest.mark.django_db
 def test_asset_ids_json_is_html_escaped_in_x_init(
     client: Client, bulk_assets: list[Asset]
 ) -> None:


### PR DESCRIPTION
## Summary

Adds the long-requested ability to act on multiple assets at once from the home page (closes #3046). Operators with large libraries no longer have to enable/disable or edit assets one row at a time.

- **Row selection** — a checkbox on every asset row, plus a per-section "select all" in each surface header (works on mobile too, since it lives in the header rather than the hidden-on-mobile `thead`).
- **Bulk-action bar** — a floating bar appears whenever a selection is active, with **Enable**, **Disable**, **Edit**, **Delete**, and a clear-selection control. It shows the live selection count.
- **Bulk edit** — a modal that applies common schedule fields across the whole selection: start/end dates, duration, play-from/until times, and weekdays. Each field group is opt-in via a "Change …" toggle, so an operator only overwrites the fields they ticked.

## Backend

Two new server-rendered endpoints, both reusing the shared `_asset_table_response` so the entire batch swaps the table partial and nudges the viewer **once** rather than one HTTP round-trip per row (the painful scripting workaround this feature replaces):

- `assets_bulk_action` — enable / disable / delete a selected set. Delete routes through `delete_asset_with_file`, so on-disk cleanup matches the per-asset path (the GH #2908 behaviour).
- `assets_bulk_update` — applies the ticked schedule fields. Everything is parsed up-front, so a bad date/time surfaces a toast **without** leaving a half-applied batch. Video duration stays owned by the probe task, mirroring the per-asset `assets_update` guard.

## Frontend

Selection state lives in the `homeApp` Alpine store (`selectedIds`), so each row's `:checked` binding re-evaluates after the table's 5s HTMX swap and the selection survives. The table partial re-publishes its on-screen ids via `setVisible()` on every swap, which drives the select-all indeterminate/checked state and prunes a selection of rows that have since disappeared. The bulk-edit modal reuses the existing flatpickr date/time inputs.

## Tests

Added coverage in `tests/test_template_views.py` for bulk enable/disable/delete (including selected-subset and no-op guards) and bulk update (dates, duration skipping videos, time window set/clear, partial-window rejection, weekdays, no-flags and invalid-input no-ops), plus the new `asset_ids` filter and the rendered selection controls.

- `uv run pytest -m "not integration"` — 1093 passed
- `ruff check` + `ruff format --check` clean
- JS/CSS bundles rebuilt; `tsc` clean (only pre-existing alpinejs declaration warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)