### PR TITLE
fix(viewer): clear stale PulseAudio pid file so audio survives reboot

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -154,6 +154,17 @@ start_pulseaudio() {
         echo 'load-module module-always-sink'
     } > "$pa_config"
 
+    # Clear the stale pid file a previously SIGKILLed daemon left behind.
+    # XDG_RUNTIME_DIR is a persistent path in the container's writable
+    # layer, not a per-boot tmpfs like on the host, so the pid file (and
+    # socket) survive a container restart or a device reboot. On the next
+    # start, --daemonize's self-exec re-runs pa_pid_file_create() and
+    # racily reads that pid file as a live pulseaudio — its own pre-exec
+    # PID — and aborts with "Daemon already running", leaving video silent
+    # (issue #3112). Removing the pid file makes every restart clean; the
+    # socket is unlinked by module-native-protocol-unix's own stale check.
+    rm -f "${XDG_RUNTIME_DIR}/pulse/pid"
+
     # --daemonize blocks until the daemon is initialised, so the
     # socket is guaranteed to exist before AnthiasViewer's
     # QMediaDevices first looks for a server. exit-idle-time=-1


### PR DESCRIPTION
### Issues Fixed

Fixes #3112 (follow-up to #3001).

### Description

On Qt 6 boards (Pi 4/5, x86), HDMI audio works on a fresh install but dies after a reboot — intermittently. The viewer logs the generic `E: [pulseaudio] main.c: Daemon startup failed.` and falls into the "video will play without audio" branch; with no PulseAudio server, QtMultimedia has no audio backend and video plays silent.

**Root cause (captured on real hardware via `--log-target=file:`):** the hidden reason is `E: [pulseaudio] pid.c: Daemon already running.` — a stale `${XDG_RUNTIME_DIR}/pulse/pid`. In Docker, `/run` is **not** a per-boot tmpfs like on bare metal — it lives in the container's writable layer — so the pid file survives a container restart or a device reboot (the `restart: always` viewer is *restarted*, reusing the layer). `--daemonize=yes` self-re-execs the daemon; the pre-exec process overwrites the stale pid file with its own PID, then the re-exec'd process re-runs `pa_pid_file_create()` and racily reads that PID as a live `pulseaudio` (itself) and aborts. The race is why the failure is intermittent.

**Fix:** remove the stale pid file before starting the daemon. The stale socket is already handled by `module-native-protocol-unix`'s own stale-socket unlink, so only the pid file needs clearing.

**Validation (A/B via a `docker restart` loop that reproduces the exact stale-`/run` condition):**

| Board | Baseline (no fix) | With fix |
|---|---|---|
| Pi 4 | 13/14 DOWN (+ 5/5 host reboots failed) | **18/18 UP** |
| Pi 5 | 12/12 DOWN | **12/12 UP** |
| x86  | 12/12 DOWN | **12/12 UP** |

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes. (no unit coverage for this shell path)
- [x] I have done an end-to-end test for Raspberry Pi devices. (real Pi 4 and Pi 5, full container stack)
- [x] I have tested my changes for x86 devices. (real x86 testbed)
- [ ] I added a documentation for the changes I have made (when necessary). (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)