### PR TITLE
fix(assets): bound asset duration to prevent viewer crash-loop

### DIFF
--- a/src/anthias_server/api/serializers/__init__.py
+++ b/src/anthias_server/api/serializers/__init__.py
@@ -12,8 +12,32 @@ from rest_framework.serializers import (
     Serializer,
 )
 
-from anthias_server.app.models import Asset
+from anthias_server.app.models import Asset, DURATION_S_MAX
 from anthias_common.utils import validate_url
+
+
+DURATION_RANGE_ERROR = (
+    f'duration must be between 0 and {DURATION_S_MAX} seconds.'
+)
+
+
+def parse_duration(value: Any) -> int:
+    """Parse and bound a client-supplied asset duration (seconds).
+
+    Shared by the v1-family write paths, which model ``duration`` as a
+    CharField for back-compat. Raises DRF ``ValidationError`` (plain
+    message — callers decide the field key) so out-of-range values
+    become a 400 instead of landing in the DB, where the viewer would
+    feed them to ``threading.Event.wait`` and crash-loop on
+    OverflowError (Sentry ANTHIAS-3E).
+    """
+    try:
+        duration = int(value)
+    except (TypeError, ValueError):
+        raise ValidationError('A valid integer is required.')
+    if not 0 <= duration <= DURATION_S_MAX:
+        raise ValidationError(DURATION_RANGE_ERROR)
+    return duration
 
 
 def get_unique_name(name: str) -> str:
@@ -132,6 +156,11 @@ class UpdateAssetSerializer(Serializer[Asset]):
     skip_asset_check: Field[Any, Any, Any, Any] = IntegerField(
         min_value=0, max_value=1, required=False
     )
