### PR TITLE
fix(celery): survive a down balena supervisor in reboot/shutdown

### DIFF
--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -143,12 +143,22 @@ def get_balena_device_info(
     )
 
 
-def shutdown_via_balena_supervisor() -> requests.Response:
-    return get_balena_supervisor_api_response(method='post', action='shutdown')
+def shutdown_via_balena_supervisor(
+    *,
+    timeout: float | tuple[float, float] | None = None,
+) -> requests.Response:
+    return get_balena_supervisor_api_response(
+        method='post', action='shutdown', timeout=timeout
+    )
 
 
-def reboot_via_balena_supervisor() -> requests.Response:
-    return get_balena_supervisor_api_response(method='post', action='reboot')
+def reboot_via_balena_supervisor(
+    *,
+    timeout: float | tuple[float, float] | None = None,
+) -> requests.Response:
+    return get_balena_supervisor_api_response(
+        method='post', action='reboot', timeout=timeout
+    )
 
 
 def get_balena_supervisor_version() -> str:

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -1180,14 +1180,19 @@ def _run_supervisor_command(command: Any, action: str) -> None:
                 # A 5xx from a half-started supervisor must retry too,
                 # not read as "command accepted".
                 response.raise_for_status()
-    except RetryError:
+    except RetryError as exc:
+        # Surface the terminal failure's cause (connection refused vs
+        # an HTTP 503, say) — it's the difference between "supervisor
+        # restarting" and "supervisor misconfigured" when diagnosing.
+        last_error = exc.last_attempt.exception()
         logging.warning(
             'Balena supervisor did not accept the %s command within '
-            '%s seconds; giving up. The supervisor may be restarting '
-            '(e.g. mid-OTA) — retry from the UI if the device does '
-            'not %s on its own.',
+            '%s seconds (last error: %r); giving up. The supervisor '
+            'may be restarting (e.g. mid-OTA) — retry from the UI if '
+            'the device does not %s on its own.',
             action,
             SUPERVISOR_CMD_RETRY_WINDOW_S,
+            last_error,
             action,
         )
 

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -12,10 +12,12 @@ from celery import Celery, Task
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.signals import worker_init
 from django.apps import apps as _django_apps
+import requests
 from PIL import UnidentifiedImageError
 from tenacity import (
     RetryError,
     Retrying,
+    retry_if_exception_type,
     stop_after_delay,
     wait_exponential,
 )
@@ -1164,6 +1166,14 @@ def _run_supervisor_command(command: Any, action: str) -> None:
         for attempt in Retrying(
             stop=stop_after_delay(SUPERVISOR_CMD_RETRY_WINDOW_S),
             wait=wait_exponential(multiplier=1, max=SUPERVISOR_CMD_WAIT_MAX_S),
+            # Only transport/HTTP failures are retryable. Anything
+            # else (a TypeError, celery's SoftTimeLimitExceeded)
+            # must propagate immediately instead of being masked as
+            # "supervisor didn't accept the command" — retrying it
+            # would also pin the worker until the hard limit.
+            retry=retry_if_exception_type(
+                requests.exceptions.RequestException
+            ),
         ):
             with attempt:
                 response = command(timeout=SUPERVISOR_CMD_REQUEST_TIMEOUT_S)

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -13,7 +13,12 @@ from celery.exceptions import SoftTimeLimitExceeded
 from celery.signals import worker_init
 from django.apps import apps as _django_apps
 from PIL import UnidentifiedImageError
-from tenacity import Retrying, stop_after_attempt, wait_fixed
+from tenacity import (
+    RetryError,
+    Retrying,
+    stop_after_delay,
+    wait_exponential,
+)
 
 # ``django.setup()`` is not reentrant — calling it while
 # ``apps.populate()`` is still running (e.g. when an ``AppConfig.ready``
@@ -1131,34 +1136,76 @@ def download_remote_video_asset(asset_id: str, uri: str) -> None:
     dispatch_normalize_video(asset_id)
 
 
