### PR TITLE
fix(balena): add missing device types to unpin fleet map

### DIFF
--- a/bin/balena_unpin_devices.py
+++ b/bin/balena_unpin_devices.py
@@ -111,9 +111,11 @@ FLEETS = [
 FLEET_DEVICE_TYPE = {
     'screenly_ose/anthias-pi2': 'raspberry-pi2',
     'screenly_ose/anthias-pi3': 'raspberrypi3',
+    'screenly_ose/anthias-pi3-64': 'raspberrypi3-64',
     'screenly_ose/anthias-pi4': 'raspberrypi4-64',
     'screenly_ose/anthias-pi5': 'raspberrypi5',
     'screenly_ose/anthias-x86': 'generic-amd64',
+    'screenly_ose/anthias-rockpi4': 'rockpi-4b-rk3399',
 }
 
 KEEP_PINNED_TAG = 'anthias_keep_pinned'


### PR DESCRIPTION
### Issues Fixed

The scheduled **Balena unpin devices** workflow has been failing (exit 1). Example run: actions/runs/27294787701. The job ended with `errors=2`:

```
! unknown device type for screenly_ose/anthias-pi3-64
! unknown device type for screenly_ose/anthias-rockpi4
```

### Description

`bin/balena_unpin_devices.py` iterates every fleet in `FLEETS` (7 entries), but its `FLEET_DEVICE_TYPE` map only had 5 — the two newer fleets (`anthias-pi3-64`, `anthias-rockpi4`) were missing. Each fell into the `! unknown device type` branch, counted as an error, and the run exited 1.

The map had drifted from its sibling `bin/balena_fleet_maintenance.py` (which already has all 7), despite the in-file comment saying they must stay in sync.

Fix: add the two missing entries, copying the exact device-type slugs from `balena_fleet_maintenance.py`:

- `screenly_ose/anthias-pi3-64` -> `raspberrypi3-64`
- `screenly_ose/anthias-rockpi4` -> `rockpi-4b-rk3399`

Verified locally with a dry-run against the live balena API: both fleets now resolve their device type and target OS/supervisor, and the run finishes with `errors=0` (exit 0). `ruff check` and `ruff format --check` pass.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
