### PR TITLE
fix(api): gate youtube_asset downloads on a real YouTube URL

### DIFF
--- a/src/anthias_server/api/serializers/mixins.py
+++ b/src/anthias_server/api/serializers/mixins.py
@@ -3,6 +3,7 @@ from inspect import cleandoc
 from os import path, rename
 from typing import Any
 
+from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import CharField, Serializer
 
 from anthias_server.api.errors import AssetCreationError
@@ -112,8 +113,13 @@ class CreateAssetSerializerMixin:
         # hosts) would be fetched server-side through yt-dlp's generic
         # extractor. The URI already passed ``validate_uri``.
         if is_youtube and not is_youtube_url(uri):
-            raise AssetCreationError(
-                'A youtube_asset URI must point at a YouTube URL.'
+            # DRF ``ValidationError`` (not ``AssetCreationError``) so
+            # ``serializer.is_valid()`` catches it and the create view
+            # returns a 400 keyed on ``uri`` — matching the v1.1
+            # serializer. A bare ``AssetCreationError`` from here would
+            # escape ``is_valid()`` and surface as a 500.
+            raise ValidationError(
+                {'uri': 'A youtube_asset URI must point at a YouTube URL.'}
             )
         if is_youtube:
             # Defer the download to download_youtube_asset (Celery).

--- a/src/anthias_server/api/serializers/mixins.py
+++ b/src/anthias_server/api/serializers/mixins.py
@@ -14,7 +14,7 @@ from anthias_common.utils import (
     get_video_duration,
     url_fails,
 )
-from anthias_common.youtube import youtube_destination_path
+from anthias_common.youtube import is_youtube_url, youtube_destination_path
 from anthias_server.processing import needs_image_normalisation
 from anthias_server.settings import settings
 
@@ -104,6 +104,17 @@ class CreateAssetSerializerMixin:
         # missing/None mimetype. Both bugs were inherited from the
         # pre-celery code path.
         is_youtube = asset['mimetype'] == 'youtube_asset'
+        # ``mimetype`` is a free-form CharField, so a client can claim
+        # ``youtube_asset`` for any URI. Confirm the URI is actually a
+        # YouTube link before handing it to yt-dlp, mirroring the
+        # ``is_youtube_url`` gate the HTML create path applies — without
+        # it, an arbitrary http(s) URL (including internal / metadata
+        # hosts) would be fetched server-side through yt-dlp's generic
+        # extractor. The URI already passed ``validate_uri``.
+        if is_youtube and not is_youtube_url(uri):
+            raise AssetCreationError(
+                'A youtube_asset URI must point at a YouTube URL.'
+            )
         if is_youtube:
             # Defer the download to download_youtube_asset (Celery).
             # The row lands with mimetype='video', is_processing set,

--- a/src/anthias_server/api/serializers/v1_1.py
+++ b/src/anthias_server/api/serializers/v1_1.py
@@ -16,7 +16,7 @@ from anthias_common.utils import (
     get_video_duration,
     url_fails,
 )
-from anthias_common.youtube import youtube_destination_path
+from anthias_common.youtube import is_youtube_url, youtube_destination_path
 from anthias_server.settings import settings
 
 from . import (
@@ -105,6 +105,17 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
         # would also fire on `not_youtube_asset` and crash on a
         # missing/None mimetype. Both bugs predate the celery refactor.
         is_youtube = asset['mimetype'] == 'youtube_asset'
+        # ``mimetype`` is a free-form CharField, so a client can claim
+        # ``youtube_asset`` for any URI. Confirm the URI is actually a
+        # YouTube link before handing it to yt-dlp, mirroring the
+        # ``is_youtube_url`` gate the HTML create path applies — without
+        # it, an arbitrary http(s) URL (including internal / metadata
+        # hosts) would be fetched server-side through yt-dlp's generic
+        # extractor. The URI already passed ``validate_uri``.
+        if is_youtube and not is_youtube_url(uri):
+            raise ValidationError(
+                {'uri': 'A youtube_asset URI must point at a YouTube URL.'}
+            )
         if is_youtube:
             # Defer the download to download_youtube_asset (Celery).
             # The row is persisted with mimetype='video',

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -585,7 +585,8 @@ def test_create_youtube_asset_rejects_non_youtube_uri(
     """
     payload = {
         **ASSET_CREATION_DATA,
-        'uri': 'http://169.254.169.254/latest/meta-data/',
+        # Cloud-metadata endpoint — the SSRF target this gate blocks.
+        'uri': 'http://169.254.169.254/latest/meta-data/',  # NOSONAR
         'mimetype': 'youtube_asset',
         'duration': 0,
     }
@@ -617,8 +618,11 @@ def test_create_youtube_asset_rejects_non_youtube_uri(
             asset_list_url, data=get_request_data(payload, version)
         )
 
-    # Rejected outright, and yt-dlp is never dispatched on any version.
-    assert response.status_code != status.HTTP_201_CREATED
+    # Rejected as a 400 keyed on ``uri`` (every version routes the
+    # failure through serializer validation), and yt-dlp is never
+    # dispatched on any version.
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'uri' in response.data
     for dispatcher in (
         v1_dispatch,
         v1_1_dispatch,

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -2,6 +2,8 @@
 Tests for asset-related API endpoints.
 """
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from unittest import mock
 
@@ -61,6 +63,46 @@ def _get_asset(client: APIClient, asset_id: str, version: str) -> Any:
 def _delete_asset(client: APIClient, asset_id: str, version: str) -> Any:
     url = reverse(f'api:asset_detail_{version}', args=[asset_id])
     return client.delete(url)
+
+
+@contextmanager
+def _patched_youtube_dispatch() -> Iterator[dict[str, Any]]:
+    """Patch every version's ``dispatch_download`` plus ``url_fails``.
+
+    Both YouTube create tests share this scaffolding: the four per-view
+    ``dispatch_download`` hooks (so a test can assert which one fired,
+    or that none did) and ``url_fails`` on both serializer modules (so
+    the reachability probe never touches the network). Yields the
+    dispatch mocks keyed by API version.
+    """
+    with (
+        mock.patch(
+            'anthias_server.api.views.v1.dispatch_download'
+        ) as v1_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v1_1.dispatch_download'
+        ) as v1_1_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v1_2.dispatch_download'
+        ) as v1_2_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v2.dispatch_download'
+        ) as v2_dispatch,
+        mock.patch(
+            'anthias_server.api.serializers.mixins.url_fails',
+            return_value=False,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.url_fails',
+            return_value=False,
+        ),
+    ):
+        yield {
+            'v1': v1_dispatch,
+            'v1_1': v1_1_dispatch,
+            'v1_2': v1_2_dispatch,
+            'v2': v2_dispatch,
+        }
 
 
 @pytest.mark.django_db
