### PR TITLE
feat(viewer): add "Prefer dark mode" setting for web page assets

### DIFF
--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -311,6 +311,7 @@ class DeviceSettingsSerializerV2(Serializer[Any]):
     shuffle_playlist = BooleanField()
     use_24_hour_clock = BooleanField()
     debug_logging = BooleanField()
+    prefer_dark_mode = BooleanField()
     # Mirror the PATCH-side ChoiceField so the OpenAPI schema
     # advertises the same enum on both directions — clients can rely
     # on the value being one of {0, 90, 180, 270} when reading too.
@@ -329,6 +330,7 @@ class UpdateDeviceSettingsSerializerV2(Serializer[Any]):
     shuffle_playlist = BooleanField(required=False)
     use_24_hour_clock = BooleanField(required=False)
     debug_logging = BooleanField(required=False)
+    prefer_dark_mode = BooleanField(required=False)
     screen_rotation = ChoiceField(
         required=False, choices=SCREEN_ROTATION_CHOICES
     )

--- a/src/anthias_server/api/tests/test_v2_endpoints.py
+++ b/src/anthias_server/api/tests/test_v2_endpoints.py
@@ -46,6 +46,7 @@ def test_get_device_settings(
         'shuffle_playlist': False,
         'use_24_hour_clock': True,
         'debug_logging': False,
+        'prefer_dark_mode': True,
         'screen_rotation': 90,
     }[key]
 
@@ -65,6 +66,7 @@ def test_get_device_settings(
         'shuffle_playlist': False,
         'use_24_hour_clock': True,
         'debug_logging': False,
+        'prefer_dark_mode': True,
         'screen_rotation': 90,
         'username': '',
     }
@@ -278,6 +280,7 @@ def test_disable_basic_auth(
         'shuffle_playlist': False,
         'use_24_hour_clock': True,
         'debug_logging': False,
+        'prefer_dark_mode': False,
         'screen_rotation': 0,
     }[key]
     settings_mock.__setitem__ = mock.MagicMock()

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -602,6 +602,7 @@ class DeviceSettingsViewV2(APIView):
                 'shuffle_playlist': settings['shuffle_playlist'],
                 'use_24_hour_clock': settings['use_24_hour_clock'],
                 'debug_logging': settings['debug_logging'],
+                'prefer_dark_mode': settings['prefer_dark_mode'],
                 # Clamp on read too — the OpenAPI schema advertises
                 # an enum of {0,90,180,270}, but a hand-edited conf
                 # could have a stale 45 or any other int sitting on
@@ -685,6 +686,8 @@ class DeviceSettingsViewV2(APIView):
                 settings['use_24_hour_clock'] = data['use_24_hour_clock']
             if 'debug_logging' in data:
                 settings['debug_logging'] = data['debug_logging']
+            if 'prefer_dark_mode' in data:
+                settings['prefer_dark_mode'] = data['prefer_dark_mode']
             if 'screen_rotation' in data:
                 settings['screen_rotation'] = int(data['screen_rotation'])
 

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -233,6 +233,7 @@ def device_settings() -> dict[str, Any]:
         'shuffle_playlist': settings['shuffle_playlist'],
         'use_24_hour_clock': settings['use_24_hour_clock'],
         'debug_logging': settings['debug_logging'],
+        'prefer_dark_mode': settings['prefer_dark_mode'],
         # Clamp on the read side so a stale conf value (e.g. an
         # old 45 from a hand-edit) doesn't leave the dropdown with no
         # ``selected`` option — the template's {% if screen_rotation

--- a/src/anthias_server/app/templates/settings.html
+++ b/src/anthias_server/app/templates/settings.html
@@ -91,6 +91,7 @@
         {% include "_settings_toggle.html" with name="show_splash" label="Show splash screen" hint="Display the device's IP address on screen at boot." checked=show_splash %}
         {% include "_settings_toggle.html" with name="default_assets" label="Include default sample assets" hint="Auto-add the bundled sample assets to a fresh playlist." checked=default_assets %}
         {% include "_settings_toggle.html" with name="shuffle_playlist" label="Shuffle playlist" hint="Randomise the play order on every loop." checked=shuffle_playlist %}
