### PR TITLE
feat(assets): add signage app store to the Add Asset flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,11 +10,13 @@
         "alpinejs": "^3.15.12",
         "flatpickr": "^4.6.13",
         "htmx.org": "^2.0.10",
+        "leaflet": "^1.9.4",
         "qrcode": "^1.5.4",
       },
       "devDependencies": {
         "@tailwindcss/cli": "^4.3.2",
         "@tailwindcss/forms": "^0.5.11",
+        "@types/leaflet": "^1.9.21",
         "@types/qrcode": "^1.5.6",
         "sass": "^1.101.0",
         "tailwindcss": "^4.3.2",
@@ -110,6 +112,10 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ=="],
 
     "@thednp/dommatrix": ["@thednp/dommatrix@3.0.4", "", {}, "sha512-xpKtQZqFOuAPfQDbePIh9f48YKfmULV7z9C+anPBSHiOG4P+T3ct7Cx2AZOoUeXbxiDkz7SONANy1bB7p2uysg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/leaflet": ["@types/leaflet@1.9.21", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
@@ -302,6 +308,8 @@
     "jsonc-eslint-parser": ["jsonc-eslint-parser@2.4.2", "", { "dependencies": { "acorn": "^8.5.0", "eslint-visitor-keys": "^3.0.0", "espree": "^9.0.0", "semver": "^7.3.5" } }, "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA=="],
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "leaflet": ["leaflet@1.9.4", "", {}, "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "alpinejs": "^3.15.12",
     "flatpickr": "^4.6.13",
     "htmx.org": "^2.0.10",
+    "leaflet": "^1.9.4",
     "qrcode": "^1.5.4"
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.3.2",
     "@tailwindcss/forms": "^0.5.11",
+    "@types/leaflet": "^1.9.21",
     "@types/qrcode": "^1.5.6",
     "sass": "^1.101.0",
     "tailwindcss": "^4.3.2",

--- a/src/anthias_server/app/helpers.py
+++ b/src/anthias_server/app/helpers.py
@@ -4,6 +4,7 @@ from os import getenv, path, remove
 from typing import Any
 
 import yaml
+from django.conf import settings as django_settings
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.utils import timezone
@@ -39,6 +40,10 @@ def template(
         'default_filters': ['template_handle_unicode'],
     }
     context['use_24_hour_clock'] = settings['use_24_hour_clock']
+    # Store-catalog index URL for the Add → Apps tab (read client-side
+    # off a <meta> tag). Sourced from Django settings so it stays
+    # env-overridable in one place.
+    context['app_store_index_url'] = django_settings.APP_STORE_INDEX_URL
     # Navbar needs is_balena / up_to_date / player_name on every page.
     context.update(_navbar_context())
 

--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -2552,3 +2552,279 @@ body.auth-body {
   .modal-alert__recipe { flex-direction: column; }
   .modal-alert__copy { align-self: stretch; }
 }
+
+// -----------------------------------------------------------------------------
+// Add → Apps tab: store catalog grid + manifest-driven config form.
+// The grid, cards and config controls are project-namespaced (.app-*)
+// to match the rest of the modal; the location-map wraps Leaflet.
+// -----------------------------------------------------------------------------
+
+// Centred loading / error / empty state inside the modal body.
+.app-cfg-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  text-align: center;
+  min-height: 12rem;
+}
+
+.app-cfg-spin {
+  font-size: 2rem;
+  color: var(--color-text-muted);
+  animation: app-cfg-spin 0.9s linear infinite;
+}
+
+@keyframes app-cfg-spin {
+  to { transform: rotate(360deg); }
+}
+
+// Responsive catalog grid — auto-fills as the modal widens.
+.app-grid {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+}
+
+.app-card {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+  padding: var(--space-3);
+  text-align: left;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast),
+    transform var(--t-fast);
+
+  &:hover {
+    border-color: var(--color-link);
+    box-shadow: var(--shadow-sm);
+    transform: translateY(-1px);
+  }
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-link);
+    box-shadow: 0 0 0 var(--ring-width) var(--color-focus-ring);
+  }
+}
+
+.app-card__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface-tint);
+  color: var(--color-text-muted);
+  overflow: hidden;
+
+  img { width: 100%; height: 100%; object-fit: cover; }
+  i { font-size: 1.5rem; }
+
+  &--lg {
+    width: 3.5rem;
+    height: 3.5rem;
+    i { font-size: 2rem; }
+  }
+}
+
+.app-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.app-card__name {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.app-card__text {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  // Clamp the summary to two lines so cards stay even.
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.app-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-top: var(--space-2);
+}
+
+.app-card__tag {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--radius-pill);
+  color: var(--color-text-muted);
+  background-color: var(--color-surface-tint);
+}
+
+// Config panel header (back link + app identity).
+.app-cfg-back {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  padding: 0;
+  margin-bottom: var(--space-3);
+  cursor: pointer;
+
+  &:hover { color: var(--color-link); }
+}
+
+.app-cfg-head {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.app-cfg-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+// Manifest-driven form controls.
+.app-cfg-fields { margin-top: var(--space-4); }
+
+.app-cfg-field {
+  margin-bottom: var(--space-4);
+  &:last-child { margin-bottom: 0; }
+}
+
+.app-cfg-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
+}
+
+.app-cfg-input {
+  @extend .app-input;
+}
+
+.app-cfg-help {
+  margin: var(--space-2) 0 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.app-cfg-group {
+  margin: var(--space-5) 0 var(--space-3);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.app-cfg-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  cursor: pointer;
+
+  input { flex: 0 0 auto; }
+  span { font-size: 0.95rem; color: var(--color-text); }
+}
+
+.app-cfg-nosettings { margin-top: var(--space-3); }
+
+// Location-map widget (Leaflet + OSM). A fixed centre pin over a
+// draggable map; the map canvas fills the frame and the pin/readout
+// float above it.
+.app-cfg-map {
+  position: relative;
+  height: 16rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+  background-color: var(--color-surface-tint);
+}
+
+.app-cfg-map__canvas {
+  // Fill the sized parent with explicit width/height rather than
+  // inset:0 — Leaflet stamps `.leaflet-container { position: relative }`
+  // on this same element, which beats our `position: absolute` in the
+  // cascade and would leave inset ignored and the canvas 0-height (so
+  // only a few tiles load and the map reads blank). 100% of the fixed
+  // 16rem parent is robust to whichever `position` wins.
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  // Leaflet needs an explicit z-index floor so its panes sit below the
+  // pin/readout but above the frame background.
+  z-index: 0;
+}
+
+.app-cfg-map__pin {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1.5rem;
+  height: 1.5rem;
+  // Anchor the pin's tip (bottom-centre) on the map centre.
+  transform: translate(-50%, -100%);
+  pointer-events: none;
+  z-index: 500;
+  background-color: var(--color-danger);
+  border: 2px solid #fff;
+  border-radius: 50% 50% 50% 0;
+  box-shadow: var(--shadow-sm);
+  rotate: -45deg;
+}
+
+.app-cfg-map__readout,
+.app-cfg-map__hint {
+  position: absolute;
+  bottom: var(--space-2);
+  left: var(--space-2);
+  z-index: 500;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-on-dark);
+  background-color: rgba(0, 0, 0, 0.55);
+  pointer-events: none;
+}
+
+// Until the operator picks a point (or the map was seeded with a saved
+// pin), show the "Drag to set location" hint instead of coordinates —
+// the numbers would otherwise imply a location is set when it isn't.
+.app-cfg-map__readout { display: none; }
+.app-cfg-map__hint { display: block; }
+.app-cfg-map.is-touched {
+  .app-cfg-map__readout { display: block; }
+  .app-cfg-map__hint { display: none; }
+}
+
+.app-cfg-map--unavailable {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  height: auto;
+  min-height: 6rem;
+}

--- a/src/anthias_server/app/static/sass/anthias.scss
+++ b/src/anthias_server/app/static/sass/anthias.scss
@@ -1,3 +1,6 @@
 @import "fonts";
 @import "flatpickr/dist/flatpickr";
+// Leaflet powers the Apps tab's location-map widget. Bundled locally
+// (no CDN) alongside the library JS; tiles load from OSM at runtime.
+@import "leaflet/dist/leaflet";
 @import "styles";

--- a/src/anthias_server/app/static/src/alpinejs.d.ts
+++ b/src/anthias_server/app/static/src/alpinejs.d.ts
@@ -1,0 +1,26 @@
+// Ambient declarations for Alpine.js.
+//
+// alpinejs ships no type declarations of its own (no "types" field, no
+// bundled .d.ts) and there is no maintained @types/alpinejs, so under
+// `strict` / `noImplicitAny` a bare `import Alpine from 'alpinejs'`
+// resolves to an implicit any. We type just the surface this codebase
+// touches — `window.Alpine.store(...)` and the registration helpers —
+// so `typeof Alpine` on the Window interface is meaningful. Alpine
+// itself is loaded as a global via the vendor bundle, not tree-shaken
+// through here.
+
+declare module 'alpinejs' {
+  interface Alpine {
+    // A store's shape is defined by whoever registers it, so reads come
+    // back as `unknown` for the caller to narrow / cast to its own type.
+    store(name: string): unknown
+    store(name: string, value: unknown): void
+    data(name: string, callback: (...args: unknown[]) => unknown): void
+    magic(name: string, callback: (...args: unknown[]) => unknown): void
+    directive(name: string, callback: (...args: unknown[]) => unknown): void
+    start(): void
+  }
+
+  const Alpine: Alpine
+  export default Alpine
+}

