### PR TITLE
fix(api): confine absolute-path asset URIs to the asset directory

### DIFF
--- a/src/anthias_server/api/serializers/__init__.py
+++ b/src/anthias_server/api/serializers/__init__.py
@@ -29,9 +29,30 @@ def get_unique_name(name: str) -> str:
     return name
 
 
+def _is_within_assetdir(uri: str) -> bool:
+    """True when ``uri`` resolves to a real path inside the asset dir.
+
+    Absolute-path URIs are only legitimate for the two-step upload
+    flow: the ``file_asset`` endpoint stages the upload at
+    ``<assetdir>/<uuid>.tmp`` and the create request then submits that
+    path. ``prepare_asset`` will ``rename`` a ``/``-prefixed URI into
+    the asset store and the content endpoint reads it straight back, so
+    without this guard a create request could point an asset at any
+    host file the process can read (``/data/.anthias/anthias.conf`` —
+    which holds ``django_secret_key`` — the SQLite DB, etc.), then GET
+    its contents. ``realpath`` is applied to both sides so a symlink
+    staged inside the asset dir can't resolve back out.
+    """
+    from anthias_server.settings import settings
+
+    base = path.realpath(settings['assetdir']) + path.sep
+    target = path.realpath(uri)
+    return target.startswith(base)
+
+
 def validate_uri(uri: str) -> None:
     if uri.startswith('/'):
-        if not path.isfile(uri):
+        if not _is_within_assetdir(uri) or not path.isfile(uri):
             raise Exception('Invalid file path. Failed to add asset.')
     else:
         if not validate_url(uri):

--- a/src/anthias_server/api/serializers/__init__.py
+++ b/src/anthias_server/api/serializers/__init__.py
@@ -2,6 +2,7 @@ from datetime import timezone
 from os import path
 from typing import Any
 
+from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import (
     CharField,
     DateTimeField,
@@ -51,12 +52,18 @@ def _is_within_assetdir(uri: str) -> bool:
 
 
 def validate_uri(uri: str) -> None:
+    # Raise DRF ``ValidationError`` (keyed on ``uri``) rather than a
+    # bare ``Exception`` so ``serializer.is_valid()`` catches it and the
+    # create view returns a 400 instead of a 500 — ``validate_uri`` only
+    # runs inside the create serializers' ``prepare_asset``.
     if uri.startswith('/'):
         if not _is_within_assetdir(uri) or not path.isfile(uri):
-            raise Exception('Invalid file path. Failed to add asset.')
+            raise ValidationError(
+                {'uri': 'Invalid file path. Failed to add asset.'}
+            )
     else:
         if not validate_url(uri):
-            raise Exception('Invalid URL. Failed to add asset.')
+            raise ValidationError({'uri': 'Invalid URL. Failed to add asset.'})
 
 
 class AssetSerializer(ModelSerializer[Asset]):

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -130,6 +130,56 @@ def test_create_video_asset_v2_with_non_zero_duration_should_fail(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+def test_create_asset_rejects_absolute_uri_outside_assetdir(
+    api_client: APIClient, version: str, tmp_path: Any
+) -> None:
+    """A create request must reject an absolute ``uri`` that points
+    outside the asset directory.
+
+    Regression guard for the arbitrary-file-read/-move flaw: without
+    the ``_is_within_assetdir`` confinement in ``validate_uri`` a
+    ``/``-prefixed uri such as ``/data/.anthias/anthias.conf`` would be
+    ``rename``d into the asset store and then served verbatim by the
+    content endpoint — disclosing ``django_secret_key`` / operator
+    password hashes and destroying the source file. A real file placed
+    *outside* the asset dir proves the guard rejects on location, not
+    merely on non-existence.
+    """
+    from anthias_server.app.models import Asset
+
+    secret_file = tmp_path / 'anthias.conf'
+    secret_file.write_text('[main]\ndjango_secret_key = topsecret\n')
+
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': str(secret_file),
+        'mimetype': 'image',
+    }
+    asset_list_url = reverse(f'api:asset_list_{version}')
+
+    with (
+        mock.patch(
+            'anthias_server.api.serializers.mixins.rename'
+        ) as mixins_rename,
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.rename'
+        ) as v1_1_rename,
+    ):
+        response = api_client.post(
+            asset_list_url, data=get_request_data(payload, version)
+        )
+
+    # Rejected before the destructive rename, with no row persisted and
+    # the source file left intact.
+    assert response.status_code != status.HTTP_201_CREATED
+    mixins_rename.assert_not_called()
+    v1_1_rename.assert_not_called()
+    assert Asset.objects.count() == 0
+    assert secret_file.exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
 def test_get_assets_after_create_should_return_1_asset(
     api_client: APIClient, version: str
 ) -> None:

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -169,9 +169,10 @@ def test_create_asset_rejects_absolute_uri_outside_assetdir(
             asset_list_url, data=get_request_data(payload, version)
         )
 
-    # Rejected before the destructive rename, with no row persisted and
-    # the source file left intact.
-    assert response.status_code != status.HTTP_201_CREATED
+    # Rejected as a 400 keyed on ``uri``, before the destructive
+    # rename, with no row persisted and the source file left intact.
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'uri' in response.data
     mixins_rename.assert_not_called()
     v1_1_rename.assert_not_called()
     assert Asset.objects.count() == 0


### PR DESCRIPTION
## Summary

The asset-create API accepts an absolute-path (`/`-prefixed) `uri` after only an existence check, then moves it into the asset store and serves it back — a pre-auth arbitrary file read (and destructive move) on a default install.

- `validate_uri` (`api/serializers/__init__.py`) only ran `path.isfile(uri)` for a `/`-prefixed URI, with no confinement to the asset directory.
- `prepare_asset` then `rename`s that file into `<assetdir>/<uuid>` (source removed), and `AssetContentViewMixin.get` reads it back as base64.
- Because `auth_backend` defaults to `''`, `@authorized` no-ops, so any unauthenticated LAN client could:
  1. `POST /api/v2/assets {"uri": "/data/.anthias/anthias.conf", "mimetype": "image", ...}` → the file is moved into the asset store.
  2. `GET /api/v1/assets/<id>/content` → base64 of `anthias.conf`, which contains `django_secret_key` (enough to forge signed sessions and the internal-auth token). Targeting `anthias.db` discloses operator password hashes; either target is also destroyed by the move.

## Fix

Confine `/`-prefixed URIs to `settings['assetdir']` in the shared `validate_uri`, applying `realpath` to both sides so a symlink staged inside the asset dir can't resolve back out. The trailing separator prevents a sibling-prefix bypass (`<assetdir>_evil`).

The only legitimate absolute-path flow is the two-step `file_asset` upload, which stages files as `<assetdir>/<uuid>.tmp` — inside the asset dir, so it is unaffected. The HTML create path already rejects absolute paths via `validate_url`; this gap was API-only.

## Tests

Adds `test_create_asset_rejects_absolute_uri_outside_assetdir` (parametrized across v1/v1.1/v1.2/v2): a real file placed *outside* the asset dir is rejected before the `rename`, no row is persisted, and the source file is left intact. Verified the confinement accepts a genuine in-`assetdir` path and blocks `/etc/passwd`, the sibling `.anthias/anthias.conf`, `..` traversal, and the `_evil` sibling-prefix case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)