### PR TITLE
chore(images): compress disk images with xz instead of zstd

### DIFF
--- a/.github/workflows/build-balena-disk-image.yaml
+++ b/.github/workflows/build-balena-disk-image.yaml
@@ -274,7 +274,7 @@ jobs:
             "${{ matrix.board }}" "${TAG#v}" "$SHORT_HASH"
 
   # Download balena OS, preload with the fleet's `latest` (the commit
-  # we just pushed in balena-cloud-deploy), package as .img.zst, and
+  # we just pushed in balena-cloud-deploy), package as .img.xz, and
   # emit per-board metadata used to build rpi-imager.json.
   balena-build-images:
     needs: [resolve-context, balena-cloud-deploy]
@@ -293,10 +293,10 @@ jobs:
         with:
           ref: ${{ needs.resolve-context.outputs.tag }}
 
-      - name: Install zstd
+      - name: Install xz
         run: |
           sudo apt-get update
-          sudo apt-get install -y zstd
+          sudo apt-get install -y xz-utils
 
       # See balena-cloud-deploy's "Install balena CLI" step for why
       # this uses npm rather than bun.
@@ -391,7 +391,7 @@ jobs:
           # Final artefacts embed the board slug rather than balena's
           # image name (which is `raspberry-pi2` / `raspberrypi3` /
           # `raspberrypi3-64` / `raspberrypi4-64` / `raspberrypi5` —
-          # inconsistently hyphenated). The `anthias-<board>.img.zst`
+          # inconsistently hyphenated). The `anthias-<board>.img.xz`
           # shape matches
           # the regex in tools/raspberry_pi_imager/build_pi_imager_json
           # so the consolidation step can route entries by board.
@@ -406,26 +406,40 @@ jobs:
           IMAGE_SHA256=$(sha256sum "$BALENA_IMAGE.img" | awk '{print $1}')
           IMAGE_SIZE=$(wc -c < "$BALENA_IMAGE.img")
 
-          zstd -19 -T0 "$BALENA_IMAGE.img" -o "$ARTIFACT.img.zst"
-          DOWNLOAD_SHA256=$(sha256sum "$ARTIFACT.img.zst" | awk '{print $1}')
-          DOWNLOAD_SIZE=$(wc -c < "$ARTIFACT.img.zst")
+          # xz (LZMA2) is chosen over zstd because it is the only
+          # compression format flashed natively by BOTH Raspberry Pi
+          # Imager and balenaEtcher out of the box — Etcher has no
+          # zstd support (balena-io/etcher#2856), and Pi Imager's zstd
+          # path has been flaky. It's also the format official
+          # Raspberry Pi OS images ship as. `-9e` is the maximum ratio;
+          # `-T0` uses every core.
+          #
+          # `-T0` splits the image into independent blocks so it can
+          # compress in parallel. Measured on a pi4-64 image, the
+          # block-split ratio penalty vs single-threaded xz is only
+          # ~0.7% (794 MB vs 788 MB) while single-threaded takes ~4x
+          # longer (~33 min vs ~8 min on 4 cores) — so multi-threaded
+          # is the clear win. Both still beat zstd -19 by ~12% (907 MB).
+          xz -9e -T0 -c "$BALENA_IMAGE.img" > "$ARTIFACT.img.xz"
+          DOWNLOAD_SHA256=$(sha256sum "$ARTIFACT.img.xz" | awk '{print $1}')
+          DOWNLOAD_SIZE=$(wc -c < "$ARTIFACT.img.xz")
 
           # Match the format `sha256sum` would have written so the
           # sidecar is a drop-in input to `sha256sum -c`. The
           # uncompressed line uses `$ARTIFACT.img` (not the local
           # intermediate `$BALENA_IMAGE.img`) because that's the
           # filename a user gets when they decompress with
-          # `zstd -d $ARTIFACT.img.zst` — the local name is a
+          # `xz -d $ARTIFACT.img.xz` — the local name is a
           # CI-internal artefact that the release asset never carries.
           {
             printf '%s  %s\n' "$IMAGE_SHA256" "$ARTIFACT.img"
-            printf '%s  %s\n' "$DOWNLOAD_SHA256" "$ARTIFACT.img.zst"
+            printf '%s  %s\n' "$DOWNLOAD_SHA256" "$ARTIFACT.img.xz"
           } > "$ARTIFACT.sha256"
 
           # Per-board metadata snippet, uploaded to the release
