### PR TITLE
fix(server): classify RTSP/streaming URLs as streaming, not webpage

### DIFF
--- a/src/anthias_common/remote_video.py
+++ b/src/anthias_common/remote_video.py
@@ -230,9 +230,16 @@ def is_streaming_uri(uri: str) -> bool:
     """
     if not uri:
         return False
-    if _url_scheme(uri) in _STREAM_SCHEMES:
+    scheme = _url_scheme(uri)
+    if scheme in _STREAM_SCHEMES:
         return True
-    return _url_path_ext(uri) in _STREAM_MANIFEST_EXTS
+    # Manifests are HTTP-delivered (HLS/DASH); only treat a manifest
+    # extension as streaming over http(s). A ``file:///…/index.m3u8``
+    # (or any other scheme) is not a live stream and must not be
+    # classified as one.
+    if scheme in ('http', 'https'):
+        return _url_path_ext(uri) in _STREAM_MANIFEST_EXTS
+    return False
 
 
 def remote_video_destination_path(

--- a/src/anthias_common/remote_video.py
+++ b/src/anthias_common/remote_video.py
@@ -203,6 +203,31 @@ def is_downloadable_remote_video(uri: str) -> tuple[bool, str]:
     return _head_probe(uri)
 
 
+def is_streaming_uri(uri: str) -> bool:
+    """True when *uri* is a live stream the viewer plays directly via
+    its video pipeline rather than a downloadable file or a renderable
+    web page.
+
+    Covers both streaming-by-construction schemes (``rtsp://``,
+    ``rtmp://``, ``srt://``, ``udp://``, ``mms://``) and HTTP-delivered
+    streaming manifests (HLS ``.m3u8``, DASH ``.mpd``, legacy ``.m3u``,
+    Smooth Streaming ``.ism``). The create paths use this to stamp such
+    URIs as ``mimetype='streaming'`` so the viewer routes them to
+    ``view_video`` instead of loading them in QtWebEngine (which can't
+    open ``rtsp://`` and renders a manifest as plain text).
+
+    Shares the same scheme / extension sets as
+    ``is_downloadable_remote_video`` so the "leave the URI verbatim"
+    decision there and the "classify it as streaming" decision here can
+    never drift apart.
+    """
+    if not uri:
+        return False
+    if _url_scheme(uri) in _STREAM_SCHEMES:
+        return True
+    return _url_path_ext(uri) in _STREAM_MANIFEST_EXTS
+
+
 def remote_video_destination_path(
     asset_id: str,
     ext: str,

--- a/src/anthias_common/remote_video.py
+++ b/src/anthias_common/remote_video.py
@@ -58,8 +58,15 @@ _VIDEO_CONTAINER_EXTS = frozenset(
 # never rewrites these to a local download even when the URL path's
 # extension suggests a single file (``rtsp://host/stream.mp4`` is
 # still an RTSP session, not an HTTP MP4). The viewer plays them
-# through mpv's network stack as-is.
-_STREAM_SCHEMES = frozenset({'rtsp', 'rtmp', 'srt', 'udp', 'mms'})
+# through QtMultimedia's network stack as-is.
+#
+# ``rtmp`` is deliberately absent. Qt6's QMediaPlayer (FFmpeg backend)
+# can't open it: the backend sets a ``timeout`` AVFormatContext option
+# the rtmp protocol misreads as TCP *listen* mode, so the open fails
+# and the screen stays black. ``validate_url`` rejects ``rtmp://`` at
+# create time; keeping it out of this set too means ``is_streaming_uri``
+# never classifies a (legacy) rtmp row as a playable stream.
+_STREAM_SCHEMES = frozenset({'rtsp', 'srt', 'udp', 'mms'})
 
 # HTTP-delivered manifests that describe a stream rather than a single
 # downloadable file. ``.m3u8`` (HLS), ``.mpd`` (DASH), ``.m3u`` (legacy
@@ -175,9 +182,9 @@ def is_downloadable_remote_video(uri: str) -> tuple[bool, str]:
     Three-step decision:
 
     1. **Stream short-circuit** — non-http(s) streaming schemes
-       (``rtsp://``, ``rtmp://``, ``srt://``, ``udp://``, ``mms://``)
-       and manifest extensions (``.m3u8`` / ``.mpd`` / ...) never
-       download, no HEAD call.
+       (``rtsp://``, ``srt://``, ``udp://``, ``mms://``) and manifest
+       extensions (``.m3u8`` / ``.mpd`` / ...) never download, no HEAD
+       call.
     2. **Extension match** — the URL path's lowercase extension is in
        ``_VIDEO_CONTAINER_EXTS``: ``(True, ext)``, no HEAD call.
        Common path, zero network round-trips.
@@ -209,8 +216,8 @@ def is_streaming_uri(uri: str) -> bool:
     web page.
 
     Covers both streaming-by-construction schemes (``rtsp://``,
-    ``rtmp://``, ``srt://``, ``udp://``, ``mms://``) and HTTP-delivered
-    streaming manifests (HLS ``.m3u8``, DASH ``.mpd``, legacy ``.m3u``,
+    ``srt://``, ``udp://``, ``mms://``) and HTTP-delivered streaming
+    manifests (HLS ``.m3u8``, DASH ``.mpd``, legacy ``.m3u``,
     Smooth Streaming ``.ism``). The create paths use this to stamp such
     URIs as ``mimetype='streaming'`` so the viewer routes them to
     ``view_video`` instead of loading them in QtWebEngine (which can't

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -88,12 +88,18 @@ def validate_url(string: str) -> bool:
     True
     >>> validate_url("https://wireload.net/logo.png")
     True
+    >>> validate_url("rtsp://camera.local/stream")
+    True
+    >>> validate_url("rtmp://media.example.com/live")
+    False
     """
 
     checker = urlparse(string)
-    return bool(
-        checker.scheme in ('http', 'https', 'rtsp', 'rtmp') and checker.netloc
-    )
+    # rtmp is intentionally excluded: Qt6's QMediaPlayer (FFmpeg
+    # backend) can't open it — see remote_video._STREAM_SCHEMES — so
+    # accepting it would only let an operator add a stream that renders
+    # black on the screen.
+    return bool(checker.scheme in ('http', 'https', 'rtsp') and checker.netloc)
 
 
 def get_balena_supervisor_api_response(

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -214,7 +214,20 @@ def assets_create(request: HttpRequest) -> HttpResponse:
 
     uri = (request.POST.get('uri') or '').strip()
     if not uri or not validate_url(uri):
-        messages.error(request, 'Invalid URL.')
+        # RTMP is a well-formed URL, but Qt6's QMediaPlayer can't open
+        # it (the FFmpeg backend sets a `timeout` option the rtmp
+        # protocol misreads as TCP listen mode), so the stream would
+        # only ever render black. validate_url already rejects it;
+        # give the operator a clear reason and a working alternative
+        # rather than the generic "Invalid URL".
+        if uri and urlparse(uri).scheme.lower() == 'rtmp':
+            messages.error(
+                request,
+                'RTMP streams are not supported. '
+                'Use an RTSP, HLS, or DASH URL instead.',
+            )
+        else:
+            messages.error(request, 'Invalid URL.')
         return _asset_table_response(request)
 
     # Best-effort mimetype guess; default to webpage. Order matters:
@@ -222,9 +235,9 @@ def assets_create(request: HttpRequest) -> HttpResponse:
     #   1. YouTube first — its watch URLs end in `?v=…` not a video
     #      extension, so the file-extension heuristic below would
     #      otherwise classify them as a webpage.
-    #   2. Live streams (rtsp:// / rtmp:// schemes, HLS/DASH manifests)
-    #      next — these are streaming-by-construction regardless of the
-    #      URL's path extension (`rtsp://host/feed.mp4` is still an RTSP
+    #   2. Live streams (rtsp:// scheme, HLS/DASH manifests) next —
+    #      these are streaming-by-construction regardless of the URL's
+    #      path extension (`rtsp://host/feed.mp4` is still an RTSP
     #      session, not a downloadable MP4). They must land as
     #      `mimetype='streaming'` so the viewer routes them through
     #      view_video; classifying them as a webpage (the pre-#2818

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -202,6 +202,7 @@ def assets_create(request: HttpRequest) -> HttpResponse:
     queued to fetch the file. The "Processing" pill on the table row
     clears once the worker completes.
     """
+    from anthias_common.remote_video import is_streaming_uri
     from anthias_common.utils import validate_url
     from anthias_common.youtube import (
         dispatch_download,
@@ -216,13 +217,25 @@ def assets_create(request: HttpRequest) -> HttpResponse:
         messages.error(request, 'Invalid URL.')
         return _asset_table_response(request)
 
-    # Best-effort mimetype guess from extension; default to webpage.
-    # YouTube takes priority — its watch URLs end in `?v=…` not a
-    # video extension, so the file-extension heuristic below would
-    # otherwise classify them as a webpage.
+    # Best-effort mimetype guess; default to webpage. Order matters:
+    #
+    #   1. YouTube first — its watch URLs end in `?v=…` not a video
+    #      extension, so the file-extension heuristic below would
+    #      otherwise classify them as a webpage.
+    #   2. Live streams (rtsp:// / rtmp:// schemes, HLS/DASH manifests)
+    #      next — these are streaming-by-construction regardless of the
+    #      URL's path extension (`rtsp://host/feed.mp4` is still an RTSP
+    #      session, not a downloadable MP4). They must land as
+    #      `mimetype='streaming'` so the viewer routes them through
+    #      view_video; classifying them as a webpage (the pre-#2818
+    #      regression) makes QtWebEngine try to open the URL and the
+    #      stream never plays.
+    #   3. Extension heuristic last.
     is_youtube = is_youtube_url(uri)
     if is_youtube:
         mimetype = 'video'
+    elif is_streaming_uri(uri):
+        mimetype = 'streaming'
     else:
         mimetype = 'webpage'
         lower = uri.lower()
@@ -269,11 +282,22 @@ def assets_create(request: HttpRequest) -> HttpResponse:
             toast=('info', 'Downloading YouTube video…'),
         )
 
+    # Streams have no intrinsic length, so they reuse the dedicated
+    # `default_streaming_duration` window (how long each stream holds
+    # the screen before rotation) the same way the pre-#2818 React
+    # frontend did. Everything else gets the standard default. int()
+    # because `default_streaming_duration` is stored as a string in
+    # the config file (BigIntegerField on the model wants an int).
+    if mimetype == 'streaming':
+        duration = int(settings['default_streaming_duration'])
+    else:
+        duration = settings['default_duration']
+
     Asset.objects.create(
         name=uri,
         uri=uri,
         mimetype=mimetype,
-        duration=settings['default_duration'],
+        duration=duration,
         is_enabled=True,
         is_processing=False,
         play_order=play_order,

--- a/tests/test_remote_video.py
+++ b/tests/test_remote_video.py
@@ -131,7 +131,10 @@ def test_classify_streaming_scheme_with_mp4_path_returns_stream() -> None:
         'udp://stream.example.test:1234',
         'mms://media.example.com/live',
         'https://cdn.example.com/live/index.m3u8',  # HLS over http(s)
-        'http://example.com/stream.mpd',  # DASH over http(s)
+        # DASH over http (not https) is deliberate here: it exercises
+        # the http manifest branch of is_streaming_uri. Test fixture,
+        # no real traffic.
+        'http://example.com/stream.mpd',  # NOSONAR S5332
         'https://example.com/legacy.m3u',
         'https://example.com/smooth.ism',
         'https://cdn.example.com/live/index.m3u8?token=abc',  # query

--- a/tests/test_remote_video.py
+++ b/tests/test_remote_video.py
@@ -21,6 +21,7 @@ import requests
 
 from anthias_common.remote_video import (
     is_downloadable_remote_video,
+    is_streaming_uri,
     remote_video_destination_path,
 )
 from anthias_server.settings import AnthiasSettings
@@ -113,6 +114,47 @@ def test_classify_streaming_scheme_with_mp4_path_returns_stream() -> None:
     assert ok is False
     assert ext == ''
     head.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# is_streaming_uri — the create-path classifier that maps stream URIs
+# to mimetype='streaming' (counterpart to is_downloadable_remote_video)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'uri',
+    [
+        'rtsp://camera.local/feed',
+        'rtsp://camera/feed.mp4',  # scheme wins over path extension
+        'rtmp://media.example.com/live',
+        'srt://stream.example.com:9000',
+        'udp://stream.example.test:1234',
+        'mms://media.example.com/live',
+        'https://cdn.example.com/live/index.m3u8',  # HLS over http(s)
+        'http://example.com/stream.mpd',  # DASH over http(s)
+        'https://example.com/legacy.m3u',
+        'https://example.com/smooth.ism',
+        'https://cdn.example.com/live/index.m3u8?token=abc',  # query
+    ],
+)
+def test_is_streaming_uri_true_for_streams(uri: str) -> None:
+    assert is_streaming_uri(uri) is True
+
+
+@pytest.mark.parametrize(
+    'uri',
+    [
+        '',
+        'https://example.com/clip.mp4',  # downloadable video, not a stream
+        'https://example.com/photo.jpg',
+        'https://dashboard.example.com/',  # plain web page
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'file:///tmp/clip.mp4',
+    ],
+)
+def test_is_streaming_uri_false_for_non_streams(uri: str) -> None:
+    assert is_streaming_uri(uri) is False
 
 
 def test_classify_non_http_scheme_returns_stream() -> None:

--- a/tests/test_remote_video.py
+++ b/tests/test_remote_video.py
@@ -153,6 +153,10 @@ def test_is_streaming_uri_true_for_streams(uri: str) -> None:
         # rtmp is NOT a playable stream — Qt6 can't open it, so it is
         # excluded from _STREAM_SCHEMES and rejected by validate_url.
         'rtmp://media.example.com/live',
+        # A manifest extension over a non-http(s) scheme is not a live
+        # stream — manifests are HTTP-delivered (HLS/DASH).
+        'file:///media/playlists/index.m3u8',
+        'file:///media/manifest.mpd',
     ],
 )
 def test_is_streaming_uri_false_for_non_streams(uri: str) -> None:

--- a/tests/test_remote_video.py
+++ b/tests/test_remote_video.py
@@ -89,16 +89,16 @@ def test_classify_streaming_manifest_extensions_return_stream(
     'uri',
     [
         'rtsp://camera.local/feed',
-        'rtmp://media.example.com/live',
         'srt://stream.example.com:9000',
         'udp://stream.example.test:1234',
         'mms://media.example.com/live',
     ],
 )
 def test_classify_streaming_schemes_return_stream(uri: str) -> None:
-    """RTSP / RTMP / SRT / UDP / MMS are streaming-by-construction,
-    even if the URL's path happens to end in ``.mp4``. The viewer
-    plays them live via mpv's network stack."""
+    """RTSP / SRT / UDP / MMS are streaming-by-construction, even if
+    the URL's path happens to end in ``.mp4``. The viewer plays them
+    live via QtMultimedia's network stack. (rtmp is excluded — Qt6
+    can't open it; see _STREAM_SCHEMES.)"""
     with mock.patch('anthias_common.remote_video._session.head') as head:
         ok, ext = is_downloadable_remote_video(uri)
     assert ok is False
@@ -127,7 +127,6 @@ def test_classify_streaming_scheme_with_mp4_path_returns_stream() -> None:
     [
         'rtsp://camera.local/feed',
         'rtsp://camera/feed.mp4',  # scheme wins over path extension
-        'rtmp://media.example.com/live',
         'srt://stream.example.com:9000',
         'udp://stream.example.test:1234',
         'mms://media.example.com/live',
@@ -151,6 +150,9 @@ def test_is_streaming_uri_true_for_streams(uri: str) -> None:
         'https://dashboard.example.com/',  # plain web page
         'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
         'file:///tmp/clip.mp4',
+        # rtmp is NOT a playable stream — Qt6 can't open it, so it is
+        # excluded from _STREAM_SCHEMES and rejected by validate_url.
+        'rtmp://media.example.com/live',
     ],
 )
 def test_is_streaming_uri_false_for_non_streams(uri: str) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -317,6 +317,20 @@ def test_assets_create_routes_rtsp_to_streaming(client: Client) -> None:
 
 
 @pytest.mark.django_db
+def test_assets_create_rejects_rtmp(client: Client) -> None:
+    """RTMP is well-formed but Qt6's QMediaPlayer can't open it, so the
+    Add modal must reject rtmp:// rather than create an asset that
+    renders black. No row is written."""
+    rtmp_url = 'rtmp://media.example.com/live'
+    response = client.post(
+        reverse('anthias_app:assets_create'),
+        data={'uri': rtmp_url},
+    )
+    assert response.status_code in (200, 302)
+    assert not Asset.objects.filter(uri=rtmp_url).exists()
+
+
+@pytest.mark.django_db
 def test_assets_create_routes_hls_manifest_to_streaming(
     client: Client,
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -290,6 +290,53 @@ def test_assets_create_routes_youtube_to_celery(client: Client) -> None:
 
 
 @pytest.mark.django_db
+def test_assets_create_routes_rtsp_to_streaming(client: Client) -> None:
+    """Pasting an RTSP URL into the Add modal must classify it as
+    mimetype='streaming' (not 'webpage'), otherwise the viewer hands
+    it to QtWebEngine instead of the video player and the stream never
+    appears. Regression guard for the classifier dropped in the
+    React→Django migration (#2818)."""
+    from anthias_server.settings import settings
+
+    rtsp_url = 'rtsp://camera.local:554/stream'
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': rtsp_url},
+        )
+    assert response.status_code in (200, 302)
+    row = Asset.objects.filter(uri=rtsp_url).first()
+    assert row is not None
+    assert row.mimetype == 'streaming'
+    # Streams have no intrinsic length — they take the dedicated
+    # streaming-duration window, not the standard default.
+    assert row.duration == int(settings['default_streaming_duration'])
+
+
+@pytest.mark.django_db
+def test_assets_create_routes_hls_manifest_to_streaming(
+    client: Client,
+) -> None:
+    """An HTTP-delivered HLS manifest (.m3u8) is a live stream, not a
+    downloadable file or a web page — it must classify as streaming."""
+    hls_url = 'https://cdn.example.com/live/index.m3u8'
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': hls_url},
+        )
+    row = Asset.objects.filter(uri=hls_url).first()
+    assert row is not None
+    assert row.mimetype == 'streaming'
+
+
+@pytest.mark.django_db
 def test_assets_create_youtube_short_form(client: Client) -> None:
     """youtu.be short URLs are recognised the same as full URLs."""
     short_url = 'https://youtu.be/dQw4w9WgXcQ'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,7 +133,9 @@ def test_string_to_bool_invalid_raises(value: str) -> None:
         ('http://wireload.net/logo.png', True),
         ('https://wireload.net/logo.png', True),
         ('rtsp://example.com/stream', True),
-        ('rtmp://example.com/stream', True),
+        # rtmp is rejected — Qt6's QMediaPlayer can't open it, so we
+        # don't let operators add a stream that renders black.
+        ('rtmp://example.com/stream', False),
         ('hello', False),
         ('ftp://example.com', False),
         ('http://', False),


### PR DESCRIPTION
### Issues Fixed

Not tied to a tracked issue. Adding an RTSP (or HLS/DASH) URL through the **Add asset → From URL** tab created the asset as `mimetype='webpage'`, so the viewer handed it to QtWebEngine instead of the video player and the stream never played — even though the modal advertises "streaming URLs are all supported." Regression from the React→Django frontend migration (#2818), whose new `assets_create` handler dropped the scheme check that the old React `getMimetype` had.

### Description

- Add `is_streaming_uri()` to `anthias_common.remote_video`, reusing the existing stream-scheme and manifest-extension (`.m3u8/.mpd/.m3u/.ism`, http(s) only) sets so it can't drift from `is_downloadable_remote_video`.
- `assets_create` now classifies stream URLs as `mimetype='streaming'` (after YouTube, before the extension heuristic) and applies the dedicated `default_streaming_duration` window — previously dead config.
- **Reject `rtmp://`** at `validate_url` (gates the UI form and the API) with a clear "use RTSP/HLS/DASH" message, and drop it from `_STREAM_SCHEMES`. On-device testing showed RTMP renders black on every board: Qt6's QMediaPlayer sets a `timeout` option the rtmp protocol misreads as TCP *listen* mode, so the open fails (`libavformat` itself plays rtmp fine). Rather than let operators add a stream that never shows, we don't accept it.
- Regression tests for the classifier, the rtmp rejection, and the form handler.

### Testing

Unit: classifier + form-handler + rtmp-rejection tests; full suite green, ruff clean.

On-device, full stack, across the entire testbed. An ffmpeg-fed feed (Big Buck Bunny) was streamed from a LAN host via mediamtx (RTSP) and nginx (HLS/DASH); playback was verified from `playback-stats.log` (`position-ms` advancing + `frames-rendered` climbing), HW-decoder fds, and screenshots.

| Board (decode) | RTSP H.264 | RTSP H.265 | HLS | DASH | RTMP |
|---|---|---|---|---|---|
| x86 (SW) | ✅ visual+reader | ❌ QtMultimedia FormatError¹ | ✅ played to EOF | ✅ progressive+visual | ❌ rejected |
| Pi 5 | ✅ frames advancing | ✅ **HW** (`/dev/video19`, Hantro G2) | — | — | ❌ rejected |
| Pi 4 | ✅ **HW** (`/dev/video10`) | — | — | — | ❌ rejected |
| Rock Pi 4, 1 GB (SW, 360p) | ✅ no OOM | — | — | — | ❌ rejected |

RTSP — the regression target — plays on every board, with hardware decode on the Pi 4 (H.264) and Pi 5 (H.265). HLS/DASH play on x86 (HLS needs a Range-capable HTTP origin — any real server/CDN).

¹ **x86 H.265 over RTSP** fails inside QtMultimedia (`FormatError`, 0 frames) even though x86's own `libavcodec` decodes the same stream fine over both UDP and TCP, and H.264-over-RTSP works on x86. It's an x86 QtMultimedia HEVC limitation, unrelated to this change.

### Known follow-up (pre-existing, out of scope)

- **`srt/udp/mms`** are recognised by `is_streaming_uri` but rejected by `validate_url`, so they're unreachable end-to-end (untouched here).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices. (RTSP H.264 on Pi 5/Pi 4/Rock Pi 4; H.265 HW-decoded on Pi 5)
- [x] I have tested my changes for x86 devices. (RTSP, HLS, DASH)
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)