--- a/src/anthias_server/app/static/src/apps.ts
+++ b/src/anthias_server/app/static/src/apps.ts
@@ -1,0 +1,274 @@
+// Add → Apps tab: browse the signage-app store catalog, configure an
+// app from its manifest, and install it as a webpage asset.
+//
+// Exposes `appsTab()` as an Alpine component factory (registered on
+// window by home.ts). The catalog fetch, manifest-form rendering and
+// launch-URL building live in ./apps/*; this file is the reactive glue
+// and owns nothing that isn't UI state. The actual create request is an
+// htmx <form> in _asset_modal.html (hidden inputs bound to this
+// component), so app installs reuse the exact same #asset-table swap +
+// asset-saved contract as the "From URL" tab.
+
+import { fetchManifest, loadCatalog } from './apps/catalog'
+import { buildLaunchUrl } from './apps/launch-url'
+import { renderManifestForm } from './apps/manifest-form'
+import type { CatalogApp, SettingValue } from './apps/types'
+
+type Phase = 'loading' | 'ready' | 'error' | 'config'
+
+export interface AppsTabData {
+  phase: Phase
+  apps: CatalogApp[]
+  error: string
+  selected: CatalogApp | null
+  // Bound to hidden form inputs (see the install <form>).
+  assetName: string
+  launchUrl: string
+  valuesJson: string
+  loaded: boolean
+  init(): void
+  load(): Promise<void>
+  retry(): void
+  select(app: CatalogApp): void
+  back(): void
+  // The app currently being configured has a settings schema.
+  readonly hasConfig: boolean
+  // Fields the install form needs alongside the built launch URL.
+  readonly appId: string
+  readonly manifestUrl: string
+  readonly manifestVersion: string
+  readonly refreshIntervalS: string
+}
+
+function indexUrl(): string {
+  const el = document.querySelector<HTMLMetaElement>(
+    'meta[name="anthias-app-store-index"]',
+  )
+  return el?.content ?? ''
+}
+
+// Leaflet's control container measures itself at mount; when a config
+// panel opens we let Alpine insert the host, then render into it on the
+// next frame.
+type WithRefs = AppsTabData & { $refs: Record<string, HTMLElement> }
+
+export function appsTab(): AppsTabData {
+  let abort: AbortController | null = null
+
+  return {
+    phase: 'loading',
+    apps: [],
+    error: '',
+    selected: null,
+    assetName: '',
+    launchUrl: '',
+    valuesJson: '{}',
+    loaded: false,
+
+    init(this: AppsTabData) {
+      // Lazy: only hit the network the first time the tab is shown.
+      // The Apps pane calls load() via x-init when it becomes visible.
+    },
+
+    async load(this: AppsTabData) {
+      if (this.loaded && this.phase !== 'error') return
+      const url = indexUrl()
+      if (!url) {
+        this.phase = 'error'
+        this.error = 'No app store configured.'
+        return
+      }
+      this.phase = 'loading'
+      this.error = ''
+      abort?.abort()
+      abort = new AbortController()
+      try {
+        this.apps = await loadCatalog(url, abort.signal)
+        this.loaded = true
+        if (!this.apps.length) {
+          this.phase = 'error'
+          this.error = 'No apps are available right now.'
+          return
+        }
+        this.phase = 'ready'
+      } catch (e) {
+        if (e instanceof DOMException && e.name === 'AbortError') return
+        this.phase = 'error'
+        this.error =
+          "Couldn't reach the app store. Check the device's connection " +
+          'and try again.'
+      }
+    },
+
+    retry(this: AppsTabData) {
+      this.loaded = false
+      void this.load()
+    },
+
+    select(this: WithRefs, app: CatalogApp) {
+      this.selected = app
+      this.assetName = app.manifest.name
+      this.phase = 'config'
+      const launch = app.manifest.launch
+      const properties = app.manifest.settings?.properties
+      const hasProps = !!(properties && Object.keys(properties).length)
+      // A no-settings app installs at its base URL with no values.
+      this.launchUrl = launch.baseUrl
+      this.valuesJson = '{}'
+      // Always clear the config host (Alpine keeps the same element
+      // across selections, so a prior app's rendered fields would
+      // otherwise linger — visibly wrong for a no-settings app). Render
+      // the new form only when there are settings.
+      requestAnimationFrame(() => {
+        const host = this.$refs.configHost
+        if (!host) return
+        host.replaceChildren()
+        if (!hasProps || !properties) return
+        renderManifestForm(host, properties, {}, (values, defaults) => {
+          this.launchUrl = buildLaunchUrl(
+            launch.baseUrl,
+            launch.template ?? '',
+            values,
+            defaults,
+          )
+          this.valuesJson = JSON.stringify(pruneEmpty(values, defaults))
+        })
+      })
+    },
+
+    back(this: AppsTabData) {
+      this.selected = null
+      this.phase = this.loaded ? 'ready' : 'loading'
+      this.launchUrl = ''
+      this.valuesJson = '{}'
+    },
+
+    get hasConfig(): boolean {
+      const props = this.selected?.manifest.settings?.properties
+      return Boolean(props && Object.keys(props).length)
+    },
+    get appId(): string {
+      return this.selected?.manifest.id ?? ''
+    },
+    get manifestUrl(): string {
+      return this.selected?.manifestUrl ?? ''
+    },
+    get manifestVersion(): string {
+      return this.selected?.manifest.manifestVersion ?? ''
+    },
+    get refreshIntervalS(): string {
+      const s = this.selected?.manifest.playback?.refreshIntervalS
+      return s ? String(s) : ''
+    },
+  }
+}
+
+// Minimal shape of the edit modal's asset blob that appEdit reads.
+interface AppAssetMeta {
+  app?: {
+    id?: string
+    manifest_url?: string
+    values?: Record<string, SettingValue>
+  }
+}
+export interface EditAsset {
+  uri?: string | null
+  metadata?: AppAssetMeta | null
+}
+
+export interface AppEditData {
+  phase: 'loading' | 'ready' | 'error'
+  error: string
+  // Bound to the edit form's hidden app_uri / app_values inputs.
+  appUri: string
+  appValuesJson: string
+  init(): void
+}
+
+// Edit-side counterpart of appsTab: reopen an installed app's config
+// form seeded from its saved metadata.app.values, and rebuild the
+// launch URL + values as the operator changes them. The edit <form>
+// posts appUri/appValuesJson back to assets_update. Rendered only for
+// assets that carry metadata.app (see the edit modal template).
+export function appEdit(asset: EditAsset): AppEditData {
+  let abort: AbortController | null = null
+
+  return {
+    phase: 'loading',
+    error: '',
+    appUri: asset?.uri ?? '',
+    appValuesJson: JSON.stringify(asset?.metadata?.app?.values ?? {}),
+
+    init(this: WithEditRefs) {
+      const app = asset?.metadata?.app
+      const manifestUrl = app?.manifest_url
+      if (!manifestUrl) {
+        this.phase = 'error'
+        this.error = 'This app has no manifest reference.'
+        return
+      }
+      abort = new AbortController()
+      fetchManifest(manifestUrl, abort.signal)
+        .then((manifest) => {
+          const launch = manifest.launch
+          const properties = manifest.settings?.properties
+          if (!properties || !Object.keys(properties).length) {
+            // A no-settings app has nothing to reconfigure; keep the
+            // saved URL and show a note.
+            this.phase = 'ready'
+            return
+          }
+          this.phase = 'ready'
+          requestAnimationFrame(() => {
+            const host = this.$refs.appEditHost
+            if (!host) return
+            const saved = app?.values ?? {}
+            renderManifestForm(
+              host,
+              properties,
+              saved,
+              (values, defaults) => {
+                this.appUri = buildLaunchUrl(
+                  launch.baseUrl,
+                  launch.template ?? '',
+                  values,
+                  defaults,
+                )
+                this.appValuesJson = JSON.stringify(
+                  pruneEmpty(values, defaults),
+                )
+              },
+            )
+          })
+        })
+        .catch((e) => {
+          if (e instanceof DOMException && e.name === 'AbortError') return
+          this.phase = 'error'
+          this.error =
+            "Couldn't load this app's settings. Check the connection " +
+            'and reopen.'
+        })
+    },
+  }
+}
+
+type WithEditRefs = AppEditData & { $refs: Record<string, HTMLElement> }
+
+// Keep only the values the operator actually set (differ from their
+// schema default / non-empty), matching what buildLaunchUrl emits, so
+// metadata.app.values round-trips 1:1 with the launch URL rather than
+// carrying every untouched default.
+function pruneEmpty(
+  values: Record<string, SettingValue>,
+  defaults: Record<string, SettingValue>,
+): Record<string, SettingValue> {
+  const out: Record<string, SettingValue> = {}
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined || value === null || value === '' || value === false) {
+      continue
+    }
+    if (JSON.stringify(value) === JSON.stringify(defaults[key])) continue
+    out[key] = value
+  }
+  return out
+}

--- a/src/anthias_server/app/static/src/apps.ts
+++ b/src/anthias_server/app/static/src/apps.ts
@@ -66,8 +66,10 @@ export function appsTab(): AppsTabData {
     loaded: false,
 
     init(this: AppsTabData) {
-      // Lazy: only hit the network the first time the tab is shown.
-      // The Apps pane calls load() via x-init when it becomes visible.
+      // Lazy: nothing here. The Apps pane triggers load() the first
+      // time it becomes visible via x-effect="if (tab === 'apps')
+      // load()" in the template, so the catalog is only fetched when
+      // the operator actually opens the tab.
     },
 
     async load(this: AppsTabData) {
@@ -95,7 +97,7 @@ export function appsTab(): AppsTabData {
         if (e instanceof DOMException && e.name === 'AbortError') return
         this.phase = 'error'
         this.error =
-          "Couldn't reach the app store. Check the device's connection " +
+          "Couldn't reach the app store. Check your network connection " +
           'and try again.'
       }
     },
@@ -247,8 +249,8 @@ export function appEdit(asset: EditAsset): AppEditData {
           if (e instanceof DOMException && e.name === 'AbortError') return
           this.phase = 'error'
           this.error =
-            "Couldn't load this app's settings. Check the connection " +
-            'and reopen.'
+            "Couldn't load this app's settings. Check your network " +
+            'connection and reopen.'
         })
     },
   }

--- a/src/anthias_server/app/static/src/apps.ts
+++ b/src/anthias_server/app/static/src/apps.ts
@@ -11,7 +11,7 @@
 
 import { fetchManifest, loadCatalog } from './apps/catalog'
 import { buildLaunchUrl } from './apps/launch-url'
-import { renderManifestForm } from './apps/manifest-form'
+import { renderManifestForm, teardownHost } from './apps/manifest-form'
 import type { CatalogApp, SettingValue } from './apps/types'
 
 type Phase = 'loading' | 'ready' | 'error' | 'config'
