### PR TITLE
fix(install): accept pi3-64 in Ansible playbook validation

### DIFF
--- a/ansible/roles/system/tasks/docker.yml
+++ b/ansible/roles/system/tasks/docker.yml
@@ -32,6 +32,7 @@
       x86: amd64
       pi5: arm64
       pi4-64: arm64
+      pi3-64: arm64
       pi3: armhf
       pi2: armhf
       arm64: arm64
@@ -108,7 +109,7 @@
     # authoritative discriminator and is validated upstream in
     # ansible/site.yml's pre_tasks.
     device_is_pi: &is_pi >-
-      {{ device_type in ['pi2', 'pi3', 'pi4-64', 'pi5'] }}
+      {{ device_type in ['pi2', 'pi3', 'pi3-64', 'pi4-64', 'pi5'] }}
 
 - name: Ensure Anthias user is in required groups
   ansible.builtin.user:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -16,11 +16,11 @@
           - anthias_user | length > 0
           - anthias_branch | length > 0
           - device_type | length > 0
-          - device_type in ['pi2', 'pi3', 'pi4-64', 'pi5', 'x86', 'arm64']
+          - device_type in ['pi2', 'pi3', 'pi3-64', 'pi4-64', 'pi5', 'x86', 'arm64']
         fail_msg: >-
           Required environment variables missing or invalid.
           USER must be set; DEVICE_TYPE must be one of
-          pi2, pi3, pi4-64, pi5, x86, arm64.
+          pi2, pi3, pi3-64, pi4-64, pi5, x86, arm64.
 
   roles:
     - system


### PR DESCRIPTION
## Problem

A user reported that installing Anthias v2026.6.3 on a Raspberry Pi 3 B+ stops halfway with:

> Required environment variables missing or invalid. USER must be set; DEVICE_TYPE must be one of pi2, pi3, pi4-64, pi5, x86, arm64.

The install aborts at the Ansible playbook's first pre-task (right after "Gathering Facts"), before any real work runs. Reported at forums.screenly.io/t/anthias-v2026-6-3-installation-stops-halfway-on-pi3-b/6716.

## Root cause

A Pi 3 on a **64-bit OS** is detected as `DEVICE_TYPE=pi3-64`. Both `bin/install.sh::set_device_type` and `bin/upgrade_containers.sh` correctly emit `pi3-64`, the docker-build workflow publishes `latest-pi3-64` images, and the viewer/processing code all handle `pi3-64`. But the Ansible side was never updated to accept it:

1. **`ansible/site.yml`** — the `pre_tasks` validation assertion only allowed `pi2, pi3, pi4-64, pi5, x86, arm64`. A 64-bit Pi 3 fails this assertion immediately. This is the exact error the user hit.
2. **`ansible/roles/system/tasks/docker.yml`** — `docker_arch_by_device_type` is exhaustive-by-design (raises on an unmapped key). `pi3-64` had no entry, so even past the assertion it would have crashed resolving the dpkg architecture. Added `pi3-64: arm64`.
3. **`ansible/roles/system/tasks/docker.yml`** — `device_is_pi` omitted `pi3-64`, which would have dropped the `gpio` group on a board that is in fact a Pi.

A 32-bit-OS Pi 3 (`pi3`) was unaffected, which is why this slipped through.

## Fix

Add `pi3-64` to all three lists. No behavioural change for any other board.

## Testing

- `python3 -c "import yaml; ..."` parses both edited YAML files cleanly.
- Verified `pi3-64` is the value emitted by `set_device_type`/`upgrade_containers.sh` on aarch64 Pi 3 and that `latest-pi3-64` images are produced by the docker-build workflow, so the rendered compose image tag (`anthias-server:latest-pi3-64`) resolves.

## E2E

Not run on hardware (no 64-bit Pi 3 testbed in the loop). The change is a validation-list addition on a code path already exercised by every other board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)