### PR TITLE
fix(install): detect Pi 3 image stream from userspace arch, not kernel

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -417,12 +417,19 @@ function set_device_type() {
         export DEVICE_TYPE="pi4-64"
     elif grep -qF "Raspberry Pi 3" /proc/device-tree/model || grep -qF "Compute Module 3" /proc/device-tree/model; then
         # A Pi 3 reports the same model string on both a 32-bit and a
-        # 64-bit OS — the split is the running kernel/userland arch. On
-        # a 64-bit OS use the arm64 Qt 6 viewer (`pi3-64`, the
-        # recommended stream); a 32-bit OS gets the legacy armhf/Qt5
-        # `pi3` image. There's no in-place arch switch: a device only
-        # changes streams by reflashing to a different-arch OS.
-        if [ "$(uname -m)" = "aarch64" ]; then
+        # 64-bit OS — the split is the running userland arch. On a 64-bit
+        # OS use the arm64 Qt 6 viewer (`pi3-64`, the recommended
+        # stream); a 32-bit OS gets the legacy armhf/Qt5 `pi3` image.
+        # There's no in-place arch switch: a device only changes streams
+        # by reflashing to a different-arch OS.
+        #
+        # Gate on the *userspace* arch, not `uname -m`: 32-bit Raspberry
+        # Pi OS ships a 64-bit kernel by default on Pi 3 (arm_64bit=1),
+        # so `uname -m` reports aarch64 while Docker/apt are armhf.
+        # Selecting `pi3-64` there fails the image pull with "no matching
+        # manifest for linux/arm/v8". `dpkg --print-architecture` maps
+        # 1:1 to the image platform (armhf/arm64).
+        if [ "$(dpkg --print-architecture)" = "arm64" ]; then
             export DEVICE_TYPE="pi3-64"
         else
             export DEVICE_TYPE="pi3"

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -77,7 +77,14 @@ elif grep -qF "Raspberry Pi 3" /proc/device-tree/model || grep -qF "Compute Modu
     # 64-bit OS on a Pi 3 → arm64 Qt 6 viewer (`pi3-64`); a 32-bit OS
     # keeps the legacy armhf/Qt5 `pi3` image. See
     # bin/install.sh::set_device_type for the full rationale.
-    if [ "$(uname -m)" = "aarch64" ]; then
+    #
+    # Key off the *userspace* arch, not `uname -m`: 32-bit Raspberry Pi
+    # OS ships a 64-bit kernel by default on Pi 3 (arm_64bit=1), so
+    # `uname -m` reports aarch64 even though Docker/apt are armhf. Pulling
+    # the arm64 `pi3-64` image there fails with "no matching manifest for
+    # linux/arm/v8". `dpkg --print-architecture` maps 1:1 to the image
+    # platform (armhf/arm64).
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then
         export DEVICE_TYPE="pi3-64"
     else
         export DEVICE_TYPE="pi3"


### PR DESCRIPTION
### Issues Fixed

Container init fails on a Pi 3 running 32-bit Raspberry Pi OS:

```
no matching manifest for linux/arm/v8 in the manifest list entries
```

### Description

The `pi3` vs `pi3-64` device-type split keyed off `uname -m`, which reports the **kernel** arch. 32-bit Raspberry Pi OS ships a **64-bit kernel by default** on Pi 3 (`arm_64bit=1`), so `uname -m` returns `aarch64` even though Docker/apt are 32-bit armhf. That mispicked the arm64 `pi3-64` image; the 32-bit Docker daemon then requested its native platform `linux/arm/v8`, which isn't in the arm64 manifest → the pull fails.

Fix: in `bin/install.sh` and `bin/upgrade_containers.sh`, gate on `dpkg --print-architecture` (userspace arch, maps 1:1 to the image platform `armhf`/`arm64`) instead of `uname -m`.

Scope is deliberately narrow — only the Pi 3 branch changes:
- true 64-bit Pi 3 → `pi3-64` (unchanged)
- 32-bit OS / 64-bit kernel → `pi3` (**fixed**)
- legacy 32-bit kernel → `pi3` (unchanged)

The generic `arm64` catch-all is left as-is (no armhf counterpart image exists for generic SBCs). balena is unaffected — it bakes `DEVICE_TYPE=arm64` and detects the subtype at runtime rather than using these scripts.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)