### PR TITLE
chore(release): bump to 2026.07.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.07.0",
+  "version": "2026.07.1",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.07.0"
+version = "2026.07.1"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.7.0"
+version = "2026.7.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Release 2026.07.1

CalVer version bump `2026.07.0` → `2026.07.1` (July 2026, micro 0 → 1). Touches only the three version-of-record files — `pyproject.toml`, `package.json`, and the `anthias` entry in `uv.lock`. No dependency changes. Rebased onto current master so the release includes the recover-streaming fix (#3143).

### What's included (21 PRs merged since v2026.07.0)

**Backup / restore (streaming, low-RAM safety)**
- Stream the recover upload to disk instead of `read()` (#3143) — a multi-GB restore no longer OOMs the worker on a 1 GB Pi
- (already in .0) Stream the backup download as an async iterator so it doesn't time out (#3074)

**Viewer / display**
- Re-assert linuxfb display mode after HDMI hotplug (#3075)
- Clear stale PulseAudio pid file so audio survives reboot (#3113)
- Ship `+rpt1` ffmpeg on pi3-64 so H.264 uses HW decode (#3110)

**Server / API / security**
- Confine absolute-path asset URIs to the asset directory (#3117)
- Gate `youtube_asset` downloads on a real YouTube URL (#3118)
- Bound asset duration to prevent a viewer crash-loop (#3128)
- Handle disk-full uploads gracefully (#3133)
- Pick the latest CalVer release, not GitHub `/releases/latest` (#3130)
- Drop offline-device / operator-input Sentry noise in `before_send` (#3132, #3141)
- Tidy up x86 Device Info — CEC state + device model (#3119)
- Name store-app assets from their chosen setting, not the manifest name (#3115)

**Install / build / infra**
- Probe sudo capability instead of guessing from the sudoers filename (#3129)
- Survive a down balena supervisor during reboot/shutdown (#3131)
- Bump the frozen Qt 5 webview toolchain to 5.15.19 (#3121)

**Features**
- Add a signage app store to the Add Asset flow (#3114)
- Add "Star on GitHub" / "Review on G2" CTAs (#3116)

**Docs / website**
- Point the Screenly migration guide at the in-app wizard (#3120)
- Correct Pi 3 board status on the get-started page (#3111)
- Promote Raspberry Pi Imager across the site (#2919)

### QA

Full 6-board testbed QA of the RC is **green** (Pi 2, Pi 3-64, Pi 4, Pi 5, x86, Rock Pi 4):
- **REST API** v1 / v1.1 / v1.2 / v2 — all checks pass on every board.
- **Rendering** — image, webpage, video present on all six (HW decode verified). Note: 1080p video presentation on the Qt6 Pi boards is choppy (~6 fps presented) — a pre-existing, non-regressing limitation tracked in #2987; not introduced here.
- **Backup / restore streaming (#3074 + #3143)** — E2E-validated on all three **1 GB** boards (pi3-64, pi4-64, Rock Pi 4) with a real **641 MB** backup: streamed both directions (download TTFB ~30 ms), peak RSS ~70–170 MiB (≪ archive size), full restore, **0 OOM, 0 container restarts**.
- One non-blocking, pre-existing finding (stop/blank don't pause the loop on headless Wayland) tracked in #3136.

### Release process

Publish the GitHub release **only after** the master `Docker Image Build` completes (or preflight skips the deploy), so the `latest-<board>` images and the tag stay in lock-step.
