### PR TITLE
feat(ui): add Star on GitHub / Review on G2 CTAs

### DIFF
--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -2337,6 +2337,84 @@ body.auth-body {
 .app-toast--error   { border-left-color: var(--color-danger); > i { color: var(--color-danger); } }
 .app-toast--info    { border-left-color: var(--color-link); > i { color: var(--color-accent); } }
 
+// Star-on-GitHub / Review-on-G2 nudge — a dismissible card pinned to
+// the bottom-right, clear of the top-right toast stack so a success
+// toast from the same asset-add can sit alongside it. Surfaced by the
+// `review-cta` HX-Trigger event (see _review_cta.html).
+.review-cta {
+  position: fixed;
+  bottom: var(--space-5);
+  right: var(--space-5);
+  z-index: 1090;
+  width: min(360px, calc(100vw - var(--space-5) * 2));
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--color-border);
+
+  .review-cta__close {
+    position: absolute;
+    top: var(--space-2);
+    right: var(--space-2);
+    background: transparent;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: var(--space-1);
+    line-height: 1;
+    border-radius: var(--radius-sm);
+    transition: color var(--t-fast), background var(--t-fast);
+    &:hover { color: var(--color-text); background: var(--scrim-8); }
+  }
+
+  .review-cta__body {
+    display: flex;
+    gap: var(--space-3);
+    padding-right: var(--space-4); // clear of the close button
+  }
+  .review-cta__icon {
+    flex: none;
+    font-size: 1.5rem;
+    color: var(--color-accent);
+    line-height: 1.4;
+  }
+  .review-cta__title {
+    font-weight: 700;
+    margin: 0 0 var(--space-1);
+  }
+  .review-cta__text {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+  }
+
+  .review-cta__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-4);
+    .app-btn { flex: 1 1 auto; }
+  }
+
+  .review-cta__later {
+    display: block;
+    width: 100%;
+    margin-top: var(--space-2);
+    padding: var(--space-1);
+    background: transparent;
+    border: none;
+    color: var(--color-text-muted);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: color var(--t-fast);
+    &:hover { color: var(--color-text); }
+  }
+}
+
 // -----------------------------------------------------------------------------
 // 18. Misc
 // -----------------------------------------------------------------------------

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -497,6 +497,14 @@ function fireToastFromHeader(
   try {
     const parsed = JSON.parse(header) as {
       toast?: { kind?: 'success' | 'error' | 'info'; message?: string }
+      'review-cta'?: unknown
+    }
+    // The upload path is raw XHR, so htmx never sees this header and
+    // can't dispatch the `review-cta` event for us the way it does for
+    // the hx-* URL/App forms. Replay it by hand so the nudge surfaces
+    // after a qualifying file upload too.
+    if (parsed?.['review-cta']) {
+      window.dispatchEvent(new CustomEvent('review-cta'))
     }
     const toast = parsed?.toast
     if (toast?.message) {

--- a/src/anthias_server/app/templates/_footer.html
+++ b/src/anthias_server/app/templates/_footer.html
@@ -12,7 +12,7 @@
           <a href="https://github.com/Screenly/Anthias" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1">
             <i class="ti ti-brand-github"></i> Star on GitHub
           </a>
-          <a href="https://www.g2.com/products/anthias/reviews" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1">
+          <a href="https://www.g2.com/products/anthias/reviews?utm_source=Anthias&utm_medium=footer&utm_campaign=UI" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1">
             <i class="ti ti-star"></i> Review on G2
           </a>
           <a href="/api/docs/" target="_blank" rel="noopener noreferrer">API</a>

--- a/src/anthias_server/app/templates/_footer.html
+++ b/src/anthias_server/app/templates/_footer.html
@@ -9,13 +9,16 @@
       </div>
       <div class="md:basis-1/2 md:flex md:justify-end">
         <div class="links flex flex-wrap md:justify-end gap-4">
+          <a href="https://github.com/Screenly/Anthias" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1">
+            <i class="ti ti-brand-github"></i> Star on GitHub
+          </a>
+          <a href="https://www.g2.com/products/anthias/reviews" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1">
+            <i class="ti ti-star"></i> Review on G2
+          </a>
           <a href="/api/docs/" target="_blank" rel="noopener noreferrer">API</a>
           <a href="https://anthias.screenly.io/faq/?utm_source=Anthias&utm_medium=footer&utm_campaign=UI" target="_blank" rel="noopener noreferrer">FAQ</a>
           <a href="https://screenly.io/?utm_source=Anthias&utm_medium=footer&utm_campaign=UI" target="_blank" rel="noopener noreferrer">Screenly.io</a>
           <a href="https://forums.screenly.io/" target="_blank" rel="noopener noreferrer">Support</a>
-          <a href="https://github.com/Screenly/Anthias" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1">
-            <i class="ti ti-brand-github"></i> GitHub
-          </a>
         </div>
       </div>
     </div>

--- a/src/anthias_server/app/templates/_layout.html
+++ b/src/anthias_server/app/templates/_layout.html
@@ -8,4 +8,5 @@
 </main>
 {% include "_footer.html" %}
 {% include "_toasts.html" %}
+{% include "_review_cta.html" %}
 {% endblock %}

--- a/src/anthias_server/app/templates/_review_cta.html
+++ b/src/anthias_server/app/templates/_review_cta.html
@@ -68,7 +68,7 @@
       <i class="ti ti-brand-github"></i> Star on GitHub
     </a>
     <a
-      href="https://www.g2.com/products/anthias/reviews"
+      href="https://www.g2.com/products/anthias/reviews?utm_source=Anthias&utm_medium=review_cta&utm_campaign=UI"
       target="_blank"
       rel="noopener noreferrer"
       class="app-btn app-btn-light"

--- a/src/anthias_server/app/templates/_review_cta.html
+++ b/src/anthias_server/app/templates/_review_cta.html
@@ -1,0 +1,84 @@
+{% comment %}
+  "Star on GitHub / Review on G2" nudge. Stays hidden until the server
+  fires the `review-cta` HX-Trigger event on a qualifying asset-add
+  (see views._maybe_offer_review_cta) — htmx dispatches that event for
+  the URL/App forms, and home.ts replays it for the raw-XHR upload path.
+  Acting on either CTA dismisses it permanently; "Maybe later" snoozes.
+{% endcomment %}
+<div
+  id="review-cta"
+  class="review-cta"
+  role="dialog"
+  aria-modal="false"
+  aria-labelledby="review-cta-title"
+  x-cloak
+  x-data="{
+    open: false,
+    post(url) {
+      fetch(url, {
+        method: 'POST',
+        headers: { 'X-CSRFToken': this.$refs.csrf.value },
+      }).catch(() => {})
+    },
+    dismiss() {
+      this.open = false
+      this.post('{% url 'anthias_app:review_cta_dismiss' %}')
+    },
+    later() {
+      this.open = false
+      this.post('{% url 'anthias_app:review_cta_snooze' %}')
+    },
+  }"
+  x-show="open"
+  x-transition.opacity.duration.200ms
+  @review-cta.window="open = true"
+>
+  <input type="hidden" x-ref="csrf" value="{{ csrf_token }}">
+
+  <button
+    type="button"
+    class="review-cta__close"
+    @click="later()"
+    aria-label="Maybe later"
+  >
+    <i class="ti ti-x"></i>
+  </button>
+
+  <div class="review-cta__body">
+    <i class="ti ti-heart-handshake review-cta__icon" aria-hidden="true"></i>
+    <div>
+      <p id="review-cta-title" class="review-cta__title">
+        Enjoying Anthias?
+      </p>
+      <p class="review-cta__text">
+        Anthias is free and open source. A quick star or review helps
+        others find it and keeps the project going.
+      </p>
+    </div>
+  </div>
+
+  <div class="review-cta__actions">
+    <a
+      href="https://github.com/Screenly/Anthias"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="app-btn app-btn-primary"
+      @click="dismiss()"
+    >
+      <i class="ti ti-brand-github"></i> Star on GitHub
+    </a>
+    <a
+      href="https://www.g2.com/products/anthias/reviews"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="app-btn app-btn-light"
+      @click="dismiss()"
+    >
+      <i class="ti ti-star"></i> Review on G2
+    </a>
+  </div>
+
+  <button type="button" class="review-cta__later" @click="later()">
+    Maybe later
+  </button>
+</div>

--- a/src/anthias_server/app/urls.py
+++ b/src/anthias_server/app/urls.py
@@ -44,6 +44,16 @@ urlpatterns = [
         views.assets_table_partial,
         name='assets_table',
     ),
+    path(
+        'review-cta/dismiss/',
+        views.review_cta_dismiss,
+        name='review_cta_dismiss',
+    ),
+    path(
+        'review-cta/snooze/',
+        views.review_cta_snooze,
+        name='review_cta_snooze',
+    ),
     path('assets/new/', views.assets_create, name='assets_create'),
     # Path deliberately avoids the `assets/new` prefix: a test/selector
     # matching form[action*="assets/new"] would otherwise also match

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1395,8 +1395,10 @@ def _asset_table_response(
 
 
 def _merge_hx_trigger(response: HttpResponse, key: str, value: Any) -> None:
-    """Set ``response['HX-Trigger'][key] = value``, merging with any
-    trigger already attached so stacked callers don't clobber each other.
+    """Merge ``{key: value}`` into the response's ``HX-Trigger`` header,
+    preserving any keys already present so stacked callers don't clobber
+    each other. The header is a JSON-encoded object; this decodes it,
+    sets ``key``, and re-encodes.
 
     htmx dispatches one client event per top-level key on the swapped
     element (the toast store and the review-CTA nudge both listen this

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1456,6 +1456,11 @@ def _review_cta_suppressed() -> bool:
             # Corrupt hand-edited value — treat as no snooze rather
             # than suppressing forever.
             return False
+        if until.tzinfo is None:
+            # We always write an aware ISO timestamp; a naive value can
+            # only come from a hand edit. Anchor it to the current zone
+            # so the comparison below doesn't raise on aware-vs-naive.
+            until = timezone.make_aware(until)
         if timezone.now() < until:
             return True
 

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1493,8 +1493,8 @@ def _maybe_offer_review_cta(response: HttpResponse) -> None:
 @authorized
 @require_http_methods(['POST'])
 def review_cta_dismiss(request: HttpRequest) -> HttpResponse:
-    """Operator acted on the star/review nudge (starred, reviewed, or
-    said no thanks) — silence it permanently."""
+    """Operator acted on a star/review CTA (starred or reviewed) —
+    silence the nudge permanently."""
     settings.load()
     settings['review_cta_dismissed'] = True
     settings.save()

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1481,9 +1481,11 @@ def _maybe_offer_review_cta(response: HttpResponse) -> None:
     if _review_cta_suppressed():
         return
 
+    # Only the threshold matters, so cap the scan at REVIEW_CTA_MIN_ASSETS
+    # rows rather than counting the whole (possibly large) asset table.
     real_enabled = (
         Asset.objects.filter(is_enabled=True)
-        .exclude(asset_id__startswith='default_')
+        .exclude(asset_id__startswith='default_')[:REVIEW_CTA_MIN_ASSETS]
         .count()
     )
     if real_enabled < REVIEW_CTA_MIN_ASSETS:
@@ -1506,8 +1508,9 @@ def review_cta_dismiss(request: HttpRequest) -> HttpResponse:
 @authorized
 @require_http_methods(['POST'])
 def review_cta_snooze(request: HttpRequest) -> HttpResponse:
-    """ "Maybe later" — suppress the nudge for REVIEW_CTA_SNOOZE_DAYS,
-    after which it may resurface on a future asset-add."""
+    """Snooze the nudge for REVIEW_CTA_SNOOZE_DAYS (the "Maybe later"
+    and close actions), after which it may resurface on a future
+    asset-add."""
     from datetime import timedelta
 
     settings.load()

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -294,6 +294,7 @@ def assets_create(request: HttpRequest) -> HttpResponse:
         return _asset_table_response(
             request,
             toast=('info', 'Downloading YouTube video…'),
+            offer_review_cta=True,
         )
 
     # Streams have no intrinsic length, so they reuse the dedicated
@@ -318,7 +319,9 @@ def assets_create(request: HttpRequest) -> HttpResponse:
         start_date=now,
         end_date=now + timedelta(days=30),
     )
-    return _asset_table_response(request, toast=('success', 'Asset added'))
+    return _asset_table_response(
+        request, toast=('success', 'Asset added'), offer_review_cta=True
+    )
 
 
 def _host_allowed(host: str) -> bool:
@@ -446,7 +449,9 @@ def assets_create_app(request: HttpRequest) -> HttpResponse:
         end_date=now + timedelta(days=30),
         metadata=metadata,
     )
-    return _asset_table_response(request, toast=('success', 'App added'))
+    return _asset_table_response(
+        request, toast=('success', 'App added'), offer_review_cta=True
+    )
 
 
 @authorized
@@ -682,6 +687,7 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
                 'info',
                 f'Uploaded {upload_name} — reading metadata…',
             ),
+            offer_review_cta=True,
         )
     if needs_image_normalize:
         from anthias_server.processing import dispatch_normalize_image
