### PR TITLE
chore(webview): bump frozen Qt 5 toolchain to 5.15.19

### DIFF
--- a/bin/rebuild_qt5_toolchain.sh
+++ b/bin/rebuild_qt5_toolchain.sh
@@ -2,14 +2,14 @@
 #
 # Rebuild the Qt 5 cross-compile toolchain tarballs for the surviving
 # 32-bit Pi boards (pi2, pi3) on Debian Trixie. Produces
-#     qt5-5.15.14-trixie-{pi2,pi3}.tar.gz       (+ .sha256)
+#     qt5-5.15.19-trixie-{pi2,pi3}.tar.gz       (+ .sha256)
 # under .qt5-toolchain-build/release/ at the repo root, ready to be
 # attached to a `WebView-v*` GitHub release.
 #
 # This is an out-of-band prereq: docker/Dockerfile.qt5-webview-builder.j2
 # fetches these tarballs from the release the viewer image references
 # via tools/image_builder/utils.py (qt5_toolchain_url, currently
-# WebView-v2026.04.1). If that release doesn't have trixie-* artifacts
+# WebView-v2026.07.0). If that release doesn't have trixie-* artifacts
 # for both pi2 and pi3, pi2/pi3 viewer image builds fail with
 #     sha256sum: no properly formatted checksum lines found
 # (the curl on the missing .sha256 falls back to a 404 HTML page).
@@ -65,8 +65,30 @@ echo "==> Building ${IMAGE_TAG} (BuildKit layer cache will short-circuit if unch
 GIT_HASH=$(git -C "${REPO_ROOT}" rev-parse HEAD)
 GIT_SHORT_HASH=$(git -C "${REPO_ROOT}" rev-parse --short HEAD)
 GIT_BRANCH=$(git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD)
+
+# Build on the same buildx builder CI uses (docker-build.yaml creates
+# `multiarch-builder`) and read the same GHCR registry buildcache that
+# `tools/image_builder` populates for the viewer image. This is
+# READ-ONLY: the anthias-* GHCR packages are public so pulls need no
+# auth, but writing back needs a packages:write token that only CI
+# holds, so we deliberately omit --cache-to (a local token without that
+# scope would fail the export mid-build). Shared base/apt layers hit;
+# the toolchain builder's own layers fall back to the local BuildKit
+# cache. Override the builder with BUILDX_BUILDER; set
+# QT5_NO_REGISTRY_CACHE=1 to skip the registry pulls entirely (e.g.
+# offline).
+BUILDX_BUILDER="${BUILDX_BUILDER:-multiarch-builder}"
+cache_from_args=()
+if [[ -z "${QT5_NO_REGISTRY_CACHE:-}" ]]; then
+    for cache_board in pi3 pi2; do
+        cache_from_args+=(--cache-from \
+            "type=registry,ref=ghcr.io/screenly/anthias-viewer:buildcache-${cache_board}")
+    done
+fi
 docker buildx build \
+    --builder "${BUILDX_BUILDER}" \
     --load \
+    "${cache_from_args[@]}" \
     --build-arg "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
     --build-arg "GIT_HASH=${GIT_HASH}" \
     --build-arg "GIT_SHORT_HASH=${GIT_SHORT_HASH}" \
@@ -75,7 +97,7 @@ docker buildx build \
     "${WEBVIEW_DIR}"
 
 for board in "${BOARDS[@]}"; do
-    expected_tarball="${OUT_DIR}/qt5-5.15.14-trixie-${board}.tar.gz"
+    expected_tarball="${OUT_DIR}/qt5-5.15.19-trixie-${board}.tar.gz"
     if [[ -f "${expected_tarball}" ]]; then
         echo "==> ${expected_tarball} already exists; skipping ${board}"
         echo "    (delete the .tar.gz to force a rebuild)"
@@ -106,12 +128,12 @@ echo "==> Toolchain build complete. Artifacts in ${OUT_DIR}:"
 ls -lah "${OUT_DIR}" 2>/dev/null || true
 echo
 echo "Verify checksums:"
-echo "  (cd '${OUT_DIR}' && sha256sum -c qt5-5.15.14-trixie-*.tar.gz.sha256)"
+echo "  (cd '${OUT_DIR}' && sha256sum -c qt5-5.15.19-trixie-*.tar.gz.sha256)"
 echo
 echo "Upload to a WebView-v* release. If you re-use the tag the viewer"
 echo "image references in tools/image_builder/utils.py via qt5_toolchain_url"
