### PR TITLE
fix(system-info): tidy up x86 Device Info (CEC state + device model)

### DIFF
--- a/src/anthias_common/device_helper.py
+++ b/src/anthias_common/device_helper.py
@@ -63,6 +63,46 @@ def _read_cpu_brand() -> str:
     return ''
 
 
+# Trailing corporate-suffix tokens peeled off a DMI vendor string.
+# Compared case-insensitively with any trailing comma stripped, so
+# 'Co.,' matches 'co.'. Multi-token suffixes like 'Co., Ltd.' fall out
+# of the peel loop naturally.
+_VENDOR_SUFFIX_TOKENS = frozenset(
+    {
+        'corporation',
+        'incorporated',
+        'corp.',
+        'corp',
+        'inc.',
+        'inc',
+        'ltd.',
+        'ltd',
+        'co.',
+        'co',
+        'llc',
+        'gmbh',
+        'ag',
+    }
+)
+
+
+def _strip_corporate_suffix(vendor: str) -> str:
+    """Drop trailing corporate-suffix tokens from a DMI vendor string.
+
+    'Intel Corporation' -> 'Intel', 'Dell Inc.' -> 'Dell',
+    'ASUSTeK Computer INC.' -> 'ASUSTeK Computer', 'Foo Co., Ltd.' ->
+    'Foo'. Leaves a vendor that is *only* a suffix untouched so we never
+    return an empty string here (the caller decides the fallback).
+    """
+    tokens = vendor.split()
+    while (
+        len(tokens) > 1
+        and tokens[-1].lower().rstrip(',') in _VENDOR_SUFFIX_TOKENS
+    ):
+        tokens.pop()
+    return ' '.join(tokens)
+
+
 def get_friendly_device_model() -> str:
     """Operator-facing label for the host the player is running on.
 
@@ -116,6 +156,20 @@ def get_friendly_device_model() -> str:
         vendor = ''
     if product in placeholders or _looks_virtual(product):
         product = ''
+
+    # Trim the corporate suffix DMI vendors carry ('Intel Corporation',
+    # 'Dell Inc.', 'ASUSTeK Computer INC.') — noise in a device label.
+    vendor = _strip_corporate_suffix(vendor)
+
+    # Drop the board vendor when the CPU brand already names it. Whitebox
+    # / reference boards set sys_vendor to the CPU maker ('Intel
+    # Corporation' next to an 'Intel Celeron ...' CPU), which stutters as
+    # 'Intel ... · Intel ...'. Branded OEM boxes (Dell, Lenovo) keep
+    # their vendor because it differs from the CPU maker.
+    if vendor and cpu_brand:
+        if vendor.split()[0].lower() in cpu_brand.lower().split():
+            vendor = ''
+
     chassis = ' '.join(part for part in (vendor, product) if part).strip()
 
     parts = [p for p in (chassis, cpu_brand) if p]

--- a/src/anthias_common/device_helper.py
+++ b/src/anthias_common/device_helper.py
@@ -103,20 +103,24 @@ def _strip_corporate_suffix(vendor: str) -> str:
     return ' '.join(tokens)
 
 
-def get_friendly_device_model() -> str:
-    """Operator-facing label for the host the player is running on.
+def get_device_model_parts() -> tuple[str, str]:
+    """(primary, secondary) label for the host, for a two-line card.
 
-    Pi:  whatever the firmware Model line reads
-         ('Raspberry Pi 5 Model B Rev 1.0').
-    x86: '<vendor> <product> · <CPU>' when DMI is exposed via
-         /sys/class/dmi/id, otherwise just the CPU brand. Falls back
-         to 'Generic x86_64 Device' when neither is readable so the
-         System Info card never renders blank.
+    Returns the board/chassis as the primary line and the CPU brand as
+    the secondary line so the System Info card can stack them rather than
+    cramming both onto one row joined by a separator.
+
+    Pi:  ('Raspberry Pi 5 Model B Rev 1.0', '') — the firmware Model
+         line, no separate CPU line.
+    x86: ('Whiskey Platform', 'Intel Celeron 4205U @ 1.80GHz') when DMI
+         exposes a real chassis; ('Intel Celeron ...', '') when it only
+         yields a CPU. Falls back to ('Generic x86_64 Device', '') when
+         neither is readable so the card never renders blank.
     """
     cpu_info = parse_cpu_info()
     pi_model = cpu_info.get('model')
     if isinstance(pi_model, str) and pi_model:
-        return pi_model
+        return pi_model, ''
 
     vendor = _read_sysfs('/sys/class/dmi/id/sys_vendor')
     product = _read_sysfs('/sys/class/dmi/id/product_name')
@@ -163,22 +167,24 @@ def get_friendly_device_model() -> str:
 
     # Drop the board vendor when the CPU brand already names it. Whitebox
     # / reference boards set sys_vendor to the CPU maker ('Intel
-    # Corporation' next to an 'Intel Celeron ...' CPU), which stutters as
-    # 'Intel ... · Intel ...'. Branded OEM boxes (Dell, Lenovo) keep
-    # their vendor because it differs from the CPU maker.
+    # Corporation' next to an 'Intel Celeron ...' CPU), which would stutter
+    # as 'Intel ...' on both the board and CPU lines. Branded OEM boxes
+    # (Dell, Lenovo) keep their vendor because it differs from the CPU.
     if vendor and cpu_brand:
         if vendor.split()[0].lower() in cpu_brand.lower().split():
             vendor = ''
 
     chassis = ' '.join(part for part in (vendor, product) if part).strip()
 
-    parts = [p for p in (chassis, cpu_brand) if p]
-    if parts:
-        return ' · '.join(parts)
+    if chassis:
+        # Board on the primary line, CPU (when known) on the secondary.
+        return chassis, cpu_brand
+    if cpu_brand:
+        return cpu_brand, ''
 
     from platform import machine
 
-    return f'Generic {machine() or "x86_64"} Device'
+    return f'Generic {machine() or "x86_64"} Device', ''
 
 
 def get_device_type() -> str:

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -66,7 +66,7 @@ def system_info() -> dict[str, Any]:
     disk_free = slash.f_bavail * slash.f_frsize
     disk_used = max(0, disk_total - disk_free)
     uptime = timedelta(seconds=diagnostics.get_uptime())
-    device_model = device_helper.get_friendly_device_model()
+    device_model, device_model_detail = device_helper.get_device_model_parts()
 
     anthias_version = diagnostics.get_anthias_version()
     anthias_version_head = diagnostics.get_anthias_version_head()
@@ -172,6 +172,7 @@ def system_info() -> dict[str, Any]:
         'display_power': _redis.get('display_power'),
         'resolution': _resolved_resolution(),
         'device_model': device_model,
+        'device_model_detail': device_model_detail,
         'anthias_version': anthias_version,
         'anthias_version_head': anthias_version_head,
         'anthias_version_meta': anthias_version_meta,

--- a/src/anthias_server/app/templates/system_info.html
+++ b/src/anthias_server/app/templates/system_info.html
@@ -134,6 +134,7 @@
       <div class="stat-card stat-card--span-2">
         <p class="stat-card__label">Device model</p>
         <div class="stat-card__value">{{ device_model }}</div>
+        {% if device_model_detail %}<div class="stat-card__meta">{{ device_model_detail }}</div>{% endif %}
       </div>
       <div class="stat-card">
         <p class="stat-card__label">Resolution</p>

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -317,6 +317,18 @@ def get_display_power() -> None:
     # passes the value through, so 'True'/'False'/'CEC error' all fit
     # — and the on/off state now actually populates instead of only
     # the error cases ever landing.