@@ -693,9 +699,12 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
                 'info',
                 f'Uploaded {upload_name} — converting image…',
             ),
+            offer_review_cta=True,
         )
     return _asset_table_response(
-        request, toast=('success', f'Uploaded {upload_name}')
+        request,
+        toast=('success', f'Uploaded {upload_name}'),
+        offer_review_cta=True,
     )
 
 
@@ -1342,6 +1351,7 @@ def _asset_table_response(
     request: HttpRequest,
     *,
     toast: tuple[str, str] | None = None,
+    offer_review_cta: bool = False,
 ) -> HttpResponse:
     """Shared response helper for all write endpoints.
 
@@ -1350,7 +1360,12 @@ def _asset_table_response(
 
     Pass `toast=("success", "Asset deleted")` to fire a client toast
     via the HX-Trigger header (HTMX requests) or a Django flash
-    message (full-page reload)."""
+    message (full-page reload).
+
+    Pass `offer_review_cta=True` from the asset-*add* endpoints so the
+    "Star on GitHub / Review on G2" nudge can surface at that positive
+    moment — but only once the operator has enough real content on the
+    device to have gotten value (see `_maybe_offer_review_cta`)."""
     # Fan out a refresh nudge over the WebSocket so other browsers
     # currently looking at the home page repaint without waiting for
     # their next 5s poll. Skipped on read endpoints (those don't call
@@ -1365,6 +1380,8 @@ def _asset_table_response(
         response = _render(request, '_asset_table.html', page_context.assets())
         if toast is not None:
             _set_toast_header(response, toast[0], toast[1])
+        if offer_review_cta:
+            _maybe_offer_review_cta(response)
         return response
 
     if toast is not None:
@@ -1377,26 +1394,121 @@ def _asset_table_response(
     return redirect(reverse('anthias_app:home'))
 
 
-def _set_toast_header(response: HttpResponse, kind: str, message: str) -> None:
-    """Attach an HX-Trigger header so the global Alpine store
-    (registered in vendor.ts) renders a toast for this response."""
+def _merge_hx_trigger(response: HttpResponse, key: str, value: Any) -> None:
+    """Set ``response['HX-Trigger'][key] = value``, merging with any
+    trigger already attached so stacked callers don't clobber each other.
+
+    htmx dispatches one client event per top-level key on the swapped
+    element (the toast store and the review-CTA nudge both listen this
+    way), so each feature just claims its own key."""
     import json as _json
 
-    payload = {'toast': {'kind': kind, 'message': message}}
-    # Merge with any existing HX-Trigger so callers stacking triggers
-    # don't clobber each other.
+    payload: dict[str, Any] = {}
     existing = response.headers.get('HX-Trigger')
     if existing:
         try:
-            merged = _json.loads(existing)
-            if isinstance(merged, dict):
-                merged.update(payload)
-                payload = merged
+            parsed = _json.loads(existing)
+            if isinstance(parsed, dict):
+                payload = parsed
         except _json.JSONDecodeError:
-            # Existing value was a bare event name, not JSON — drop
-            # it; the toast payload supersedes for our use case.
+            # Existing value was a bare event name, not JSON — drop it;
+            # our structured payload supersedes for our use case.
             pass
+    payload[key] = value
     response['HX-Trigger'] = _json.dumps(payload)
+
+
+def _set_toast_header(response: HttpResponse, kind: str, message: str) -> None:
+    """Attach an HX-Trigger header so the global Alpine store
+    (registered in vendor.ts) renders a toast for this response."""
+    _merge_hx_trigger(response, 'toast', {'kind': kind, 'message': message})
+
+
+# How many real (operator-added, enabled) assets a device must carry
+# before the star/review nudge is allowed to appear. Below this the
+# operator hasn't invested enough content to have felt the product's
+# value, so asking would be premature. "default_*" seed assets don't
+# count — they're not the operator's own work.
+REVIEW_CTA_MIN_ASSETS = 3
+
+# "Maybe later" hides the nudge for this many days before it may
+# resurface on a future asset-add.
+REVIEW_CTA_SNOOZE_DAYS = 90
+
+
+def _review_cta_suppressed() -> bool:
+    """True when the nudge must stay hidden: the operator has already
+    acted on it (permanent), or "Maybe later" hasn't elapsed yet."""
+    from datetime import datetime
+
+    # Re-read from disk: a "dismiss"/"snooze" POST may have been served
+    # by a different uvicorn worker than the one handling this add.
+    settings.load()
+
+    if settings['review_cta_dismissed']:
+        return True
+
+    snooze = settings['review_cta_snooze_until'] or ''
+    if snooze:
+        try:
+            until = datetime.fromisoformat(snooze)
+        except ValueError:
+            # Corrupt hand-edited value — treat as no snooze rather
+            # than suppressing forever.
+            return False
+        if timezone.now() < until:
+            return True
+
+    return False
+
+
+def _maybe_offer_review_cta(response: HttpResponse) -> None:
+    """Attach the ``review-cta`` HX-Trigger when the operator has just
+    added an asset and the device has crossed into "engaged" territory.
+
+    Fires on every qualifying add (not just the crossing one) so an
+    operator who ignored it without dismissing gets another gentle
+    chance next time; "dismiss"/"snooze" are what actually stop it."""
+    from anthias_server.app.models import Asset
+
+    if _review_cta_suppressed():
+        return
+
+    real_enabled = (
+        Asset.objects.filter(is_enabled=True)
+        .exclude(asset_id__startswith='default_')
+        .count()
+    )
+    if real_enabled < REVIEW_CTA_MIN_ASSETS:
+        return
+
+    _merge_hx_trigger(response, 'review-cta', True)
+
+
+@authorized
+@require_http_methods(['POST'])
+def review_cta_dismiss(request: HttpRequest) -> HttpResponse:
+    """Operator acted on the star/review nudge (starred, reviewed, or
+    said no thanks) — silence it permanently."""
+    settings.load()
+    settings['review_cta_dismissed'] = True
+    settings.save()
+    return HttpResponse(status=204)
+
+
+@authorized
+@require_http_methods(['POST'])
+def review_cta_snooze(request: HttpRequest) -> HttpResponse:
+    """ "Maybe later" — suppress the nudge for REVIEW_CTA_SNOOZE_DAYS,
+    after which it may resurface on a future asset-add."""
+    from datetime import timedelta
+
+    settings.load()
+    settings['review_cta_snooze_until'] = (
+        timezone.now() + timedelta(days=REVIEW_CTA_SNOOZE_DAYS)
+    ).isoformat()
+    settings.save()
+    return HttpResponse(status=204)
 
 
 @authorized