-echo "(currently WebView-v2026.04.1), no source change is needed;"
+echo "(currently WebView-v2026.07.0), no source change is needed;"
 echo "otherwise bump that URL to the new tag in the same commit."
 echo "  gh release upload <WebView-vX.Y.Z> \\"
-echo "      '${OUT_DIR}'/qt5-5.15.14-trixie-pi2.tar.gz{,.sha256} \\"
-echo "      '${OUT_DIR}'/qt5-5.15.14-trixie-pi3.tar.gz{,.sha256}"
+echo "      '${OUT_DIR}'/qt5-5.15.19-trixie-pi2.tar.gz{,.sha256} \\"
+echo "      '${OUT_DIR}'/qt5-5.15.19-trixie-pi3.tar.gz{,.sha256}"

--- a/docker/Dockerfile.qt5-webview-builder.j2
+++ b/docker/Dockerfile.qt5-webview-builder.j2
@@ -8,11 +8,11 @@
         at via `-sysroot /sysroot`.
      2. webview-builder  — host x86 (`$BUILDPLATFORM`); installs the
         Linaro gcc-7.4.1 cross-compiler plus the pre-built Qt 5
-        toolchain pinned to WebView-v2026.04.1, then compiles the
+        toolchain pinned to WebView-v2026.07.0, then compiles the
         in-tree src/anthias_webview/ source.
 
    Qt 5 is frozen for pi2/pi3 boards, so the toolchain artifact at
-   WebView-v2026.04.1 never changes. To CVE-patch the toolchain run
+   WebView-v2026.07.0 never changes. To CVE-patch the toolchain run
    bin/rebuild_qt5_toolchain.sh and re-upload to that tag.
 #}
 FROM --platform=linux/arm/v7 {{ base_image }}:{{ base_image_tag }} AS qt5-sysroot
@@ -214,7 +214,7 @@ RUN mkdir -p /src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf/bin && \
             "/src/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf/bin/$(basename "$tool")"; \
     done
 
-# Pre-built Qt 5 toolchain — pinned permanently to WebView-v2026.04.1
+# Pre-built Qt 5 toolchain — pinned permanently to WebView-v2026.07.0
 # (Qt 5 is frozen for pi2/pi3). The qt5pi/ tree contains both host
 # qmake (x86) and armhf libs the webview app links against.
 RUN mkdir -p /src/{{ artifact_board }} && \

--- a/src/anthias_webview/Dockerfile
+++ b/src/anthias_webview/Dockerfile
@@ -5,7 +5,7 @@
 # docker/Dockerfile.qt5-webview-builder.j2). This file remains only
 # for the rare Qt 5 toolchain rebuild (CVE patch, base image bump)
 # driven by bin/rebuild_qt5_toolchain.sh, which uploads the resulting
-# qt5-5.15.14-trixie-{pi2,pi3}.tar.gz tarballs to a WebView-v* GitHub
+# qt5-5.15.19-trixie-{pi2,pi3}.tar.gz tarballs to a WebView-v* GitHub
 # release.
 
 ARG BUILDER_BASE_PLATFORM=linux/arm/v7
@@ -91,7 +91,6 @@ RUN apt-get update && \
         libpulse-dev \
         libraspberrypi-bin \
         libraspberrypi0 \
-        libre2-dev \
         librsvg2-common \
         libsnappy-dev \
         libsqlite3-dev \
@@ -156,6 +155,18 @@ FROM mirror.gcr.io/library/debian:trixie
 USER root
 
 # This list can most likely be slimmed down *a lot* but that's for another day.
+#
+# 32-bit x86 host toolchain (lib32gcc-14-dev, lib32stdc++-14-dev, libc6-dev-i386,
+# lib32z1-dev): QtWebEngine's Chromium builds its V8 snapshot generator as a
+# 32-bit x86 host binary (g++ -m32) so the snapshot's pointer width matches the
+# 32-bit ARM target, so the host needs working `g++ -m32` + 32-bit libc/libstdc++/
+# zlib. We can NOT use the usual gcc-multilib/g++-multilib metapackages: on trixie
+# gcc-14-arm-linux-gnueabihf (pulled in by crossbuild-essential-armhf, needed for
+# the ARM target build) declares Conflicts: gcc-multilib, so apt would evict the
+# ARM cross-gcc. The lib32*-14-dev + libc6-dev-i386 packages provide the same -m32
+# capability without that conflict (they're amd64 multilib libs, no i386 foreign
+# arch required). Version-pinned to -14 to match the trixie gcc; bump if the base
+# image's gcc major changes.
 RUN apt-get update && \
     apt-get -y install \
         bison \
