### PR TITLE
fix(sentry): don't report settings-save input validation as errors

### DIFF
--- a/src/anthias_server/api/tests/test_v2_endpoints.py
+++ b/src/anthias_server/api/tests/test_v2_endpoints.py
@@ -612,3 +612,57 @@ def test_display_power_returns_503_when_no_cec_adapter(
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     set_display_power_mock.assert_not_called()
     assert 'adapter' in response.data['message']
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v2.settings')
+def test_patch_device_settings_password_mismatch_is_not_logged_as_error(
+    settings_mock: Any,
+    api_client: APIClient,
+    device_settings_url: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A mismatched-password PATCH is operator input validation, not a
+    server bug. It must return 400 with the operator-friendly message
+    AND be logged at WARNING (no traceback) so Sentry's logging
+    integration doesn't turn it into an event (ANTHIAS-3D)."""
+    import logging
+
+    user = _make_operator(username='testuser', pwd=_FIXTURE_PASSWORD)
+    api_client.force_authenticate(user=user)
+
+    settings_mock.load = mock.MagicMock()
+    settings_mock.save = mock.MagicMock()
+    settings_mock.__getitem__.side_effect = lambda key: {
+        'auth_backend': 'auth_basic',
+    }[key]
+    settings_mock.__setitem__ = mock.MagicMock()
+
+    data = {
+        'auth_backend': 'auth_basic',
+        'current_password': _FIXTURE_PASSWORD,
+        'username': 'testuser',
+        'password': 'brand-new-password',  # NOSONAR
+        'password_2': 'does-not-match',  # NOSONAR
+    }
+
+    with caplog.at_level(logging.WARNING):
+        response = api_client.patch(
+            device_settings_url, data=data, format='json'
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    # The operator-friendly message is echoed, not a generic string.
+    assert 'do not match' in response.data['error']
+    # Nothing was persisted — the validation aborted before save().
+    settings_mock.save.assert_not_called()
+
+    save_records = [
+        r for r in caplog.records if 'Settings save' in r.getMessage()
+    ]
+    assert save_records, 'expected a log line for the rejected save'
+    # The rejection logs at WARNING, never ERROR, and carries no
+    # exc_info — an ERROR record (logger.exception) is what becomes a
+    # Sentry event.
+    assert all(r.levelno == logging.WARNING for r in save_records)
+    assert all(r.exc_info is None for r in save_records)

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -31,6 +31,7 @@ from anthias_server.api.helpers import (
     save_active_assets_ordering,
 )
 from anthias_server.lib.auth import (
+    AuthSettingsError,
     apply_auth_settings,
     operator_username,
 )
@@ -696,6 +697,16 @@ class DeviceSettingsViewV2(APIView):
             publisher.send_to_viewer('reload')
 
             return Response({'message': 'Settings were successfully saved.'})
+        except AuthSettingsError as exc:
+            # Operator input the client should have caught — mismatched
+            # or incorrect password, a taken username, a too-weak
+            # password. Expected and self-correcting, so log at warning
+            # (no traceback) and echo the operator-friendly message
+            # instead of logger.exception + a generic error: the
+            # ERROR-level record is what Sentry's logging integration
+            # turns into an event (ANTHIAS-3D).
+            logger.warning('Settings save rejected: %s', exc)
+            return Response({'error': str(exc)}, status=400)
         except Exception:
             logger.exception('Settings save failed')
             return Response(

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -31,6 +31,7 @@ from anthias_server.app.models import clamp_refresh_interval
 from anthias_server.celery_tasks import reboot_anthias, shutdown_anthias
 from anthias_server.lib import backup_helper, diagnostics
 from anthias_server.lib.auth import (
+    AuthSettingsError,
     apply_auth_settings,
     authorized,
 )
@@ -1265,6 +1266,15 @@ def settings_save(request: HttpRequest) -> HttpResponse:
         ViewerPublisher.get_instance().send_to_viewer('reload')
 
         messages.success(request, 'Settings were successfully saved.')
+    except AuthSettingsError as exc:
+        # Operator input the form should have caught — mismatched or
+        # incorrect password, a taken username, a too-weak password.
+        # Expected, self-correcting, and already surfaced to the
+        # operator, so log at warning (no traceback) instead of
+        # logger.exception; the ERROR-level record is what Sentry's
+        # logging integration turns into an event (ANTHIAS-3D).
+        logger.warning('Settings save rejected: %s', exc)
+        messages.error(request, str(exc) or 'Failed to save settings.')
     except Exception as exc:
         logger.exception('Settings save failed')
         messages.error(request, str(exc) or 'Failed to save settings.')

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -121,7 +121,22 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
       * ``asyncio.CancelledError`` — an HTTP client hanging up
         mid-request under ASGI; Django/uvicorn cancel the handler by
         design (Sentry ANTHIAS-N).
+      * ``AuthSettingsError`` — an operator-facing validation failure
+        from the settings-save flow (mismatched/incorrect password,
+        a taken username, a too-weak password). It is expected input
+        validation, not a bug: the message is already shown to the
+        operator and the next attempt self-corrects. The save views
+        now log it at warning rather than ``logger.exception`` so it
+        never reaches the logging integration in the first place; this
+        is the backstop for any other path that logs it as an error
+        (Sentry ANTHIAS-3D).
     """
+    # Imported lazily — this runs only when an event is about to send,
+    # well after Django is configured, and avoids an import cycle at
+    # settings-module load. ``lib.auth`` only pulls stdlib at import
+    # time, so the cost is a cached module lookup.
+    from anthias_server.lib.auth import AuthSettingsError
+
     exc_info = hint.get('exc_info')
     if not exc_info:
         return event
@@ -133,6 +148,8 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
         if isinstance(exc, asyncio.CancelledError):
             return None
         if isinstance(exc, transient_redis):
+            return None
+        if isinstance(exc, AuthSettingsError):
             return None
     return event
 

--- a/src/anthias_server/lib/auth.py
+++ b/src/anthias_server/lib/auth.py
@@ -69,7 +69,15 @@ import logging
 import os.path
 import re
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, ParamSpec, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ParamSpec,
+    TypeAlias,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -82,7 +90,11 @@ if TYPE_CHECKING:
     # Request wraps the underlying Django request and delegates
     # ``.user``, so the body of these helpers handles both shapes
     # the same way; the annotation just needs to admit either one.
-    AnyRequest = HttpRequest | DRFRequest
+    # Spelled as an explicit ``TypeAlias`` so mypy always resolves the
+    # forward-ref ``'AnyRequest'`` as a type rather than a module
+    # variable — the implicit form flipped to "not valid as a type"
+    # once settings.py started importing this module (ANTHIAS-3D).
+    AnyRequest: TypeAlias = HttpRequest | DRFRequest
 
 P = ParamSpec('P')
 R = TypeVar('R')

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -134,6 +134,20 @@ class TestBeforeSendTransientNoise:
         hint = self._hint_for(asyncio.CancelledError())
         assert _sentry_before_send({'event_id': 'x'}, hint) is None
 
+    def test_drops_auth_settings_error(self) -> None:
+        # AuthSettingsError is operator-facing input validation from
+        # the settings-save flow (mismatched password, taken username,
+        # weak password), not a bug. The save views log it at warning
+        # so it never reaches the logging integration; this is the
+        # backstop for any other path (Sentry ANTHIAS-3D).
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+        from anthias_server.lib.auth import AuthSettingsError
+
+        hint = self._hint_for(AuthSettingsError('New passwords do not match!'))
+        assert _sentry_before_send({'event_id': 'x'}, hint) is None
+
     def test_keeps_ordinary_exceptions(self) -> None:
         from anthias_server.django_project.settings import (
             _sentry_before_send,


### PR DESCRIPTION
### Issues Fixed

Sentry **ANTHIAS-3D** (`AuthSettingsError: New passwords do not match!`, culprit `/settings/save/`).

### Description

`AuthSettingsError` is operator **input validation** from the settings-save flow — a mismatched or incorrect password, a username already taken, or a password that fails the strength validators. It is not a bug: the message is already shown to the operator and the next attempt self-corrects.

Both settings-save surfaces (the HTML view and the DRF v2 view) caught it under a broad `except Exception` followed by `logger.exception(...)`. Sentry's logging integration turns that ERROR-level record into an event, so an operator typo pages us.

This fixes it at the source and adds a backstop:

- **Catch `AuthSettingsError` ahead of the generic handler** in both `settings_save` (HTML) and `DeviceSettingsViewV2.patch` (DRF). Log it at `warning` (no traceback) instead of `logger.exception` — a WARNING record never becomes a Sentry event. The DRF view now also echoes the operator-friendly message instead of burying it under a generic "An error occurred while saving settings."
- **Add `AuthSettingsError` to the `before_send` drop filter** as a backstop for any other code path that might log it as an error — this is the "ignore for similar things" net.
- **Spell `auth.py`'s `AnyRequest` as an explicit `TypeAlias`.** The implicit `AnyRequest = HttpRequest | DRFRequest` form flipped to mypy `Variable … is not valid as a type` once `settings.py` started importing the module for the filter; the explicit alias resolves the forward-ref robustly regardless of import order.
- **Regression tests** for the `before_send` drop and for the warning-level, no-traceback v2 rejection (asserts 400 + the specific message, nothing persisted, and no ERROR/`exc_info` record).

This mirrors the same "expected transient/expected state, not a bug" treatment the `before_send` filter already gives redis blips and client disconnects.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)