--- a/src/anthias_server/settings.py
+++ b/src/anthias_server/settings.py
@@ -29,6 +29,15 @@ DEFAULTS = {
         'use_ssl': False,
         'auth_backend': '',
         'django_secret_key': '',
+        # State for the "Star on GitHub / Review on G2" nudge (server-
+        # side so it survives a browser/cache clear and stays consistent
+        # across every device the operator opens the UI from).
+        # ``review_cta_dismissed`` is set once the operator acts on it
+        # (starred, reviewed, or said no) and permanently silences it;
+        # ``review_cta_snooze_until`` is an ISO-8601 timestamp set by
+        # "Maybe later" that suppresses the nudge until it passes.
+        'review_cta_dismissed': False,
+        'review_cta_snooze_until': '',
     },
     'viewer': {
         'audio_output': 'hdmi',

--- a/src/anthias_server/settings.py
+++ b/src/anthias_server/settings.py
@@ -32,10 +32,11 @@ DEFAULTS = {
         # State for the "Star on GitHub / Review on G2" nudge (server-
         # side so it survives a browser/cache clear and stays consistent
         # across every device the operator opens the UI from).
-        # ``review_cta_dismissed`` is set once the operator acts on it
-        # (starred, reviewed, or said no) and permanently silences it;
+        # ``review_cta_dismissed`` is set once the operator acts on a
+        # CTA (starred or reviewed) and permanently silences the nudge;
         # ``review_cta_snooze_until`` is an ISO-8601 timestamp set by
-        # "Maybe later" that suppresses the nudge until it passes.
+        # "Maybe later" (and the close button) that suppresses the nudge
+        # until it passes.
         'review_cta_dismissed': False,
         'review_cta_snooze_until': '',
     },

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2872,3 +2872,128 @@ def test_no_bootstrap_class_names_in_templates() -> None:
         'under .app-* now, and Bootstrap Icons were replaced by Tabler '
         '(.ti / .ti-*):\n  ' + '\n  '.join(seen)
     )