+
+    def validate_duration(self, value: Any) -> int:
+        # Runs for v2's IntegerField override too — redundant there
+        # (the field bounds already reject), but harmless.
+        return parse_duration(value)
 
     def update(
         self,

--- a/src/anthias_server/api/serializers/mixins.py
+++ b/src/anthias_server/api/serializers/mixins.py
@@ -24,7 +24,7 @@ from . import (
     get_unique_name,
     validate_uri,
 )
-from anthias_server.app.models import DURATION_S_MAX
+from anthias_server.app.models import DURATION_S_MAX, clamp_duration
 
 
 class CreateAssetSerializerMixin:
@@ -201,9 +201,12 @@ class CreateAssetSerializerMixin:
                         raise AssetCreationError(
                             f'Could not determine duration of video {uri!r}'
                         )
-                    duration = video_duration.total_seconds()
-                    asset['duration'] = (
-                        duration if version == 'v2' else int(duration)
+                    # Clamp (not reject): the file itself is playable,
+                    # only a corrupted container header can advertise
+                    # an out-of-range length — and that must not put
+                    # an over-cap value in the DB (Sentry ANTHIAS-3E).
+                    asset['duration'] = clamp_duration(
+                        video_duration.total_seconds()
                     )
             else:
                 raise AssetCreationError(

--- a/src/anthias_server/api/serializers/mixins.py
+++ b/src/anthias_server/api/serializers/mixins.py
@@ -20,9 +20,11 @@ from anthias_server.processing import needs_image_normalisation
 from anthias_server.settings import settings
 
 from . import (
+    DURATION_RANGE_ERROR,
     get_unique_name,
     validate_uri,
 )
+from anthias_server.app.models import DURATION_S_MAX
 
 
 class CreateAssetSerializerMixin:
@@ -212,9 +214,16 @@ class CreateAssetSerializerMixin:
             duration = data.get('duration', settings['default_duration'])
 
             if version == 'v2':
+                # Already an int bounded by the v2 IntegerField.
                 asset['duration'] = duration
             else:
+                # v1.2 models duration as a CharField, so bound the
+                # parsed value here — an out-of-range duration would
+                # otherwise crash-loop the viewer's Event.wait
+                # (Sentry ANTHIAS-3E).
                 asset['duration'] = int(duration)
+                if not 0 <= asset['duration'] <= DURATION_S_MAX:
+                    raise ValidationError({'duration': DURATION_RANGE_ERROR})
 
         asset['play_order'] = (
             data.get('play_order') if data.get('play_order') else 0

--- a/src/anthias_server/api/serializers/mixins.py
+++ b/src/anthias_server/api/serializers/mixins.py
@@ -184,7 +184,18 @@ class CreateAssetSerializerMixin:
             and not is_remote_video_download
         ):
             duration_raw = data.get('duration')
-            if duration_raw is not None and int(duration_raw) == 0:
+            # Guarded parse: v1.2 models duration as a CharField, so
+            # ``'abc'`` must 400 keyed on ``duration``, not escape as
+            # an unhandled ValueError (500).
+            try:
+                duration_is_zero = (
+                    duration_raw is not None and int(duration_raw) == 0
+                )
+            except (TypeError, ValueError):
+                raise ValidationError(
+                    {'duration': 'A valid integer is required.'}
+                )
+            if duration_is_zero:
                 if needs_video:
                     # Defer ffprobe to ``normalize_video_asset``: a
                     # passthrough-eligible upload still needs a

--- a/src/anthias_server/api/serializers/mixins.py
+++ b/src/anthias_server/api/serializers/mixins.py
@@ -210,18 +210,23 @@ class CreateAssetSerializerMixin:
                     'Duration must be zero for video assets.'
                 )
         elif not is_youtube and not is_remote_video_download:
-            # Crashes if it's not an int. We want that.
             duration = data.get('duration', settings['default_duration'])
 
             if version == 'v2':
                 # Already an int bounded by the v2 IntegerField.
                 asset['duration'] = duration
             else:
-                # v1.2 models duration as a CharField, so bound the
-                # parsed value here — an out-of-range duration would
-                # otherwise crash-loop the viewer's Event.wait
-                # (Sentry ANTHIAS-3E).
-                asset['duration'] = int(duration)
+                # v1.2 models duration as a CharField, so parse and
+                # bound the value here — a non-integer must 400 like
+                # the other keyed validation errors (not 500), and an
+                # out-of-range duration would crash-loop the viewer's
+                # Event.wait (Sentry ANTHIAS-3E).
+                try:
+                    asset['duration'] = int(duration)
+                except (TypeError, ValueError):
+                    raise ValidationError(
+                        {'duration': 'A valid integer is required.'}
+                    )
                 if not 0 <= asset['duration'] <= DURATION_S_MAX:
                     raise ValidationError({'duration': DURATION_RANGE_ERROR})
 

--- a/src/anthias_server/api/serializers/v1_1.py
+++ b/src/anthias_server/api/serializers/v1_1.py
@@ -17,7 +17,7 @@ from anthias_common.utils import (
     url_fails,
 )
 from anthias_common.youtube import is_youtube_url, youtube_destination_path
-from anthias_server.app.models import DURATION_S_MAX
+from anthias_server.app.models import DURATION_S_MAX, clamp_duration
 from anthias_server.settings import settings
 
 from . import (
@@ -157,7 +157,13 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
                             )
                         }
                     )
-                asset['duration'] = int(video_duration.total_seconds())
+                # Clamp (not reject): the file itself is playable,
+                # only a corrupted container header can advertise an
+                # out-of-range length — and that must not put an
+                # over-cap value in the DB (Sentry ANTHIAS-3E).
+                asset['duration'] = clamp_duration(
+                    video_duration.total_seconds()
+                )
             elif duration_int < 0 or duration_int > DURATION_S_MAX:
                 raise ValidationError({'duration': DURATION_RANGE_ERROR})
             else:

--- a/src/anthias_server/api/serializers/v1_1.py
+++ b/src/anthias_server/api/serializers/v1_1.py
@@ -17,9 +17,11 @@ from anthias_common.utils import (
     url_fails,
 )
 from anthias_common.youtube import is_youtube_url, youtube_destination_path
+from anthias_server.app.models import DURATION_S_MAX
 from anthias_server.settings import settings
 
 from . import (
+    DURATION_RANGE_ERROR,
     get_unique_name,
     validate_uri,
 )
@@ -156,6 +158,8 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
                         }
                     )
                 asset['duration'] = int(video_duration.total_seconds())
