### PR TITLE
fix(install): add python3-dev for armv7l cffi build

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -261,6 +261,11 @@ function install_packages() {
         "git"
         "libffi-dev"
         "libssl-dev"
+        # On 32-bit ARM (armv7l) there is no python-build-standalone
+        # binary, so uv falls back to the system interpreter and has to
+        # compile cffi from its sdist (no armv7 wheel exists). That build
+        # needs the CPython headers (Python.h), provided by python3-dev.
+        "python3-dev"
         "whois"
     )
 


### PR DESCRIPTION
### Issues Fixed

32-bit Raspberry Pi OS (armv7l) installs of v2026.6.x abort while building `cffi` with:

```
fatal error: Python.h: No such file or directory
```

Reported on the forum: https://forums.screenly.io/t/anthias-v2026-6-3-installation-stops-halfway-on-pi3-b/6716

### Description

`bin/install.sh` uses `uv`, which normally manages its own Python interpreter (headers included). But `python-build-standalone` has no armv7l build, so on 32-bit Pi OS uv falls back to the **system** `python3`. There is also no prebuilt `cffi` wheel for armv7, so uv compiles it from sdist — which needs the CPython development headers (`Python.h`). The apt list already had `libffi-dev` and `libssl-dev` (cffi's C-lib deps) but not the Python headers.

Adds `python3-dev` to the apt install list. 64-bit/arm64/x86 installs use uv's managed Python and prebuilt wheels, so they never compile cffi — installing the package there is harmless and keeps the path uniform.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)