### PR TITLE
fix(install): probe sudo capability instead of guessing from sudoers filename

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -472,10 +472,20 @@ function run_ansible_playbook() {
 
     cd "${ANTHIAS_REPO_DIR}/ansible"
 
-    # If the user doesn't have NOPASSWD sudo yet (first install), Ansible
-    # needs --ask-become-pass to elevate. The blanket NOPASSWD rule is
-    # written by modify_permissions later in this script.
-    if [ ! -f "/etc/sudoers.d/010_${USER}-nopasswd" ]; then
+    # If the user can't elevate without a password, Ansible needs
+    # --ask-become-pass. Probe the actual sudo capability instead of
+    # looking for our own sudoers file (the blanket NOPASSWD rule that
+    # modify_permissions writes later): stock Raspberry Pi OS already
+    # grants the first user passwordless sudo via
+    # /etc/sudoers.d/010_pi-nopasswd — a fixed filename whatever the
+    # username — so a filename check misfires there and leaves Ansible
+    # prompting for a password that unattended runs can never type.
+    # `sudo -K` first drops any cached credential so a password typed
+    # for an earlier apt call can't masquerade as passwordless sudo;
+    # without it the playbook outlives the sudo timestamp and dies
+    # mid-run with "Missing sudo password" instead.
+    sudo -K
+    if ! sudo -n true 2>/dev/null; then
         ANSIBLE_PLAYBOOK_ARGS+=("--ask-become-pass")
         echo "Note: Ansible may prompt for your sudo password below."
         echo


### PR DESCRIPTION
### Issues Fixed

Unattended/headless installs hang forever at `BECOME password:` on stock Raspberry Pi OS: `run_ansible_playbook` decides whether Ansible needs `--ask-become-pass` by checking for the installer's own convention file (`/etc/sudoers.d/010_<user>-nopasswd`), but Raspberry Pi OS grants the first user passwordless sudo via `010_pi-nopasswd` — a fixed filename whatever the username — so the check misfires and Ansible prompts for a password that is never needed.

### Description

Replace the filename check with a capability probe: `sudo -K` followed by `sudo -n true`. The `-K` matters — without it, a password typed for an earlier `apt-get` call leaves a cached credential that makes `sudo -n` succeed, the prompt is skipped, and the playbook then dies mid-run with "Missing sudo password" once the sudo timestamp expires.

Verified:
- Full installer run from this branch on a Raspberry Pi 5 (Pi OS trixie, cloud-init NOPASSWD grant only, no `010_<user>-nopasswd` file): no `BECOME password:` prompt appeared, playbook completed `ok=59 failed=0`, all containers healthy after reboot. The unfixed installer on the identical setup hangs at the prompt.
- x86 device with NOPASSWD sudo: probe passes, `--ask-become-pass` skipped.
- Container with a password-only sudo user and a freshly cached credential: without `-K` the probe wrongly passes; with `-K` it correctly falls back to `--ask-become-pass`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