+            elif duration_int < 0 or duration_int > DURATION_S_MAX:
+                raise ValidationError({'duration': DURATION_RANGE_ERROR})
             else:
                 asset['duration'] = duration_int
         elif not is_youtube:
@@ -172,6 +176,8 @@ class CreateAssetSerializerV1_1(Serializer[dict[str, Any]]):
                 raise ValidationError(
                     {'duration': 'A valid integer is required.'}
                 )
+            if not 0 <= asset['duration'] <= DURATION_S_MAX:
+                raise ValidationError({'duration': DURATION_RANGE_ERROR})
 
         asset['skip_asset_check'] = int(data.get('skip_asset_check', 0))
 

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -20,6 +20,7 @@ from rest_framework.serializers import (
 from anthias_common.utils import SCREEN_ROTATION_CHOICES
 from anthias_server.app.models import (
     Asset,
+    DURATION_S_MAX,
     REFRESH_INTERVAL_S_MAX,
     clamp_refresh_interval,
 )
@@ -202,7 +203,7 @@ class CreateAssetSerializerV2(
     uri = CharField()
     start_date = DateTimeField(default_timezone=timezone.utc)
     end_date = DateTimeField(default_timezone=timezone.utc)
-    duration = IntegerField()
+    duration = IntegerField(min_value=0, max_value=DURATION_S_MAX)
     mimetype = CharField()
     is_enabled = BooleanField()
     is_processing = BooleanField(required=False)
@@ -257,7 +258,7 @@ class UpdateAssetSerializerV2(UpdateAssetSerializer):
     is_processing = BooleanField(required=False)
     nocache = BooleanField(required=False)
     skip_asset_check = BooleanField(required=False)
-    duration = IntegerField()
+    duration = IntegerField(min_value=0, max_value=DURATION_S_MAX)
     play_days = ListField(
         child=IntegerField(min_value=1, max_value=7),
         required=False,
@@ -322,8 +323,16 @@ class DeviceSettingsSerializerV2(Serializer[Any]):
 class UpdateDeviceSettingsSerializerV2(Serializer[Any]):
     player_name = CharField(required=False, allow_blank=True)
     audio_output = CharField(required=False)
-    default_duration = IntegerField(required=False)
-    default_streaming_duration = IntegerField(required=False)
+    # Bounded like Asset.duration — these defaults get copied onto new
+    # asset rows (CreateAssetSerializerMixin, HTML add-asset path), so
+    # a poisoned default would reach the viewer's Event.wait the same
+    # way a bad per-asset duration does (Sentry ANTHIAS-3E).
+    default_duration = IntegerField(
+        required=False, min_value=0, max_value=DURATION_S_MAX
+    )
+    default_streaming_duration = IntegerField(
+        required=False, min_value=0, max_value=DURATION_S_MAX
+    )
     date_format = CharField(required=False)
     show_splash = BooleanField(required=False)
     default_assets = BooleanField(required=False)

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -527,6 +527,83 @@ def test_create_asset_non_integer_duration_rejected(
 
 
 @pytest.mark.django_db
+def test_v1_1_create_video_clamps_absurd_probed_duration(
+    api_client: APIClient,
+) -> None:
+    """A corrupted container header can advertise an out-of-range
+    length; the probe-inferred duration must be bounded like operator
+    input would be — clamped rather than rejected, since the file
+    itself is playable (Sentry ANTHIAS-3E)."""
+    from datetime import timedelta
+
+    from anthias_server.app.models import Asset
+
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': '/data/anthias_assets/test-video.mp4',
+        'mimetype': 'video',
+        'duration': 0,
+    }
+    with (
+        mock.patch('anthias_server.processing.dispatch_normalize_video'),
+        mock.patch('anthias_server.processing.stamp_processing_start'),
+        mock.patch('anthias_server.api.serializers.v1_1.rename'),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.validate_uri',
+            return_value=True,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.url_fails',
+            return_value=False,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.v1_1.get_video_duration',
+            return_value=timedelta(seconds=9999999999999),
+        ),
+    ):
+        response = api_client.post(
+            reverse('api:asset_list_v1_1'),
+            data=get_request_data(payload, 'v1_1'),
+        )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Asset.objects.get().duration == DURATION_S_MAX
+
+
+@pytest.mark.django_db
+def test_v1_2_create_stream_clamps_absurd_probed_duration(
+    api_client: APIClient,
+) -> None:
+    """Same as above for the mixin's probe path (v1.2/v2), reached via
+    a non-downloadable remote video URI."""
+    from datetime import timedelta
+
+    from anthias_server.app.models import Asset
+
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': 'rtsp://example.com/stream',
+        'mimetype': 'video',
+        'duration': 0,
+    }
+    with (
+        mock.patch(
+            'anthias_server.api.serializers.mixins.url_fails',
+            return_value=False,
+        ),
+        mock.patch(
+            'anthias_server.api.serializers.mixins.get_video_duration',
+            return_value=timedelta(seconds=9999999999999),
+        ),
+    ):
+        response = api_client.post(
+            reverse('api:asset_list_v1_2'),
+            data=get_request_data(payload, 'v1_2'),
+        )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Asset.objects.get().duration == DURATION_S_MAX
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
 def test_update_asset_duration_out_of_range_rejected(
     api_client: APIClient, version: str

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -604,6 +604,30 @@ def test_v1_2_create_stream_clamps_absurd_probed_duration(
 
 
 @pytest.mark.django_db
+def test_v1_2_create_video_non_integer_duration_rejected(
+    api_client: APIClient,
+) -> None:
+    """The video branch's zero-check parses the raw CharField value —
+    ``'abc'`` must be a keyed 400, not an unhandled ValueError."""
+    payload = {
+        **ASSET_CREATION_DATA,
+        'uri': 'rtsp://example.com/stream',
+        'mimetype': 'video',
+        'duration': 'abc',
+    }
+    with mock.patch(
+        'anthias_server.api.serializers.mixins.url_fails',
+        return_value=False,
+    ):
+        response = api_client.post(
+            reverse('api:asset_list_v1_2'),
+            data=get_request_data(payload, 'v1_2'),
+        )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'duration' in str(response.data)
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
 def test_update_asset_duration_out_of_range_rejected(
     api_client: APIClient, version: str

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -18,6 +18,7 @@ from anthias_server.api.tests.test_common import (
     ASSET_UPDATE_DATA_V2,
     get_request_data,
 )
+from anthias_server.app.models import DURATION_S_MAX
 
 
 @pytest.fixture
@@ -467,6 +468,64 @@ def test_v2_patch_refresh_interval_out_of_range_rejected(
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert 'refresh_interval_s' in response.data
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'value',
+    [-1, DURATION_S_MAX + 1],
+    ids=['negative', 'over-one-year-cap'],
+)
+def test_v2_patch_duration_out_of_range_rejected(
+    api_client: APIClient, v2_asset_detail_url: str, value: int
+) -> None:
+    """Both bounds of the 0..DURATION_S_MAX range must 400 on write.
+    A stored duration past C ``PyTime_t`` range crash-loops the
+    viewer's ``Event.wait`` (Sentry ANTHIAS-3E — an operator entered
+    9999999999999 to mean "forever" and took the screen down)."""
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'duration': value},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'duration' in response.data
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+def test_create_asset_duration_out_of_range_rejected(
+    api_client: APIClient, version: str
+) -> None:
+    """Every create path must bound duration — the v1 family models it
+    as a CharField, so the range check lives in the prepare_asset
+    paths rather than on the field (Sentry ANTHIAS-3E)."""
+    response = api_client.post(
+        reverse(f'api:asset_list_{version}'),
+        data=get_request_data(
+            {**ASSET_CREATION_DATA, 'duration': 9999999999999}, version
+        ),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+def test_update_asset_duration_out_of_range_rejected(
+    api_client: APIClient, version: str
+) -> None:
+    asset = _create_asset(api_client, ASSET_CREATION_DATA, version)
+
+    if version == 'v2':
+        data = ASSET_UPDATE_DATA_V2
+    else:
+        data = ASSET_UPDATE_DATA_V1_2
+
+    response = api_client.put(
+        reverse(f'api:asset_detail_{version}', args=[asset['asset_id']]),
+        data=get_request_data({**data, 'duration': 9999999999999}, version),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.django_db

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -511,6 +511,23 @@ def test_create_asset_duration_out_of_range_rejected(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
+def test_create_asset_non_integer_duration_rejected(
+    api_client: APIClient, version: str
+) -> None:
+    """A non-integer duration must be a keyed 400, not a 500 — the
+    v1.2 path used to let ``int('abc')`` escape as an unhandled
+    ValueError."""
+    response = api_client.post(
+        reverse(f'api:asset_list_{version}'),
+        data=get_request_data(
+            {**ASSET_CREATION_DATA, 'duration': 'abc'}, version
+        ),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
 def test_update_asset_duration_out_of_range_rejected(
     api_client: APIClient, version: str
 ) -> None:

--- a/src/anthias_server/app/models.py
+++ b/src/anthias_server/app/models.py
@@ -19,6 +19,35 @@ ALL_DAYS = [1, 2, 3, 4, 5, 6, 7]
 REFRESH_INTERVAL_S_MAX = 86400
 
 
+# Upper bound for ``Asset.duration`` (seconds). The hard constraint is
+# the viewer: ``asset_loop`` / ``view_video`` feed the value straight
+# into ``threading.Event.wait``, and a timeout past C ``PyTime_t``
+# range (~2.9e11 s) raises OverflowError, crash-looping the viewer
+# (Sentry ANTHIAS-3E — an operator typed 9999999999999 to mean
+# "forever" and took the screen down). One year is effectively
+# "pinned forever" for signage while staying a typo guard. Enforced
+# by the v2 serializers + settings (write validation), the
+# v1/v1.1/v1.2 create paths, the page-form handlers (clamping), and
+# the viewer's read-side clamp.
+DURATION_S_MAX = 365 * 24 * 60 * 60
+
+
+def clamp_duration(value: Any) -> int:
+    """Coerce an arbitrary ``Asset.duration`` value to a safe int in
+    ``[0, DURATION_S_MAX]``.
+
+    The API write paths reject out-of-range values, but a hand-edited
+    row or a legacy import can still hold junk, and the viewer must
+    never crash on a DB value. Same contract as
+    ``clamp_refresh_interval`` below: garbage coerces to 0.
+    """
+    try:
+        duration = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(duration, DURATION_S_MAX))
+
+
 def clamp_refresh_interval(value: Any) -> int:
     """Coerce an arbitrary ``metadata['refresh_interval_s']`` value to
     a safe int in ``[0, REFRESH_INTERVAL_S_MAX]``.

--- a/src/anthias_server/app/models.py
+++ b/src/anthias_server/app/models.py
@@ -22,7 +22,8 @@ REFRESH_INTERVAL_S_MAX = 86400
 # Upper bound for ``Asset.duration`` (seconds). The hard constraint is
 # the viewer: ``asset_loop`` / ``view_video`` feed the value straight
 # into ``threading.Event.wait``, and a timeout past C ``PyTime_t``
-# range (~2.9e11 s) raises OverflowError, crash-looping the viewer
+# range (int64 nanoseconds, ~9.2e9 s ≈ 292 years) raises
+# OverflowError, crash-looping the viewer
 # (Sentry ANTHIAS-3E — an operator typed 9999999999999 to mean
 # "forever" and took the screen down). One year is effectively
 # "pinned forever" for signage while staying a typo guard. Enforced

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -28,7 +28,10 @@ from django.utils.http import (
 from django.views.decorators.http import require_http_methods
 
 from anthias_server.app import page_context
-from anthias_server.app.models import clamp_refresh_interval
+from anthias_server.app.models import (
+    clamp_duration,
+    clamp_refresh_interval,
+)
 from anthias_server.celery_tasks import reboot_anthias, shutdown_anthias
 from anthias_server.lib import backup_helper, diagnostics
 from anthias_server.lib.auth import (
@@ -733,7 +736,10 @@ def assets_update(request: HttpRequest, asset_id: str) -> HttpResponse:
         # that try to write a duration anyway.
         pass
     else:
-        asset.duration = int(
+        # Clamp (rather than reject) like the refresh-interval handler
+        # below — an out-of-range duration would crash-loop the
+        # viewer's Event.wait (Sentry ANTHIAS-3E).
+        asset.duration = clamp_duration(
             request.POST.get('duration') or asset.duration or 0
         )
     start = request.POST.get('start_date')
@@ -1555,10 +1561,13 @@ def settings_save(request: HttpRequest) -> HttpResponse:
         settings['auth_backend'] = auth_backend
 
         settings['player_name'] = request.POST.get('player_name', '')
-        settings['default_duration'] = int(
+        # Clamped for the same reason as the per-asset duration: these
+        # defaults get copied onto new asset rows and would reach the
+        # viewer's Event.wait (Sentry ANTHIAS-3E).
+        settings['default_duration'] = clamp_duration(
             request.POST.get('default_duration') or 0
         )
-        settings['default_streaming_duration'] = int(
+        settings['default_streaming_duration'] = clamp_duration(
             request.POST.get('default_streaming_duration') or 0
         )
         settings['audio_output'] = request.POST.get('audio_output', 'hdmi')

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -53,6 +53,7 @@ from anthias_common.utils import (  # noqa: E402
     string_to_bool,
 )
 from anthias_server.app.models import Asset  # noqa: E402
+from anthias_server.app.models import clamp_duration  # noqa: E402
 from anthias_server.app.models import clamp_refresh_interval  # noqa: E402
 from anthias_viewer.messaging import ViewerSubscriber  # noqa: E402
 from anthias_viewer.scheduling import Scheduler  # noqa: E402
@@ -1407,6 +1408,12 @@ def asset_loop(scheduler: Any) -> None:
 
     elif _asset_is_displayable(asset):
         name, mime, uri = asset['name'], asset['mimetype'], asset['uri']
+        # Both waits below feed this into ``threading.Event.wait``,
+        # where an out-of-range timeout raises OverflowError and
+        # crash-loops the whole viewer (Sentry ANTHIAS-3E). The API
+        # rejects such values on write, but a pre-existing row must
+        # not take the screen down.
+        duration = clamp_duration(asset['duration'])
         logging.info('Showing asset %s (%s)', name, mime)
         logging.debug('Asset URI %s', uri)
         watchdog()
@@ -1433,12 +1440,11 @@ def asset_loop(scheduler: Any) -> None:
             # or ('streaming' in mime)`` — the truthy literal short-
             # circuits and the branch runs for every mimetype, making
             # the ``else: Unknown MimeType`` arm below unreachable.
-            view_video(uri, asset['duration'])
+            view_video(uri, duration)
         else:
             logging.error('Unknown MimeType %s', mime)
 
         if 'image' in mime or 'web' in mime:
-            duration = int(asset['duration'])
             logging.info('Sleeping for %s', duration)
             skip_event = get_skip_event()
             skip_event.clear()

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -20,7 +20,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from anthias_server.app import page_context
-from anthias_server.app.models import Asset
+from anthias_server.app.models import DURATION_S_MAX, Asset
 from anthias_server.app.templatetags.asset_filters import to_json
 
 
@@ -1110,6 +1110,33 @@ def test_assets_update_clamps_oversize_refresh_interval(
         )
     asset.refresh_from_db()
     assert asset.metadata.get('refresh_interval_s') == 86400
+
+
+@pytest.mark.django_db
+def test_assets_update_clamps_oversize_duration(
+    client: Client, asset: Asset
+) -> None:
+    """Same clamp-not-400 policy as the refresh interval above. The
+    posted value is the real one from Sentry ANTHIAS-3E: an operator
+    typed 9999999999999 to mean "forever", and the stored row
+    crash-looped the viewer's ``Event.wait`` on OverflowError."""
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_update', args=[asset.asset_id]),
+            data={
+                'name': asset.name,
+                'mimetype': 'webpage',
+                'duration': '9999999999999',
+                'start_date': '2026-01-01T00:00',
+                'end_date': '2027-01-01T00:00',
+                'refresh_interval_s': '',
+            },
+        )
+    asset.refresh_from_db()
+    assert asset.duration == DURATION_S_MAX
 
 
 @pytest.mark.django_db

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -11,6 +11,7 @@ from unittest import mock
 import pytest
 
 import anthias_viewer as viewer
+from anthias_server.app.models import DURATION_S_MAX
 from anthias_server.settings import settings
 from anthias_viewer.scheduling import Scheduler
 from anthias_viewer.utils import get_skip_event
@@ -894,6 +895,34 @@ def test_asset_loop_rechecks_unreachable_remote_asset() -> None:
     ):
         viewer.asset_loop(scheduler)
     trigger.assert_called_once_with('remote')
+
+
+def test_asset_loop_clamps_out_of_range_duration() -> None:
+    """A stored duration past C ``PyTime_t`` range must not crash the
+    loop (Sentry ANTHIAS-3E) — ``threading.Event.wait`` raises
+    OverflowError on such a timeout and the whole viewer crash-loops.
+    The API rejects these on write; this is the read-side guard for
+    pre-existing rows. 9999999999999 is the real value from the
+    incident."""
+    scheduler = mock.Mock()
+    scheduler.get_next_asset.return_value = {
+        'asset_id': 'huge',
+        'name': 'huge',
+        'uri': 'https://example.com/pinned.png',
+        'mimetype': 'image',
+        'duration': 9999999999999,
+        'skip_asset_check': True,
+        'is_reachable': True,
+    }
+    skip_event = mock.Mock()
+    skip_event.wait.return_value = False
+    with (
+        mock.patch('anthias_viewer.view_image'),
+        mock.patch('anthias_viewer.watchdog'),
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
+    ):
+        viewer.asset_loop(scheduler)
+    skip_event.wait.assert_called_once_with(timeout=DURATION_S_MAX)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Issues Fixed

- Fixes #3122 (Sentry ANTHIAS-3E)

### Description

An out-of-range asset duration — 9999999999999, typed by an operator to mean "forever" — reached `threading.Event.wait` in the viewer's `asset_loop`, which raises `OverflowError` for timeouts past C `PyTime_t` range. The exception propagates out of `main()`, so the viewer crash-looped and took the screen down (875 Sentry events from one pi5 in under a day).

The fix bounds duration at every layer, mirroring the existing `REFRESH_INTERVAL_S_MAX` / `clamp_refresh_interval` pattern:

- `DURATION_S_MAX` (1 year — effectively "forever" for signage) + `clamp_duration()` in `app.models`.
- Viewer clamps on read, so a pre-existing bad row can never crash the loop (regression test asserts the wait gets the clamped value).
- v2 API rejects out-of-range `duration`, `default_duration`, and `default_streaming_duration` via `IntegerField(min_value, max_value)`.
- v1/v1.1/v1.2 (duration is a CharField there) get the same bounds in their parse paths.
- HTML form handlers clamp (same clamp-not-400 policy as the refresh interval).

### Validation on real hardware

Exercised on the physical testbeds (Pi 4 aarch64 and x86), not just unit tests:

- **x86 viewer, full end-to-end** — injected a huge-duration (`9999999999999`) enabled asset straight into the DB, bypassing the API to simulate a legacy / hand-edited row, then let the live `asset_loop` run. The viewer displayed the asset and logged `Sleeping for 31536000` (the clamped 365 days, not the raw value) with **zero crashes** — the container's `RestartCount` stayed at `0`. Before the fix this exact scenario crash-looped the viewer.
- **x86 API** — `POST` and `PATCH` to `/api/v2/assets` with `duration=9999999999999` both returned **HTTP 400** (`Ensure this value is less than or equal to 31536000`); a sane duration still returned `201`.
- **Pi 4 (aarch64) viewer container** — reproduced the crash on the real arm64 image: `threading.Event.wait(timeout=9999999999999)` → `OverflowError: timestamp too large to convert to C PyTime_t` (the ANTHIAS-3E crash). With the fix, `clamp_duration(9999999999999)` → `31536000` and the wait succeeds; confirmed `asset_loop` calls `clamp_duration` before the wait. (The Pi 4 testbed is display-headless so its `asset_loop` is display-gated — the arch-specific crash-and-fix was confirmed in the real container, and the full live-rotation e2e above ran on x86.)

Both testbeds were restored to their pinned images afterward.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices. <!-- Pi 4 testbed is display-headless; arch-specific crash+fix confirmed in the real aarch64 container, full-rotation e2e on x86 -->
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