-@celery.task
+# Retry budget for the balena supervisor power commands. The
+# supervisor is routinely down for a stretch exactly when these fire —
+# a reboot often follows an OTA apply, which restarts the supervisor
+# itself — so the old 5 x 1s window was far too tight and the task
+# died in an unhandled RetryError with the command silently dropped
+# (Sentry ANTHIAS-3F). Each HTTP attempt is individually bounded so a
+# hung supervisor socket can't pin the worker, and the task-level
+# limits below stay comfortably above window + one full attempt as
+# the SIGKILL backstop.
+SUPERVISOR_CMD_RETRY_WINDOW_S = 120
+SUPERVISOR_CMD_REQUEST_TIMEOUT_S = 10
+SUPERVISOR_CMD_WAIT_MAX_S = 15
+SUPERVISOR_CMD_SOFT_TIME_LIMIT_S = (
+    SUPERVISOR_CMD_RETRY_WINDOW_S + 2 * SUPERVISOR_CMD_REQUEST_TIMEOUT_S
+)
+SUPERVISOR_CMD_TIME_LIMIT_S = SUPERVISOR_CMD_SOFT_TIME_LIMIT_S + 30
+
+
+def _run_supervisor_command(command: Any, action: str) -> None:
+    """Post a power command to the balena supervisor, retrying with
+    backoff while it's down/restarting. Terminal failure is logged at
+    warning — a down supervisor is an expected transient (the operator
+    can retry from the UI), not a crash worth a Sentry event.
+    """
+    try:
+        for attempt in Retrying(
+            stop=stop_after_delay(SUPERVISOR_CMD_RETRY_WINDOW_S),
+            wait=wait_exponential(multiplier=1, max=SUPERVISOR_CMD_WAIT_MAX_S),
+        ):
+            with attempt:
+                response = command(timeout=SUPERVISOR_CMD_REQUEST_TIMEOUT_S)
+                # A 5xx from a half-started supervisor must retry too,
+                # not read as "command accepted".
+                response.raise_for_status()
+    except RetryError:
+        logging.warning(
+            'Balena supervisor did not accept the %s command within '
+            '%s seconds; giving up. The supervisor may be restarting '
+            '(e.g. mid-OTA) — retry from the UI if the device does '
+            'not %s on its own.',
+            action,
+            SUPERVISOR_CMD_RETRY_WINDOW_S,
+            action,
+        )
+
+
+@celery.task(
+    soft_time_limit=SUPERVISOR_CMD_SOFT_TIME_LIMIT_S,
+    time_limit=SUPERVISOR_CMD_TIME_LIMIT_S,
+)
 def reboot_anthias() -> None:
     """
     Background task to reboot Anthias
     """
     if is_balena_app():
-        for attempt in Retrying(
-            stop=stop_after_attempt(5),
-            wait=wait_fixed(1),
-        ):
-            with attempt:
-                reboot_via_balena_supervisor()
+        _run_supervisor_command(reboot_via_balena_supervisor, 'reboot')
     else:
         r.publish('hostcmd', 'reboot')
 
 
-@celery.task
+@celery.task(
+    soft_time_limit=SUPERVISOR_CMD_SOFT_TIME_LIMIT_S,
+    time_limit=SUPERVISOR_CMD_TIME_LIMIT_S,
+)
 def shutdown_anthias() -> None:
     """
     Background task to shutdown Anthias
     """
     if is_balena_app():
-        for attempt in Retrying(
-            stop=stop_after_attempt(5),
-            wait=wait_fixed(1),
-        ):
-            with attempt:
-                shutdown_via_balena_supervisor()
+        _run_supervisor_command(shutdown_via_balena_supervisor, 'shutdown')
     else:
         r.publish('hostcmd', 'shutdown')
 

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -371,10 +371,10 @@ def test_reboot_anthias_terminal_supervisor_failure_warns_not_raises() -> None:
             celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0
         ),
         mock.patch.object(celery_tasks_module, 'SUPERVISOR_CMD_WAIT_MAX_S', 0),
-        mock.patch.object(
-            celery_tasks_module.logging, 'warning'
+        mock.patch(
+            'anthias_server.celery_tasks.logging.warning'
         ) as mock_warning,
-        mock.patch.object(celery_tasks_module.logging, 'error') as mock_error,
+        mock.patch('anthias_server.celery_tasks.logging.error') as mock_error,
     ):
         result = reboot_anthias.apply()
     assert result.successful()
@@ -400,8 +400,8 @@ def test_shutdown_anthias_terminal_supervisor_failure_warns_not_raises() -> (
             celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0
         ),
         mock.patch.object(celery_tasks_module, 'SUPERVISOR_CMD_WAIT_MAX_S', 0),
