### PR TITLE
chore(release): bump to 2026.07.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.06.3",
+  "version": "2026.07.0",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.06.3"
+version = "2026.07.0"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.6.3"
+version = "2026.7.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
### Issues Fixed

N/A — routine release version bump.

### Description

Bump the Anthias version to `2026.07.0` (CalVer `YYYY.0M.MICRO`; July 2026, micro resets to 0) ahead of cutting the next release.

- `package.json` + `pyproject.toml`: `2026.07.0`
- `uv.lock`: regenerated via `uv lock` (`anthias` `2026.6.3` → `2026.7.0`, no dependency churn)

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