+
+
+# ---------------------------------------------------------------------------
+# "Star on GitHub / Review on G2" nudge (review-CTA)
+# ---------------------------------------------------------------------------
+def _make_enabled_assets(count: int) -> None:
+    """Create ``count`` real (non-default) enabled assets."""
+    now = timezone.now()
+    for i in range(count):
+        Asset.objects.create(
+            name=f'real-{i}',
+            uri=f'https://example.com/{i}.png',
+            mimetype='image',
+            duration=10,
+            is_enabled=True,
+            is_processing=False,
+            play_order=i,
+            start_date=now,
+            end_date=now + timedelta(days=30),
+        )
+
+
+@pytest.fixture
+def _reset_review_cta() -> Any:
+    """Clear the persisted nudge state before and after each test so the
+    module-level ``settings`` singleton doesn't leak dismiss/snooze
+    across tests."""
+    from anthias_server.settings import settings
+
+    def _clear() -> None:
+        settings['review_cta_dismissed'] = False
+        settings['review_cta_snooze_until'] = ''
+        settings.save()
+
+    _clear()
+    yield
+    _clear()
+
+
+@pytest.mark.django_db
+def test_review_cta_fires_after_enough_assets(
+    client: Client, _reset_review_cta: Any
+) -> None:
+    """Adding an asset that lands the device at >= REVIEW_CTA_MIN_ASSETS
+    real assets attaches the ``review-cta`` HX-Trigger."""
+    _make_enabled_assets(2)  # 3rd is added by the POST below
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': 'https://anthias.example.com/third.png'},
+            HTTP_HX_REQUEST='true',
+        )
+    assert response.status_code == 200
+    assert 'review-cta' in response.headers.get('HX-Trigger', '')
+
+
+@pytest.mark.django_db
+def test_review_cta_silent_below_threshold(
+    client: Client, _reset_review_cta: Any
+) -> None:
+    """Below the engagement threshold the nudge stays silent — a fresh
+    device with its first asset shouldn't be asked to review."""
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': 'https://anthias.example.com/first.png'},
+            HTTP_HX_REQUEST='true',
+        )
+    assert response.status_code == 200
+    assert 'review-cta' not in response.headers.get('HX-Trigger', '')
+
+
+@pytest.mark.django_db
+def test_review_cta_suppressed_after_dismiss(
+    client: Client, _reset_review_cta: Any
+) -> None:
+    """Once dismissed, the nudge never fires again even on a qualifying
+    add."""
+    _make_enabled_assets(3)
+    dismiss = client.post(reverse('anthias_app:review_cta_dismiss'))
+    assert dismiss.status_code == 204
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': 'https://anthias.example.com/another.png'},
+            HTTP_HX_REQUEST='true',
+        )
+    assert response.status_code == 200
+    assert 'review-cta' not in response.headers.get('HX-Trigger', '')
+
+
+@pytest.mark.django_db
+def test_review_cta_suppressed_while_snoozed(
+    client: Client, _reset_review_cta: Any
+) -> None:
+    """ "Maybe later" persists a future snooze timestamp and suppresses
+    the nudge until it passes."""
+    from anthias_server.settings import settings
+
+    _make_enabled_assets(3)
+    snooze = client.post(reverse('anthias_app:review_cta_snooze'))
+    assert snooze.status_code == 204
+    assert settings['review_cta_snooze_until']  # a future ISO timestamp
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': 'https://anthias.example.com/snoozed.png'},
+            HTTP_HX_REQUEST='true',
+        )
+    assert response.status_code == 200
+    assert 'review-cta' not in response.headers.get('HX-Trigger', '')

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2974,6 +2974,33 @@ def test_review_cta_suppressed_after_dismiss(
 
 
 @pytest.mark.django_db
+def test_review_cta_naive_snooze_does_not_crash(
+    client: Client, _reset_review_cta: Any
+) -> None:
+    """A hand-edited *naive* snooze timestamp (no tz offset) must not
+    raise aware-vs-naive on comparison; a future naive value is anchored
+    to the current zone and still suppresses the nudge."""
+    from anthias_server.settings import settings
+
+    _make_enabled_assets(3)
+    future_naive = (timezone.now() + timedelta(days=30)).replace(tzinfo=None)
+    settings['review_cta_snooze_until'] = future_naive.isoformat()
+    settings.save()
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_create'),
+            data={'uri': 'https://anthias.example.com/naive.png'},
+            HTTP_HX_REQUEST='true',
+        )
+    assert response.status_code == 200
+    assert 'review-cta' not in response.headers.get('HX-Trigger', '')
+
+
+@pytest.mark.django_db
 def test_review_cta_suppressed_while_snoozed(
     client: Client, _reset_review_cta: Any
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -3004,8 +3004,8 @@ def test_review_cta_naive_snooze_does_not_crash(
 def test_review_cta_suppressed_while_snoozed(
     client: Client, _reset_review_cta: Any
 ) -> None:
-    """ "Maybe later" persists a future snooze timestamp and suppresses
-    the nudge until it passes."""
+    """The "Maybe later" action persists a future snooze timestamp and
+    suppresses the nudge until it passes."""
     from anthias_server.settings import settings
 
     _make_enabled_assets(3)

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2895,20 +2895,26 @@ def _make_enabled_assets(count: int) -> None:
 
 
 @pytest.fixture
-def _reset_review_cta() -> Any:
-    """Clear the persisted nudge state before and after each test so the
-    module-level ``settings`` singleton doesn't leak dismiss/snooze
-    across tests."""
+def _reset_review_cta(tmp_path: Any) -> Any:
+    """Redirect the settings singleton's config file to a per-test temp
+    path so the dismiss/snooze ``settings.save()`` writes stay hermetic
+    (the test env otherwise resolves ``conf_file`` to the real
+    ``~/.anthias/anthias.conf``), and clear the nudge state around each
+    test so it can't leak dismiss/snooze across tests."""
     from anthias_server.settings import settings
 
-    def _clear() -> None:
-        settings['review_cta_dismissed'] = False
-        settings['review_cta_snooze_until'] = ''
-        settings.save()
-
-    _clear()
-    yield
-    _clear()
+    original_conf_file = settings.conf_file
+    settings.conf_file = str(tmp_path / 'anthias.conf')
+    settings['review_cta_dismissed'] = False
+    settings['review_cta_snooze_until'] = ''
+    settings.save()
+    try:
+        yield
+    finally:
+        # Point back at the real config and reload it so the singleton's
+        # in-memory state is restored for any later test.
+        settings.conf_file = original_conf_file
+        settings.load()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What

Adds two lightweight "help the project" CTAs to the web UI:

- **Footer links** — the plain "GitHub" footer link is replaced by two labelled CTAs: **Star on GitHub** and **Review on G2** (Tabler icons).
- **Post-add nudge** — a dismissible bottom-right card ("Enjoying Anthias?") that surfaces after a successful asset add, offering the same two actions plus a **Maybe later**.

## When the nudge appears

Only at a genuinely positive moment, and never nags:

- Fires after an asset is added (URL, App, YouTube, or file upload).
- Gated on the device carrying **≥3 real (operator-added, enabled) assets** — seed `default_*` assets don't count. A fresh device with its first asset is never asked.
- Acting on either CTA silences it **permanently**; **Maybe later** snoozes it for **90 days**.
- State lives server-side in `anthias.conf` (`review_cta_dismissed`, `review_cta_snooze_until`), so it survives a browser/cache clear and stays consistent across every browser/device the operator uses.

## Implementation notes

- `_maybe_offer_review_cta()` attaches a `review-cta` HX-Trigger on qualifying adds. `_set_toast_header` was refactored into a shared `_merge_hx_trigger` so the toast and CTA triggers stack in one header without clobbering each other.
- The file-upload path is raw XHR, so htmx never sees the header — `home.ts` replays the `review-cta` event by hand for that path.
- Two POST endpoints back the card: `review_cta_dismiss` and `review_cta_snooze`.

## Tests

Four cases in `tests/test_template_views.py`: fires at threshold, silent below threshold, suppressed after dismiss, suppressed while snoozed. `ruff check` / `ruff format --check` clean.

## Note for reviewers

The G2 link points at `https://www.g2.com/products/anthias/reviews` — please confirm that product page exists before merge (otherwise the CTA 404s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