@@ -167,12 +178,13 @@ RUN apt-get update && \
         flex \
         freetds-dev \
         g++ \
-        g++-multilib \
-        gcc-multilib \
         git \
         gperf \
         gyp \
+        lib32gcc-14-dev \
+        lib32stdc++-14-dev \
         lib32z1-dev \
+        libc6-dev-i386 \
         libasound2 \
         libasound2-dev \
         libavcodec-dev \
@@ -204,7 +216,6 @@ RUN apt-get update && \
         libpci-dev \
         libpng16-16t64 \
         libpulse-dev \
-        libre2-dev \
         libsecret-1-0 \
         libsnappy-dev \
         libsrtp2-dev \
@@ -222,6 +233,7 @@ RUN apt-get update && \
         ninja-build \
         nodejs \
         python3 \
+        python3-html5lib \
         rsync \
         ruby \
         subversion \
@@ -229,7 +241,7 @@ RUN apt-get update && \
         make && \
     apt-get clean
 
-# Qt 5.15.14's QtWebEngine `configure` hard-rejects Python 3 (the
+# Qt 5.15.19's QtWebEngine `configure` hard-rejects Python 3 (the
 # bundled chromium gn/gyp scripts predate py3 support); it needs a
 # Python 2.7 interpreter to produce QtWebEngineCore at all. Trixie
 # dropped py2 from main, but bullseye still ships 2.7.18 — pull it

--- a/src/anthias_webview/README.md
+++ b/src/anthias_webview/README.md
@@ -25,7 +25,7 @@ viewer image build:
   Qt 5 toolchain, all in
   `docker/Dockerfile.qt5-webview-builder.j2`. Qt 5 is frozen for
   these boards, so the toolchain itself is a permanent artifact at
-  the `WebView-v2026.04.1` GitHub release.
+  the `WebView-v2026.07.0` GitHub release.
 
 To rebuild a viewer image (which rebuilds the binary):
 
@@ -38,8 +38,8 @@ uv run python -m tools.image_builder \
 
 If the Qt 5 toolchain itself needs to change (CVE patch, base image
 bump), `bin/rebuild_qt5_toolchain.sh` produces fresh
