### PR TITLE
fix(website): correct Pi 3 board status on get-started page

### DIFF
--- a/website/layouts/_default/get-started.html
+++ b/website/layouts/_default/get-started.html
@@ -96,11 +96,16 @@
                     <tr class="border-b border-black/5">
                         <td class="py-3 pr-4">Raspberry Pi 3 Model B+</td>
                         <td class="py-3 pr-4">64-bit</td>
-                        <td class="py-3"><span class="text-zinc-400">Maintenance</span></td>
+                        <td class="py-3"><span class="text-blue-700 font-medium">Supported</span></td>
                     </tr>
                     <tr class="border-b border-black/5">
                         <td class="py-3 pr-4">Raspberry Pi 3 Model B</td>
                         <td class="py-3 pr-4">64-bit</td>
+                        <td class="py-3"><span class="text-blue-700 font-medium">Supported</span></td>
+                    </tr>
+                    <tr class="border-b border-black/5">
+                        <td class="py-3 pr-4">Raspberry Pi 3 (legacy 32-bit image)</td>
+                        <td class="py-3 pr-4">32-bit</td>
                         <td class="py-3"><span class="text-zinc-400">Maintenance</span></td>
                     </tr>
                     <tr class="border-b border-black/5">


### PR DESCRIPTION
### Issues Fixed

The [Supported hardware](https://anthias.screenly.io/get-started/#supported-hardware) table on the get-started page marked the 64-bit Raspberry Pi 3 rows as **Maintenance**, which is inaccurate: the 64-bit Qt6 `pi3-64` stream is the current recommendation (Pi 3 users are steered to it in Raspberry Pi Imager), and the code explicitly treats it as *not* a maintenance board. Only the frozen 32-bit armhf/Qt5 streams (`pi2`, `pi3`) are maintenance.

### Description

- Mark the 64-bit Raspberry Pi 3 (Model B / B+) rows as **Supported** (new blue tier, distinct from the green top-tier Recommended and grey Maintenance).
- Add a separate **Raspberry Pi 3 (legacy 32-bit image)** row marked **Maintenance**, alongside the Pi 2.
- README needs no change — its Compatibility section defers to this table rather than duplicating board status, so it stays the single source of truth.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)