### PR TITLE
fix(build): replace retired Linaro armhf toolchain with Debian's

### DIFF
--- a/docker/Dockerfile.qt5-webview-builder.j2
+++ b/docker/Dockerfile.qt5-webview-builder.j2
@@ -151,10 +151,13 @@ USER root
 # stage must run on x86_64. CI is amd64; arm64 build hosts (e.g. Apple
 # Silicon) will execute this stage under QEMU.
 #
-# Host build tools only. The webview app builds against the pre-built
-# Qt 5 toolchain, so we don't need the Qt 5 / QtWebEngine source-build
-# stack (chromium's bison/flex/gperf/ninja/gyp/python2.7). python3 is
-# required for sysroot-relativelinks.py.
+# Host build tools plus the armhf cross-toolchain. The webview app
+# builds against the pre-built Qt 5 toolchain, so we don't need the
+# Qt 5 / QtWebEngine source-build stack (chromium's
+# bison/flex/gperf/ninja/gyp/python2.7). python3 is required for
+# sysroot-relativelinks.py; crossbuild-essential-armhf provides the
+# arm-linux-gnueabihf- cross-compiler the Qt 5 qmake.conf invokes (see
+# the symlink step below).
 {% if disable_cache_mounts %}
 RUN \
 {% else %}
@@ -164,9 +167,9 @@ RUN --mount=type=cache,target=/var/cache/apt,id=qt5-host-apt,sharing=locked \
     apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
+        crossbuild-essential-armhf \
         curl \
-        python3 \
-        xz-utils
+        python3
 
 WORKDIR /build
 
@@ -189,19 +192,26 @@ COPY --from=qt5-sysroot /usr/share/pkgconfig/ /sysroot/usr/share/pkgconfig/
 
 RUN python3 /usr/local/bin/sysroot-relativelinks.py /sysroot
 
-# Linaro gcc-7.4.1 — hardcoded path matches the CROSS_COMPILE setting
-# baked into the Qt 5 toolchain's qmake.conf at original toolchain
-# build time (src/anthias_webview/build_qt5.sh
-# `-device-option CROSS_COMPILE=`).
-# SHA256-pinned: Linaro doesn't publish signed manifests for these
-# legacy 7.4 binaries, so the hash is the trust anchor.
-RUN mkdir -p /src && \
-    cd /src && \
-    curl --proto '=https' --tlsv1.2 -fsSL -o gcc-linaro.tar.xz \
-        https://releases.linaro.org/components/toolchain/binaries/7.4-2019.02/arm-linux-gnueabihf/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf.tar.xz && \
-    echo '3c951cf1941d0fa06d64cc0d5e88612b209d8123b273fa26c16d70bd7bc6b163  gcc-linaro.tar.xz' | sha256sum -c - && \
-    tar xf gcc-linaro.tar.xz && \
-    rm gcc-linaro.tar.xz
+# armhf cross-compiler. The pre-built Qt 5 toolchain's qmake.conf bakes
+# CROSS_COMPILE=/src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
+# (set in src/anthias_webview/build_qt5.sh at toolchain-build time), so
+# qmake invokes the cross-gcc from that exact path and prefix.
+#
+# We used to fetch Linaro's legacy gcc-7.4.1 tarball here, but Linaro
+# retired releases.linaro.org — the download now fails to connect and
+# broke every pi2/pi3 CI build (which froze the floating latest-* tags,
+# since publish-latest only advances on a fully green matrix). Use
+# Debian's own supported armhf cross-toolchain (crossbuild-essential-armhf,
+# installed above) and expose it under the legacy path the pinned
+# qmake.conf expects. The prefix is identical (arm-linux-gnueabihf-), so
+# the frozen Qt 5 artifact needs no rebuild, and the app still links
+# against the Raspbian /sysroot (-sysroot) so the target glibc is
+# unchanged.
+RUN mkdir -p /src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf/bin && \
+    for tool in /usr/bin/arm-linux-gnueabihf-*; do \
+        ln -s "$tool" \
+            "/src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf/bin/$(basename "$tool")"; \
+    done
 
 # Pre-built Qt 5 toolchain — pinned permanently to WebView-v2026.04.1
 # (Qt 5 is frozen for pi2/pi3). The qt5pi/ tree contains both host

--- a/docker/Dockerfile.qt5-webview-builder.j2
+++ b/docker/Dockerfile.qt5-webview-builder.j2
@@ -146,10 +146,11 @@ FROM --platform=linux/amd64 {{ base_image }}:{{ base_image_tag }} AS webview-bui
 
 USER root
 
-# Pinned to linux/amd64 (not $BUILDPLATFORM): the Linaro 7.4.1
-# cross-compiler downloaded below is the x86_64 host tarball, so this
-# stage must run on x86_64. CI is amd64; arm64 build hosts (e.g. Apple
-# Silicon) will execute this stage under QEMU.
+# Pinned to linux/amd64 (not $BUILDPLATFORM): the pre-built Qt 5
+# toolchain bundle ships an x86_64 host qmake under qt5pi/bin, and the
+# Debian armhf cross-compiler installed below is the x86_64-hosted
+# toolchain — so this stage must run on x86_64. CI is amd64; arm64
+# build hosts (e.g. Apple Silicon) will execute this stage under QEMU.
 #
 # Host build tools plus the armhf cross-toolchain. The webview app
 # builds against the pre-built Qt 5 toolchain, so we don't need the