+        {% include "_settings_toggle.html" with name="prefer_dark_mode" label="Prefer dark mode" hint="Ask web page assets to render in dark mode where they support it." checked=prefer_dark_mode %}
         {% include "_settings_toggle.html" with name="use_24_hour_clock" label="Use 24-hour clock" hint="Display times in 24-hour format across the UI." checked=use_24_hour_clock %}
         {% include "_settings_toggle.html" with name="debug_logging" label="Debug logging" hint="Verbose viewer logs. Leave off unless you're chasing a problem." checked=debug_logging %}
       </div>

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -946,6 +946,7 @@ def settings_save(request: HttpRequest) -> HttpResponse:
 
         settings['show_splash'] = _checkbox(request, 'show_splash')
         settings['shuffle_playlist'] = _checkbox(request, 'shuffle_playlist')
+        settings['prefer_dark_mode'] = _checkbox(request, 'prefer_dark_mode')
         settings['use_24_hour_clock'] = _checkbox(request, 'use_24_hour_clock')
         settings['debug_logging'] = _checkbox(request, 'debug_logging')
 

--- a/src/anthias_server/settings.py
+++ b/src/anthias_server/settings.py
@@ -36,6 +36,7 @@ DEFAULTS = {
         'default_duration': 10,
         'default_streaming_duration': '300',
         'player_name': '',
+        'prefer_dark_mode': False,
         'resolution': '1920x1080',
         'screen_rotation': 0,
         'show_splash': True,

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -88,6 +88,14 @@ scheduler: Any = None
 # operator changed rotation from the UI and we need to re-apply.
 _last_applied_rotation: int = 0
 
+# Whether the webview currently running was launched with "Prefer dark
+# mode" on. ``_maybe_reapply_dark_mode`` compares this to the freshly
+# loaded ``settings['prefer_dark_mode']`` after a ``reload`` to decide
+# whether the operator toggled the setting and the webview needs to be
+# respawned to pick up the new ANTHIAS_PREFER_DARK_MODE env var. Latched
+# at each spawn in ``load_browser``.
+_last_applied_dark_mode: bool = False
+
 # Cross-thread handoff for the linuxfb rotation-change path. The
 # subscriber thread (ViewerSubscriber) runs _handle_reload when a
 # `reload` arrives on Redis pub/sub, but ``browser`` and
@@ -182,6 +190,17 @@ def _build_webview_env() -> dict[str, str]:
       us at no perf cost.
     """
     env = dict(os.environ)
+
+    # "Prefer dark mode" applies to every board (the C++ webview turns
+    # this into a Chromium blink flag at launch — see applyDarkModePreference
+    # in src/anthias_webview/src/main.cpp), so set it before the
+    # board-specific rotation branches below. Pop a stale value so dialling
+    # the setting back off actually drops the flag on the respawned process.
+    if settings['prefer_dark_mode']:
+        env['ANTHIAS_PREFER_DARK_MODE'] = '1'
+    else:
+        env.pop('ANTHIAS_PREFER_DARK_MODE', None)
+
     rotation = _rotation_value()
     if _is_wayland_board():
         return env
@@ -593,7 +612,13 @@ def load_browser(
     """
     global browser, _webview_supports_set_reload_interval
     global _last_applied_rotation, current_browser_url
+    global _last_applied_dark_mode
     logging.info('Loading browser...')
+
+    # Latch the dark-mode preference the spawned process is about to be
+    # launched with (via _build_webview_env), so a later ``reload`` only
+    # bounces the webview when the operator actually changed the setting.
+    _last_applied_dark_mode = bool(settings['prefer_dark_mode'])
 
     if max_attempts is None:
         max_attempts = BROWSER_SPAWN_MAX_ATTEMPTS
@@ -926,6 +951,7 @@ def _handle_reload() -> None:
     """
     load_settings()
     _maybe_reapply_rotation()
+    _maybe_reapply_dark_mode()
     _skip_if_current_asset_inactive()
 
 
@@ -1012,6 +1038,45 @@ def _maybe_reapply_rotation() -> None:
     # the bounce happens promptly rather than after the current
     # asset's full duration elapses.
     _last_applied_rotation = rotation
+    _rotation_bounce_pending = True
+    get_skip_event().set()
+
+
+def _maybe_reapply_dark_mode() -> None:
+    """Respawn the webview when the operator toggled "Prefer dark mode".
+
+    The preference is realised by the C++ webview reading the
+    ANTHIAS_PREFER_DARK_MODE env var at launch and setting a Chromium
+    blink flag before QtWebEngine initialises (see
+    applyDarkModePreference in src/anthias_webview/src/main.cpp), so a
+    live toggle only takes effect on a fresh process. Unlike rotation
+    this applies to every board (linuxfb, eglfs and Wayland alike), so
+    there's no platform branch: latch the new value and request a webview
+    respawn that the main asset_loop thread performs.
+
+    We piggy-back on ``_rotation_bounce_pending`` — despite the name it
+    is simply the cross-thread "the main thread must terminate the webview
+    so it respawns with fresh env" handoff, which is exactly what a
+    dark-mode change needs too. ``_handle_reload`` runs on the subscriber
+    thread, which must not touch ``browser`` directly (see
+    _maybe_reapply_rotation), so the flag + skip_event is the only safe
+    path.
+
+    No-op when the on-disk value matches what the running webview was
+    launched with, so unrelated ``reload`` traffic doesn't blank the
+    screen.
+    """
+    global _last_applied_dark_mode, _rotation_bounce_pending
+    prefer_dark = bool(settings['prefer_dark_mode'])
+    if prefer_dark == _last_applied_dark_mode:
+        return
+
+    logging.info(
+        'Prefer-dark-mode changed: %s -> %s',
+        _last_applied_dark_mode,
+        prefer_dark,
+    )
+    _last_applied_dark_mode = prefer_dark
     _rotation_bounce_pending = True
     get_skip_event().set()
 

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -1,11 +1,42 @@
 #include <QApplication>
+#include <QByteArray>
 #include <QDebug>
 #include <QtDBus>
 
 #include "mainwindow.h"
 
+namespace {
+// Realise the operator's "Prefer dark mode" setting. The Python viewer
+// plumbs the Django setting in via the ANTHIAS_PREFER_DARK_MODE env var
+// (see _build_webview_env in src/anthias_viewer/__init__.py); here we
+// translate that into the Chromium switch that makes QtWebEngine render
+// web pages dark. Going through --blink-settings keeps one code path
+// across Qt5 (Pi 1-4) and Qt6 (Pi 5/x86) without a version macro: it
+// sets the same Blink runtime flag that QWebEngineSettings::ForceDarkMode
+// toggles on Qt 6.7+. Dark-aware sites get their own dark theme (Chromium
+// then reports prefers-color-scheme: dark) and the rest are auto-darkened.
+// Must run before QApplication constructs QtWebEngine's Chromium context,
+// since the switch is only read once at engine init.
+void applyDarkModePreference()
+{
+    const QByteArray preference = qgetenv("ANTHIAS_PREFER_DARK_MODE");
+    if (preference != "1" && preference != "true") {
+        return;
+    }
+
+    QByteArray flags = qgetenv("QTWEBENGINE_CHROMIUM_FLAGS");
+    if (!flags.isEmpty()) {
+        flags.append(' ');
+    }
+    flags.append("--blink-settings=forceDarkModeEnabled=true");
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", flags);
+}
+}  // namespace
+
 int main(int argc, char *argv[])
 {
+    applyDarkModePreference();
+
     QApplication app(argc, argv);
 
     QApplication::setOverrideCursor(QCursor(Qt::BlankCursor));

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -25,10 +25,32 @@ void applyDarkModePreference()
     }
 
     QByteArray flags = qgetenv("QTWEBENGINE_CHROMIUM_FLAGS");
-    if (!flags.isEmpty()) {
-        flags.append(' ');
+
+    // Idempotent: nothing to do if dark mode is already requested.
+    if (flags.contains("forceDarkModeEnabled")) {
+        return;
     }
-    flags.append("--blink-settings=forceDarkModeEnabled=true");
+
+    const QByteArray darkSetting = "forceDarkModeEnabled=true";
+    const int blinkIdx = flags.indexOf("--blink-settings=");
+    if (blinkIdx >= 0) {
+        // Merge into the existing --blink-settings switch rather than
+        // appending a second one: Chromium keeps only the last
+        // occurrence of a given switch, so a duplicate would silently
+        // drop whatever Blink settings were already configured. The
+        // switch's comma-separated value runs to the next space (or the
+        // end of the string).
+        int valueEnd = flags.indexOf(' ', blinkIdx);
+        if (valueEnd < 0) {
+            valueEnd = flags.size();
+        }
+        flags.insert(valueEnd, "," + darkSetting);
+    } else {
+        if (!flags.isEmpty()) {
+            flags.append(' ');
+        }
+        flags.append("--blink-settings=" + darkSetting);
+    }
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", flags);
 }
 }  // namespace

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,6 +18,7 @@ audio_output = hdmi
 shuffle_playlist = on
 verify_ssl = off
 debug_logging = on
+prefer_dark_mode = on
 resolution = 1920x1080
 default_duration = 45
 
@@ -109,6 +110,7 @@ def test_parse_settings(settings_env: None) -> None:
         assert settings['show_splash'] is False
         assert settings['shuffle_playlist'] is True
         assert settings['debug_logging'] is True
+        assert settings['prefer_dark_mode'] is True
         assert settings['default_duration'] == 45
 
 
@@ -129,6 +131,10 @@ def test_default_settings(settings_env: None) -> None:
         assert (
             settings['debug_logging']
             == mod_settings.DEFAULTS['viewer']['debug_logging']
+        )
+        assert (
+            settings['prefer_dark_mode']
+            == mod_settings.DEFAULTS['viewer']['prefer_dark_mode']
         )
         assert (
             settings['default_duration']

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1063,6 +1063,97 @@ def test_rotation_value_clamps(raw: Any, expected: int) -> None:
         assert viewer._rotation_value() == expected
 
 
+# ---------------------------------------------------------------------------
+# Prefer dark mode — the C++ webview reads ANTHIAS_PREFER_DARK_MODE at
+# launch (applyDarkModePreference in src/anthias_webview/src/main.cpp).
+
+
+@pytest.fixture
+def reset_dark_mode_state() -> Iterator[None]:
+    """_last_applied_dark_mode + _rotation_bounce_pending are module
+    state — snapshot and restore so these tests don't bleed into each
+    other or the rotation tests that share the bounce flag."""
+    prior_dark = viewer._last_applied_dark_mode
+    prior_pending = viewer._rotation_bounce_pending
+    try:
+        viewer._last_applied_dark_mode = False
+        viewer._rotation_bounce_pending = False
+        yield
+    finally:
+        viewer._last_applied_dark_mode = prior_dark
+        viewer._rotation_bounce_pending = prior_pending
+
+
+def test_build_webview_env_sets_dark_mode_flag_when_enabled() -> None:
+    with (
+        mock.patch.dict(settings, {'prefer_dark_mode': True}),
+        mock.patch.dict(
+            os.environ, {'QT_QPA_PLATFORM': 'linuxfb'}, clear=False
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['ANTHIAS_PREFER_DARK_MODE'] == '1'
+
+
+def test_build_webview_env_drops_dark_mode_flag_when_disabled() -> None:
+    # A stale value inherited from the process env must not leak into the
+    # spawned webview when the operator turns the setting back off.
+    with (
+        mock.patch.dict(settings, {'prefer_dark_mode': False}),
+        mock.patch.dict(
+            os.environ,
+            {'QT_QPA_PLATFORM': 'linuxfb', 'ANTHIAS_PREFER_DARK_MODE': '1'},
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert 'ANTHIAS_PREFER_DARK_MODE' not in env
+
+
+def test_handle_reload_queues_bounce_on_dark_mode_change(
+    reset_dark_mode_state: None,
+) -> None:
+    """The dark-mode flag is only read at webview launch, so a live
+    toggle has to respawn AnthiasViewer. Like the rotation path,
+    _handle_reload runs on the subscriber thread and MUST NOT terminate
+    the browser directly — it only latches the new value and sets the
+    bounce flag the main thread consumes."""
+    fake_browser = mock.Mock()
+    skip = mock.Mock()
+    with (
+        mock.patch.dict(settings, {'prefer_dark_mode': True}),
+        mock.patch.object(viewer, 'load_settings'),
+        mock.patch.object(viewer, '_maybe_reapply_rotation'),
+        mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
+        mock.patch.object(viewer, 'browser', fake_browser),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip),
+    ):
+        viewer._handle_reload()
+    fake_browser.terminate.assert_not_called()
+    assert viewer._rotation_bounce_pending is True
+    skip.set.assert_called_once()
+    # Latched immediately so a second `reload` in the gap before the
+    # respawn doesn't re-queue another bounce.
+    assert viewer._last_applied_dark_mode is True
+
+
+def test_handle_reload_no_op_when_dark_mode_unchanged(
+    reset_dark_mode_state: None,
+) -> None:
+    skip = mock.Mock()
+    viewer._last_applied_dark_mode = True
+    with (
+        mock.patch.dict(settings, {'prefer_dark_mode': True}),
+        mock.patch.object(viewer, 'load_settings'),
+        mock.patch.object(viewer, '_maybe_reapply_rotation'),
+        mock.patch.object(viewer, '_skip_if_current_asset_inactive'),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip),
+    ):
+        viewer._handle_reload()
+    assert viewer._rotation_bounce_pending is False
+    skip.set.assert_not_called()
+
+
 @pytest.mark.parametrize(
     'qpa, expected',
     [

--- a/tests/test_webview_dark_mode.py
+++ b/tests/test_webview_dark_mode.py
@@ -21,10 +21,11 @@ two in sync; the test fails loudly if Chromium ever stops honouring it.
 """
 
 import io
+from typing import Any
 
 import pytest
 from PIL import Image
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import BrowserType
 
 # Must match applyDarkModePreference() in src/anthias_webview/src/main.cpp.
 FORCE_DARK_FLAG = '--blink-settings=forceDarkModeEnabled=true'
@@ -47,30 +48,38 @@ LIGHT_THRESHOLD = 200
 DARK_THRESHOLD = 120
 
 
-def _mean_center_luminance(extra_args: list[str]) -> float:
+def _mean_center_luminance(
+    browser_type: BrowserType,
+    launch_args: dict[str, Any],
+    extra_args: list[str],
+) -> float:
     """Render the white page in headless Chromium and return the mean
     luminance (0-255) of the centre of the screenshot.
+
+    Launches through the suite's ``browser_type`` /
+    ``browser_type_launch_args`` fixtures (rather than a bare
+    ``sync_playwright`` call) so any suite-wide launch configuration —
+    notably the ``--no-sandbox`` override in conftest.py needed because
+    the test container runs as root — is inherited here too and can't
+    drift. We must launch our own browser instead of reusing the shared
+    ``page`` fixture because the force-dark switch differs per test and
+    Chromium only reads it at startup.
 
     Cropping to the centre quarter avoids any window-chrome or
     scrollbar pixels skewing a full-frame average.
     """
-    with sync_playwright() as p:
-        browser = p.chromium.launch(
-            # --no-sandbox mirrors the suite-wide launch override in
-            # conftest.py: the test container runs as root, where
-            # Chromium's setuid sandbox refuses to start.
-            args=['--no-sandbox', '--hide-scrollbars', *extra_args],
-        )
-        try:
-            page = browser.new_page(viewport={'width': 400, 'height': 300})
-            page.set_content(WHITE_PAGE, wait_until='load')
-            # Force-dark is applied during paint; give the compositor a
-            # beat so the screenshot captures the darkened frame rather
-            # than the initial white flash.
-            page.wait_for_timeout(300)
-            png = page.screenshot()
-        finally:
-            browser.close()
+    args = [*launch_args.get('args', []), '--hide-scrollbars', *extra_args]
+    browser = browser_type.launch(**{**launch_args, 'args': args})
+    try:
+        page = browser.new_page(viewport={'width': 400, 'height': 300})
+        page.set_content(WHITE_PAGE, wait_until='load')
+        # Force-dark is applied during paint; give the compositor a
+        # beat so the screenshot captures the darkened frame rather
+        # than the initial white flash.
+        page.wait_for_timeout(300)
+        png = page.screenshot()
+    finally:
+        browser.close()
 
     image = Image.open(io.BytesIO(png)).convert('L')
     width, height = image.size
@@ -82,10 +91,15 @@ def _mean_center_luminance(extra_args: list[str]) -> float:
 
 
 @pytest.mark.integration
-def test_force_dark_flag_renders_web_page_dark() -> None:
+def test_force_dark_flag_renders_web_page_dark(
+    browser_type: BrowserType,
+    browser_type_launch_args: dict[str, Any],
+) -> None:
     """ "Prefer dark mode" on: the Chromium switch the webview injects
     must darken an otherwise-white page."""
-    luminance = _mean_center_luminance([FORCE_DARK_FLAG])
+    luminance = _mean_center_luminance(
+        browser_type, browser_type_launch_args, [FORCE_DARK_FLAG]
+    )
     assert luminance < DARK_THRESHOLD, (
         f'expected a dark render with {FORCE_DARK_FLAG}, '
         f'got mean luminance {luminance:.1f}'
@@ -93,11 +107,16 @@ def test_force_dark_flag_renders_web_page_dark() -> None:
 
 
 @pytest.mark.integration
-def test_without_flag_web_page_stays_light() -> None:
+def test_without_flag_web_page_stays_light(
+    browser_type: BrowserType,
+    browser_type_launch_args: dict[str, Any],
+) -> None:
     """ "Prefer dark mode" off: with no flag the same white page must
     render light, proving the dark result above is caused by the flag
     and not the harness."""
-    luminance = _mean_center_luminance([])
+    luminance = _mean_center_luminance(
+        browser_type, browser_type_launch_args, []
+    )
     assert luminance > LIGHT_THRESHOLD, (
         'expected a light render without the force-dark flag, '
         f'got mean luminance {luminance:.1f}'

--- a/tests/test_webview_dark_mode.py
+++ b/tests/test_webview_dark_mode.py
@@ -77,7 +77,7 @@ def _mean_center_luminance(extra_args: list[str]) -> float:
     centre = image.crop(
         (width // 4, height // 4, 3 * width // 4, 3 * height // 4)
     )
-    pixels = list(centre.getdata())
+    pixels: list[int] = list(centre.getdata())
     return sum(pixels) / len(pixels)
 
 

--- a/tests/test_webview_dark_mode.py
+++ b/tests/test_webview_dark_mode.py
@@ -1,0 +1,104 @@
+"""Integration coverage for the "Prefer dark mode" setting.
+
+The setting is realised entirely inside the C++ webview: when the
+operator enables it, the Python viewer exports
+``ANTHIAS_PREFER_DARK_MODE=1`` (see ``_build_webview_env`` in
+``src/anthias_viewer/__init__.py``) and ``applyDarkModePreference`` in
+``src/anthias_webview/src/main.cpp`` translates that into the Chromium
+switch ``--blink-settings=forceDarkModeEnabled=true`` before QtWebEngine
+boots its Chromium context.
+
+These tests pin the behaviour of that exact switch by driving Chromium —
+the same Blink engine QtWebEngine embeds — headless, rendering a plain
+white page, screenshotting it, and asserting on the average pixel
+luminance: dark with the flag, light without it. Running the full
+AnthiasViewer binary end-to-end (offscreen QPA + screenshot) belongs on
+a real testbed, not CI; this validates the engine-level mechanism the
+device relies on.
+
+The flag literal below is duplicated from main.cpp on purpose — keep the
+two in sync; the test fails loudly if Chromium ever stops honouring it.
+"""
+
+import io
+
+import pytest
+from PIL import Image
+from playwright.sync_api import sync_playwright
+
+# Must match applyDarkModePreference() in src/anthias_webview/src/main.cpp.
+FORCE_DARK_FLAG = '--blink-settings=forceDarkModeEnabled=true'
+
+# A deliberately light page: a pure-white viewport with no
+# ``prefers-color-scheme`` hints, so Chromium's force-dark feature has
+# something to invert and the no-flag baseline stays bright.
+WHITE_PAGE = (
+    '<!doctype html><html><head><meta charset="utf-8">'
+    '<style>html,body{margin:0;padding:0;height:100%;'
+    'background:#ffffff;color:#000;}</style></head>'
+    '<body><div style="width:100vw;height:100vh;"></div></body></html>'
+)
+
+# Pure white renders at luminance ~255; Chromium force-darkens it to a
+# near-black canvas (~#121212). The thresholds leave a wide margin either
+# side of the midpoint so anti-aliasing or a future engine tweak to the
+# exact dark shade can't flip the result.
+LIGHT_THRESHOLD = 200
+DARK_THRESHOLD = 120
+
+
+def _mean_center_luminance(extra_args: list[str]) -> float:
+    """Render the white page in headless Chromium and return the mean
+    luminance (0-255) of the centre of the screenshot.
+
+    Cropping to the centre quarter avoids any window-chrome or
+    scrollbar pixels skewing a full-frame average.
+    """
+    with sync_playwright() as p:
+        browser = p.chromium.launch(
+            # --no-sandbox mirrors the suite-wide launch override in
+            # conftest.py: the test container runs as root, where
+            # Chromium's setuid sandbox refuses to start.
+            args=['--no-sandbox', '--hide-scrollbars', *extra_args],
+        )
+        try:
+            page = browser.new_page(viewport={'width': 400, 'height': 300})
+            page.set_content(WHITE_PAGE, wait_until='load')
+            # Force-dark is applied during paint; give the compositor a
+            # beat so the screenshot captures the darkened frame rather
+            # than the initial white flash.
+            page.wait_for_timeout(300)
+            png = page.screenshot()
+        finally:
+            browser.close()
+
+    image = Image.open(io.BytesIO(png)).convert('L')
+    width, height = image.size
+    centre = image.crop(
+        (width // 4, height // 4, 3 * width // 4, 3 * height // 4)
+    )
+    pixels = list(centre.getdata())
+    return sum(pixels) / len(pixels)
+
+
+@pytest.mark.integration
+def test_force_dark_flag_renders_web_page_dark() -> None:
+    """ "Prefer dark mode" on: the Chromium switch the webview injects
+    must darken an otherwise-white page."""
+    luminance = _mean_center_luminance([FORCE_DARK_FLAG])
+    assert luminance < DARK_THRESHOLD, (
+        f'expected a dark render with {FORCE_DARK_FLAG}, '
+        f'got mean luminance {luminance:.1f}'
+    )
+
+
+@pytest.mark.integration
+def test_without_flag_web_page_stays_light() -> None:
+    """ "Prefer dark mode" off: with no flag the same white page must
+    render light, proving the dark result above is caused by the flag
+    and not the harness."""
+    luminance = _mean_center_luminance([])
+    assert luminance > LIGHT_THRESHOLD, (
+        'expected a light render without the force-dark flag, '
+        f'got mean luminance {luminance:.1f}'
+    )


### PR DESCRIPTION
### Issues Fixed

No associated issue. Adds a requested **Prefer dark mode** setting that instructs the Qt webview to render web page assets in dark mode.

### Description

Adds a "Prefer dark mode" toggle to **Settings**. The dark-mode realization lives in the C++ webview, which is where it belongs; Python only owns the setting and passes the preference down.

- **Webview (`src/anthias_webview/src/main.cpp`)** — new `applyDarkModePreference()` reads the `ANTHIAS_PREFER_DARK_MODE` env var and injects `--blink-settings=forceDarkModeEnabled=true` into `QTWEBENGINE_CHROMIUM_FLAGS` before QtWebEngine boots its Chromium context. Using the Blink switch keeps one code path across **Qt5 (Pi 1-4)** and **Qt6 (Pi 5/x86)** with no version macro — it sets the same flag `QWebEngineSettings::ForceDarkMode` toggles on Qt 6.7+. Dark-aware sites use their own dark theme (`prefers-color-scheme: dark`); the rest are auto-darkened.
- **Viewer** — `_build_webview_env()` exports the env var on every board; a toggle triggers a webview respawn (reusing the existing rotation-bounce handoff) so it takes effect immediately.
- **Server** — wired through the settings page, `page_context`, the form POST, and the v2 `device_settings` API (GET + PATCH).

**Validated on a Pi 5 testbed (full integrated stack):**

| Setting | `AnthiasViewer` env | Chromium renderers with `--blink-settings=forceDarkModeEnabled=true` |
|---|---|---|
| on | `ANTHIAS_PREFER_DARK_MODE=1` | 2 (`type=renderer`) |
| off | unset | 0 (renderer still present, just not dark) |

The webview C++ change was also compile-checked against the real Qt6 WebEngine headers (`g++ -Wall -Wextra`, clean).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices. (Pi 5 testbed: deployed the full arm64 viewer image and verified the setting→env→Chromium flag chain on/off.)
- [ ] I have tested my changes for x86 devices. (x86 testbed was unavailable; the webview was compile-checked on native amd64 but not runtime-tested on an x86 device.)
- [ ] I added a documentation for the changes I have made (when necessary). (The setting carries an inline UI hint; no separate docs needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)