### PR TITLE
fix(server): pick latest CalVer release, not GitHub /releases/latest

### DIFF
--- a/src/anthias_server/lib/github.py
+++ b/src/anthias_server/lib/github.py
@@ -187,9 +187,11 @@ def is_up_to_date() -> bool:
     published Anthias release.
 
     Compares ``importlib.metadata.version('anthias')`` (CalVer, sourced
-    from ``pyproject.toml``) against the ``tag_name`` of GitHub's
-    ``/releases/latest`` endpoint. Caches the remote tag for 24h and
-    falls back to the last computed verdict if GitHub is unreachable.
+    from ``pyproject.toml``) against the highest CalVer-parseable
+    ``tag_name`` in GitHub's ``/releases`` list (non-app releases like
+    ``WebView-*`` are skipped — see ``_latest_parseable_tag``). Caches
+    the remote tag for 24h and falls back to the last computed verdict
+    if GitHub is unreachable.
 
     Returns ``True`` (suppressing the "Update available" indicator)
     when the local CalVer can't be parsed, e.g. on dev / branch builds

--- a/src/anthias_server/lib/github.py
+++ b/src/anthias_server/lib/github.py
@@ -30,8 +30,17 @@ LAST_VERDICT_KEY_PREFIX = 'is-up-to-date:last-verdict'
 
 DEFAULT_REQUESTS_TIMEOUT = 5  # seconds
 