@@ -515,32 +557,7 @@ def test_create_youtube_asset_dispatches_celery_task(
     }
 
     asset_list_url = reverse(f'api:asset_list_{version}')
-    with (
-        mock.patch(
-            'anthias_server.api.views.v1.dispatch_download'
-        ) as v1_dispatch,
-        mock.patch(
-            'anthias_server.api.views.v1_1.dispatch_download'
-        ) as v1_1_dispatch,
-        mock.patch(
-            'anthias_server.api.views.v1_2.dispatch_download'
-        ) as v1_2_dispatch,
-        mock.patch(
-            'anthias_server.api.views.v2.dispatch_download'
-        ) as v2_dispatch,
-        # Skip the network probe — url_fails would be invoked on the
-        # local mp4 destination, which is a no-op in practice but
-        # avoids any future url_fails behaviour change leaking into
-        # this test.
-        mock.patch(
-            'anthias_server.api.serializers.mixins.url_fails',
-            return_value=False,
-        ),
-        mock.patch(
-            'anthias_server.api.serializers.v1_1.url_fails',
-            return_value=False,
-        ),
-    ):
+    with _patched_youtube_dispatch() as dispatchers:
         response = api_client.post(
             asset_list_url, data=get_request_data(payload, version)
         )
@@ -548,22 +565,11 @@ def test_create_youtube_asset_dispatches_celery_task(
     assert response.status_code == status.HTTP_201_CREATED
     asset_id = response.data['asset_id']
 
-    dispatch_for_version = {
-        'v1': v1_dispatch,
-        'v1_1': v1_1_dispatch,
-        'v1_2': v1_2_dispatch,
-        'v2': v2_dispatch,
-    }[version]
-    dispatch_for_version.assert_called_once_with(asset_id, youtube_url)
+    dispatchers[version].assert_called_once_with(asset_id, youtube_url)
 
     # The other versions' dispatchers must stay untouched — proves
     # we routed through the right view, not just any of them.
-    for v, m in {
-        'v1': v1_dispatch,
-        'v1_1': v1_1_dispatch,
-        'v1_2': v1_2_dispatch,
-        'v2': v2_dispatch,
-    }.items():
+    for v, m in dispatchers.items():
         if v != version:
             m.assert_not_called()
 
@@ -592,28 +598,7 @@ def test_create_youtube_asset_rejects_non_youtube_uri(
     }
     asset_list_url = reverse(f'api:asset_list_{version}')
 
-    with (
-        mock.patch(
-            'anthias_server.api.views.v1.dispatch_download'
-        ) as v1_dispatch,
-        mock.patch(
-            'anthias_server.api.views.v1_1.dispatch_download'
-        ) as v1_1_dispatch,
-        mock.patch(
-            'anthias_server.api.views.v1_2.dispatch_download'
-        ) as v1_2_dispatch,
-        mock.patch(
-            'anthias_server.api.views.v2.dispatch_download'
-        ) as v2_dispatch,
-        mock.patch(
-            'anthias_server.api.serializers.mixins.url_fails',
-            return_value=False,
-        ),
-        mock.patch(
-            'anthias_server.api.serializers.v1_1.url_fails',
-            return_value=False,
-        ),
-    ):
+    with _patched_youtube_dispatch() as dispatchers:
         response = api_client.post(
             asset_list_url, data=get_request_data(payload, version)
         )
@@ -623,12 +608,7 @@ def test_create_youtube_asset_rejects_non_youtube_uri(
     # dispatched on any version.
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert 'uri' in response.data
-    for dispatcher in (
-        v1_dispatch,
-        v1_1_dispatch,
-        v1_2_dispatch,
-        v2_dispatch,
-    ):
+    for dispatcher in dispatchers.values():
         dispatcher.assert_not_called()
 
 

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -568,6 +568,66 @@ def test_create_youtube_asset_dispatches_celery_task(
             m.assert_not_called()
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+def test_create_youtube_asset_rejects_non_youtube_uri(
+    api_client: APIClient, version: str
+) -> None:
+    """A ``youtube_asset`` create must be rejected when its URI is not a
+    YouTube URL.
+
+    ``mimetype`` is a free-form CharField, so without the
+    ``is_youtube_url`` gate a client could claim ``youtube_asset`` for
+    any http(s) URL and have the device fetch it server-side through
+    yt-dlp's generic extractor — an SSRF to internal / cloud-metadata
+    hosts. The HTML create path already enforces this; every API
+    version must match.
+    """
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': 'http://169.254.169.254/latest/meta-data/',
+        'mimetype': 'youtube_asset',
+        'duration': 0,
+    }
+    asset_list_url = reverse(f'api:asset_list_{version}')
+
+    with (
+        mock.patch(
+            'anthias_server.api.views.v1.dispatch_download'
+        ) as v1_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v1_1.dispatch_download'
+        ) as v1_1_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v1_2.dispatch_download'
+        ) as v1_2_dispatch,
+        mock.patch(
+            'anthias_server.api.views.v2.dispatch_download'
+        ) as v2_dispatch,
+        mock.patch(
+            'anthias_server.api.serializers.mixins.url_fails',
+            return_value=False,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.url_fails',
+            return_value=False,
+        ),
+    ):
+        response = api_client.post(
+            asset_list_url, data=get_request_data(payload, version)
+        )
+
+    # Rejected outright, and yt-dlp is never dispatched on any version.
+    assert response.status_code != status.HTTP_201_CREATED
+    for dispatcher in (
+        v1_dispatch,
+        v1_1_dispatch,
+        v1_2_dispatch,
+        v2_dispatch,
+    ):
+        dispatcher.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Viewer wake-ups on mutation — issue #2430
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The asset-create API triggers a server-side yt-dlp download based only on the client-supplied `mimetype` string, with no check that the URI is actually a YouTube link — an SSRF via yt-dlp's generic extractor.