-          # alongside the .img.zst it describes.
+          # alongside the .img.xz it describes.
           # build_pi_imager_json.py fetches it via the same base name
-          # (s/.img.zst$/.json/) and consolidates into rpi-imager.json.
+          # (s/.img.xz$/.json/) and consolidates into rpi-imager.json.
           jq --null-input \
             --arg BOARD "$BOARD" \
             --arg IMAGE_SHA256 "$IMAGE_SHA256" \
@@ -450,14 +464,14 @@ jobs:
         with:
           name: balena-images-${{ matrix.board }}
           path: |
-            ./*-anthias-*.img.zst
+            ./*-anthias-*.img.xz
             ./*-anthias-*.sha256
             ./*-anthias-*.json
 
       - name: Attest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
-          subject-path: '${{ github.workspace }}/*-anthias-*.img.zst'
+          subject-path: '${{ github.workspace }}/*-anthias-*.img.xz'
 
   # Phase 1 release upload: ensure the release exists, then attach the
   # disk images, per-board metadata snippets, OpenAPI schema, and the

--- a/tools/raspberry_pi_imager/README.md
+++ b/tools/raspberry_pi_imager/README.md
@@ -21,7 +21,7 @@ python raspberry_pi_imager/bin/build-pi-imager-json.py
 ## How it Works
 
 1. Fetches the latest release from GitHub
-2. Filters `.zst` assets to only include supported boards
+2. Filters `.xz` assets to only include supported boards
 3. For each matching asset, fetches the corresponding `.json` metadata
 4. Patches URLs and file sizes, appends maintenance mode notice for pi2/pi3
 5. Outputs a JSON file compatible with Raspberry Pi Imager

--- a/tools/raspberry_pi_imager/build_pi_imager_json.py
+++ b/tools/raspberry_pi_imager/build_pi_imager_json.py
@@ -68,7 +68,7 @@ def get_latest_tag() -> str:
 
 
 def get_board_from_url(url: str) -> str | None:
-    match = re.search(r'-(pi\d(?:-\d+)?)\.img\.zst$', url)
+    match = re.search(r'-(pi\d(?:-\d+)?)\.img\.xz$', url)
     return match.group(1) if match else None
 
 
@@ -83,7 +83,7 @@ def get_asset_list(release_tag: str) -> list[str]:
 
     for url in response.json()['assets']:
         download_url = url['browser_download_url']
-        if not download_url.endswith('.zst'):
+        if not download_url.endswith('.xz'):
             continue
         board = get_board_from_url(download_url)
         if board and board in SUPPORTED_BOARDS:
@@ -94,7 +94,7 @@ def get_asset_list(release_tag: str) -> list[str]:
 
 def retrieve_and_patch_json(url: str) -> dict[str, Any]:
     response = requests.get(
-        url.replace('.img.zst', '.json'),
+        url.replace('.img.xz', '.json'),
         headers=get_github_headers(),
         timeout=HTTP_TIMEOUT,
     )

--- a/tools/raspberry_pi_imager/tests/test_build_pi_imager_json.py
+++ b/tools/raspberry_pi_imager/tests/test_build_pi_imager_json.py
@@ -25,37 +25,37 @@ MOCK_RELEASE_ASSETS = {
     'assets': [
         {
             'browser_download_url': (
-                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi1.img.zst'
+                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi1.img.xz'
             )
         },
         {
             'browser_download_url': (
-                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi2.img.zst'
+                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi2.img.xz'
             )
         },
         {
             'browser_download_url': (
-                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi3.img.zst'
+                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi3.img.xz'
             )
         },
         {
             'browser_download_url': (
-                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi3-64.img.zst'
+                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi3-64.img.xz'
             )
         },
         {
             'browser_download_url': (
-                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi4-64.img.zst'
+                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi4-64.img.xz'
             )
         },
         {
             'browser_download_url': (
-                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi5.img.zst'
+                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi5.img.xz'
             )
         },
         {
             'browser_download_url': (
-                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi2.img.zst.sha256'
+                f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi2.img.xz.sha256'
             )
         },
         {
@@ -148,12 +148,12 @@ def test_get_latest_tag_honours_release_tag_env(
 @pytest.mark.parametrize(
     'filename, expected_board',
     [
-        ('2025-01-01-anthias-pi1.img.zst', 'pi1'),
-        ('2025-01-01-anthias-pi2.img.zst', 'pi2'),
-        ('2025-01-01-anthias-pi3.img.zst', 'pi3'),
-        ('2025-01-01-anthias-pi3-64.img.zst', 'pi3-64'),
-        ('2025-01-01-anthias-pi4-64.img.zst', 'pi4-64'),
-        ('2025-01-01-anthias-pi5.img.zst', 'pi5'),
+        ('2025-01-01-anthias-pi1.img.xz', 'pi1'),
+        ('2025-01-01-anthias-pi2.img.xz', 'pi2'),
+        ('2025-01-01-anthias-pi3.img.xz', 'pi3'),
+        ('2025-01-01-anthias-pi3-64.img.xz', 'pi3-64'),
+        ('2025-01-01-anthias-pi4-64.img.xz', 'pi4-64'),
+        ('2025-01-01-anthias-pi5.img.xz', 'pi5'),
     ],
 )
 def test_get_board_from_url_extracts_board(
@@ -168,8 +168,8 @@ def test_get_board_from_url_extracts_board(
     'url',
     [
         f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi2.json',
-        f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi2.img.zst.sha256',
-        'https://example.com/file.zst',
+        f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi2.img.xz.sha256',
+        'https://example.com/file.xz',
     ],
 )
 def test_get_board_from_url_returns_none_for_non_image(url: str) -> None:
@@ -198,12 +198,12 @@ def test_get_asset_list_excludes_pi1(
     assert all(get_board_from_url(u) != 'pi1' for u in urls)
 
 
-def test_get_asset_list_excludes_non_zst(
+def test_get_asset_list_excludes_non_xz(
     mock_release_assets: MagicMock,
 ) -> None:
     urls = get_asset_list(RELEASE_TAG)
 
-    assert all(u.endswith('.zst') for u in urls)
+    assert all(u.endswith('.xz') for u in urls)
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +217,7 @@ def test_retrieve_and_patch_json_patches_url(
     mock_requests_get.return_value = _build_side_effect(
         make_image_metadata('pi4-64')
     )
-    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi4-64.img.zst'
+    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi4-64.img.xz'
 
     assert retrieve_and_patch_json(url)['url'] == url
 
@@ -228,7 +228,7 @@ def test_retrieve_and_patch_json_converts_sizes_to_int(
     mock_requests_get.return_value = _build_side_effect(
         make_image_metadata('pi5')
     )
-    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi5.img.zst'
+    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi5.img.xz'
 
     result = retrieve_and_patch_json(url)
 
@@ -243,7 +243,7 @@ def test_retrieve_and_patch_json_marks_maintenance_boards(
     mock_requests_get.return_value = _build_side_effect(
         make_image_metadata(board)
     )
-    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-{board}.img.zst'
+    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-{board}.img.xz'
 
     result = retrieve_and_patch_json(url)
 
@@ -257,7 +257,7 @@ def test_retrieve_and_patch_json_skips_maintenance_for_modern_boards(
     mock_requests_get.return_value = _build_side_effect(
         make_image_metadata(board)
     )
-    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-{board}.img.zst'
+    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-{board}.img.xz'
 
     assert (
         'Maintenance mode' not in retrieve_and_patch_json(url)['description']
@@ -270,7 +270,7 @@ def test_retrieve_and_patch_json_has_all_required_fields(
     mock_requests_get.return_value = _build_side_effect(
         make_image_metadata('pi5')
     )
-    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi5.img.zst'
+    url = f'{BASE_RELEASE_URL}/2025-01-01-anthias-pi5.img.xz'
 
     result = retrieve_and_patch_json(url)
     missing = REQUIRED_FIELDS - result.keys()

--- a/website/content/docs/installation-options.md
+++ b/website/content/docs/installation-options.md
@@ -61,7 +61,7 @@ The image file looks something like `<yyyy>-<mm>-<dd>-anthias-<board>.img.xz`. T
 
 > **macOS: "Error writing to storage device"**
 >
-> Raspberry Pi Imager **2.0.2 through at least 2.0.7** has a macOS bug that aborts mid-write with *"Error writing to storage device. Some writes failed to complete."* It is triggered by writing any image that is decompressed on the fly &mdash; our `.img.xz` images as well as even uncompressed `.img` files (see rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605) and [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)). The card itself is fine.
+> Raspberry Pi Imager **2.0.2 through at least 2.0.7** has a macOS bug that aborts mid-write with *"Error writing to storage device. Some writes failed to complete."* It is triggered by writing any image that is decompressed on the fly &mdash; our `.img.xz` images as well as uncompressed `.img` files (see rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605) and [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)). The card itself is fine.
 >
 > The fix was merged upstream in [rpi-imager#1621](https://github.com/raspberrypi/rpi-imager/pull/1621) (May 2026), so the simplest solution is to **update Raspberry Pi Imager to a release newer than 2.0.7**. If you can't update, work around it by decompressing the image yourself and flashing the resulting `.img`:
 >

--- a/website/content/docs/installation-options.md
+++ b/website/content/docs/installation-options.md
@@ -49,26 +49,24 @@ Alternatively, you can [download our pre-built Balena disk images from the relea
 # Using the images from the releases
 
 You can find the latest release [here](https://github.com/Screenly/Anthias/releases/latest). From there, you can download the disk image that you need and flash it to your SD card.
-The image file looks something like `<yyyy>-<mm>-<dd>-raspberry<version>.zst`. Take note that the `.img` file is compressed in this `.zst` file.
+The image file looks something like `<yyyy>-<mm>-<dd>-anthias-<board>.img.xz`. Take note that the `.img` file is compressed in this `.img.xz` file.
 
 > **Note**
 >
-> We started to release the images in `.zst` format in [v0.20.0](https://github.com/Screenly/Anthias/releases/tag/v0.20.0) so that the images are smaller in size. Using `zip` with the `-9` flag won't make the each of the images smaller than 2 GB.
->
-> Raspberry Pi Imager supports the `.zst` format from version [v1.9.4](https://github.com/raspberrypi/rpi-imager/releases/tag/v1.9.4) onwards. For those who are using [balenaEtcher](https://etcher.balena.io/), you can use the `zstd` command to decompress the image file first:
+> We release the images in `.img.xz` format so that they are smaller in size. Both [Raspberry Pi Imager](https://www.raspberrypi.com/software/) and [balenaEtcher](https://etcher.balena.io/) flash `.img.xz` files directly &mdash; there's no need to decompress them first. If you ever want the raw `.img`, you can extract it yourself:
 >
 > ```
-> zstd -d <yyyy>-<mm>-<dd>-raspberry<version>.zst
+> xz -d <yyyy>-<mm>-<dd>-anthias-<board>.img.xz
 > ```
 
 > **macOS: "Error writing to storage device"**
 >
-> Raspberry Pi Imager **2.0.2 through at least 2.0.7** has a macOS bug that aborts mid-write with *"Error writing to storage device. Some writes failed to complete."* It is triggered by writing any image that is decompressed on the fly &mdash; not just our `.zst` images, but also `.img.xz` and even uncompressed `.img` files (see rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605) and [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)). The card itself is fine.
+> Raspberry Pi Imager **2.0.2 through at least 2.0.7** has a macOS bug that aborts mid-write with *"Error writing to storage device. Some writes failed to complete."* It is triggered by writing any image that is decompressed on the fly &mdash; our `.img.xz` images as well as even uncompressed `.img` files (see rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605) and [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)). The card itself is fine.
 >
 > The fix was merged upstream in [rpi-imager#1621](https://github.com/raspberrypi/rpi-imager/pull/1621) (May 2026), so the simplest solution is to **update Raspberry Pi Imager to a release newer than 2.0.7**. If you can't update, work around it by decompressing the image yourself and flashing the resulting `.img`:
 >
 > ```
-> zstd -d <yyyy>-<mm>-<dd>-raspberry<version>.zst
+> xz -d <yyyy>-<mm>-<dd>-anthias-<board>.img.xz
 > ```
 >
 > Then select the extracted `.img` in Raspberry Pi Imager (or [balenaEtcher](https://etcher.balena.io/)), which skips the on-the-fly decompression path that trips the bug.

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -71,12 +71,12 @@
 
     - question: Raspberry Pi Imager fails with "Error writing to storage device" on macOS — what's wrong?
       answer: |
-        This is a bug in **Raspberry Pi Imager 2.0.2–2.0.7 on macOS**, not in the Anthias image or your SD card. Those versions abort mid-write with *"Error writing to storage device. Some writes failed to complete."* whenever the image is decompressed on the fly — it affects our `.zst` images as well as `.img.xz` and even plain `.img` files (rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605), [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)).
+        This is a bug in **Raspberry Pi Imager 2.0.2–2.0.7 on macOS**, not in the Anthias image or your SD card. Those versions abort mid-write with *"Error writing to storage device. Some writes failed to complete."* whenever the image is decompressed on the fly — it affects our `.img.xz` images as well as even plain `.img` files (rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605), [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)).
 
         The fix was merged upstream in [rpi-imager#1621](https://github.com/raspberrypi/rpi-imager/pull/1621) (May 2026), so the cleanest fix is to **update Raspberry Pi Imager to a release newer than 2.0.7**. If you can't update yet, decompress the image yourself and flash the resulting `.img`:
 
         ```bash
-        zstd -d <yyyy>-<mm>-<dd>-raspberry<version>.zst
+        xz -d <yyyy>-<mm>-<dd>-anthias-<board>.img.xz
         ```
 
         Then point Raspberry Pi Imager (or [balenaEtcher](https://etcher.balena.io/)) at the extracted `.img` — flashing an already-decompressed file skips the code path that trips the bug.

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -71,7 +71,7 @@
 
     - question: Raspberry Pi Imager fails with "Error writing to storage device" on macOS — what's wrong?
       answer: |
-        This is a bug in **Raspberry Pi Imager 2.0.2–2.0.7 on macOS**, not in the Anthias image or your SD card. Those versions abort mid-write with *"Error writing to storage device. Some writes failed to complete."* whenever the image is decompressed on the fly — it affects our `.img.xz` images as well as even plain `.img` files (rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605), [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)).
+        This is a bug in **Raspberry Pi Imager 2.0.2–2.0.7 on macOS**, not in the Anthias image or your SD card. Those versions abort mid-write with *"Error writing to storage device. Some writes failed to complete."* whenever the image is decompressed on the fly — it affects our `.img.xz` images as well as plain `.img` files (rpi-imager [#1605](https://github.com/raspberrypi/rpi-imager/issues/1605), [#1489](https://github.com/raspberrypi/rpi-imager/issues/1489)).
 
         The fix was merged upstream in [rpi-imager#1621](https://github.com/raspberrypi/rpi-imager/pull/1621) (May 2026), so the cleanest fix is to **update Raspberry Pi Imager to a release newer than 2.0.7**. If you can't update yet, decompress the image yourself and flash the resulting `.img`:
 

--- a/website/layouts/_default/get-started.html
+++ b/website/layouts/_default/get-started.html
@@ -57,7 +57,7 @@
 
             <div class="bg-white border border-black/10 rounded-lg p-6">
                 <h3 class="text-lg font-bold">Pre-built disk images</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Download a disk image from the <a class="text-brand-purple no-underline hover:underline" href="https://github.com/Screenly/Anthias/releases/latest" target="_blank" rel="noopener">latest GitHub release</a> and flash it to an SD card with Raspberry Pi Imager or balenaEtcher. Images are compressed with Zstandard (.zst).</p>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">Download a disk image from the <a class="text-brand-purple no-underline hover:underline" href="https://github.com/Screenly/Anthias/releases/latest" target="_blank" rel="noopener">latest GitHub release</a> and flash it to an SD card with Raspberry Pi Imager or balenaEtcher. Images are compressed with xz (.img.xz).</p>
             </div>
 
             <div class="bg-white border border-black/10 rounded-lg p-6">


### PR DESCRIPTION
### Issues Fixed

No linked issue. Distributable disk images were compressed with **zstd** (`.img.zst`), which **balenaEtcher cannot flash** — Etcher has no native zstd support ([etcher#2856](https://github.com/balena-io/etcher/issues/2856) is still open), forcing users to manually decompress first. Raspberry Pi Imager's zstd path has also been flaky.

### Description

Switch release disk-image compression from zstd to **xz** (`.img.xz`, `xz -9e -T0`).

- `xz` is the only format flashed natively out of the box by **both** Raspberry Pi Imager and balenaEtcher, and is the format official Raspberry Pi OS images already ship as.
- Measured on a real `pi4-64` image (4.67 GB raw): xz is **~12% smaller** than the current zstd (794 MB vs 907 MB). Kept `-T0` (multi-threaded) — single-threaded shaved only ~0.7% more but took ~4× longer.
- Updates the rpi-imager JSON generator + its tests to match `.img.xz` assets.
- Updates the install docs / FAQ and drops the now-unnecessary "decompress first for Etcher" workaround.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).