-        mock.patch.object(
-            celery_tasks_module.logging, 'warning'
+        mock.patch(
+            'anthias_server.celery_tasks.logging.warning'
         ) as mock_warning,
     ):
         result = shutdown_anthias.apply()

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -294,6 +294,94 @@ def test_shutdown_anthias_uses_balena_supervisor_on_balena() -> None:
     mock_shutdown.assert_called_once()
 
 
+def test_reboot_anthias_retries_until_supervisor_recovers() -> None:
+    """The supervisor is routinely down right when a reboot fires
+    (it restarts itself during an OTA apply) — the task must keep
+    retrying past the first refused connection and also treat a 5xx
+    from a half-started supervisor as retryable (Sentry ANTHIAS-3F)."""
+    import requests as requests_module
+
+    error_response = mock.MagicMock()
+    error_response.raise_for_status.side_effect = (
+        requests_module.exceptions.HTTPError('503')
+    )
+    ok_response = mock.MagicMock()
+    ok_response.raise_for_status.return_value = None
+    with (
+        mock.patch.object(
+            celery_tasks_module, 'is_balena_app', return_value=True
+        ),
+        mock.patch.object(
+            celery_tasks_module,
+            'reboot_via_balena_supervisor',
+            side_effect=[
+                requests_module.exceptions.ConnectionError(),
+                error_response,
+                ok_response,
+            ],
+        ) as mock_reboot,
+    ):
+        result = reboot_anthias.apply()
+    assert result.successful()
+    assert mock_reboot.call_count == 3
+
+
+def test_reboot_anthias_terminal_supervisor_failure_warns_not_raises() -> None:
+    """When the supervisor never comes back within the retry window the
+    task must log a warning and exit cleanly — an unhandled RetryError
+    here was a Sentry event per attempt fleet-wide (ANTHIAS-3F)."""
+    import requests as requests_module
+
+    with (
+        mock.patch.object(
+            celery_tasks_module, 'is_balena_app', return_value=True
+        ),
+        mock.patch.object(
+            celery_tasks_module,
+            'reboot_via_balena_supervisor',
+            side_effect=requests_module.exceptions.ConnectionError(),
+        ),
+        # Shrink the two-minute budget so the test doesn't sleep it out.
+        mock.patch.object(
+            celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0.1
+        ),
+        mock.patch.object(
+            celery_tasks_module.logging, 'warning'
+        ) as mock_warning,
+        mock.patch.object(celery_tasks_module.logging, 'error') as mock_error,
+    ):
+        result = reboot_anthias.apply()
+    assert result.successful()
+    mock_warning.assert_called_once()
+    mock_error.assert_not_called()
+
+
+def test_shutdown_anthias_terminal_supervisor_failure_warns_not_raises() -> (
+    None
+):
+    import requests as requests_module
+
+    with (
+        mock.patch.object(
+            celery_tasks_module, 'is_balena_app', return_value=True
+        ),
+        mock.patch.object(
+            celery_tasks_module,
+            'shutdown_via_balena_supervisor',
+            side_effect=requests_module.exceptions.ConnectionError(),
+        ),
+        mock.patch.object(
+            celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0.1
+        ),
+        mock.patch.object(
+            celery_tasks_module.logging, 'warning'
+        ) as mock_warning,
+    ):
+        result = shutdown_anthias.apply()
+    assert result.successful()
+    mock_warning.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # revalidate_asset_urls (periodic sweep)
 # ---------------------------------------------------------------------------

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -365,10 +365,10 @@ def test_reboot_anthias_terminal_supervisor_failure_warns_not_raises() -> None:
             'reboot_via_balena_supervisor',
             side_effect=requests_module.exceptions.ConnectionError(),
         ),
-        # Shrink the two-minute budget and zero the backoff so the
-        # test neither sleeps out the window nor between attempts.
+        # Zero the budget so stop_after_delay trips right after the
+        # first attempt — no sleeping and no tight retry loop.
         mock.patch.object(
-            celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0.1
+            celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0
         ),
         mock.patch.object(celery_tasks_module, 'SUPERVISOR_CMD_WAIT_MAX_S', 0),
         mock.patch.object(
@@ -397,7 +397,7 @@ def test_shutdown_anthias_terminal_supervisor_failure_warns_not_raises() -> (
             side_effect=requests_module.exceptions.ConnectionError(),
         ),
         mock.patch.object(
-            celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0.1
+            celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0
         ),
         mock.patch.object(celery_tasks_module, 'SUPERVISOR_CMD_WAIT_MAX_S', 0),
         mock.patch.object(

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -320,10 +320,34 @@ def test_reboot_anthias_retries_until_supervisor_recovers() -> None:
                 ok_response,
             ],
         ) as mock_reboot,