- `prepare_asset` (both `serializers/mixins.py` for v1.2/v2 and `serializers/v1_1.py` for v1/v1.1) keys the YouTube branch off `asset['mimetype'] == 'youtube_asset'`.
- `mimetype` is an unconstrained `CharField`, and the URI only has to pass `validate_url` (any `http`/`https`/`rtsp` URL with a netloc).
- So a client sends `{"mimetype": "youtube_asset", "uri": "http://169.254.169.254/latest/meta-data/"}` and the **device** fetches that internal URL through yt-dlp (which follows redirects and pulls embedded media). The `_YOUTUBE_HOSTS` allowlist in `is_youtube_url` was only enforced on the HTML create path (`app/views.py`), never on the API.

## Fix

Apply the existing `is_youtube_url(uri)` check in both create serializers: a `youtube_asset` create whose URI isn't a recognised YouTube host is rejected before the download is dispatched. Each serializer raises using its local idiom (`AssetCreationError` in the mixin, DRF `ValidationError` in v1.1). Legitimate YouTube URLs are unaffected.

## Tests

Adds `test_create_youtube_asset_rejects_non_youtube_uri` (parametrized across v1/v1.1/v1.2/v2): a `youtube_asset` create pointing at `169.254.169.254` is rejected and `dispatch_download` is never called on any version. The existing `test_create_youtube_asset_dispatches_celery_task` (real `youtube.com` URL) still passes, confirming genuine YouTube assets keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)