### PR TITLE
feat(webview): append Anthias version to the User-Agent

### DIFF
--- a/src/anthias_common/http.py
+++ b/src/anthias_common/http.py
@@ -20,18 +20,34 @@ from anthias_common.version import get_anthias_release
 ANTHIAS_HOMEPAGE = 'https://anthias.screenly.io'
 
 
+def get_anthias_product_token() -> str:
+    """Return the ``Anthias/<release>`` product token.
+
+    Single source of truth for the ``Anthias/<version>`` label. Shared
+    by :func:`get_user_agent` (which wraps it with the ``(+homepage)``
+    comment for pure-HTTP clients) and the C++ webview, which appends
+    the bare token to Chromium's browser ``User-Agent`` via the
+    ``ANTHIAS_UA_TOKEN`` env var — browser UAs conventionally carry a
+    bare ``Product/Version`` token rather than a ``(+URL)`` comment.
+    Falls back to ``unknown`` only when ``get_anthias_release()`` finds
+    neither the installed package metadata nor the repo-root
+    pyproject.toml.
+    """
+    release = get_anthias_release() or 'unknown'
+    return f'Anthias/{release}'
+
+
 def get_user_agent() -> str:
     """Return the canonical Anthias ``User-Agent`` string.
 
     Format: ``Anthias/<release> (+<homepage>)`` — the standard
     ``Product/Version (+URL)`` convention used by well-behaved
     crawlers so ops at the receiving end can identify the source
-    without parsing the path. Falls back to ``unknown`` only when
-    ``get_anthias_release()`` finds neither the installed package
-    metadata nor the repo-root pyproject.toml.
+    without parsing the path. Builds on
+    :func:`get_anthias_product_token` so the ``Anthias/<release>`` label
+    (and its ``unknown`` fallback) lives in exactly one place.
     """
-    release = get_anthias_release() or 'unknown'
-    return f'Anthias/{release} (+{ANTHIAS_HOMEPAGE})'
+    return f'{get_anthias_product_token()} (+{ANTHIAS_HOMEPAGE})'
 
 
 class AnthiasSession(requests.Session):

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -16,6 +16,7 @@ import redis.exceptions
 import requests
 import sh as sh
 
+from anthias_common.http import get_anthias_product_token
 from anthias_server.settings import LISTEN, PORT, ReplySender, settings
 from anthias_viewer.constants import EMPTY_PL_DELAY as EMPTY_PL_DELAY
 from anthias_viewer.constants import SERVER_WAIT_TIMEOUT as SERVER_WAIT_TIMEOUT