+        # Zero the exponential backoff so the retries don't sleep.
+        mock.patch.object(celery_tasks_module, 'SUPERVISOR_CMD_WAIT_MAX_S', 0),
     ):
         result = reboot_anthias.apply()
     assert result.successful()
     assert mock_reboot.call_count == 3
+
+
+def test_reboot_anthias_non_transport_error_propagates() -> None:
+    """Only transport/HTTP failures are retryable — anything else
+    (a TypeError-class bug, celery's SoftTimeLimitExceeded) must
+    escape immediately instead of being retried for the full window
+    and masked as 'supervisor didn't accept the command'."""
+    with (
+        mock.patch.object(
+            celery_tasks_module, 'is_balena_app', return_value=True
+        ),
+        mock.patch.object(
+            celery_tasks_module,
+            'reboot_via_balena_supervisor',
+            side_effect=TypeError('a real bug'),
+        ) as mock_reboot,
+        mock.patch.object(celery_tasks_module, 'SUPERVISOR_CMD_WAIT_MAX_S', 0),
+    ):
+        result = reboot_anthias.apply()
+    assert result.failed()
+    assert isinstance(result.result, TypeError)
+    mock_reboot.assert_called_once()
 
 
 def test_reboot_anthias_terminal_supervisor_failure_warns_not_raises() -> None:
@@ -341,10 +365,12 @@ def test_reboot_anthias_terminal_supervisor_failure_warns_not_raises() -> None:
             'reboot_via_balena_supervisor',
             side_effect=requests_module.exceptions.ConnectionError(),
         ),
-        # Shrink the two-minute budget so the test doesn't sleep it out.
+        # Shrink the two-minute budget and zero the backoff so the
+        # test neither sleeps out the window nor between attempts.
         mock.patch.object(
             celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0.1
         ),
+        mock.patch.object(celery_tasks_module, 'SUPERVISOR_CMD_WAIT_MAX_S', 0),
         mock.patch.object(
             celery_tasks_module.logging, 'warning'
         ) as mock_warning,
@@ -373,6 +399,7 @@ def test_shutdown_anthias_terminal_supervisor_failure_warns_not_raises() -> (
         mock.patch.object(
             celery_tasks_module, 'SUPERVISOR_CMD_RETRY_WINDOW_S', 0.1
         ),
+        mock.patch.object(celery_tasks_module, 'SUPERVISOR_CMD_WAIT_MAX_S', 0),
         mock.patch.object(
             celery_tasks_module.logging, 'warning'
         ) as mock_warning,


### PR DESCRIPTION
### Issues Fixed

- Fixes #3123 (Sentry ANTHIAS-3F)

### Description

`reboot_anthias`/`shutdown_anthias` retried the balena supervisor API 5 times, 1 second apart, with no HTTP timeout and no status check. The supervisor is routinely down exactly when these fire — it restarts itself during an OTA apply — so the tasks died in an unhandled `RetryError` (60 Sentry events in a day from one pi4-64) and the power command was silently dropped.

Now:

- Retries with exponential backoff (capped at 15s) for up to **2 minutes**, which covers a supervisor restart.
- Each HTTP attempt is bounded at 10s so a hung supervisor socket can't pin the Celery worker; the task gets soft/hard time limits as the SIGKILL backstop (same pattern as the periodic pokes from #3063).
- `raise_for_status()` so a 5xx from a half-started supervisor retries instead of silently counting as "command accepted".
- Terminal failure logs a **warning** with an actionable message instead of an unhandled traceback — a down supervisor is an expected transient, and per the module's Sentry-noise policy it shouldn't page as an error.

### Validation on real hardware

This path only runs under balenaOS (it talks to the balena supervisor API), and our testbeds are plain docker-compose devices — so there is **no supervisor to exercise it against on the testbed**. The behaviour is covered by unit tests (retry-until-recovery, non-transport-error propagation, terminal-failure-warns-not-raises for both reboot and shutdown). The non-balena branch (`r.publish('hostcmd', ...)`) is unchanged. Real-device confirmation would need a balena fleet device.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices. <!-- balena-supervisor-only path; not reachable on the docker-compose testbeds -->
- [ ] I have tested my changes for x86 devices. <!-- balena-supervisor-only path; not reachable on the docker-compose testbeds -->
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