@@ -122,7 +122,9 @@ export function appsTab(): AppsTabData {
       requestAnimationFrame(() => {
         const host = this.$refs.configHost
         if (!host) return
-        host.replaceChildren()
+        // Tear down a prior app's controls (incl. any Leaflet map) even
+        // when the new app has no settings — a bare clear would leak.
+        teardownHost(host)
         if (!hasProps || !properties) return
         renderManifestForm(host, properties, {}, (values, defaults) => {
           this.launchUrl = buildLaunchUrl(

--- a/src/anthias_server/app/static/src/apps/catalog.ts
+++ b/src/anthias_server/app/static/src/apps/catalog.ts
@@ -1,0 +1,86 @@
+// Fetch the signage-app store catalog entirely in the operator's
+// browser: the pointers-only index, then each app's self-hosted
+// manifest. Both the index and the manifests send
+// Access-Control-Allow-Origin: *, so the device itself never has to
+// reach the store — only the browser session does.
+
+import type { AppManifest, CatalogApp, StoreIndex } from './types'
+
+// A manifest must carry at least these to be usable by the picker
+// (mirrors the store's own required set). We skip — rather than
+// render — anything malformed so one bad app can't break the grid.
+function isUsableManifest(m: unknown): m is AppManifest {
+  if (!m || typeof m !== 'object') return false
+  const manifest = m as Partial<AppManifest>
+  return Boolean(
+    manifest.manifestVersion &&
+      manifest.id &&
+      manifest.name &&
+      manifest.description &&
+      manifest.launch &&
+      manifest.launch.baseUrl,
+  )
+}
+
+async function fetchJson(url: string, signal?: AbortSignal): Promise<unknown> {
+  const res = await fetch(url, { signal, credentials: 'omit' })
+  if (!res.ok) {
+    throw new Error(`Fetch failed (${res.status}) for ${url}`)
+  }
+  return res.json()
+}
+
+// Fetch and validate a single app manifest by URL (used by the edit
+// modal to reopen an installed app's config form). Throws on a bad
+// response or a manifest missing its required fields.
+export async function fetchManifest(
+  url: string,
+  signal?: AbortSignal,
+): Promise<AppManifest> {
+  const manifest = await fetchJson(url, signal)
+  if (!isUsableManifest(manifest)) {
+    throw new Error('Manifest is missing required fields')
+  }
+  return manifest
+}
+
+// Load the index and resolve every app's manifest in parallel. A
+// manifest that fails to load or is malformed is dropped (logged) so a
+// single dead origin degrades gracefully to a shorter list. Resolves
+// in index order.
+export async function loadCatalog(
+  indexUrl: string,
+  signal?: AbortSignal,
+): Promise<CatalogApp[]> {
+  const index = (await fetchJson(indexUrl, signal)) as StoreIndex
+  if (!index || !Array.isArray(index.apps)) {
+    throw new Error('Store index is missing an apps list')
+  }
+
+  const settled = await Promise.allSettled(
+    index.apps.map(async (entry): Promise<CatalogApp> => {
+      const manifest = await fetchJson(entry.manifest, signal)
+      if (!isUsableManifest(manifest)) {
+        throw new Error(`Manifest for ${entry.id} is missing required fields`)
+      }
+      return { id: entry.id, manifestUrl: entry.manifest, manifest }
+    }),
+  )
+
+  const apps: CatalogApp[] = []
+  settled.forEach((result, i) => {
+    if (result.status === 'fulfilled') {
+      apps.push(result.value)
+    } else {
+      // Don't spam the console with abort noise when the modal closes
+      // mid-load; those reject with an AbortError we simply ignore.
+      const reason = result.reason
+      if (!(reason instanceof DOMException && reason.name === 'AbortError')) {
+        console.warn(
+          `Skipping app "${index.apps[i]?.id}": ${String(reason)}`,
+        )
+      }
+    }
+  })
+  return apps
+}

--- a/src/anthias_server/app/static/src/apps/launch-url.test.ts
+++ b/src/anthias_server/app/static/src/apps/launch-url.test.ts
@@ -1,0 +1,90 @@
+// Behavioural tests for the manifest launch-URL builder. Run with
+// `bun test src/anthias_server/app/static/src/apps/launch-url.test.ts`.
+// These pin the RFC 6570 `{?…}` expansion the config form relies on so
+// an installed app's URL matches what the app store would build.
+
+import { describe, expect, test } from 'bun:test'
+
+import { buildLaunchUrl } from './launch-url'
+
+describe('buildLaunchUrl', () => {
+  test('returns the base URL when there is no template', () => {
+    expect(buildLaunchUrl('https://quotes.srly.io/', '')).toBe(
+      'https://quotes.srly.io/',
+    )
+  })
+
+  test('omits values that are empty or still at their default', () => {
+    const url = buildLaunchUrl(
+      'https://weather.srly.io/',
+      '{?locale,24h}',
+      { locale: '', '24h': '' },
+      { locale: '', '24h': '' },
+    )
+    expect(url).toBe('https://weather.srly.io/')
+  })
+
+  test('emits only the changed values, first one takes the ?', () => {
+    const url = buildLaunchUrl(
+      'https://weather.srly.io/',
+      '{?locale,24h}',
+      { locale: '', '24h': '1' },
+      { locale: '', '24h': '' },
+    )
+    expect(url).toBe('https://weather.srly.io/?24h=1')
+  })
+
+  test('a boolean true becomes name=1, false is omitted', () => {
+    expect(
+      buildLaunchUrl(
+        'https://world-clock.srly.io/',
+        '{?seconds}',
+        { seconds: true },
+        { seconds: false },
+      ),
+    ).toBe('https://world-clock.srly.io/?seconds=1')
+    expect(
+      buildLaunchUrl(
+        'https://world-clock.srly.io/',
+        '{?seconds}',
+        { seconds: false },
+        { seconds: false },
+      ),
+    ).toBe('https://world-clock.srly.io/')
+  })
+
+  test('explodes an object into its key=value pairs', () => {
+    const url = buildLaunchUrl(
+      'https://weather.srly.io/',
+      '{?location*}',
+      { location: { lat: '51.5', lng: '-0.1' } },
+      {},
+    )
+    expect(url).toBe('https://weather.srly.io/?lat=51.5&lng=-0.1')
+  })
+
+  test('explodes an array into repeated params', () => {
+    const url = buildLaunchUrl(
+      'https://world-clock.srly.io/',
+      '{?tz*}',
+      { tz: ['Europe/London', 'America/New_York'] },
+      {},
+    )
+    // Slash is kept literal; other reserved chars are percent-encoded.
+    expect(url).toBe(
+      'https://world-clock.srly.io/?tz=Europe/London&tz=America/New_York',
+    )
+  })
+
+  test('keeps the zone|label pipe literal in composite tokens', () => {
+    const url = buildLaunchUrl(
+      'https://world-clock.srly.io/',
+      '{?tz*}',
+      { tz: ['Europe/Stockholm|Home'] },
+      {},
+    )
+    expect(url).toBe(
+      'https://world-clock.srly.io/?tz=Europe/Stockholm|Home',
+    )
+  })
+})

--- a/src/anthias_server/app/static/src/apps/launch-url.ts
+++ b/src/anthias_server/app/static/src/apps/launch-url.ts
@@ -1,0 +1,92 @@
+// Build a signage-app launch URL from its manifest's `launch.template`
+// (an RFC 6570 URI Template) and the current setting values. Pure
+// function — no DOM — so it can be unit tested and reused by both the
+// add and edit config forms.
+//
+// Ported faithfully from the app store's expand-template.js (the store
+// renders the same config forms from the same manifests), so a URL
+// built here matches the one the store would build for identical
+// values. Every signage-app manifest expresses its launch URL as a
+// single form-style query expression, e.g. `{?name,tz,format}` or
+// `{?location*,locale,24h}`. We implement exactly that operator:
+// `{?var,var*,...}`. A trailing `*` explodes an array (repeated
+// `name=` params) or an object (its `key=value` pairs).
+//
+// Only meaningful values reach the URL: a value that is undefined,
+// empty, `false` or equal to its schema default is omitted (so the URL
+// stays at the app's defaults until the user actually changes
+// something). A boolean `true` becomes `name=1`. Slashes and the
+// `zone|label` pipe are kept literal — matching the links apps
+// document for themselves — while other reserved characters are
+// percent-encoded (consumers decode them either way).
+
+import type { SettingValue, SettingValues } from './types'
+
+export type { SettingValue, SettingValues }
+
+const encodeToken = (value: string): string =>
+  encodeURIComponent(value).replace(/%2F/g, '/').replace(/%7C/g, '|')
+
+// A scalar value we drop from the URL: nothing chosen, or still at the
+// default.
+function isEmpty(value: SettingValue, def: SettingValue): boolean {
+  if (value === undefined || value === null || value === '' || value === false) {
+    return true
+  }
+  return def !== undefined && value === def
+}
+
+// Expand one template variable spec (optionally `name*`) into
+// `key=value` parts.
+function expandVar(
+  spec: string,
+  values: SettingValues,
+  defaults: SettingValues,
+): string[] {
+  const explode = spec.endsWith('*')
+  const name = explode ? spec.slice(0, -1) : spec
+  const value = values[name]
+
+  if (explode) {
+    // Omit an exploded array/object that is still at its (non-empty)
+    // default.
+    const def = defaults[name]
+    if (def !== undefined && JSON.stringify(value) === JSON.stringify(def)) {
+      return []
+    }
+    if (Array.isArray(value)) {
+      return value
+        .filter((v) => v !== undefined && v !== null && v !== '')
+        .map((v) => `${name}=${encodeToken(String(v))}`)
+    }
+    if (value && typeof value === 'object') {
+      return Object.entries(value)
+        .filter(([, v]) => v !== undefined && v !== null && v !== '')
+        .map(([k, v]) => `${encodeToken(k)}=${encodeToken(String(v))}`)
+    }
+    return []
+  }
+
+  if (isEmpty(value, defaults[name])) return []
+  return [`${name}=${encodeToken(value === true ? '1' : String(value))}`]
+}
+
+export function buildLaunchUrl(
+  baseUrl: string,
+  template: string,
+  values: SettingValues = {},
+  defaults: SettingValues = {},
+): string {
+  if (!template) return baseUrl
+  const match = template.match(/\{\?([^}]*)\}/)
+  if (!match) return baseUrl
+
+  const parts: string[] = []
+  for (const spec of match[1]
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    parts.push(...expandVar(spec, values, defaults))
+  }
+  return parts.length ? `${baseUrl}?${parts.join('&')}` : baseUrl
+}

--- a/src/anthias_server/app/static/src/apps/location-map.ts
+++ b/src/anthias_server/app/static/src/apps/location-map.ts
@@ -20,7 +20,11 @@ const DEFAULT_ZOOM = 11
 const DEFAULT_PRECISION = 4
 
 export interface LocationMapOptions {
-  onChange?: (coords: { lat: string; lng: string }) => void
+  // Coordinates are reported as numbers (not toFixed strings) so a
+  // {lat,lng} value compares cleanly against a numeric schema default
+  // in buildLaunchUrl — a string "51.5" would never equal the number
+  // 51.5 and would leak into the URL as a phantom change.
+  onChange?: (coords: { lat: number; lng: number }) => void
   precision?: number
 }
 
@@ -33,10 +37,15 @@ function showUnavailable(mount: HTMLElement): void {
     'Map unavailable — the app will auto-detect a location.'
 }
 
+const noop = (): void => {}
+
+// Returns a teardown that removes the map and disconnects its
+// ResizeObserver; the form renderer calls it before re-rendering so
+// repeated open/select cycles don't leak detached Leaflet maps.
 export function initLocationMap(
   mount: HTMLElement,
   options: LocationMapOptions = {},
-): void {
+): () => void {
   const { onChange, precision = DEFAULT_PRECISION } = options
 
   // Host markup may seed the starting view via data-attributes (add
@@ -98,12 +107,10 @@ export function initLocationMap(
       const c = map.getCenter()
       readout.textContent = `${c.lat.toFixed(precision)}, ${c.lng.toFixed(precision)}`
     }
+    const round = (n: number): number => Number(n.toFixed(precision))
     const emit = (): void => {
       const c = map.getCenter()
-      onChange?.({
-        lat: c.lat.toFixed(precision),
-        lng: c.lng.toFixed(precision),
-      })
+      onChange?.({ lat: round(c.lat), lng: round(c.lng) })
     }
 
     map.on('dragstart', markTouched)
@@ -126,14 +133,21 @@ export function initLocationMap(
     // whenever the canvas actually gets its size — robust to the modal
     // transition and to the panel scrolling into view — where a single
     // rAF invalidateSize fired too early.
+    let ro: ResizeObserver | null = null
     if (typeof ResizeObserver !== 'undefined') {
-      const ro = new ResizeObserver(() => map.invalidateSize())
+      ro = new ResizeObserver(() => map.invalidateSize())
       ro.observe(canvas)
     } else {
       requestAnimationFrame(() => map.invalidateSize())
       setTimeout(() => map.invalidateSize(), 300)
     }
+
+    return () => {
+      ro?.disconnect()
+      map.remove()
+    }
   } catch {
     showUnavailable(mount)
+    return noop
   }
 }

--- a/src/anthias_server/app/static/src/apps/location-map.ts
+++ b/src/anthias_server/app/static/src/apps/location-map.ts
@@ -1,0 +1,139 @@
+// Reusable location-picker map, built on Leaflet + OpenStreetMap
+// tiles.
+//
+// Anthias can't use the app store's Google-Maps picker: its API key is
+// referrer-locked to *.srly.io, so it would be rejected on a device's
+// own origin. Leaflet + OSM needs no key and works from any origin, and
+// the library + its CSS are bundled locally (no CDN). Tiles are fetched
+// from OSM in the operator's browser — the same "browser has internet,
+// the device need not" model the whole Apps tab relies on.
+//
+// The UI is a fixed centre pin over a draggable map (you drag the map
+// under the pin to choose a point), matching the app store's control:
+// no Leaflet marker is placed, so none of Leaflet's marker/​layers
+// images are referenced and their absence is harmless.
+
+import L from 'leaflet'
+
+const DEFAULT_CENTER: L.LatLngTuple = [51.5287718, -0.2417001]
+const DEFAULT_ZOOM = 11
+const DEFAULT_PRECISION = 4
+
+export interface LocationMapOptions {
+  onChange?: (coords: { lat: string; lng: string }) => void
+  precision?: number
+}
+
+// Swap a mount over to a quiet fallback when Leaflet can't initialise
+// (e.g. tiles unreachable). The launch URL still works without a
+// location — the app auto-detects by IP.
+function showUnavailable(mount: HTMLElement): void {
+  mount.classList.add('app-cfg-map--unavailable')
+  mount.textContent =
+    'Map unavailable — the app will auto-detect a location.'
+}
+
+export function initLocationMap(
+  mount: HTMLElement,
+  options: LocationMapOptions = {},
+): void {
+  const { onChange, precision = DEFAULT_PRECISION } = options
+
+  // Host markup may seed the starting view via data-attributes (add
+  // mode: schema default; edit mode: the saved pin). A seeded map opens
+  // with a location already chosen; an unseeded one stays *unset* until
+  // the operator drags, so a no-default app auto-detects by IP.
+  const hasSeed = mount.dataset.lat !== undefined
+  const startCenter: L.LatLngTuple = [
+    Number(mount.dataset.lat ?? DEFAULT_CENTER[0]),
+    Number(mount.dataset.lng ?? DEFAULT_CENTER[1]),
+  ]
+  const startZoom = Number(mount.dataset.zoom ?? DEFAULT_ZOOM)
+
+  try {
+    const canvas = document.createElement('div')
+    canvas.className = 'app-cfg-map__canvas'
+    const pin = document.createElement('span')
+    pin.className = 'app-cfg-map__pin'
+    pin.setAttribute('aria-hidden', 'true')
+    const readout = document.createElement('div')
+    readout.className = 'app-cfg-map__readout'
+    // Until the operator picks a point (or the map was seeded), the
+    // readout is a hint rather than coordinates — showing the default
+    // centre's numbers would read as "a location is set" when it isn't.
+    const hint = document.createElement('div')
+    hint.className = 'app-cfg-map__hint'
+    hint.textContent = 'Drag to set location'
+    mount.append(canvas, pin, readout, hint)
+
+    const map = L.map(canvas, {
+      center: startCenter,
+      zoom: startZoom,
+      zoomControl: true,
+      attributionControl: true,
+      // Scroll-wheel zoom would hijack the modal's scroll; keep it to
+      // the +/- control and double-click.
+      scrollWheelZoom: false,
+    })
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 18,
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(map)
+
+    // Only after a real user gesture is the location considered
+    // "chosen". Programmatic moves (the initial view, invalidateSize
+    // re-layouts) fire `moveend` too, so gating the emit on this flag
+    // keeps a no-default app's location unset until the operator acts.
+    let touched = hasSeed
+    const markTouched = (): void => {
+      if (touched) return
+      touched = true
+      mount.classList.add('is-touched')
+    }
+    if (hasSeed) mount.classList.add('is-touched')
+
+    const renderCoords = (): void => {
+      const c = map.getCenter()
+      readout.textContent = `${c.lat.toFixed(precision)}, ${c.lng.toFixed(precision)}`
+    }
+    const emit = (): void => {
+      const c = map.getCenter()
+      onChange?.({
+        lat: c.lat.toFixed(precision),
+        lng: c.lng.toFixed(precision),
+      })
+    }
+
+    map.on('dragstart', markTouched)
+    // A double-click zoom recentres on the clicked point, so it also
+    // sets the location.
+    map.on('dblclick', markTouched)
+    map.on('move', renderCoords)
+    map.on('moveend', () => {
+      if (touched) emit()
+    })
+    renderCoords()
+    // Seeded (edit) maps report their saved value straight away so the
+    // form's launch URL reflects it without waiting for a drag.
+    if (hasSeed) emit()
+
+    // The map is created inside a modal panel that animates in from
+    // 0-height, so at first paint the canvas has no size and Leaflet
+    // only loads a couple of tiles for a tiny viewport (the rest of the
+    // frame stays blank). A ResizeObserver recomputes + reloads tiles
+    // whenever the canvas actually gets its size — robust to the modal
+    // transition and to the panel scrolling into view — where a single
+    // rAF invalidateSize fired too early.
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(() => map.invalidateSize())
+      ro.observe(canvas)
+    } else {
+      requestAnimationFrame(() => map.invalidateSize())
+      setTimeout(() => map.invalidateSize(), 300)
+    }
+  } catch {
+    showUnavailable(mount)
+  }
+}

--- a/src/anthias_server/app/static/src/apps/manifest-form.ts
+++ b/src/anthias_server/app/static/src/apps/manifest-form.ts
@@ -19,6 +19,25 @@ import type { SettingSchema, SettingValue } from './types'
 
 type SetFn = (key: string, value: SettingValue) => void
 
+type HostWithCleanups = HTMLElement & { __cfgCleanups?: Array<() => void> }
+
+// Run and clear any teardown callbacks a prior render stored on the
+// host (Leaflet maps + their ResizeObservers), then empty it. Use this
+// instead of a bare replaceChildren() anywhere the config host is
+// cleared, so those maps don't leak.
+export function teardownHost(host: HTMLElement): void {
+  const h = host as HostWithCleanups
+  h.__cfgCleanups?.forEach((fn) => {
+    try {
+      fn()
+    } catch {
+      /* teardown is best-effort */
+    }
+  })
+  h.__cfgCleanups = []
+  host.replaceChildren()
+}
+
 // Which control to render for a settings property.
 function widgetFor(schema: SettingSchema): string {
   if (schema['x-widget']) return schema['x-widget']
@@ -75,11 +94,18 @@ function fieldRow(
   return row
 }
 
-// One shared <datalist> of IANA time zones for all timezone fields
-// (avoids duplicate ids), created lazily when the browser can
-// enumerate zones.
+// Monotonic id source so each rendered form's timezone <datalist> gets
+// a globally-unique id — the Add-app and Edit-app config hosts both
+// live in the modal DOM, so a shared hard-coded id would produce
+// duplicate ids and an <input list=…> could bind to the wrong host's
+// list.
+let tzListSeq = 0
+
+// One shared <datalist> of IANA time zones per host (looked up by a
+// data-attribute, not the global id), created lazily when the browser
+// can enumerate zones.
 function timezoneList(host: HTMLElement): HTMLDataListElement | null {
-  const existing = host.querySelector<HTMLDataListElement>('#app-cfg-tz-list')
+  const existing = host.querySelector<HTMLDataListElement>('[data-tz-list]')
   if (existing) return existing
   const intl = Intl as typeof Intl & {
     supportedValuesOf?: (key: string) => string[]
@@ -90,7 +116,8 @@ function timezoneList(host: HTMLElement): HTMLDataListElement | null {
       : []
   if (!zones.length) return null
   const list = document.createElement('datalist')
-  list.id = 'app-cfg-tz-list'
+  list.id = `app-cfg-tz-list-${tzListSeq++}`
+  list.setAttribute('data-tz-list', '')
   for (const zone of zones) {
     const opt = document.createElement('option')
     opt.value = zone
@@ -108,6 +135,7 @@ function renderField(
   set: SetFn,
   host: HTMLElement,
   seedValue: SettingValue,
+  cleanups: Array<() => void>,
 ): HTMLElement | null {
   const id = `app-cfg-${key}`
 
@@ -182,9 +210,10 @@ function renderField(
       mount.dataset.lat = String(seed.lat)
       mount.dataset.lng = String(seed.lng)
     }
-    initLocationMap(mount, {
+    const teardown = initLocationMap(mount, {
       onChange: ({ lat, lng }) => set(key, { lat, lng }),
     })
+    cleanups.push(teardown)
     return fieldRow(schema, key, mount)
   }
 
@@ -241,7 +270,13 @@ export function renderManifestForm(
     defaults: Record<string, SettingValue>,
   ) => void,
 ): ManifestFormResult {
-  host.replaceChildren()
+  // Tear down any controls a previous render left on this host (e.g. a
+  // Leaflet map + its ResizeObserver) before replacing them, so
+  // re-rendering the same host doesn't leak detached maps.
+  teardownHost(host)
+
+  const cleanups: Array<() => void> = []
+  ;(host as HostWithCleanups).__cfgCleanups = cleanups
 
   const values: Record<string, SettingValue> = {}
   const defaults: Record<string, SettingValue> = {}
@@ -272,6 +307,7 @@ export function renderManifestForm(
       set,
       host,
       values[key],
+      cleanups,
     )
     // Seed a control that was rendered from a saved value (edit mode):
     // renderField reads schema.default for its initial display, so push

--- a/src/anthias_server/app/static/src/apps/manifest-form.ts
+++ b/src/anthias_server/app/static/src/apps/manifest-form.ts
@@ -1,0 +1,309 @@
+// Generic, manifest-driven settings form.
+//
+// Reads a signage-app manifest's `settings` JSON Schema and renders the
+// form controls — one per property, in manifest order — reporting each
+// change back through `onChange(values)`. No app re-implements its own
+// form: every manifest-driven app shares this code, exactly as the app
+// store does (this is a port of its config-manifest.js, adapted to
+// Anthias's modal styling and wired to a callback instead of writing an
+// <input> directly).
+//
+// Supported `x-widget`s (falling back to the JSON Schema type): text,
+// url, number, select (enum), toggle (boolean), timezone, and
+// location-map (a {lat,lng} object). Unknown widgets degrade to a text
+// input; unsupported structural types (arrays, non-location objects)
+// are skipped rather than mis-rendered.
+
+import { initLocationMap } from './location-map'
+import type { SettingSchema, SettingValue } from './types'
+
+type SetFn = (key: string, value: SettingValue) => void
+
+// Which control to render for a settings property.
+function widgetFor(schema: SettingSchema): string {
+  if (schema['x-widget']) return schema['x-widget']
+  if (Array.isArray(schema.enum)) return 'select'
+  if (schema.type === 'boolean') return 'toggle'
+  if (schema.type === 'number' || schema.type === 'integer') return 'number'
+  // Only a {lat,lng} object is a location map; other objects/arrays
+  // have no generic control, so mark them unsupported (skipped) rather
+  // than mis-render.
+  if (schema.type === 'object') {
+    const props = schema.properties || {}
+    return props.lat && props.lng ? 'location-map' : 'unsupported'
+  }
+  if (schema.type === 'array') return 'unsupported'
+  return 'text'
+}
+
+// A labelled wrapper shared by every control. When the control is a
+// real form element we bind a <label for>; custom controls (e.g. the
+// location map) have no focusable input, so we use a plain caption and
+// wire aria-labelledby.
+function fieldRow(
+  schema: SettingSchema,
+  key: string,
+  control: HTMLElement,
+  labelFor?: string,
+): HTMLElement {
+  const row = document.createElement('div')
+  row.className = 'app-cfg-field'
+
+  const captionText = schema.title || key
+  let caption: HTMLElement
+  if (labelFor) {
+    const label = document.createElement('label')
+    label.htmlFor = labelFor
+    caption = label
+  } else {
+    caption = document.createElement('span')
+    const captionId = `app-cfg-lbl-${key}`
+    caption.id = captionId
+    control.setAttribute('role', 'group')
+    control.setAttribute('aria-labelledby', captionId)
+  }
+  caption.className = 'app-cfg-label'
+  caption.textContent = captionText
+  row.append(caption, control)
+
+  if (schema.description) {
+    const help = document.createElement('p')
+    help.className = 'app-cfg-help'
+    help.textContent = schema.description
+    row.appendChild(help)
+  }
+  return row
+}
+
+// One shared <datalist> of IANA time zones for all timezone fields
+// (avoids duplicate ids), created lazily when the browser can
+// enumerate zones.
+function timezoneList(host: HTMLElement): HTMLDataListElement | null {
+  const existing = host.querySelector<HTMLDataListElement>('#app-cfg-tz-list')
+  if (existing) return existing
+  const intl = Intl as typeof Intl & {
+    supportedValuesOf?: (key: string) => string[]
+  }
+  const zones =
+    typeof intl.supportedValuesOf === 'function'
+      ? intl.supportedValuesOf('timeZone')
+      : []
+  if (!zones.length) return null
+  const list = document.createElement('datalist')
+  list.id = 'app-cfg-tz-list'
+  for (const zone of zones) {
+    const opt = document.createElement('option')
+    opt.value = zone
+    list.appendChild(opt)
+  }
+  host.appendChild(list)
+  return list
+}
+
+// Build the control for one property; wire it to `set(key, value)`.
+function renderField(
+  key: string,
+  schema: SettingSchema,
+  widget: string,
+  set: SetFn,
+  host: HTMLElement,
+  seedValue: SettingValue,
+): HTMLElement | null {
+  const id = `app-cfg-${key}`
+
+  // Settings with no generic control — arrays and non-location
+  // objects. Skip them rather than emit a scalar text input with the
+  // wrong value type.
+  if (widget === 'unsupported') return null
+
+  if (widget === 'select') {
+    const select = document.createElement('select')
+    select.className = 'app-cfg-input'
+    select.id = id
+    const labels = schema['x-enumLabels'] || []
+    const options = schema.enum || []
+    // <select> values read back as strings; map the chosen option back
+    // to its original enum value so a typed (number/boolean) default
+    // still compares equal and isn't emitted into the URL.
+    const typed = (raw: string): SettingValue =>
+      (options.find((v) => String(v) === raw) as SettingValue) ?? raw
+    options.forEach((value, i) => {
+      const opt = document.createElement('option')
+      opt.value = String(value)
+      opt.textContent =
+        labels[i] !== undefined
+          ? labels[i]
+          : value === ''
+            ? 'Default'
+            : String(value)
+      if (String(value) === String(schema.default ?? '')) opt.selected = true
+      select.appendChild(opt)
+    })
+    select.addEventListener('change', () => set(key, typed(select.value)))
+    return fieldRow(schema, key, select, id)
+  }
+
+  if (widget === 'toggle') {
+    const wrap = document.createElement('label')
+    wrap.className = 'app-cfg-toggle'
+    const box = document.createElement('input')
+    box.type = 'checkbox'
+    box.id = id
+    box.checked = schema.default === true
+    const text = document.createElement('span')
+    text.textContent = schema.title || key
+    wrap.append(box, text)
+    box.addEventListener('change', () => set(key, box.checked))
+    // The toggle carries its own inline label, so don't add a second
+    // one.
+    const row = document.createElement('div')
+    row.className = 'app-cfg-field'
+    row.appendChild(wrap)
+    if (schema.description) {
+      const help = document.createElement('p')
+      help.className = 'app-cfg-help'
+      help.textContent = schema.description
+      row.appendChild(help)
+    }
+    return row
+  }
+
+  if (widget === 'location-map') {
+    const mount = document.createElement('div')
+    mount.className = 'app-cfg-map'
+    // Seed the map (initLocationMap reads data-lat/lng) from the saved
+    // value first — so edit mode reopens on the operator's pin — then
+    // the schema default, so add mode opens on the app's default rather
+    // than the generic centre.
+    const seed = (seedValue ?? schema.default) as
+      | { lat?: number; lng?: number }
+      | undefined
+    if (seed && seed.lat !== undefined && seed.lng !== undefined) {
+      mount.dataset.lat = String(seed.lat)
+      mount.dataset.lng = String(seed.lng)
+    }
+    initLocationMap(mount, {
+      onChange: ({ lat, lng }) => set(key, { lat, lng }),
+    })
+    return fieldRow(schema, key, mount)
+  }
+
+  // Scalar text-like inputs: text, url, number, timezone.
+  const input = document.createElement('input')
+  input.className = 'app-cfg-input'
+  input.id = id
+  input.value = schema.default != null ? String(schema.default) : ''
+  if (widget === 'number') {
+    input.type = 'number'
+    if (schema.minimum !== undefined) input.min = String(schema.minimum)
+    if (schema.maximum !== undefined) input.max = String(schema.maximum)
+  } else if (widget === 'url') {
+    input.type = 'url'
+  } else {
+    input.type = 'text'
+  }
+  if (widget === 'timezone') {
+    const list = timezoneList(host)
+    if (list) {
+      input.setAttribute('list', list.id)
+      input.autocomplete = 'off'
+    }
+    input.placeholder = 'e.g. Europe/London'
+  }
+  // Number inputs read back as strings; store a Number so a numeric
+  // default compares equal and unchanged numeric defaults don't leak
+  // into the URL.
+  const read: () => SettingValue =
+    widget === 'number'
+      ? () => (input.value === '' ? '' : Number(input.value))
+      : () => input.value
+  input.addEventListener('input', () => set(key, read()))
+  return fieldRow(schema, key, input, id)
+}
+
+export interface ManifestFormResult {
+  // Current values keyed by setting name (seeded with defaults).
+  values: Record<string, SettingValue>
+  // Schema defaults, needed by buildLaunchUrl to omit unchanged values.
+  defaults: Record<string, SettingValue>
+}
+
+// Render the whole form for a manifest's settings into `host`,
+// starting from `initial` values (falling back to each schema
+// `default`). Calls `onChange(values, defaults)` on every edit. Returns
+// the live `values`/`defaults` maps (same objects mutated in place).
+export function renderManifestForm(
+  host: HTMLElement,
+  properties: Record<string, SettingSchema>,
+  initial: Record<string, SettingValue>,
+  onChange: (
+    values: Record<string, SettingValue>,
+    defaults: Record<string, SettingValue>,
+  ) => void,
+): ManifestFormResult {
+  host.replaceChildren()
+
+  const values: Record<string, SettingValue> = {}
+  const defaults: Record<string, SettingValue> = {}
+  const set: SetFn = (key, value) => {
+    values[key] = value
+    onChange(values, defaults)
+  }
+
+  let currentGroup: string | null = null
+  for (const [key, schema] of Object.entries(properties)) {
+    defaults[key] = schema.default as SettingValue
+    values[key] =
+      key in initial ? initial[key] : (schema.default as SettingValue)
+
+    const group = schema['x-group'] || null
+    if (group && group !== currentGroup) {
+      const heading = document.createElement('h3')
+      heading.className = 'app-cfg-group'
+      heading.textContent = group
+      host.appendChild(heading)
+    }
+    currentGroup = group
+
+    const field = renderField(
+      key,
+      schema,
+      widgetFor(schema),
+      set,
+      host,
+      values[key],
+    )
+    // Seed a control that was rendered from a saved value (edit mode):
+    // renderField reads schema.default for its initial display, so push
+    // the saved value back into the control after mounting.
+    if (field) {
+      seedControl(field, key, values[key])
+      host.appendChild(field)
+    }
+  }
+
+  onChange(values, defaults)
+  return { values, defaults }
+}
+
+// After a field is built (from schema defaults), overwrite its
+// displayed value with the seeded (saved) value so edit mode reopens on
+// the operator's last choice. Location maps seed themselves from
+// data-lat/lng set before mount, so they're excluded here.
+function seedControl(
+  field: HTMLElement,
+  key: string,
+  value: SettingValue,
+): void {
+  if (value === undefined || value === null) return
+  const input = field.querySelector<HTMLInputElement | HTMLSelectElement>(
+    `#app-cfg-${key}`,
+  )
+  if (input) {
+    if (input instanceof HTMLInputElement && input.type === 'checkbox') {
+      input.checked = value === true
+    } else {
+      input.value = String(value)
+    }
+  }
+}

--- a/src/anthias_server/app/static/src/apps/types.ts
+++ b/src/anthias_server/app/static/src/apps/types.ts
@@ -1,0 +1,96 @@
+// A single configurable setting's runtime value. Scalars, or the
+// structured values the location-map ({lat,lng}) and array widgets
+// produce. Shared by the launch-URL builder and the form renderer.
+export type SettingValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | SettingValue[]
+  | { [key: string]: SettingValue }
+
+export type SettingValues = Record<string, SettingValue>
+
+// Shapes of the signage-app store index and per-app manifest that the
+// Add → Apps tab consumes. These mirror the published contract in the
+// app store's docs/app-manifest.md and its JSON Schema
+// (static/schemas/signage-app-manifest.schema.json). We type only the
+// fields the picker actually reads; unknown keys pass through untouched.
+
+// One JSON Schema property inside `manifest.settings.properties`,
+// augmented with the store's `x-*` UI hints (which JSON Schema
+// validators ignore). The renderer keys off `x-widget` first, then
+// falls back to `type`/`enum`.
+export interface SettingSchema {
+  type?: 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'
+  title?: string
+  description?: string
+  default?: unknown
+  enum?: unknown[]
+  minimum?: number
+  maximum?: number
+  properties?: Record<string, SettingSchema>
+  items?: SettingSchema
+  required?: string[]
+  'x-widget'?: string
+  'x-enumLabels'?: string[]
+  'x-format'?: string
+  'x-group'?: string
+}
+
+export interface ManifestSettings {
+  type: 'object'
+  properties: Record<string, SettingSchema>
+}
+
+export interface ManifestLaunch {
+  baseUrl: string
+  template?: string
+}
+
+export interface ManifestPlayback {
+  pacing?: 'fixed' | 'stepped'
+  loops?: boolean
+  stepSeconds?: number
+  refreshIntervalS?: number
+}
+
+export interface AppManifest {
+  manifestVersion: string
+  id: string
+  name: string
+  description: string
+  summary?: string
+  vendor?: string
+  tags?: string[]
+  icon?: string
+  screenshots?: string[]
+  homepage?: string
+  source?: string
+  support?: string
+  playback?: ManifestPlayback
+  settings?: ManifestSettings
+  launch: ManifestLaunch
+}
+
+// One entry in the store index (/manifest.json): a pointer to an app's
+// self-hosted manifest.
+export interface IndexEntry {
+  id: string
+  manifest: string
+}
+
+export interface StoreIndex {
+  indexVersion: string
+  updated?: string
+  apps: IndexEntry[]
+}
+
+// A catalog row after the manifest has been fetched and resolved. The
+// index pointer plus its loaded manifest.
+export interface CatalogApp {
+  id: string
+  manifestUrl: string
+  manifest: AppManifest
+}

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -6,11 +6,21 @@
 import type Alpine from 'alpinejs'
 import type flatpickrLib from 'flatpickr'
 
+import {
+  appEdit,
+  appsTab,
+  type AppEditData,
+  type AppsTabData,
+  type EditAsset as AppEditAsset,
+} from './apps'
+
 declare global {
   interface Window {
     Alpine: typeof Alpine
     flatpickr: typeof flatpickrLib
     homeApp: () => HomeAppData
+    appsTab: () => AppsTabData
+    appEdit: (asset: AppEditAsset) => AppEditData
     fallbackCopyToClipboard: (text: string) => boolean
     bulkSucceeded: (event: Event) => boolean
   }
@@ -738,6 +748,8 @@ function bulkSucceeded(event: Event): boolean {
 window.bulkSucceeded = bulkSucceeded
 
 window.homeApp = homeApp
+window.appsTab = appsTab
+window.appEdit = appEdit
 
 function bootHomePage(): void {
   installProcessingToastWatcher()

--- a/src/anthias_server/app/templates/_asset_modal.html
+++ b/src/anthias_server/app/templates/_asset_modal.html
@@ -221,11 +221,18 @@
           hx-on::after-request="if (event.detail.successful) { window.dispatchEvent(new CustomEvent('asset-saved')); }"
         >
           {% csrf_token %}
+          {% comment %} App fields use an `app_`-prefixed / distinct
+             names (app_uri, app_values) rather than uri/values so they
+             don't collide with the URL-tab's visible name="uri" input
+             — two same-named inputs in the modal DOM would make a bare
+             input[name="uri"] selector ambiguous (Playwright strict
+             mode) and is just confusing. Matches the edit form, which
+             already posts app_uri/app_values. {% endcomment %}
           <input type="hidden" name="app_id" :value="appId">
           <input type="hidden" name="manifest_url" :value="manifestUrl">
           <input type="hidden" name="manifest_version" :value="manifestVersion">
-          <input type="hidden" name="uri" :value="launchUrl">
-          <input type="hidden" name="values" :value="valuesJson">
+          <input type="hidden" name="app_uri" :value="launchUrl">
+          <input type="hidden" name="app_values" :value="valuesJson">
           <input type="hidden" name="refresh_interval_s" :value="refreshIntervalS">
 
           <div class="modal-card__body" style="padding-top: var(--space-2)">

--- a/src/anthias_server/app/templates/_asset_modal.html
+++ b/src/anthias_server/app/templates/_asset_modal.html
@@ -38,6 +38,13 @@
               <i class="ti ti-cloud-upload mr-1"></i>Upload file
             </button>
           </li>
+          <li class="app-tab-item">
+            <button type="button" id="tab-apps"
+              class="app-tab-link" :class="tab === 'apps' && 'active'"
+              @click="tab = 'apps'">
+              <i class="ti ti-apps mr-1"></i>Apps
+            </button>
+          </li>
         </ul>
       </div>
 
@@ -140,6 +147,129 @@
           </button>
         </div>
       </form>
+
+      {% comment %} Apps tab — the signage-app store catalog. appsTab()
+         (apps.ts) fetches the store index + each manifest client-side
+         the first time this tab is shown (x-effect below), renders the
+         card grid, and on select renders the manifest-driven config
+         form into [x-ref=configHost]. Installing POSTs the built launch
+         URL to assets_create_app via the htmx form, reusing the same
+         #asset-table swap + asset-saved contract as the URI tab.
+      {% endcomment %}
+      <div
+        x-show="tab === 'apps'"
+        x-data="appsTab()"
+        x-effect="if (tab === 'apps') load()"
+      >
+        {# Loading #}
+        <div class="modal-card__body app-cfg-state" x-show="phase === 'loading'" x-cloak>
+          <i class="ti ti-loader-2 app-cfg-spin" aria-hidden="true"></i>
+          <p class="muted-label m-0">Loading apps…</p>
+        </div>
+
+        {# Error / empty #}
+        <div class="modal-card__body app-cfg-state" x-show="phase === 'error'" x-cloak>
+          <i class="ti ti-plug-connected-x" style="font-size: 2rem; opacity: .55" aria-hidden="true"></i>
+          <p class="mb-2" x-text="error"></p>
+          <button type="button" class="app-btn app-btn-secondary" @click="retry()">
+            <i class="ti ti-refresh"></i><span>Try again</span>
+          </button>
+        </div>
+
+        {# Catalog grid #}
+        <div x-show="phase === 'ready'" x-cloak>
+          <div class="modal-card__body" style="padding-top: 0">
+            <div class="app-grid">
+              <template x-for="app in apps" :key="app.id">
+                <button type="button" class="app-card" @click="select(app)">
+                  <span class="app-card__icon">
+                    <template x-if="app.manifest.icon">
+                      <img :src="app.manifest.icon" :alt="app.manifest.name" loading="lazy">
+                    </template>
+                    <template x-if="!app.manifest.icon">
+                      <i class="ti ti-app-window" aria-hidden="true"></i>
+                    </template>
+                  </span>
+                  <span class="app-card__body">
+                    <span class="app-card__name" x-text="app.manifest.name"></span>
+                    <span class="app-card__text"
+                      x-text="app.manifest.summary || app.manifest.description"></span>
+                    <span class="app-card__tags" x-show="app.manifest.tags && app.manifest.tags.length">
+                      <template x-for="tag in (app.manifest.tags || []).slice(0, 3)" :key="tag">
+                        <span class="app-card__tag" x-text="tag"></span>
+                      </template>
+                    </span>
+                  </span>
+                </button>
+              </template>
+            </div>
+          </div>
+          <div class="modal-card__footer">
+            <button type="button" class="app-btn app-btn-link" @click="closeModal()">Cancel</button>
+          </div>
+        </div>
+
+        {# Configure + install #}
+        <form
+          x-show="phase === 'config'"
+          x-cloak
+          method="post"
+          action="{% url 'anthias_app:assets_create_app' %}"
+          hx-post="{% url 'anthias_app:assets_create_app' %}"
+          hx-target="#asset-table"
+          hx-swap="outerHTML"
+          hx-on::after-request="if (event.detail.successful) { window.dispatchEvent(new CustomEvent('asset-saved')); }"
+        >
+          {% csrf_token %}
+          <input type="hidden" name="app_id" :value="appId">
+          <input type="hidden" name="manifest_url" :value="manifestUrl">
+          <input type="hidden" name="manifest_version" :value="manifestVersion">
+          <input type="hidden" name="uri" :value="launchUrl">
+          <input type="hidden" name="values" :value="valuesJson">
+          <input type="hidden" name="refresh_interval_s" :value="refreshIntervalS">
+
+          <div class="modal-card__body" style="padding-top: var(--space-2)">
+            <button type="button" class="app-cfg-back" @click="back()">
+              <i class="ti ti-arrow-left"></i><span>All apps</span>
+            </button>
+
+            <div class="app-cfg-head">
+              <span class="app-card__icon app-card__icon--lg">
+                <template x-if="selected && selected.manifest.icon">
+                  <img :src="selected.manifest.icon" :alt="selected.manifest.name">
+                </template>
+                <template x-if="selected && !selected.manifest.icon">
+                  <i class="ti ti-app-window" aria-hidden="true"></i>
+                </template>
+              </span>
+              <div>
+                <h3 class="app-cfg-title" x-text="selected && selected.manifest.name"></h3>
+                <p class="muted-label m-0"
+                  x-text="selected && selected.manifest.description"></p>
+              </div>
+            </div>
+
+            <div class="app-floating mt-4 mb-3">
+              <input type="text" class="app-input" id="app-asset-name" name="name" :value="assetName" placeholder=" " required>
+              <label for="app-asset-name">Name</label>
+            </div>
+
+            {# Manifest-driven settings render here (empty for no-config apps). #}
+            <div class="app-cfg-fields" x-ref="configHost"></div>
+
+            <p class="app-cfg-nosettings muted-label m-0" x-show="!hasConfig">
+              This app has no settings — it's ready to add.
+            </p>
+          </div>
+
+          <div class="modal-card__footer">
+            <button type="button" class="app-btn app-btn-link" @click="back()">Back</button>
+            <button type="submit" class="app-btn app-btn-primary">
+              <i class="ti ti-plus"></i><span>Add app</span>
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
 
     {# ---- Edit mode ---- #}
@@ -163,6 +293,9 @@
             const u = editAsset && editAsset.uri ? String(editAsset.uri) : '';
             return !(u.startsWith('http://') || u.startsWith('https://') ||
                      u.startsWith('rtsp://') || u.startsWith('rtmp://'));
+          },
+          get isAppAsset() {
+            return !!(editAsset && editAsset.metadata && editAsset.metadata.app);
           },
           get hasAdvancedDefaults() {
             const days = editAsset.play_days_list || [];
@@ -275,7 +408,10 @@
             <label for="edit-name">Name</label>
           </div>
 
-          <div class="app-floating mb-3" x-show="!isUploadedAsset">
+          {% comment %} App assets hide the machine launch URL (it's
+             rebuilt from the config form below, not hand-edited); plain
+             remote URLs still show it, uploads still collapse it. {% endcomment %}
+          <div class="app-floating mb-3" x-show="!isUploadedAsset && !isAppAsset">
             <input type="text" class="app-input" id="edit-uri" :value="editAsset.uri" readonly>
             <label for="edit-uri">Asset location</label>
           </div>
@@ -285,8 +421,33 @@
             style="border-bottom: 1px solid var(--color-border);"
           >
             <span class="muted-label">Type</span>
-            <span class="schedule-chip text-capitalize" x-text="editAsset.mimetype"></span>
+            <span class="schedule-chip text-capitalize"
+              x-text="isAppAsset ? 'App' : editAsset.mimetype"></span>
           </div>
+
+          {% comment %} App reconfiguration. appEdit() (apps.ts) refetches
+             the app's manifest by metadata.app.manifest_url, re-renders
+             the same manifest-driven config form seeded from the saved
+             metadata.app.values, and keeps the hidden app_uri/app_values
+             inputs in sync as the operator edits. assets_update rebuilds
+             the row's uri + metadata.app.values from them. Only present
+             for app assets, so a plain-webpage edit never posts these. {% endcomment %}
+          <template x-if="isAppAsset">
+            <section class="modal-section" x-data="appEdit(editAsset)" x-init="init()">
+              <h3 class="modal-section__title">App settings</h3>
+              <input type="hidden" name="app_uri" :value="appUri">
+              <input type="hidden" name="app_values" :value="appValuesJson">
+
+              <div class="app-cfg-state" x-show="phase === 'loading'" x-cloak>
+                <i class="ti ti-loader-2 app-cfg-spin" aria-hidden="true"></i>
+                <p class="muted-label m-0">Loading settings…</p>
+              </div>
+              <p class="muted-label" x-show="phase === 'error'" x-cloak x-text="error"></p>
+              <div x-show="phase === 'ready'" x-cloak>
+                <div class="app-cfg-fields" x-ref="appEditHost"></div>
+              </div>
+            </section>
+          </template>
 
           <section class="modal-section">
             <h3 class="modal-section__title">Availability</h3>

--- a/src/anthias_server/app/templates/base.html
+++ b/src/anthias_server/app/templates/base.html
@@ -14,6 +14,9 @@
      of the browser's default. {% endcomment %}
   <meta name="anthias-date-format" content="{{ date_format }}">
   <meta name="anthias-use-24h" content="{{ use_24_hour_clock|yesno:'true,false' }}">
+  {% comment %} Store-catalog index the Add → Apps tab fetches (client-side)
+     to list installable signage apps. Env-overridable server setting. {% endcomment %}
+  <meta name="anthias-app-store-index" content="{{ app_store_index_url }}">
   <link href="/static/favicons/apple-touch-icon-57x57.png" rel="apple-touch-icon-precomposed" sizes="57x57"/>
   <link href="/static/favicons/apple-touch-icon-114x114.png" rel="apple-touch-icon-precomposed" sizes="114x114"/>
   <link href="/static/favicons/apple-touch-icon-72x72.png" rel="apple-touch-icon-precomposed" sizes="72x72"/>

--- a/src/anthias_server/app/urls.py
+++ b/src/anthias_server/app/urls.py
@@ -45,7 +45,10 @@ urlpatterns = [
         name='assets_table',
     ),
     path('assets/new/', views.assets_create, name='assets_create'),
-    path('assets/new-app/', views.assets_create_app, name='assets_create_app'),
+    # Path deliberately avoids the `assets/new` prefix: a test/selector
+    # matching form[action*="assets/new"] would otherwise also match
+    # this form's submit button.
+    path('apps/install/', views.assets_create_app, name='assets_create_app'),
     path('assets/upload/', views.assets_upload, name='assets_upload'),
     path('assets/order/', views.assets_order, name='assets_order'),
     path(

--- a/src/anthias_server/app/urls.py
+++ b/src/anthias_server/app/urls.py
@@ -45,6 +45,7 @@ urlpatterns = [
         name='assets_table',
     ),
     path('assets/new/', views.assets_create, name='assets_create'),
+    path('assets/new-app/', views.assets_create_app, name='assets_create_app'),
     path('assets/upload/', views.assets_upload, name='assets_upload'),
     path('assets/order/', views.assets_order, name='assets_order'),
     path(

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime, time
 from mimetypes import guess_extension, guess_type
 from os import path, remove
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 from django.contrib import messages
@@ -318,6 +319,121 @@ def assets_create(request: HttpRequest) -> HttpResponse:
         end_date=now + timedelta(days=30),
     )
     return _asset_table_response(request, toast=('success', 'Asset added'))
+
+
+def _host_allowed(host: str) -> bool:
+    """True if ``host`` is under an allowed store-app suffix.
+
+    Suffix match on a dotted boundary so `.srly.io` matches
+    `weather.srly.io` but not a look-alike like `evilsrly.io`.
+    """
+    from django.conf import settings as django_settings
+
+    host = (host or '').lower()
+    for suffix in django_settings.APP_STORE_ALLOWED_HOST_SUFFIXES:
+        suffix = suffix.lower()
+        bare = suffix.lstrip('.')
+        if host == bare or host.endswith(suffix):
+            return True
+    return False
+
+
+@authorized
+@require_http_methods(['POST'])
+def assets_create_app(request: HttpRequest) -> HttpResponse:
+    """Install a signage-store app as a webpage asset (the Add → Apps
+    tab).
+
+    The catalog and manifest-driven config form live entirely in the
+    operator's browser (apps.ts); by the time we're called the client
+    has already built the launch URL from the app's ``launch.template``.
+    We persist it as an ordinary ``webpage`` asset — so playback,
+    scheduling and the viewer treat it like any other web page — but
+    stamp ``metadata.app`` with the app id, its manifest URL/version and
+    the raw setting *values*. Values (not just the finished URL) are
+    what let the edit modal reopen the exact config form the operator
+    last saw; the URI stays the source of truth for what actually
+    plays.
+    """
+    import json
+
+    from anthias_common.utils import validate_url
+    from anthias_server.app.models import Asset
+    from datetime import timedelta
+
+    uri = (request.POST.get('uri') or '').strip()
+    app_id = (request.POST.get('app_id') or '').strip()
+    manifest_url = (request.POST.get('manifest_url') or '').strip()
+    manifest_version = (request.POST.get('manifest_version') or '').strip()
+    name = (request.POST.get('name') or '').strip()
+
+    if not app_id or not uri or not validate_url(uri):
+        return _asset_table_response(
+            request, toast=('error', 'Could not add app — invalid app data.')
+        )
+
+    # Defence in depth: the launch URL and the manifest must sit on an
+    # allowed store origin. Without it, this endpoint would be a way to
+    # stamp the "app" badge (and its edit-time config form) onto an
+    # arbitrary URL. The operator can already add any plain webpage via
+    # the URL tab, so this guards data integrity, not access.
+    if not _host_allowed(urlparse(uri).netloc):
+        return _asset_table_response(
+            request,
+            toast=('error', 'That app is not from a recognised app store.'),
+        )
+    if manifest_url and not _host_allowed(urlparse(manifest_url).netloc):
+        return _asset_table_response(
+            request,
+            toast=('error', 'That app is not from a recognised app store.'),
+        )
+
+    # Setting values chosen in the config form, echoed back for the edit
+    # modal to reseed from. Malformed / non-object JSON degrades to an
+    # empty bag rather than 500-ing the install.
+    try:
+        values = json.loads(request.POST.get('values') or '{}')
+    except (TypeError, ValueError, json.JSONDecodeError):
+        values = {}
+    if not isinstance(values, dict):
+        values = {}
+
+    metadata: dict[str, Any] = {
+        'app': {
+            'id': app_id,
+            'manifest_url': manifest_url,
+            'manifest_version': manifest_version,
+            'values': values,
+        }
+    }
+    # Pace the page from the manifest's playback hint (refreshIntervalS),
+    # reusing the same per-asset auto-refresh the viewer already honours.
+    # Clamp with the shared helper so an out-of-range client value can't
+    # land junk in the column.
+    raw_interval = request.POST.get('refresh_interval_s')
+    if raw_interval is not None and raw_interval.strip():
+        interval = clamp_refresh_interval(raw_interval.strip())
+        if interval:
+            metadata['refresh_interval_s'] = interval
+
+    now = timezone.now()
+    play_order = Asset.objects.filter(
+        is_enabled=True, is_processing=False
+    ).count()
+
+    Asset.objects.create(
+        name=name or app_id,
+        uri=uri,
+        mimetype='webpage',
+        duration=settings['default_duration'],
+        is_enabled=True,
+        is_processing=False,
+        play_order=play_order,
+        start_date=now,
+        end_date=now + timedelta(days=30),
+        metadata=metadata,
+    )
+    return _asset_table_response(request, toast=('success', 'App added'))
 
 
 @authorized
@@ -688,6 +804,44 @@ def assets_update(request: HttpRequest, asset_id: str) -> HttpResponse:
             raw_interval.strip() or 0
         )
         asset.metadata = metadata
+
+    # Store-app reconfiguration. When editing an app asset (one carrying
+    # ``metadata.app``), the modal re-renders the manifest config form
+    # and rebuilds the launch URL client-side, posting the new URL and
+    # values back here. We refresh both the ``uri`` (the source of truth
+    # for playback) and ``metadata.app.values`` (what reseeds the form
+    # next time). Guarded by the same host allowlist as install so an
+    # app edit can't be turned into an arbitrary URL, and only when the
+    # row is actually an app — a plain-webpage edit never sends these.
+    from anthias_common.utils import validate_url
+
+    app_uri = (request.POST.get('app_uri') or '').strip()
+    app_values_raw = request.POST.get('app_values')
+    existing_app = (asset.metadata or {}).get('app')
+    if existing_app and app_values_raw is not None and app_uri:
+        if not validate_url(app_uri) or not _host_allowed(
+            urlparse(app_uri).netloc
+        ):
+            return _asset_table_response(
+                request,
+                toast=(
+                    'error',
+                    'That app URL is not from a recognised '
+                    'app store — not saved',
+                ),
+            )
+        try:
+            app_values = _json.loads(app_values_raw)
+        except (TypeError, ValueError, _json.JSONDecodeError):
+            app_values = {}
+        if not isinstance(app_values, dict):
+            app_values = {}
+        metadata = dict(asset.metadata or {})
+        app_meta = dict(metadata.get('app') or {})
+        app_meta['values'] = app_values
+        metadata['app'] = app_meta
+        asset.metadata = metadata
+        asset.uri = app_uri
 
     asset.save()
     ViewerPublisher.get_instance().send_to_viewer('reload')

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -361,7 +361,10 @@ def assets_create_app(request: HttpRequest) -> HttpResponse:
     from anthias_server.app.models import Asset
     from datetime import timedelta
 
-    uri = (request.POST.get('uri') or '').strip()
+    # The launch URL / values are posted as app_uri / app_values (not
+    # uri / values) so the Apps form's hidden inputs don't collide with
+    # the URL tab's visible name="uri" input.
+    uri = (request.POST.get('app_uri') or '').strip()
     app_id = (request.POST.get('app_id') or '').strip()
     manifest_url = (request.POST.get('manifest_url') or '').strip()
     manifest_version = (request.POST.get('manifest_version') or '').strip()
@@ -392,7 +395,7 @@ def assets_create_app(request: HttpRequest) -> HttpResponse:
     # modal to reseed from. Malformed / non-object JSON degrades to an
     # empty bag rather than 500-ing the install.
     try:
-        values = json.loads(request.POST.get('values') or '{}')
+        values = json.loads(request.POST.get('app_values') or '{}')
     except (TypeError, ValueError, json.JSONDecodeError):
         values = {}
     if not isinstance(values, dict):

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -324,16 +324,24 @@ def assets_create(request: HttpRequest) -> HttpResponse:
 def _host_allowed(host: str) -> bool:
     """True if ``host`` is under an allowed store-app suffix.
 
-    Suffix match on a dotted boundary so `.srly.io` matches
-    `weather.srly.io` but not a look-alike like `evilsrly.io`.
+    ``host`` is the URL's ``hostname`` (already port/userinfo-free and
+    lower-cased by ``urlparse``). Each configured suffix is normalised
+    to its bare domain and matched on a dotted boundary — enforced here
+    regardless of whether the operator wrote the suffix with a leading
+    dot — so ``srly.io`` / ``.srly.io`` both match ``weather.srly.io``
+    (and ``srly.io`` itself) but never a look-alike like
+    ``evilsrly.io``.
     """
     from django.conf import settings as django_settings
 
     host = (host or '').lower()
+    if not host:
+        return False
     for suffix in django_settings.APP_STORE_ALLOWED_HOST_SUFFIXES:
-        suffix = suffix.lower()
-        bare = suffix.lstrip('.')
-        if host == bare or host.endswith(suffix):
+        bare = suffix.strip().lstrip('.').lower()
+        if not bare:
+            continue
+        if host == bare or host.endswith('.' + bare):
             return True
     return False
 
@@ -380,12 +388,14 @@ def assets_create_app(request: HttpRequest) -> HttpResponse:
     # stamp the "app" badge (and its edit-time config form) onto an
     # arbitrary URL. The operator can already add any plain webpage via
     # the URL tab, so this guards data integrity, not access.
-    if not _host_allowed(urlparse(uri).netloc):
+    if not _host_allowed(urlparse(uri).hostname or ''):
         return _asset_table_response(
             request,
             toast=('error', 'That app is not from a recognised app store.'),
         )
-    if manifest_url and not _host_allowed(urlparse(manifest_url).netloc):
+    if manifest_url and not _host_allowed(
+        urlparse(manifest_url).hostname or ''
+    ):
         return _asset_table_response(
             request,
             toast=('error', 'That app is not from a recognised app store.'),
@@ -823,7 +833,7 @@ def assets_update(request: HttpRequest, asset_id: str) -> HttpResponse:
     existing_app = (asset.metadata or {}).get('app')
     if existing_app and app_values_raw is not None and app_uri:
         if not validate_url(app_uri) or not _host_allowed(
-            urlparse(app_uri).netloc
+            urlparse(app_uri).hostname or ''
         ):
             return _asset_table_response(
                 request,

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -584,6 +584,36 @@ if getenv('FORWARDED_ALLOW_IPS'):
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+# Signage app store — the pointers-only index (indexVersion, apps:
+# [{id, manifest}]) the Add → Apps tab fetches to populate the app
+# catalog. Each app then serves its own manifest at
+# /.well-known/signage-app.json on its own origin. The fetch happens
+# in the operator's browser (the manifests send Access-Control-Allow-
+# Origin: *), so the device itself never needs to reach the store.
+# Overridable via env so a device can be pointed at staging or a
+# self-hosted mirror; defaults to the staging index until the
+# production index (signage-apps.com/manifest.json) is deployed.
+APP_STORE_INDEX_URL = getenv(
+    'APP_STORE_INDEX_URL',
+    'https://stage.signage-apps.com/manifest.json',
+)
+
+# Host suffixes an installed app's launch URL / manifest may live on.
+# The catalog is fetched client-side, so the create endpoint can't
+# re-derive the app's real origin from the store; this allowlist keeps
+# a `metadata.app`-stamped asset honestly pointed at a store app rather
+# than an arbitrary URL dressed up as one. Comma-separated, env-
+# overridable for self-hosted stores. Matched as a dotted-suffix (so
+# `.srly.io` covers `weather.srly.io` but not `evilsrly.io`).
+APP_STORE_ALLOWED_HOST_SUFFIXES = [
+    h.strip()
+    for h in getenv(
+        'APP_STORE_ALLOWED_HOST_SUFFIXES',
+        '.srly.io,.signage-apps.com',
+    ).split(',')
+    if h.strip()
+]
+
 REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'EXCEPTION_HANDLER': 'anthias_server.api.helpers.custom_exception_handler',

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -590,12 +590,12 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # /.well-known/signage-app.json on its own origin. The fetch happens
 # in the operator's browser (the manifests send Access-Control-Allow-
 # Origin: *), so the device itself never needs to reach the store.
-# Overridable via env so a device can be pointed at staging or a
-# self-hosted mirror; defaults to the staging index until the
-# production index (signage-apps.com/manifest.json) is deployed.
+# Overridable via env so a device can be pointed at the staging index
+# (stage.signage-apps.com) or a self-hosted mirror; defaults to the
+# production store index.
 APP_STORE_INDEX_URL = getenv(
     'APP_STORE_INDEX_URL',
-    'https://stage.signage-apps.com/manifest.json',
+    'https://signage-apps.com/manifest.json',
 )
 
 # Host suffixes an installed app's launch URL / manifest may live on.

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -63,10 +63,14 @@ def test_home_exposes_apps_tab_and_store_index(client: Client) -> None:
     """The Add → Apps tab and the store-index <meta> the tab reads must
     both reach the rendered home page — this is the settings ->
     helpers.template -> base.html -> _asset_modal wiring end to end."""
+    from django.conf import settings as dj_settings
+
     response = client.get(reverse('anthias_app:home'))
     body = response.content.decode()
     assert 'name="anthias-app-store-index"' in body
-    assert 'signage-apps.com/manifest.json' in body
+    # Assert the actual configured index URL reached the page, not a
+    # hard-coded literal that would drift if the default changes.
+    assert dj_settings.APP_STORE_INDEX_URL in body
     assert 'id="tab-apps"' in body
     assert 'appsTab()' in body
 
@@ -480,6 +484,38 @@ def test_assets_create_app_rejects_foreign_host(client: Client) -> None:
         app_values='{}',
     )
     assert not Asset.objects.filter(uri='https://evil.example.com/').exists()
+
+
+def test_host_allowed_matching() -> None:
+    """Dotted-boundary suffix matching: real store hosts (with or
+    without a port) pass; look-alikes and foreign hosts don't."""
+    from anthias_server.app.views import _host_allowed
+
+    assert _host_allowed('weather.srly.io')
+    assert _host_allowed('srly.io')  # the bare apex
+    assert _host_allowed('WEATHER.SRLY.IO'.lower())
+    assert _host_allowed('signage-apps.com')
+    # A hostname is port/userinfo-free by the time it reaches here.
+    assert not _host_allowed('evilsrly.io')  # no dot boundary
+    assert not _host_allowed('srly.io.evil.com')
+    assert not _host_allowed('evil.com')
+    assert not _host_allowed('')
+
+
+@pytest.mark.django_db
+def test_assets_create_app_allows_port_in_uri(client: Client) -> None:
+    """A store URL with an explicit port still installs — the host
+    check runs on the port-free hostname, not the raw netloc."""
+    _post_app(
+        client,
+        app_id='weather',
+        manifest_url='https://weather.srly.io/.well-known/signage-app.json',
+        manifest_version='1',
+        name='Weather',
+        app_uri='https://weather.srly.io:8443/?24h=1',
+        app_values='{}',
+    )
+    assert Asset.objects.filter(name='Weather').exists()
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -407,8 +407,8 @@ def test_assets_create_app_stamps_metadata(client: Client) -> None:
         manifest_url='https://weather.srly.io/.well-known/signage-app.json',
         manifest_version='1',
         name='Weather',
-        uri='https://weather.srly.io/?lat=51.5&lng=-0.1&24h=1',
-        values='{"location": {"lat": 51.5, "lng": -0.1}, "24h": "1"}',
+        app_uri='https://weather.srly.io/?lat=51.5&lng=-0.1&24h=1',
+        app_values='{"location": {"lat": 51.5, "lng": -0.1}, "24h": "1"}',
     )
     assert response.status_code in (200, 302)
 
@@ -437,8 +437,8 @@ def test_assets_create_app_no_settings(client: Client) -> None:
         manifest_url='https://quotes.srly.io/.well-known/signage-app.json',
         manifest_version='1',
         name='Quotes',
-        uri='https://quotes.srly.io/',
-        values='{}',
+        app_uri='https://quotes.srly.io/',
+        app_values='{}',
     )
     assert response.status_code in (200, 302)
     asset = Asset.objects.filter(name='Quotes').first()
@@ -457,8 +457,8 @@ def test_assets_create_app_maps_refresh_interval(client: Client) -> None:
         manifest_url='https://weather.srly.io/.well-known/signage-app.json',
         manifest_version='1',
         name='Weather',
-        uri='https://weather.srly.io/',
-        values='{}',
+        app_uri='https://weather.srly.io/',
+        app_values='{}',
         refresh_interval_s='3600',
     )
     asset = Asset.objects.filter(name='Weather').first()
@@ -476,8 +476,8 @@ def test_assets_create_app_rejects_foreign_host(client: Client) -> None:
         manifest_url='https://evil.example.com/manifest.json',
         manifest_version='1',
         name='Evil',
-        uri='https://evil.example.com/',
-        values='{}',
+        app_uri='https://evil.example.com/',
+        app_values='{}',
     )
     assert not Asset.objects.filter(uri='https://evil.example.com/').exists()
 
@@ -492,8 +492,8 @@ def test_assets_create_app_rejects_lookalike_host(client: Client) -> None:
         manifest_url='https://evilsrly.io/manifest.json',
         manifest_version='1',
         name='Evil',
-        uri='https://evilsrly.io/',
-        values='{}',
+        app_uri='https://evilsrly.io/',
+        app_values='{}',
     )
     assert not Asset.objects.filter(uri='https://evilsrly.io/').exists()
 
@@ -506,8 +506,8 @@ def test_assets_create_app_rejects_invalid_uri(client: Client) -> None:
         manifest_url='https://weather.srly.io/.well-known/signage-app.json',
         manifest_version='1',
         name='Weather',
-        uri='not-a-url',
-        values='{}',
+        app_uri='not-a-url',
+        app_values='{}',
     )
     assert not Asset.objects.filter(name='Weather').exists()
 
@@ -522,8 +522,8 @@ def test_assets_create_app_tolerates_malformed_values(client: Client) -> None:
         manifest_url='https://weather.srly.io/.well-known/signage-app.json',
         manifest_version='1',
         name='Weather',
-        uri='https://weather.srly.io/',
-        values='["not", "an", "object"]',
+        app_uri='https://weather.srly.io/',
+        app_values='["not", "an", "object"]',
     )
     asset = Asset.objects.filter(name='Weather').first()
     assert asset is not None

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -493,7 +493,9 @@ def test_host_allowed_matching() -> None:
 
     assert _host_allowed('weather.srly.io')
     assert _host_allowed('srly.io')  # the bare apex
-    assert _host_allowed('WEATHER.SRLY.IO'.lower())
+    # Pass the uppercase form as-is: exercises the internal lower-casing
+    # (a URL's hostname can arrive mixed-case).
+    assert _host_allowed('WEATHER.SRLY.IO')
     assert _host_allowed('signage-apps.com')
     # A hostname is port/userinfo-free by the time it reaches here.
     assert not _host_allowed('evilsrly.io')  # no dot boundary

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -59,6 +59,19 @@ def test_home_renders(client: Client, asset: Asset) -> None:
 
 
 @pytest.mark.django_db
+def test_home_exposes_apps_tab_and_store_index(client: Client) -> None:
+    """The Add → Apps tab and the store-index <meta> the tab reads must
+    both reach the rendered home page — this is the settings ->
+    helpers.template -> base.html -> _asset_modal wiring end to end."""
+    response = client.get(reverse('anthias_app:home'))
+    body = response.content.decode()
+    assert 'name="anthias-app-store-index"' in body
+    assert 'signage-apps.com/manifest.json' in body
+    assert 'id="tab-apps"' in body
+    assert 'appsTab()' in body
+
+
+@pytest.mark.django_db
 def test_system_info_renders(client: Client) -> None:
     response = client.get(reverse('anthias_app:system_info'))
     assert response.status_code == 200
@@ -369,6 +382,254 @@ def test_assets_create_youtube_short_form(client: Client) -> None:
         )
     assert Asset.objects.filter(name=short_url, mimetype='video').exists()
     mock_dispatch.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Add → Apps tab: installing a signage-store app (assets_create_app)
+
+
+def _post_app(client: Client, **data: Any) -> Any:
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        return client.post(reverse('anthias_app:assets_create_app'), data=data)
+
+
+@pytest.mark.django_db
+def test_assets_create_app_stamps_metadata(client: Client) -> None:
+    """A configured app installs as a webpage asset carrying
+    metadata.app (id, manifest URL/version and the raw setting values)
+    so the edit modal can reopen the same config form."""
+    response = _post_app(
+        client,
+        app_id='weather',
+        manifest_url='https://weather.srly.io/.well-known/signage-app.json',
+        manifest_version='1',
+        name='Weather',
+        uri='https://weather.srly.io/?lat=51.5&lng=-0.1&24h=1',
+        values='{"location": {"lat": 51.5, "lng": -0.1}, "24h": "1"}',
+    )
+    assert response.status_code in (200, 302)
+
+    asset = Asset.objects.filter(name='Weather').first()
+    assert asset is not None
+    assert asset.mimetype == 'webpage'
+    assert asset.uri == 'https://weather.srly.io/?lat=51.5&lng=-0.1&24h=1'
+    assert asset.is_enabled is True
+    assert asset.metadata['app'] == {
+        'id': 'weather',
+        'manifest_url': (
+            'https://weather.srly.io/.well-known/signage-app.json'
+        ),
+        'manifest_version': '1',
+        'values': {'location': {'lat': 51.5, 'lng': -0.1}, '24h': '1'},
+    }
+
+
+@pytest.mark.django_db
+def test_assets_create_app_no_settings(client: Client) -> None:
+    """A no-settings app (e.g. Quotes) installs with an empty values
+    bag and the bare base URL."""
+    response = _post_app(
+        client,
+        app_id='quotes',
+        manifest_url='https://quotes.srly.io/.well-known/signage-app.json',
+        manifest_version='1',
+        name='Quotes',
+        uri='https://quotes.srly.io/',
+        values='{}',
+    )
+    assert response.status_code in (200, 302)
+    asset = Asset.objects.filter(name='Quotes').first()
+    assert asset is not None
+    assert asset.metadata['app']['values'] == {}
+
+
+@pytest.mark.django_db
+def test_assets_create_app_maps_refresh_interval(client: Client) -> None:
+    """The manifest's playback.refreshIntervalS is echoed via the
+    hidden field and stored (clamped) as metadata.refresh_interval_s,
+    reusing the viewer's existing per-asset auto-refresh."""
+    _post_app(
+        client,
+        app_id='weather',
+        manifest_url='https://weather.srly.io/.well-known/signage-app.json',
+        manifest_version='1',
+        name='Weather',
+        uri='https://weather.srly.io/',
+        values='{}',
+        refresh_interval_s='3600',
+    )
+    asset = Asset.objects.filter(name='Weather').first()
+    assert asset is not None
+    assert asset.metadata['refresh_interval_s'] == 3600
+
+
+@pytest.mark.django_db
+def test_assets_create_app_rejects_foreign_host(client: Client) -> None:
+    """A launch URL outside the store-app allowlist is refused — the
+    'app' badge can't be stamped onto an arbitrary URL."""
+    _post_app(
+        client,
+        app_id='evil',
+        manifest_url='https://evil.example.com/manifest.json',
+        manifest_version='1',
+        name='Evil',
+        uri='https://evil.example.com/',
+        values='{}',
+    )
+    assert not Asset.objects.filter(uri='https://evil.example.com/').exists()
+
+
+@pytest.mark.django_db
+def test_assets_create_app_rejects_lookalike_host(client: Client) -> None:
+    """Suffix matching is on a dotted boundary, so a look-alike domain
+    (evilsrly.io) does not satisfy the .srly.io suffix."""
+    _post_app(
+        client,
+        app_id='evil',
+        manifest_url='https://evilsrly.io/manifest.json',
+        manifest_version='1',
+        name='Evil',
+        uri='https://evilsrly.io/',
+        values='{}',
+    )
+    assert not Asset.objects.filter(uri='https://evilsrly.io/').exists()
+
+
+@pytest.mark.django_db
+def test_assets_create_app_rejects_invalid_uri(client: Client) -> None:
+    _post_app(
+        client,
+        app_id='weather',
+        manifest_url='https://weather.srly.io/.well-known/signage-app.json',
+        manifest_version='1',
+        name='Weather',
+        uri='not-a-url',
+        values='{}',
+    )
+    assert not Asset.objects.filter(name='Weather').exists()
+
+
+@pytest.mark.django_db
+def test_assets_create_app_tolerates_malformed_values(client: Client) -> None:
+    """Malformed / non-object values JSON degrades to an empty bag
+    rather than 500-ing the install."""
+    _post_app(
+        client,
+        app_id='weather',
+        manifest_url='https://weather.srly.io/.well-known/signage-app.json',
+        manifest_version='1',
+        name='Weather',
+        uri='https://weather.srly.io/',
+        values='["not", "an", "object"]',
+    )
+    asset = Asset.objects.filter(name='Weather').first()
+    assert asset is not None
+    assert asset.metadata['app']['values'] == {}
+
+
+@pytest.fixture
+def app_asset() -> Asset:
+    now = timezone.now()
+    return Asset.objects.create(
+        name='Weather',
+        uri='https://weather.srly.io/?24h=1',
+        mimetype='webpage',
+        duration=10,
+        is_enabled=True,
+        is_processing=False,
+        play_order=0,
+        start_date=now,
+        end_date=now + timedelta(days=30),
+        metadata={
+            'app': {
+                'id': 'weather',
+                'manifest_url': (
+                    'https://weather.srly.io/.well-known/signage-app.json'
+                ),
+                'manifest_version': '1',
+                'values': {'24h': '1'},
+            }
+        },
+    )
+
+
+def _update_asset(client: Client, asset: Asset, **extra: Any) -> Any:
+    data = {
+        'name': asset.name,
+        'duration': str(asset.duration),
+        'start_date': timezone.localtime(asset.start_date).strftime(
+            '%Y-%m-%dT%H:%M'
+        ),
+        'end_date': timezone.localtime(asset.end_date).strftime(
+            '%Y-%m-%dT%H:%M'
+        ),
+        **extra,
+    }
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        return client.post(
+            reverse('anthias_app:assets_update', args=[asset.asset_id]),
+            data=data,
+        )
+
+
+@pytest.mark.django_db
+def test_assets_update_app_rebuilds_uri_and_values(
+    client: Client, app_asset: Asset
+) -> None:
+    """Editing an app asset rebuilds the URI (client-built) and
+    refreshes metadata.app.values, keeping the app id/manifest intact."""
+    _update_asset(
+        client,
+        app_asset,
+        app_uri='https://weather.srly.io/?lat=40.7&lng=-74&24h=0',
+        app_values='{"location": {"lat": 40.7, "lng": -74}, "24h": "0"}',
+    )
+    app_asset.refresh_from_db()
+    assert app_asset.uri == 'https://weather.srly.io/?lat=40.7&lng=-74&24h=0'
+    assert app_asset.metadata['app']['id'] == 'weather'
+    assert app_asset.metadata['app']['values'] == {
+        'location': {'lat': 40.7, 'lng': -74},
+        '24h': '0',
+    }
+
+
+@pytest.mark.django_db
+def test_assets_update_app_rejects_foreign_uri(
+    client: Client, app_asset: Asset
+) -> None:
+    """A rebuilt URI outside the store allowlist is refused; the row's
+    original URI is left untouched."""
+    _update_asset(
+        client,
+        app_asset,
+        app_uri='https://evil.example.com/',
+        app_values='{}',
+    )
+    app_asset.refresh_from_db()
+    assert app_asset.uri == 'https://weather.srly.io/?24h=1'
+
+
+@pytest.mark.django_db
+def test_assets_update_non_app_ignores_app_fields(
+    client: Client, asset: Asset
+) -> None:
+    """A plain-webpage edit never posts app_* fields; even if forged,
+    they're ignored because the row carries no metadata.app."""
+    _update_asset(
+        client,
+        asset,
+        app_uri='https://weather.srly.io/?x=1',
+        app_values='{"x": "1"}',
+    )
+    asset.refresh_from_db()
+    assert asset.uri == 'https://example.com'
+    assert 'app' not in (asset.metadata or {})
 
 
 @pytest.mark.django_db

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,18 +7,8 @@
     "noImplicitAny": true,
     "strict": true,
     "module": "esnext",
-    "moduleResolution": "node",
-    "jsx": "react-jsx",
-    "baseUrl": ".",
-    "paths": {
-      "@/components/*": ["src/anthias_server/app/static/src/components/*"],
-      "@/constants": ["src/anthias_server/app/static/src/constants.ts"],
-      "@/hooks/*": ["src/anthias_server/app/static/src/hooks/*"],
-      "@/store/*": ["src/anthias_server/app/static/src/store/*"],
-      "@/sass/*": ["src/anthias_server/app/static/sass/*"],
-      "@/types": ["src/anthias_server/app/static/src/types.ts"],
-      "@/tests/*": ["src/anthias_server/app/static/src/tests/*"]
-    }
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx"
   },
   "include": [
     "src/anthias_server/app/static/src/**/*"
@@ -26,6 +16,10 @@
   "exclude": [
     "node_modules",
     "src/anthias_server/app/static/dist",
-    "src/anthias_server/app/static/spec"
+    "src/anthias_server/app/static/spec",
+    // Test files run under Bun's own test runner, which provides the
+    // `bun:test` module types natively; tsc (app type-check) can't
+    // resolve that import, so keep specs out of this pass.
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
### Issues Fixed

Adds a new **Apps** section to the Add Asset flow: a catalog of pre-defined signage apps from the app store (`app-store.srly.io` / `signage-apps.com`), configured from each app's published manifest. Not tied to an existing issue.

### Description

Each app publishes a self-describing manifest (`/.well-known/signage-app.json`) with a `settings` JSON Schema and a `launch` URL template. The store index lists them all. This PR consumes those manifests directly:

- **Apps tab** in the Add modal fetches the store index + per-app manifests **client-side** (operator's browser; manifests are CORS-enabled), so the device itself never reaches the store. Renders a catalog grid.
- **Manifest-driven config form**, ported from the store's tested `expand-template.js` + `config-manifest.js`: text / select / toggle / number / url / timezone widgets, plus a **Leaflet + OpenStreetMap** location-map (no Google Maps, no API key — bundled locally, tiles fetched in the browser only).
- **Install** creates an ordinary `webpage` asset stamped with `metadata.app` (id, manifest URL/version, chosen values). **Editing** an app reopens the same config form seeded from the saved values and rebuilds the launch URL.
- New `assets_create_app` endpoint + app-edit path in `assets_update`, both guarded by a store-host allowlist. `playback.refreshIntervalS` maps to the viewer's existing per-asset auto-refresh.
- `APP_STORE_INDEX_URL` setting defaults to the production store index (`signage-apps.com/manifest.json`) and stays env-overridable (staging / a self-hosted mirror).

Also: added an ambient `alpinejs.d.ts` (the package ships no types) and modernized `tsconfig` (`moduleResolution: bundler`, dropped dead React-era `paths`).

**Live walkthrough (x86 dev host, headless Chromium against the running server + staging catalog):** all 12 apps render with **0 JS errors**; install and edit round-trips verified; found and fixed 3 bugs during the audit — spurious location emit (no-default apps now stay unset for IP auto-detect), a blank map (Leaflet collapsed the canvas to 0 height), and stale config fields when switching to a no-settings app.

**Known limitation:** the generic renderer skips array widgets (World Clock's repeatable city list) — same as the app store, which uses a bespoke form there. World Clock installs with its default cities; other settings are configurable.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes. (12 new Python endpoint tests + 7 bun launch-URL tests; full `test_template_views.py` green.)
- [x] I have done an end-to-end test for Raspberry Pi devices. _(Pi 4 `mvip@…141`: built the arm64 server image from this branch, deployed it to the device, installed an app through the on-device UI (12-app catalog loaded, `clock.srly.io` built), and confirmed the viewer rendered it — logs show `Showing asset Digital Clock (webpage)` / `Current url is https://clock.srly.io/` on eglfs. eglfs has no compositor grab, so no pixel screenshot; verified via viewer logs + the QtWebEngine process + the on-device UI screenshot. Restored afterward.)_
- [x] I have tested my changes for x86 devices. _(x86 `jdoe@…208`: built + deployed the x86 server image from this branch, installed an app on-device, and grim-captured the **rendered display** showing the clock app live (`clock.srly.io`). Restored afterward.)_
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