-GITHUB_RELEASES_LATEST_URL = (
-    'https://api.github.com/repos/Screenly/Anthias/releases/latest'
+# The releases *list*, not ``/releases/latest``: that endpoint returns
+# the newest non-draft, non-prerelease release of ANY kind, and the
+# repo also publishes non-app releases (e.g. the frozen Qt 5 toolchain,
+# tagged ``WebView-v2026.07.0``). The day such a release goes out,
+# ``/releases/latest`` stops pointing at an Anthias CalVer tag and the
+# update check degrades fleet-wide until the next app release (Sentry
+# ANTHIAS-3P). Listing lets us pick the highest CalVer-parseable tag
+# instead. 20 releases is years of headroom for non-app tags published
+# between app releases.
+GITHUB_RELEASES_URL = (
+    'https://api.github.com/repos/Screenly/Anthias/releases?per_page=20'
 )
 GITHUB_API_ACCEPT = 'application/vnd.github+json'
 
@@ -67,10 +76,41 @@ def handle_github_error(
     )
 
 
+def _latest_parseable_tag(payload: object) -> str | None:
+    """Pick the highest CalVer-parseable ``tag_name`` from a
+    ``/releases`` list payload.
+
+    Skips drafts, prereleases, and any release whose tag doesn't parse
+    (non-app releases like ``WebView-v2026.07.0``, hand-edited tags
+    like ``nightly``). Highest-by-version rather than first-in-list:
+    the list is ordered by creation date, and a non-app release
+    created after the newest app release would otherwise mask it.
+    """
+    if not isinstance(payload, list):
+        return None
+    best: str | None = None
+    best_version = None
+    for release in payload:
+        if not isinstance(release, dict):
+            continue
+        if release.get('draft') or release.get('prerelease'):
+            continue
+        tag = release.get('tag_name')
+        if not isinstance(tag, str) or not tag:
+            continue
+        version = _parse_version(tag)
+        if version is None:
+            continue
+        if best_version is None or version > best_version:
+            best, best_version = tag, version
+    return best
+
+
 def _fetch_latest_release_tag() -> str | None:
-    """Return the latest release tag from GitHub, hitting the API at
-    most once per ``LATEST_RELEASE_TTL`` and short-circuiting while a
-    prior error backoff is active. Returns ``None`` on any failure.
+    """Return the latest Anthias release tag from GitHub, hitting the
+    API at most once per ``LATEST_RELEASE_TTL`` and short-circuiting
+    while a prior error backoff is active. Returns ``None`` on any
+    failure.
     """
     cached = r.get(LATEST_RELEASE_TAG_KEY)
     if cached:
@@ -82,7 +122,7 @@ def _fetch_latest_release_tag() -> str | None:
 
     try:
         resp = requests_get(
-            GITHUB_RELEASES_LATEST_URL,
+            GITHUB_RELEASES_URL,
             headers={'Accept': GITHUB_API_ACCEPT},
             timeout=DEFAULT_REQUESTS_TIMEOUT,
         )
@@ -92,29 +132,24 @@ def _fetch_latest_release_tag() -> str | None:
         return None
 
     # Trip the same 5-minute backoff for malformed bodies as for
-    # transport failures. Without this, a bad JSON body or missing
-    # tag_name from a 200 response would re-fire the GitHub call on
-    # every page render until upstream fixed the payload.
+    # transport failures. Without this, a bad JSON body or a payload
+    # with no usable tag from a 200 response would re-fire the GitHub
+    # call on every page render until upstream fixed the payload.
     try:
         payload = resp.json()
     except ValueError:
-        logging.warning('Malformed JSON from GitHub /releases/latest')
+        logging.warning('Malformed JSON from GitHub /releases')
         _set_github_error_backoff('latest release: malformed JSON')
         return None
 
-    tag = payload.get('tag_name') if isinstance(payload, dict) else None
-    if not isinstance(tag, str) or not tag:
-        logging.warning('Missing tag_name in /releases/latest response')
-        _set_github_error_backoff('latest release: missing tag_name')
-        return None
-
     # Validate parseability *before* caching. Otherwise a bad upstream
-    # tag (e.g. a hand-edited release with `nightly`) would be cached
-    # for 24h, locking is_up_to_date() into the fallback verdict for
-    # the full TTL even after upstream corrects the tag.
-    if _parse_version(tag) is None:
-        logging.warning('Unparseable tag_name from GitHub: %r', tag)
-        _set_github_error_backoff('latest release: unparseable tag_name')
+    # payload would be cached for 24h, locking is_up_to_date() into
+    # the fallback verdict for the full TTL even after upstream
+    # corrects it.
+    tag = _latest_parseable_tag(payload)
+    if tag is None:
+        logging.warning('No parseable release tag in GitHub /releases')
+        _set_github_error_backoff('latest release: no parseable tag')
         return None
 
     r.set(LATEST_RELEASE_TAG_KEY, tag)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -78,14 +78,68 @@ def test_fetch_latest_release_tag_backoff_skips_fetch(
 def test_fetch_latest_release_tag_happy_path(
     github_env: None, redis_data: dict[str, str]
 ) -> None:
-    resp = _resp(200, json_data={'tag_name': 'v2026.6.0', 'name': 'Release'})
+    resp = _resp(200, json_data=[{'tag_name': 'v2026.6.0', 'name': 'Release'}])
     with mock.patch.object(
         github, 'requests_get', return_value=resp
     ) as mock_get:
         assert github._fetch_latest_release_tag() == 'v2026.6.0'
     assert redis_data[github.LATEST_RELEASE_TAG_KEY] == 'v2026.6.0'
     url = mock_get.call_args.args[0]
-    assert url.endswith('/repos/Screenly/Anthias/releases/latest')
+    assert '/repos/Screenly/Anthias/releases' in url
+    assert '/releases/latest' not in url
+
+
+def test_fetch_latest_release_tag_skips_non_app_releases(
+    github_env: None, redis_data: dict[str, str]
+) -> None:
+    """The ANTHIAS-3P scenario: a non-app release (frozen Qt 5
+    toolchain, tagged ``WebView-v2026.07.0``) is the newest release in
+    the repo. ``/releases/latest`` would return it and break the
+    update check fleet-wide; the list-based fetch must skip it and
+    pick the newest parseable CalVer tag instead."""
+    resp = _resp(
+        200,
+        json_data=[
+            {'tag_name': 'WebView-v2026.07.0', 'name': 'WebView toolchain'},
+            {'tag_name': 'v2026.7.0', 'name': 'Anthias'},
+            {'tag_name': 'v2026.6.3', 'name': 'Anthias'},
+        ],
+    )
+    with mock.patch.object(github, 'requests_get', return_value=resp):
+        assert github._fetch_latest_release_tag() == 'v2026.7.0'
+    assert redis_data[github.LATEST_RELEASE_TAG_KEY] == 'v2026.7.0'
+    assert 'github-api-error' not in redis_data
+
+
+def test_fetch_latest_release_tag_picks_highest_version_not_first(
+    github_env: None, redis_data: dict[str, str]
+) -> None:
+    """The list is ordered by creation date, not by version — a
+    hotfix tagged out of order must not mask the real latest."""
+    resp = _resp(
+        200,
+        json_data=[
+            {'tag_name': 'v2026.5.1', 'name': 'Hotfix, created last'},
+            {'tag_name': 'v2026.6.0', 'name': 'Anthias'},
+        ],
+    )
+    with mock.patch.object(github, 'requests_get', return_value=resp):
+        assert github._fetch_latest_release_tag() == 'v2026.6.0'
+
+
+def test_fetch_latest_release_tag_skips_drafts_and_prereleases(
+    github_env: None, redis_data: dict[str, str]
+) -> None:
+    resp = _resp(
+        200,
+        json_data=[
+            {'tag_name': 'v2026.8.0', 'draft': True},
+            {'tag_name': 'v2026.7.1', 'prerelease': True},
+            {'tag_name': 'v2026.7.0'},
+        ],
+    )
+    with mock.patch.object(github, 'requests_get', return_value=resp):
+        assert github._fetch_latest_release_tag() == 'v2026.7.0'
 
 
 def test_fetch_latest_release_tag_request_exception(
@@ -121,35 +175,32 @@ def test_fetch_latest_release_tag_invalid_json(
     assert github.LATEST_RELEASE_TAG_KEY not in redis_data
 
 
-def test_fetch_latest_release_tag_missing_tag_name(
-    github_env: None, redis_data: dict[str, str]
+@pytest.mark.parametrize(
+    'json_data',
+    [
+        [],
+        [{'name': 'Release without tag_name'}],
+        [{'tag_name': 12345}],
+        [{'tag_name': 'nightly'}, {'tag_name': 'WebView-v2026.07.0'}],
+        {'tag_name': 'v2026.6.0'},  # dict (old /latest shape), not a list
+    ],
+    ids=[
+        'empty-list',
+        'missing-tag-name',
+        'non-string-tag-name',
+        'no-parseable-tags',
+        'non-list-payload',
+    ],
+)
+def test_fetch_latest_release_tag_unusable_payload_arms_backoff(
+    github_env: None, redis_data: dict[str, str], json_data: object
 ) -> None:
-    resp = _resp(200, json_data={'name': 'Release without tag_name'})
-    with mock.patch.object(github, 'requests_get', return_value=resp):
-        assert github._fetch_latest_release_tag() is None
-    assert 'github-api-error' in redis_data
-    assert github.LATEST_RELEASE_TAG_KEY not in redis_data
-
-
-def test_fetch_latest_release_tag_non_string_tag_name(
-    github_env: None, redis_data: dict[str, str]
-) -> None:
-    resp = _resp(200, json_data={'tag_name': 12345})
-    with mock.patch.object(github, 'requests_get', return_value=resp):
-        assert github._fetch_latest_release_tag() is None
-    assert 'github-api-error' in redis_data
-    assert github.LATEST_RELEASE_TAG_KEY not in redis_data
-
-
-def test_fetch_latest_release_tag_unparseable_tag_name(
-    github_env: None, redis_data: dict[str, str]
-) -> None:
-    """An upstream tag like ``nightly`` must not be cached: with a
-    24h TTL, caching it would pin is_up_to_date() to the fallback
-    verdict for a day even after upstream corrects the tag. Trip the
-    5-minute backoff instead so the next attempt re-fetches once
-    upstream is fixed."""
-    resp = _resp(200, json_data={'tag_name': 'nightly'})
+    """A payload with no usable tag must not be cached: with a 24h
+    TTL, caching would pin is_up_to_date() to the fallback verdict
+    for a day even after upstream corrects it. Trip the 5-minute
+    backoff instead so the next attempt re-fetches once upstream is
+    fixed."""
+    resp = _resp(200, json_data=json_data)
     with mock.patch.object(github, 'requests_get', return_value=resp):
         assert github._fetch_latest_release_tag() is None
     assert 'github-api-error' in redis_data


### PR DESCRIPTION
### Issues Fixed

- Fixes #3124 (Sentry ANTHIAS-3P)

### Description

The update check fetched GitHub `/releases/latest` and parsed its `tag_name` as CalVer. That endpoint returns the newest non-draft, non-prerelease release of *any* kind — so publishing the frozen Qt 5 toolchain release (`WebView-v2026.07.0`) made every device hit the unparseable-tag path: warning + 5-minute backoff in a loop, with `is_up_to_date()` stuck on the fallback verdict fleet-wide until the next app release.

The fetch now lists `/releases` (20 newest) and picks the **highest CalVer-parseable tag**, skipping drafts, prereleases, and non-app tags. Highest-by-version rather than first-in-list, so a non-app release created after the newest app release can't mask it (and neither can an out-of-order hotfix tag).

All failure shapes (empty list, no parseable tags, non-list payload, malformed JSON) keep the existing 5-minute error backoff semantics — nothing unparseable is ever cached for the 24h TTL.

### Validation on real hardware

Exercised in the real server container on the x86 testbed against **live GitHub**: `_fetch_latest_release_tag()` returned `v2026.07.0` — correctly skipping `WebView-v2026.07.0`, which is exactly what `/releases/latest` would have wrongly returned. `_latest_parseable_tag()` with a synthetic list containing the WebView tag also picked the CalVer release. Server-side and arch-independent, so this validates the fix for all boards.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices. <!-- server-side, arch-independent; validated live against GitHub in the real server container on the x86 testbed -->
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