-`qt5-5.15.14-trixie-{pi2,pi3}.tar.gz` tarballs. Re-uploading them to
-the same `WebView-v2026.04.1` release tag means no source change is
+`qt5-5.15.19-trixie-{pi2,pi3}.tar.gz` tarballs. Re-uploading them to
+the same `WebView-v2026.07.0` release tag means no source change is
 needed elsewhere; uploading to a new tag means bumping
 `qt5_toolchain_url` in `tools/image_builder/utils.py`. Runtime is
 ~2-4 hours per board on a beefy x86 host (Qt 5 + QtWebEngine under

--- a/src/anthias_webview/build_qt5.sh
+++ b/src/anthias_webview/build_qt5.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Qt 5 toolchain builder. Run via bin/rebuild_qt5_toolchain.sh inside
 # the src/anthias_webview/Dockerfile builder image; emits
-# qt5-5.15.14-trixie-{pi2,pi3}.tar.gz under /build for upload to a
+# qt5-5.15.19-trixie-{pi2,pi3}.tar.gz under /build for upload to a
 # WebView-v* GitHub release. Not wired into CI — the viewer image
 # now compiles the webview app inline against the toolchain artifact
 # this script produces (see docker/Dockerfile.qt5-webview-builder.j2).
@@ -15,7 +15,7 @@ BUILD_TARGET=/build
 SRC=/src
 QT_MAJOR="5"
 QT_MINOR="15"
-QT_BUG_FIX="14"
+QT_BUG_FIX="19"
 QT_VERSION="$QT_MAJOR.$QT_MINOR.$QT_BUG_FIX"
 DEBIAN_VERSION=$(lsb_release -cs)
 # MAKE_CORES caps parallelism. Overridable via env so the wrapper can
@@ -23,6 +23,15 @@ DEBIAN_VERSION=$(lsb_release -cs)
 # ~3-4 GB during the chromium compile, so the default `nproc + 2`
 # happily OOMs anything <40 GB RAM on a 16-core box.
 MAKE_CORES="${MAKE_CORES:-$(expr $(nproc) + 2)}"
+
+# QtWebEngine's chromium build does NOT inherit `make -j`: qmake shells
+# out to its bundled ninja, which self-detects nproc and floods the box
+# with ~nproc parallel cc1plus regardless of MAKE_CORES. That inner
+# ninja is the real RAM driver (it, not the outer make, caused the
+# box-wide OOMs). NINJAFLAGS is the documented knob qtwebengine honours,
+# so pin it to MAKE_CORES too — otherwise MAKE_CORES=1 is a no-op for
+# the only phase that actually matters.
+export NINJAFLAGS="-j${MAKE_CORES}"
 
 mkdir -p "$BUILD_TARGET"
 mkdir -p "$SRC"
@@ -259,7 +268,7 @@ function build_qt () {
     # (docker/Dockerfile.qt5-webview-builder.j2 includes this Qt 5
     # toolchain at build time). This script only emits the toolchain
     # tarball — bin/rebuild_qt5_toolchain.sh uploads it to the frozen
-    # WebView-v2026.04.1 release.
+    # WebView-v2026.07.0 release.
 }
 
 # Modify paths for build process

--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -170,11 +170,11 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
     # Qt version is only relevant for the Qt 5 path: pi2/pi3 pull the
     # cross-built Qt 5 toolchain tarball at build time. Qt 5 is frozen
     # for these boards, so the toolchain stays pinned to the
-    # WebView-v2026.04.1 release indefinitely. Qt 6 boards install Qt
+    # WebView-v2026.07.0 release indefinitely. Qt 6 boards install Qt
     # straight from Debian apt (qt6-*-dev in viewer_extra_apt below).
-    qt_version = '6.4.2' if is_qt6 else '5.15.14'
+    qt_version = '6.4.2' if is_qt6 else '5.15.19'
     qt_major_version = qt_version.split('.')[0]
-    qt5_toolchain_url = f'{releases_url}/WebView-v2026.04.1'
+    qt5_toolchain_url = f'{releases_url}/WebView-v2026.07.0'
 
     # Viewer-only apt deps. The shared runtime set (cec-utils, curl,
     # ffmpeg, git, libcec7, procps, psmisc, python-is-python3,


### PR DESCRIPTION
### Issues Fixed

None — routine maintenance bump of the frozen Qt 5 cross-compile toolchain used by the 32-bit Qt 5 Pi boards (pi2, pi3).

### Description

Bumps the pi2/pi3 armhf Qt 5 toolchain from **5.15.14 → 5.15.19** (latest Qt 5.15 LTS patch). Qt 6 boards are untouched (they track trixie apt).

- Point `qt5_toolchain_url` at the new **`WebView-v2026.07.0`** release. The rebuilt `qt5-5.15.19-trixie-{pi2,pi3}.tar.gz` (+ `.sha256`) are already attached there and verified end-to-end (download SHA matches), so pi2/pi3 image builds won't 404.
- **Fix the box-wide OOMs** rebuilding the toolchain on trixie: QtWebEngine's inner Chromium `ninja` never inherited `make -j`, flooding the host with ~nproc `cc1plus`. Pin it with `NINJAFLAGS=-j$MAKE_CORES` so `MAKE_CORES` actually bounds the RAM-heavy phase.
- Trixie build-env drift fixes so 5.15.19 compiles at all: drop `libre2-dev` (use chromium's vendored re2 — trixie re2 API break), swap `gcc/g++-multilib` (conflicts `crossbuild-essential-armhf`) for `lib32gcc-14`/`lib32stdc++-14`/`libc6-dev-i386`, add `python3-html5lib` (catapult vulcanize step).

Toolchain rebuild driven by `bin/rebuild_qt5_toolchain.sh`; both boards built clean at `MAKE_CORES=2` with the ninja cap.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes. _(build-tooling only; no unit-test surface — CI will run)_
- [ ] I have done an end-to-end test for Raspberry Pi devices. _(toolchain tarballs built + verified; a full pi2/pi3 viewer-image build against the new release is the remaining integrated check)_
- [ ] I have tested my changes for x86 devices. _(N/A — Qt 5 path is pi2/pi3 only; x86 is Qt 6)_
- [x] I added a documentation for the changes I have made (when necessary).