@@ -195,6 +196,15 @@ def _build_webview_env() -> dict[str, str]:
       us at no perf cost.
     """
     env = dict(os.environ)
+
+    # Pass the Anthias product token ("Anthias/<version>") to the C++
+    # webview, which appends it to QtWebEngine's User-Agent (see the
+    # profile setup in src/anthias_webview/src/view.cpp). Composed by the
+    # canonical get_anthias_product_token() helper so the format lives in
+    # one place. Set unconditionally — before the board-specific early
+    # returns below — so every platform plugin gets it and any stale
+    # inherited value is overwritten.
+    env['ANTHIAS_UA_TOKEN'] = get_anthias_product_token()
 
     # "Prefer dark mode" applies to every board (the C++ webview turns
     # this into a Chromium blink flag at launch — see applyDarkModePreference

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -185,6 +185,24 @@ View::View(QWidget* parent) : QWidget(parent)
         qDebug() << "Accept-Language:" << acceptLanguage;
     }
 
+    // Append the Anthias product token to QtWebEngine's default
+    // User-Agent so sites still see a normal "Mozilla/5.0 ...
+    // Chrome/... Safari/..." string (preserving compatibility) while
+    // ops at the receiving end can spot that the request came from an
+    // Anthias screen and which release. The token ("Anthias/<version>")
+    // is composed once in Python by get_anthias_product_token() and
+    // passed through ANTHIAS_UA_TOKEN by _build_webview_env() in
+    // src/anthias_viewer/__init__.py, so the format lives in a single
+    // place. Left untouched when the token is absent — the Python side
+    // always sets it, so this only guards a standalone launch.
+    const QByteArray uaToken = qgetenv("ANTHIAS_UA_TOKEN");
+    if (!uaToken.isEmpty()) {
+        const QString userAgent = profile->httpUserAgent()
+            + QStringLiteral(" ") + QString::fromUtf8(uaToken);
+        profile->setHttpUserAgent(userAgent);
+        qDebug() << "User-Agent:" << userAgent;
+    }
+
     currentWebView = webView1;
     nextWebView = webView2;
     nextWebViewReady = false;

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,30 @@
+from unittest import mock
+
+from anthias_common.http import (
+    ANTHIAS_HOMEPAGE,
+    get_anthias_product_token,
+    get_user_agent,
+)
+
+
+def test_product_token_uses_release() -> None:
+    with mock.patch(
+        'anthias_common.http.get_anthias_release', return_value='2026.6.3'
+    ):
+        assert get_anthias_product_token() == 'Anthias/2026.6.3'
+
+
+def test_product_token_falls_back_to_unknown() -> None:
+    # get_anthias_release() returns '' when neither the installed package
+    # metadata nor the repo-root pyproject.toml can be read.
+    with mock.patch(
+        'anthias_common.http.get_anthias_release', return_value=''
+    ):
+        assert get_anthias_product_token() == 'Anthias/unknown'
+
+
+def test_user_agent_wraps_product_token_with_homepage() -> None:
+    with mock.patch(
+        'anthias_common.http.get_anthias_release', return_value='2026.6.3'
+    ):
+        assert get_user_agent() == (f'Anthias/2026.6.3 (+{ANTHIAS_HOMEPAGE})')

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1111,6 +1111,48 @@ def test_build_webview_env_drops_dark_mode_flag_when_disabled() -> None:
     assert 'ANTHIAS_PREFER_DARK_MODE' not in env
 
 
+# User-Agent token — the C++ webview appends ANTHIAS_UA_TOKEN to
+# QtWebEngine's default User-Agent (the profile setup in
+# src/anthias_webview/src/view.cpp). The token is composed by the
+# canonical get_anthias_product_token() helper.
+
+
+def test_build_webview_env_sets_ua_token() -> None:
+    with (
+        mock.patch.dict(
+            os.environ, {'QT_QPA_PLATFORM': 'linuxfb'}, clear=False
+        ),
+        mock.patch(
+            'anthias_viewer.get_anthias_product_token',
+            return_value='Anthias/1.2.3',
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['ANTHIAS_UA_TOKEN'] == 'Anthias/1.2.3'
+
+
+def test_build_webview_env_overwrites_stale_ua_token() -> None:
+    # The token is set unconditionally, so a stale value inherited from
+    # the process env is always overwritten with the freshly composed
+    # one (parity with the dark-mode set-or-clear discipline).
+    with (
+        mock.patch.dict(
+            os.environ,
+            {
+                'QT_QPA_PLATFORM': 'linuxfb',
+                'ANTHIAS_UA_TOKEN': 'Anthias/stale',
+            },
+            clear=False,
+        ),
+        mock.patch(
+            'anthias_viewer.get_anthias_product_token',
+            return_value='Anthias/1.2.3',
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['ANTHIAS_UA_TOKEN'] == 'Anthias/1.2.3'
+
+
 def test_handle_reload_queues_bounce_on_dark_mode_change(
     reset_dark_mode_state: None,
 ) -> None:


### PR DESCRIPTION
### Issues Fixed

No associated issue. The Qt webview used QtWebEngine's default User-Agent, so outbound page/subresource requests were indistinguishable from generic Chromium — ops on the receiving end couldn't tell traffic came from an Anthias screen or which release.

### Description

Append an `Anthias/<version>` product token to QtWebEngine's default User-Agent. The string still reads as a normal browser (`Mozilla/5.0 … Chrome/… Safari/… Anthias/2026.6.3`), preserving site compatibility while making Anthias traffic identifiable.

- `anthias_common/http.py` — new `get_anthias_product_token()` is the single source of truth for the `Anthias/<version>` label (and its `unknown` fallback). `get_user_agent()` now builds on it, so the format lives in one place.
- `anthias_viewer/__init__.py` — `_build_webview_env()` composes the token via that helper and passes it to the webview through the **`ANTHIAS_UA_TOKEN`** env var. Set unconditionally, before the board-specific early returns, so every platform plugin gets it and any stale inherited value is overwritten.
- `anthias_webview/src/view.cpp` — reads `ANTHIAS_UA_TOKEN` and appends it verbatim to `profile->httpUserAgent()`. No token-format logic in C++.

Resulting UA: `Mozilla/5.0 … Chrome/… Safari/… Anthias/<version>` — valid per RFC 9110 §10.1.5 (`product = token ["/" product-version]`).

**Verification.** Compile-verified on both Qt majors via the image builder — Qt6 (x86) and Qt5 (pi3 armhf): `view.cpp` recompiled from source on each toolchain and the `ANTHIAS_UA_TOKEN` symbol confirmed present in each `AnthiasViewer` binary (old `ANTHIAS_VERSION` absent). Unit tests added for the token helper (`tests/test_http.py`) and the env injection (`tests/test_viewer.py`); full local run green.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices. (Compile-verified on Qt5/Qt6 via the image builder; not run on a live device.)
- [ ] I have tested my changes for x86 devices. (Compile-verified; not run on a live device.)
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)