### PR TITLE
fix(viewer): detect DB changes under WAL so new assets load

### DIFF
--- a/src/anthias_viewer/scheduling.py
+++ b/src/anthias_viewer/scheduling.py
@@ -230,8 +230,28 @@ class Scheduler:
         )
 
     def get_db_mtime(self) -> float:
-        # get database file last modification time
-        try:
-            return path.getmtime(settings['database'])
-        except (OSError, TypeError):
+        # Newest mtime across the SQLite database and its WAL sidecars.
+        #
+        # Since the DB is opened with journal_mode=WAL (#3015), commits
+        # are written to ``anthias.db-wal`` and ``anthias.db-shm``; the
+        # main ``anthias.db`` file's mtime stays frozen until a (rare)
+        # checkpoint. Stat'ing only the main file therefore never sees
+        # an asset add/edit, so refresh_playlist() never reloads — most
+        # visibly, the first asset on a fresh install never displays
+        # (its empty playlist has no deadline fallback either). Take the
+        # max over all three so a write bumps the value regardless of
+        # journal mode: WAL commits move ``-wal``/``-shm``, and a
+        # checkpoint moves the main file.
+        database = settings['database']
+        if not database:
             return 0
+
+        newest = 0.0
+        for suffix in ('', '-wal', '-shm'):
+            try:
+                mtime = path.getmtime(database + suffix)
+            except OSError:
+                continue
+            if mtime > newest:
+                newest = mtime
+        return newest

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -211,6 +211,32 @@ def test_check_get_db_mtime(restore_shuffle_setting: None) -> None:
 
 
 @pytest.mark.django_db
+def test_get_db_mtime_tracks_wal_sidecar(
+    restore_shuffle_setting: None,
+) -> None:
+    # Under journal_mode=WAL (#3015) commits land in the -wal/-shm
+    # sidecars while the main DB file's mtime stays frozen. get_db_mtime
+    # must surface the newer sidecar mtime, otherwise refresh_playlist
+    # never reloads and the first asset on a fresh install never shows
+    # (issue #3061).
+    wal_path = FAKE_DB_PATH + '-wal'
+    original_database = settings['database']
+    try:
+        settings['database'] = FAKE_DB_PATH
+        with open(FAKE_DB_PATH, 'a'):
+            os.utime(FAKE_DB_PATH, (1000, 1000))
+        with open(wal_path, 'a'):
+            os.utime(wal_path, (2000, 2000))
+
+        # The newer -wal write wins over the stale main-file mtime.
+        assert Scheduler().get_db_mtime() == 2000
+    finally:
+        settings['database'] = original_database
+        if os.path.exists(wal_path):
+            os.remove(wal_path)
+
+
+@pytest.mark.django_db
 def test_playlist_should_be_updated_after_deadline_reached(
     restore_shuffle_setting: None,
 ) -> None:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -213,18 +213,21 @@ def test_check_get_db_mtime(restore_shuffle_setting: None) -> None:
 @pytest.mark.django_db
 def test_get_db_mtime_tracks_wal_sidecar(
     restore_shuffle_setting: None,
+    tmp_path: Any,
 ) -> None:
     # Under journal_mode=WAL (#3015) commits land in the -wal/-shm
     # sidecars while the main DB file's mtime stays frozen. get_db_mtime
     # must surface the newer sidecar mtime, otherwise refresh_playlist
     # never reloads and the first asset on a fresh install never shows
-    # (issue #3061).
-    wal_path = FAKE_DB_PATH + '-wal'
+    # (issue #3061). Uses a unique tmp_path dir so the -wal sidecar can't
+    # leak into test_check_get_db_mtime under `pytest -n auto`.
+    db_path = str(tmp_path / 'anthias.db')
+    wal_path = db_path + '-wal'
     original_database = settings['database']
     try:
-        settings['database'] = FAKE_DB_PATH
-        with open(FAKE_DB_PATH, 'a'):
-            os.utime(FAKE_DB_PATH, (1000, 1000))
+        settings['database'] = db_path
+        with open(db_path, 'a'):
+            os.utime(db_path, (1000, 1000))
         with open(wal_path, 'a'):
             os.utime(wal_path, (2000, 2000))
 
@@ -232,8 +235,6 @@ def test_get_db_mtime_tracks_wal_sidecar(
         assert Scheduler().get_db_mtime() == 2000
     finally:
         settings['database'] = original_database
-        if os.path.exists(wal_path):
-            os.remove(wal_path)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

On a freshly-flashed x86 testbed running `master`, adding the **first** asset left the viewer stuck on the standby screen, logging `Playlist is empty` forever — even though the asset was enabled, active, and visible to both the server and the viewer via the ORM. More broadly, the viewer's polling-based playlist refresh stopped detecting asset edits.

## Root cause

The viewer decides when to reload its playlist by polling the database file's mtime, stat'ing **only the main `anthias.db` file**:

```python
def get_db_mtime(self) -> float:
    try:
        return path.getmtime(settings['database'])
    except (OSError, TypeError):
        return 0
```

Since #3015 the DB is opened with `PRAGMA journal_mode=WAL`. Under WAL, commits are written to the `anthias.db-wal` sidecar (and update `anthias.db-shm`); the **main file's mtime stays frozen** until a checkpoint, which during normal operation is infrequent. So `get_db_mtime()` never advanced and `refresh_playlist()` never reloaded.

The fallbacks don't save it: an empty starting playlist yields a `None` deadline (`_compute_deadline` returns `None` with no candidates), so the deadline path can't recover the first asset; and for non-empty playlists the deadline is the soonest `end_date`, typically far in the future.

This is a regression from #3015 — the viewer's change-detection wasn't updated for WAL's sidecar files.

## Fix

Make `get_db_mtime()` WAL-aware: take the newest mtime across `anthias.db`, `anthias.db-wal`, and `anthias.db-shm`. WAL commits move the sidecars and a checkpoint moves the main file, so the value advances on every write regardless of journal mode. This keeps the existing cheap filesystem-stat design (no per-loop DB query); `PRAGMA data_version` was considered but rejected for that reason.

## Testing

- New regression test `test_get_db_mtime_tracks_wal_sidecar`: a write touching only the `-wal` sidecar is now detected.
- Full non-integration suite green (1087 passed).
- Verified live on the x86 testbed: before the fix, `touch ~/.anthias/anthias.db` was required to make the first asset appear; with WAL-aware detection the viewer picks it up on its own.

Fixes #3061