### PR TITLE
docs: point Screenly migration guide at the in-app wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,4 @@ Per-SoC hardware video decode (Rockchip `rkmpp`, Allwinner `cedrus`, Amlogic `me
 * [Website](https://anthias.screenly.io) (hosted on GitHub and the source is available [here](/website))
 * [General documentation](https://anthias.screenly.io/docs/)
 * [Developer documentation](https://anthias.screenly.io/docs/development/)
-* [Migrating assets from Anthias to Screenly](https://anthias.screenly.io/docs/migrate-to-screenly/)
 * [WebView](/src/anthias_webview/README.md)

--- a/website/content/docs/migrating-assets-to-screenly.md
+++ b/website/content/docs/migrating-assets-to-screenly.md
@@ -31,9 +31,10 @@ You'll need a Screenly API token:
    the token against Screenly before moving on.
 4. Choose which assets to migrate. All assets are selected by default; use
    **Select all** / **Select none** or the per-asset checkboxes to adjust.
-5. Click **Migrate**. Each selected asset is uploaded to Screenly in turn,
-   with live per-asset progress.
-6. When it finishes, any assets that failed can be re-uploaded with **Retry
-   failed** without repeating the ones that already succeeded.
+5. Click the **Migrate _N_ assets** button. Each selected asset is uploaded
+   to Screenly in turn, with live per-asset progress.
+6. When it finishes, any assets that failed can be re-uploaded with the
+   **Retry _N_ failed** button, without repeating the ones that already
+   succeeded.
 
 That's it — your selected assets now live in your Screenly account.

--- a/website/content/docs/migrating-assets-to-screenly.md
+++ b/website/content/docs/migrating-assets-to-screenly.md
@@ -19,21 +19,23 @@ You'll need a Screenly API token:
    [login.screenlyapp.com](https://login.screenlyapp.com/login).
 2. In the Screenly dashboard, go to **Settings → Security → API Tokens**
    and create a new token.
-3. Keep the token handy. It looks like `abcdef.123456…`. The token stays on
-   your device and is only used to talk to Screenly's API while the
-   migration runs.
+3. Keep the token handy. It looks like `abcdef.123456…`. The token is not
+   stored on the device — it is only used to talk to Screenly's API while
+   the migration runs.
 
 ## Run the migration
 
 1. Open your Anthias web interface and go to **Settings**.
 2. In the **Migrate to Screenly** section, click **Start migration**.
-3. Paste your Screenly API token and click **Continue**. Anthias validates
+3. On the **Get started** screen, review the steps and click **I have a
+   token**.
+4. Paste your Screenly API token and click **Continue**. Anthias validates
    the token against Screenly before moving on.
-4. Choose which assets to migrate. All assets are selected by default; use
+5. Choose which assets to migrate. All assets are selected by default; use
    **Select all** / **Select none** or the per-asset checkboxes to adjust.
-5. Click the **Migrate _N_ assets** button. Each selected asset is uploaded
+6. Click the **Migrate _N_ assets** button. Each selected asset is uploaded
    to Screenly in turn, with live per-asset progress.
-6. When it finishes, any assets that failed can be re-uploaded with the
+7. When it finishes, any assets that failed can be re-uploaded with the
    **Retry _N_ failed** button, without repeating the ones that already
    succeeded.
 

--- a/website/content/docs/migrating-assets-to-screenly.md
+++ b/website/content/docs/migrating-assets-to-screenly.md
@@ -1,47 +1,39 @@
 ---
 title: "Migrating Assets to Screenly"
-description: "Migrate assets from Anthias to Screenly."
+description: "Copy a player's assets from Anthias to a Screenly cloud account."
 slug: "migrate-to-screenly"
 aliases:
   - "/docs/migrating-assets-to-screenly/"
 ---
 
-> **Note**
->
-> This feature is only available in devices running Raspberry Pi OS at the moment.
+[Screenly](https://www.screenly.io/) is the commercial, cloud-managed
+sibling of Anthias. If you want to move a player's assets up to a Screenly
+account, Anthias ships a built-in migration wizard — no SSH or scripts
+required. Existing assets already on Screenly are left untouched.
 
-To get started, SSH to your Raspberry Pi running Anthias. For instance:
+## Before you start
 
-```bash
-$ ssh pi@raspberrypi
-```
+You'll need a Screenly API token:
 
-Go to the project root directory and install the dependencies required by
-the assets migration script using [uv](https://docs.astral.sh/uv/):
+1. **Sign up or sign in to Screenly** at
+   [login.screenlyapp.com](https://login.screenlyapp.com/login).
+2. In the Screenly dashboard, go to **Settings → Security → API Tokens**
+   and create a new token.
+3. Keep the token handy. It looks like `abcdef.123456…`. The token stays on
+   your device and is only used to talk to Screenly's API while the
+   migration runs.
 
-```bash
-$ cd ~/anthias
-$ uv sync --group local
-```
+## Run the migration
 
-Before running the script, you should prepare the following:
-* Your Screenly API key
-* Anthias username and password, if your device has authentication enabled
+1. Open your Anthias web interface and go to **Settings**.
+2. In the **Migrate to Screenly** section, click **Start migration**.
+3. Paste your Screenly API token and click **Continue**. Anthias validates
+   the token against Screenly before moving on.
+4. Choose which assets to migrate. All assets are selected by default; use
+   **Select all** / **Select none** or the per-asset checkboxes to adjust.
+5. Click **Migrate**. Each selected asset is uploaded to Screenly in turn,
+   with live per-asset progress.
+6. When it finishes, any assets that failed can be re-uploaded with **Retry
+   failed** without repeating the ones that already succeeded.
 
-> **Note**
->
-> The script authenticates with the device using HTTP Basic on the
-> `/api/v2/...` endpoints. If your device runs Anthias 2826 or later,
-> the server will emit a `DEPRECATED: HTTP Basic auth used …` line
-> the first time a given (user, client IP, path) tuple shows up,
-> then again roughly once per hour for the same tuple — that's
-> expected, the warning is intentionally throttled so a polling
-> client doesn't flood the log. The Basic-auth path is retained for
-> back-compat and will be replaced by a UI-managed personal-token
-> system in a future release.
-
-Run the assets migration script. Follow through the instructions & prompts carefully.
-
-```bash
-$ uv run python tools/migrate_assets_to_screenly.py
-```
+That's it — your selected assets now live in your Screenly account.


### PR DESCRIPTION
### Issues Fixed

No associated issue. The docs described a removed migration path.

### Description

The Anthias → Screenly asset migration is now a built-in wizard under **Settings → Migrate to Screenly**. The old `tools/migrate_assets_to_screenly.py` script it referenced no longer exists.

- Rewrite the docs page for the in-app wizard flow (get a Screenly API token → Start migration → paste token → pick assets → migrate, with retry-on-failure)
- Drop the removed SSH + `migrate_assets_to_screenly.py` script instructions, the deprecated HTTP-Basic-auth note, and the "Raspberry Pi OS only" caveat (the wizard is a standard Settings section, not device-gated)
- Remove the stale migration link from the README Quick Links
- Slug/alias unchanged, so the page URL and the repo redirect stub still resolve

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes. (N/A — docs only)
- [ ] I have done an end-to-end test for Raspberry Pi devices. (N/A — docs only)
- [ ] I have tested my changes for x86 devices. (N/A — docs only)
- [x] I added a documentation for the changes I have made (when necessary).