### PR TITLE
fix(build): ship +rpt1 ffmpeg on pi3-64 so H.264 uses HW decode

### DIFF
--- a/docker/_rpt1-ffmpeg-pin.j2
+++ b/docker/_rpt1-ffmpeg-pin.j2
@@ -1,4 +1,4 @@
-{% if board in ('pi4-64', 'pi5', 'arm64') %}
+{% if board in ('pi4-64', 'pi3-64', 'pi5', 'arm64') %}
 # archive.raspberrypi.com ships ffmpeg patched with v4l2_request
 # enabled (``--enable-v4l2-request --enable-libudev
 # --enable-vout-drm --enable-sand --enable-neon``). Stock Debian
@@ -9,6 +9,16 @@
 # * Pi 4-64 — V3D V4L2 M2M (H.264 via stateful v4l2m2m, works on
 #   stock too) plus the dedicated rpi-hevc-dec block (HEVC via
 #   v4l2_request, needs ``+rpt1``).
+# * Pi 3-64 — VideoCore IV bcm2835-codec H.264 (the same eglfs/Qt6
+#   video path as pi4-64). QtMultimedia only engages HW decode via
+#   the ``+rpt1`` drm / v4l2_request + SAND path; on stock Debian
+#   ffmpeg it silently falls back to SW, which can't sustain 1080p30
+#   on the Pi 3 (measured 0.74x realtime) and drops frames / stalls
+#   presentation under thermal + memory pressure (issue #3084). The
+#   hardware itself decodes fine — ``ffmpeg -c:v h264_v4l2m2m`` runs
+#   at 2.49x realtime on-device. pi3-64 was added (#2985) after this
+#   pin's board list (#2885) and grouped with pi4-64 everywhere else,
+#   so its omission here was an oversight.
 # * Pi 5 — Hantro G2 HEVC via v4l2_request (needs ``+rpt1``).
 # * arm64 — Rock Pi 4 / RK3399's ``rkvdec`` (HEVC) and Hantro VPU
 #   (H.264) are also stateless v4l2_request decoders. Live test

--- a/docker/_rpt1-ffmpeg-pin.j2
+++ b/docker/_rpt1-ffmpeg-pin.j2
@@ -9,16 +9,20 @@
 # * Pi 4-64 — V3D V4L2 M2M (H.264 via stateful v4l2m2m, works on
 #   stock too) plus the dedicated rpi-hevc-dec block (HEVC via
 #   v4l2_request, needs ``+rpt1``).
-# * Pi 3-64 — VideoCore IV bcm2835-codec H.264 (the same eglfs/Qt6
-#   video path as pi4-64). QtMultimedia only engages HW decode via
-#   the ``+rpt1`` drm / v4l2_request + SAND path; on stock Debian
-#   ffmpeg it silently falls back to SW, which can't sustain 1080p30
-#   on the Pi 3 (measured 0.74x realtime) and drops frames / stalls
-#   presentation under thermal + memory pressure (issue #3084). The
-#   hardware itself decodes fine — ``ffmpeg -c:v h264_v4l2m2m`` runs
-#   at 2.49x realtime on-device. pi3-64 was added (#2985) after this
-#   pin's board list (#2885) and grouped with pi4-64 everywhere else,
-#   so its omission here was an oversight.
+# * Pi 3-64 — VideoCore IV bcm2835-codec H.264 via the stateful
+#   V4L2 M2M path (``h264_v4l2m2m``), the same eglfs/Qt6 video path
+#   as pi4-64 — this is M2M, NOT the v4l2_request/stateless decoders
+#   pi5/arm64 use. Verified on real Pi 3 hardware: with stock Debian
+#   ffmpeg QtMultimedia never opens /dev/video10 and falls back to
+#   SW (can't sustain 1080p30 — 0.74x realtime — so it drops frames
+#   / stalls presentation under thermal + memory pressure, issue
+#   #3084); with the ``+rpt1`` libav* build it engages the M2M
+#   decoder (/dev/video10 held, 1080p dropped=0). The decoder itself
+#   works on stock standalone (``ffmpeg -c:v h264_v4l2m2m`` = 2.49x
+#   realtime) — it's QtMultimedia's HW selection that needs +rpt1.
+#   pi3-64 was added (#2985) after this pin's board list (#2885) and
+#   grouped with pi4-64 everywhere else, so its omission here was an
+#   oversight.
 # * Pi 5 — Hantro G2 HEVC via v4l2_request (needs ``+rpt1``).
 # * arm64 — Rock Pi 4 / RK3399's ``rkvdec`` (HEVC) and Hantro VPU
 #   (H.264) are also stateless v4l2_request decoders. Live test


### PR DESCRIPTION
### Issues Fixed

Addresses the video-decode/performance half of https://github.com/Screenly/Anthias/issues/3084 (pi3-64 video black / stalling).

### Description

pi3-64 was missing from the board gate in `docker/_rpt1-ffmpeg-pin.j2`, so it shipped **stock Debian ffmpeg** while its sibling `pi4-64` got the Raspberry Pi–patched **`+rpt1`** build (`--enable-v4l2-request --enable-sand --enable-vout-drm`). Without `+rpt1`, QtMultimedia can't engage the VideoCore IV `bcm2835-codec` H.264 decoder and silently falls back to **software decode**.

The gate was introduced in #2885 (`pi4-64, pi5, arm64`); the pi3-64 board was added later in #2985 and grouped with pi4-64 everywhere else (eglfs/Qt6, the video path, "shares this exact path") — this gate was just missed. One-line fix: add `pi3-64` to the tuple.

**Diagnosed live on a real Pi 3 Model B+ running the `2026.07.0` (`latest-pi3-64`) release:**

| decode path | throughput | CPU (utime, 4 s clip) |
| --- | --- | --- |
| SW `h264` (what ships today) | 22 fps / **0.74× realtime** | 5.6 s |
| HW `h264_v4l2m2m` (hardware, standalone) | 75 fps / **2.49× realtime** | 0.25 s |

The hardware decodes H.264 fine; the viewer just never reaches it. During playback `AnthiasViewer` holds only `/dev/dri/card0` — never `/dev/video10` — with zero dmesg/CMA activity, confirming pure SW decode. SW can't sustain 1080p30 on the Pi 3, so frames drop (~25% at 1080p) and, under thermal + memory pressure, presentation stalls toward zero fps — the likely driver of the reporter's black/frozen video in issue #3084. Offloading to HW (near-zero CPU) removes that pressure.

Confirmed the fix and its blast radius on the rendered Dockerfiles:

| board | `+rpt1` pin after this change |
| --- | --- |
| pi3-64 | ✅ added (was ❌) |
| pi4-64 / pi5 / arm64 | ✅ unchanged |
| x86 / pi2 / pi3 (Qt5) | ❌ unchanged (correctly stay on stock) |

Note: this ships in freshly-flashed images only on the next release; `latest-pi3-64` upgrade users get it on the next master build. The stale "Included by BOTH … Dockerfile.server.j2" comment in the template is a separate pre-existing matter (only the viewer template currently includes the pin) and is left untouched here.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)