+    #
+    # Boards without a CEC adapter (x86, and any host that doesn't pass
+    # /dev/cec0 or /dev/vchiq into the container — e.g. Pi 5) can only
+    # ever fail the libcec probe, which used to surface on the System
+    # Info card and the v2 /info API as 'CEC error' — reading like a
+    # fault when CEC simply isn't a thing on the hardware. Short-circuit
+    # on the same cec_available() gate the settings UI and the display-
+    # power SET endpoint already use: record a clear 'Not available'
+    # rather than spawning a doomed subprocess every tick.
+    if not diagnostics.cec_available():
+        r.set('display_power', 'Not available', ex=3600)
+        return
     try:
         # Single SET with ex= so the value and its TTL are written
         # atomically — a soft-limit signal landing between a separate

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -187,6 +187,12 @@ def test_get_display_power_writes_redis_as_str(
     fake_redis = mock.MagicMock()
     with (
         mock.patch.object(celery_tasks_module, 'r', fake_redis),
+        # CEC adapter present so the task runs the probe rather than
+        # short-circuiting on the cec_available() gate below.
+        mock.patch(
+            'anthias_server.celery_tasks.diagnostics.cec_available',
+            return_value=True,
+        ),
         mock.patch(
             'anthias_server.celery_tasks.diagnostics.get_display_power',
             return_value=cec_value,
@@ -201,6 +207,34 @@ def test_get_display_power_writes_redis_as_str(
     # No bool ever reaches redis — guards against the DataError.
     written = fake_redis.set.call_args.args[1]
     assert isinstance(written, str)
+
+
+def test_get_display_power_reports_not_available_without_cec() -> None:
+    """On a board with no CEC adapter the task records 'Not available'
+    and never spawns the libcec probe.
+
+    x86 (and any host that doesn't pass /dev/cec0 or /dev/vchiq into
+    the container) can only fail the probe; it used to store
+    'CEC error', which the System Info card and the v2 /info API then
+    showed as though something were broken.
+    """
+    fake_redis = mock.MagicMock()
+    with (
+        mock.patch.object(celery_tasks_module, 'r', fake_redis),
+        mock.patch(
+            'anthias_server.celery_tasks.diagnostics.cec_available',
+            return_value=False,
+        ),
+        mock.patch(
+            'anthias_server.celery_tasks.diagnostics.get_display_power'
+        ) as probe,
+    ):
+        get_display_power.apply()
+
+    fake_redis.set.assert_called_once_with(
+        'display_power', 'Not available', ex=3600
+    )
+    probe.assert_not_called()
 
 
 def test_send_telemetry_task_dispatches() -> None:
@@ -1905,6 +1939,13 @@ class TestPeriodicPokeTimeLimits:
         fake_redis = mock.MagicMock()
         with (
             mock.patch.object(celery_tasks_module, 'r', fake_redis),
+            # CEC adapter present so the task reaches the probe (which
+            # raises the soft-limit) rather than short-circuiting on the
+            # cec_available() gate.
+            mock.patch(
+                'anthias_server.celery_tasks.diagnostics.cec_available',
+                return_value=True,
+            ),
             mock.patch(
                 'anthias_server.celery_tasks.diagnostics.get_display_power',
                 side_effect=SoftTimeLimitExceeded,

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2536,8 +2536,70 @@ def test_friendly_device_model_x86_with_dmi(
         '_read_cpu_brand',
         lambda: 'Intel Core i5-1135G7 @ 2.40GHz',
     )
+    # The 'Intel Corp.' board vendor is redundant with the 'Intel Core'
+    # CPU, so it's dropped rather than stuttered — leaving the NUC
+    # product and the CPU.
     assert device_helper.get_friendly_device_model() == (
-        'Intel Corp. NUC11PAHi5 · Intel Core i5-1135G7 @ 2.40GHz'
+        'NUC11PAHi5 · Intel Core i5-1135G7 @ 2.40GHz'
+    )
+
+
+def test_friendly_device_model_x86_drops_redundant_vendor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reference / whitebox boards set sys_vendor to the CPU maker
+    ('Intel Corporation' next to an 'Intel Celeron' CPU). The stuttering
+    vendor is dropped, leaving the board product and the CPU."""
+    from anthias_common import device_helper
+
+    monkeypatch.setattr(
+        device_helper, 'parse_cpu_info', lambda: {'cpu_count': 2}
+    )
+
+    def fake_sysfs(path: str) -> str:
+        if path.endswith('sys_vendor'):
+            return 'Intel Corporation'
+        if path.endswith('product_name'):
+            return 'Whiskey Platform'
+        return ''
+
+    monkeypatch.setattr(device_helper, '_read_sysfs', fake_sysfs)
+    monkeypatch.setattr(
+        device_helper,
+        '_read_cpu_brand',
+        lambda: 'Intel Celeron 4205U @ 1.80GHz',
+    )
+    assert device_helper.get_friendly_device_model() == (
+        'Whiskey Platform · Intel Celeron 4205U @ 1.80GHz'
+    )
+
+
+def test_friendly_device_model_x86_keeps_branded_vendor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A branded OEM vendor that differs from the CPU maker is kept, but
+    its corporate suffix ('Inc.') is trimmed."""
+    from anthias_common import device_helper
+
+    monkeypatch.setattr(
+        device_helper, 'parse_cpu_info', lambda: {'cpu_count': 8}
+    )
+
+    def fake_sysfs(path: str) -> str:
+        if path.endswith('sys_vendor'):
+            return 'Dell Inc.'
+        if path.endswith('product_name'):
+            return 'OptiPlex 7090'
+        return ''
+
+    monkeypatch.setattr(device_helper, '_read_sysfs', fake_sysfs)
+    monkeypatch.setattr(
+        device_helper,
+        '_read_cpu_brand',
+        lambda: 'Intel Core i5-10500 @ 3.10GHz',
+    )
+    assert device_helper.get_friendly_device_model() == (
+        'Dell OptiPlex 7090 · Intel Core i5-10500 @ 3.10GHz'
     )
 
 

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2495,10 +2495,10 @@ def test_schedule_pills_everyday_short_circuit(asset: Asset) -> None:
 
 
 # ---------------------------------------------------------------------------
-# get_friendly_device_model — Pi vs x86 vs virt
+# get_device_model_parts — (primary, secondary) for the two-line card
 
 
-def test_friendly_device_model_pi(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_device_model_parts_pi(monkeypatch: pytest.MonkeyPatch) -> None:
     from anthias_common import device_helper
 
     monkeypatch.setattr(
@@ -2509,12 +2509,14 @@ def test_friendly_device_model_pi(monkeypatch: pytest.MonkeyPatch) -> None:
             'model': 'Raspberry Pi 5 Model B Rev 1.0',
         },
     )
-    assert device_helper.get_friendly_device_model() == (
-        'Raspberry Pi 5 Model B Rev 1.0'
+    # Pi: the firmware Model line is the whole label; no separate CPU row.
+    assert device_helper.get_device_model_parts() == (
+        'Raspberry Pi 5 Model B Rev 1.0',
+        '',
     )
 
 
-def test_friendly_device_model_x86_with_dmi(
+def test_device_model_parts_x86_with_dmi(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from anthias_common import device_helper
@@ -2537,19 +2539,21 @@ def test_friendly_device_model_x86_with_dmi(
         lambda: 'Intel Core i5-1135G7 @ 2.40GHz',
     )
     # The 'Intel Corp.' board vendor is redundant with the 'Intel Core'
-    # CPU, so it's dropped rather than stuttered — leaving the NUC
-    # product and the CPU.
-    assert device_helper.get_friendly_device_model() == (
-        'NUC11PAHi5 · Intel Core i5-1135G7 @ 2.40GHz'
+    # CPU, so it's dropped — leaving the NUC product on the primary line
+    # and the CPU on the secondary.
+    assert device_helper.get_device_model_parts() == (
+        'NUC11PAHi5',
+        'Intel Core i5-1135G7 @ 2.40GHz',
     )
 
 
-def test_friendly_device_model_x86_drops_redundant_vendor(
+def test_device_model_parts_x86_drops_redundant_vendor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Reference / whitebox boards set sys_vendor to the CPU maker
     ('Intel Corporation' next to an 'Intel Celeron' CPU). The stuttering
-    vendor is dropped, leaving the board product and the CPU."""
+    vendor is dropped, leaving the board product as the primary line and
+    the CPU as the secondary."""
     from anthias_common import device_helper
 
     monkeypatch.setattr(
@@ -2569,12 +2573,13 @@ def test_friendly_device_model_x86_drops_redundant_vendor(
         '_read_cpu_brand',
         lambda: 'Intel Celeron 4205U @ 1.80GHz',
     )
-    assert device_helper.get_friendly_device_model() == (
-        'Whiskey Platform · Intel Celeron 4205U @ 1.80GHz'
+    assert device_helper.get_device_model_parts() == (
+        'Whiskey Platform',
+        'Intel Celeron 4205U @ 1.80GHz',
     )
 
 
-def test_friendly_device_model_x86_keeps_branded_vendor(
+def test_device_model_parts_x86_keeps_branded_vendor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A branded OEM vendor that differs from the CPU maker is kept, but
@@ -2598,12 +2603,13 @@ def test_friendly_device_model_x86_keeps_branded_vendor(
         '_read_cpu_brand',
         lambda: 'Intel Core i5-10500 @ 3.10GHz',
     )
-    assert device_helper.get_friendly_device_model() == (
-        'Dell OptiPlex 7090 · Intel Core i5-10500 @ 3.10GHz'
+    assert device_helper.get_device_model_parts() == (
+        'Dell OptiPlex 7090',
+        'Intel Core i5-10500 @ 3.10GHz',
     )
 
 
-def test_friendly_device_model_drops_virt_chassis(
+def test_device_model_parts_drops_virt_chassis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from anthias_common import device_helper
@@ -2625,12 +2631,15 @@ def test_friendly_device_model_drops_virt_chassis(
         '_read_cpu_brand',
         lambda: 'AMD Ryzen 7 5700G',
     )
-    # Chassis is dropped because both vendor + product look virtual;
-    # only the CPU brand survives.
-    assert device_helper.get_friendly_device_model() == 'AMD Ryzen 7 5700G'
+    # Chassis is dropped because both vendor + product look virtual; the
+    # CPU brand becomes the primary line with no secondary.
+    assert device_helper.get_device_model_parts() == (
+        'AMD Ryzen 7 5700G',
+        '',
+    )
 
 
-def test_friendly_device_model_generic_fallback(
+def test_device_model_parts_generic_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from anthias_common import device_helper
@@ -2640,8 +2649,9 @@ def test_friendly_device_model_generic_fallback(
     )
     monkeypatch.setattr(device_helper, '_read_sysfs', lambda _path: '')
     monkeypatch.setattr(device_helper, '_read_cpu_brand', lambda: '')
-    out = device_helper.get_friendly_device_model()
-    assert out.startswith('Generic ') and out.endswith(' Device')
+    primary, secondary = device_helper.get_device_model_parts()
+    assert primary.startswith('Generic ') and primary.endswith(' Device')
+    assert secondary == ''
 
 
 def test_cpu_brand_strips_marketing(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Three fixes to the **Display & hardware** section of the System Info page as it renders on x86 players, reviewed against the x86 testbed.

### 1. Display Power (CEC) showed "CEC error"

x86 (and any host without a CEC adapter — no `/dev/cec0` / `/dev/vchiq`, e.g. Pi 5) can only fail the libcec probe, so the periodic `get_display_power` task stored `'CEC error'`, which the System Info card and the v2 `/info` API surfaced verbatim — reading like a fault when CEC simply isn't present.

Now short-circuits on the existing `diagnostics.cec_available()` gate (the same one the Settings page and the display-power SET endpoint use): records a clear **`Not available`** and skips spawning a doomed subprocess every tick. CEC-capable boards (Pi 1–4) still report live On/Off.

### 2 & 3. Device model: stutter + awkward wrap

The card joined the raw DMI `sys_vendor` + `product_name` + CPU brand into one string with a `·`, so the x86 label both stuttered and word-wrapped at an arbitrary point (splitting the CPU model, e.g. `Intel Celeron` | `4205U …`):

**Before**
```
Device model
Intel Corporation Whiskey Platform · Intel Celeron
4205U @ 1.80GHz
```

**After**
```
Device model
Whiskey Platform
Intel Celeron 4205U @ 1.80GHz
```

- Trailing corporate suffixes (`Corporation` / `Inc.` / `Ltd.` / …) are trimmed, and the board vendor is dropped when the CPU brand already names it (whitebox/reference boards set `sys_vendor` to the CPU maker). Branded OEM boxes keep their vendor because it differs: `Dell Inc. OptiPlex 7090` → `Dell OptiPlex 7090`.
- `get_device_model_parts()` now returns `(board, cpu)` and the template stacks the CPU as the card's secondary line — no `·`, no mid-model wrap. Pi keeps its single firmware Model line.

## Tests

- `get_display_power`: existing True/False/error cases run with `cec_available() == True`; new test asserts `'Not available'` is written and the probe skipped when no CEC adapter is present; soft-limit test updated.
- `get_device_model_parts`: Pi, x86-with-DMI, redundant-vendor drop (Intel reference board), kept-but-trimmed branded vendor (Dell), virtual-chassis drop, and generic fallback — all asserting the `(primary, secondary)` tuple.
- `test_system_info_renders` covers the template with the new `device_model_detail` line.

## Verified on the x86 testbed

`cec_available()` returns `False` and the card renders **"Not available"**; the device-model helper produces `('Whiskey Platform', 'Intel Celeron 4205U @ 1.80GHz')` for the box's actual DMI values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)