--- a/src/anthias_webview/Dockerfile
+++ b/src/anthias_webview/Dockerfile
@@ -162,6 +162,7 @@ RUN apt-get update && \
         build-essential \
         ccache \
         cowsay \
+        crossbuild-essential-armhf \
         curl \
         flex \
         freetds-dev \

--- a/src/anthias_webview/build_qt5.sh
+++ b/src/anthias_webview/build_qt5.sh
@@ -33,16 +33,18 @@ if [ "${BUILD_WEBENGINE-x}" == "1" ]; then
 fi
 
 function fetch_cross_compile_tool () {
-    # The Raspberry Pi Foundation's cross compiling tools are too old so we need newer ones.
-    # References:
-    # * https://github.com/UvinduW/Cross-Compiling-Qt-for-Raspberry-Pi-4
-    # * https://releases.linaro.org/components/toolchain/binaries/latest-7/armv8l-linux-gnueabihf/
-    if [ ! -d "/src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf" ]; then
-        pushd /src/
-        wget -q https://releases.linaro.org/components/toolchain/binaries/7.4-2019.02/arm-linux-gnueabihf/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf.tar.xz
-        tar xf gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf.tar.xz
-        rm gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf.tar.xz
-        popd
+    # The Raspberry Pi Foundation's cross compiling tools are too old, so
+    # we use Debian's supported armhf cross-toolchain. (We previously
+    # fetched Linaro's gcc-7.4.1, but Linaro retired releases.linaro.org.)
+    # Expose it under the legacy gcc-linaro path so the CROSS_COMPILE
+    # baked into qmake.conf below keeps resolving. crossbuild-essential-armhf
+    # must be installed in the builder image (see ./Dockerfile).
+    local linaro_path="/src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf"
+    if [ ! -d "$linaro_path" ]; then
+        mkdir -p "$linaro_path/bin"
+        for tool in /usr/bin/arm-linux-gnueabihf-*; do
+            ln -s "$tool" "$linaro_path/bin/$(basename "$tool")"
+        done
     fi
 }
 

--- a/src/anthias_webview/build_qt5.sh
+++ b/src/anthias_webview/build_qt5.sh
@@ -37,15 +37,18 @@ function fetch_cross_compile_tool () {
     # we use Debian's supported armhf cross-toolchain. (We previously
     # fetched Linaro's gcc-7.4.1, but Linaro retired releases.linaro.org.)
     # Expose it under the legacy gcc-linaro path so the CROSS_COMPILE
-    # baked into qmake.conf below keeps resolving. crossbuild-essential-armhf
-    # must be installed in the builder image (see ./Dockerfile).
-    local linaro_path="/src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf"
-    if [ ! -d "$linaro_path" ]; then
-        mkdir -p "$linaro_path/bin"
-        for tool in /usr/bin/arm-linux-gnueabihf-*; do
-            ln -s "$tool" "$linaro_path/bin/$(basename "$tool")"
-        done
+    # baked into qmake.conf below keeps resolving.
+    if ! command -v arm-linux-gnueabihf-g++ >/dev/null 2>&1; then
+        echo "error: arm-linux-gnueabihf cross toolchain not found — " \
+             "install crossbuild-essential-armhf (see ./Dockerfile)." >&2
+        exit 1
     fi
+    # ln -sf (no -d skip) so reruns refresh the shim idempotently.
+    local linaro_path="/src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf"
+    mkdir -p "$linaro_path/bin"
+    for tool in /usr/bin/arm-linux-gnueabihf-*; do
+        ln -sf "$tool" "$linaro_path/bin/$(basename "$tool")"
+    done
 }
 
 function fetch_rpi_firmware () {


### PR DESCRIPTION
### Issues Fixed

The pi2/pi3 (armhf) image build has been failing on every push to master since 2026-06-10. The `qt5-webview-builder` stage downloads the Linaro `gcc-7.4.1` cross-compiler from `releases.linaro.org`, which Linaro has **retired** — the download now fails to connect (`curl: (7) Failed to connect ... releases.linaro.org`).

Because `publish-latest` only advances the floating `latest-<board>` tags once the **entire** build matrix is green, two dead 32-bit builds froze `latest-*` for every board. Users tracking `latest` (e.g. via `run_upgrade.sh`) stopped receiving any merged fixes — including the WAL playlist-reload fix (#3062), which is why that bug appeared to persist on `latest` even after it was merged.

### Description

- Drop the dead Linaro tarball download; install Debian's supported `crossbuild-essential-armhf` (gcc 14, **same `arm-linux-gnueabihf-` prefix**).
- Symlink it under the legacy `gcc-linaro-7.4.1-…` path that the frozen Qt 5 `qmake.conf` bakes into `CROSS_COMPILE`, so the pinned `WebView-v2026.04.1` artifact needs **no rebuild**. The app still links against the Raspbian `/sysroot` (`-sysroot`), so the target glibc is unchanged.
- Apply the same swap to the offline toolchain-rebuild path (`build_qt5.sh` + its `Dockerfile`) so the retired URL is gone everywhere.

Validated locally by building the **pi2 viewer image** end-to-end: `qmake`/`make` compile the webview sources and link `AnthiasViewer` against the pinned Qt 5 `.so` libs using the Debian cross-gcc, producing a valid `ELF 32-bit ARM EABI5 hardfloat` executable (`ld-linux-armhf.so.3`).

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

> Build-only change (armhf cross-toolchain). No Python/JS code paths affected. Validated by building the pi2 viewer image; not yet run on a physical pi2/pi3 device.