### PR TITLE
fix(sentry): drop offline-device gaierror events in before_send

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import asyncio
 import platform
 import secrets
+import socket
 import sys
 import zoneinfo
 from collections.abc import Iterator
@@ -130,6 +131,16 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
         never reaches the logging integration in the first place; this
         is the backstop for any other path that logs it as an error
         (Sentry ANTHIAS-3D).
+      * ``socket.gaierror`` — DNS resolution failing because the
+        device is offline (captive network, upstream outage, no
+        uplink at all). Being offline is a routine operating state
+        for a signage device, and a DNS-less box otherwise burns an
+        event per attempted external call — 253/day from a single
+        pi3-64, mostly via asyncio's "Future exception was never
+        retrieved" error log (Sentry ANTHIAS-3G). Chain-checked like
+        the redis errors because requests wraps it several layers
+        deep (urllib3 ``NameResolutionError`` →
+        ``requests.ConnectionError``).
     """
     # Imported lazily — this runs only when an event is about to send,
     # well after Django is configured, and avoids an import cycle at
@@ -150,6 +161,8 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
         if isinstance(exc, transient_redis):
             return None
         if isinstance(exc, AuthSettingsError):
+            return None
+        if isinstance(exc, socket.gaierror):
             return None
     return event
 

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -100,7 +100,7 @@ def _exception_chain(exc: BaseException | None) -> Iterator[BaseException]:
 def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
     """Drop events that report expected transient states, not bugs.
 
-    Two classes of noise, both observed fleet-wide on day one:
+    The classes of noise dropped here, each observed fleet-wide:
 
       * ``redis.exceptions.ConnectionError`` AND
         ``redis.exceptions.TimeoutError`` (plus subclasses and

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -148,6 +148,40 @@ class TestBeforeSendTransientNoise:
         hint = self._hint_for(AuthSettingsError('New passwords do not match!'))
         assert _sentry_before_send({'event_id': 'x'}, hint) is None
 
+    def test_drops_gaierror(self) -> None:
+        # DNS failing = the device is offline, a routine state for
+        # signage. A DNS-less box burned an event per attempted
+        # external call, mostly via asyncio's "Future exception was
+        # never retrieved" log (Sentry ANTHIAS-3G).
+        import socket
+
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        hint = self._hint_for(
+            socket.gaierror(-5, 'No address associated with hostname')
+        )
+        assert _sentry_before_send({'event_id': 'x'}, hint) is None
+
+    def test_drops_wrapped_gaierror(self) -> None:
+        # requests buries the gaierror several layers deep
+        # (urllib3 NameResolutionError -> requests.ConnectionError);
+        # the chain walk must still find it.
+        import socket
+
+        import requests
+
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        root = socket.gaierror(-5, 'No address associated with hostname')
+        wrapper = requests.exceptions.ConnectionError('resolution failed')
+        wrapper.__cause__ = root
+        hint = self._hint_for(wrapper)
+        assert _sentry_before_send({'event_id': 'x'}, hint) is None
+
     def test_keeps_ordinary_exceptions(self) -> None:
         from anthias_server.django_project.settings import (
             _sentry_before_send,

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -176,10 +176,23 @@ class TestBeforeSendTransientNoise:
             _sentry_before_send,
         )
 
-        root = socket.gaierror(-5, 'No address associated with hostname')
-        wrapper = requests.exceptions.ConnectionError('resolution failed')
-        wrapper.__cause__ = root
-        hint = self._hint_for(wrapper)
+        try:
+            try:
+                raise socket.gaierror(
+                    -5, 'No address associated with hostname'
+                )
+            except socket.gaierror as root:
+                raise requests.exceptions.ConnectionError(
+                    'resolution failed'
+                ) from root
+        except requests.exceptions.ConnectionError as wrapper:
+            hint = {
+                'exc_info': (
+                    type(wrapper),
+                    wrapper,
+                    wrapper.__traceback__,
+                )
+            }
         assert _sentry_before_send({'event_id': 'x'}, hint) is None
 
     def test_keeps_ordinary_exceptions(self) -> None:


### PR DESCRIPTION
### Issues Fixed

- Fixes #3126 (Sentry ANTHIAS-3G)

### Description

A device without working DNS (offline, captive portal, upstream outage) reported `gaierror: [Errno -5] No address associated with hostname` to Sentry on every attempted external call — 253 events in under a day from a single pi3-64. Every one of those events is the asyncio `Future exception was never retrieved` error log inside uvicorn, with no stack trace, so there's nothing actionable in them; being offline is a routine operating state for a signage device.

This adds `socket.gaierror` to the `before_send` transient-drop list, chain-checked like the redis errors so `requests`-wrapped resolution failures (urllib3 `NameResolutionError` → `requests.ConnectionError`) are dropped too. Same policy precedent as the redis blips (ANTHIAS-M/K/H/J), client disconnects (ANTHIAS-N), and AuthSettingsError (ANTHIAS-3D).

Follow-up worth tracking separately: something in the ASGI process abandons an asyncio future that resolves with the DNS error (that's how these surface as "Future exception was never retrieved"). Pinning down the creator needs a live offline-device repro; this PR stops the fleet-wide quota burn regardless of the source.

### Validation on real hardware

Exercised in the real server container on the x86 testbed: `_sentry_before_send` with a `socket.gaierror` returned `None` (event dropped), while a real `ValueError` was kept — confirming the filter drops offline noise without swallowing genuine bugs. Server-side and arch-independent.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices. <!-- server-side, arch-independent; before_send drop confirmed in the real server container on the x86 testbed -->
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
