### PR TITLE
fix(sentry): drop expected operator-input/transient noise (round 2)

### DIFF
--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -320,7 +320,11 @@ def test_recover_invalid_archive_warns_not_error(
 
     with (
         mock.patch('anthias_server.api.views.mixins.ViewerPublisher'),
-        mock.patch('anthias_server.api.views.mixins.open', mock.mock_open()),
+        mock.patch(
+            'anthias_server.api.views.mixins.open',
+            mock.mock_open(),
+            create=True,
+        ),
         mock.patch(
             'anthias_server.api.views.mixins.path.isfile', return_value=False
         ),

--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -307,6 +307,47 @@ def test_file_asset_content_range_truncates_stale_tmp(
 
 
 @pytest.mark.django_db
+def test_recover_invalid_archive_warns_not_error(
+    api_client: APIClient,
+) -> None:
+    """An operator uploading a non-backup file (here: not a gzip) is
+    input validation, not a bug — the endpoint must 400 and log at
+    warning, not logger.exception (which pages Sentry as an error,
+    Sentry ANTHIAS-3W)."""
+    import tarfile
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    with (
+        mock.patch('anthias_server.api.views.mixins.ViewerPublisher'),
+        mock.patch('anthias_server.api.views.mixins.open', mock.mock_open()),
+        mock.patch(
+            'anthias_server.api.views.mixins.path.isfile', return_value=False
+        ),
+        mock.patch(
+            'anthias_server.api.views.mixins.backup_helper.recover',
+            side_effect=tarfile.ReadError('not a gzip file'),
+        ),
+        mock.patch('anthias_server.api.views.mixins.logger') as mock_logger,
+    ):
+        response = api_client.post(
+            reverse('api:recover_v1'),
+            data={
+                'backup_upload': SimpleUploadedFile(
+                    'backup.tar.gz',
+                    b'\n\nnot a real gzip',
+                    content_type='application/x-tar',
+                )
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'backup_upload' in response.data
+    mock_logger.warning.assert_called_once()
+    mock_logger.exception.assert_not_called()
+
+
+@pytest.mark.django_db
 def test_playlist_order(
     api_client: APIClient, cleanup_asset_dir: None
 ) -> None:

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -131,8 +131,13 @@ class RecoverViewMixin(APIView):
             except (
                 backup_helper.BackupRecoverError,
                 tarfile.TarError,
-            ):
-                logger.exception('Backup recovery failed')
+            ) as exc:
+                # Operator uploaded something that isn't a valid Anthias
+                # backup (wrong file, truncated, not gzip). That's input
+                # validation, not a bug — the 400 below already tells
+                # them. Log at warning so it doesn't reach the Sentry
+                # logging integration as an error (Sentry ANTHIAS-3W).
+                logger.warning('Backup recovery failed: %s', exc)
                 raise ValidationError(
                     {'backup_upload': 'Invalid backup archive.'}
                 )

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1695,8 +1695,12 @@ def settings_recover(request: HttpRequest) -> HttpResponse:
         try:
             backup_helper.recover(location)
             messages.success(request, 'Recovery successful.')
-        except (backup_helper.BackupRecoverError, tarfile.TarError):
-            logger.exception('Backup recovery failed')
+        except (backup_helper.BackupRecoverError, tarfile.TarError) as exc:
+            # Same operator-input case as the API recover view: a bad /
+            # non-backup upload is validation, not a bug (the error
+            # message below already tells them). Warning, not exception,
+            # so it doesn't page Sentry (ANTHIAS-3W).
+            logger.warning('Backup recovery failed: %s', exc)
             messages.error(request, 'Invalid backup archive.')
     finally:
         if path.isfile(location):

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -172,9 +172,9 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
         if isinstance(exc, socket.gaierror):
             return None
         exc_cls = type(exc)
-        if (
-            exc_cls.__name__ == 'DownloadError'
-            and exc_cls.__module__.startswith('yt_dlp')
+        if exc_cls.__name__ == 'DownloadError' and (
+            exc_cls.__module__ == 'yt_dlp'
+            or exc_cls.__module__.startswith('yt_dlp.')
         ):
             return None
     return event

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -141,6 +141,13 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
         the redis errors because requests wraps it several layers
         deep (urllib3 ``NameResolutionError`` →
         ``requests.ConnectionError``).
+      * yt-dlp ``DownloadError`` — a YouTube/remote-video download that
+        failed (network timeout, geo-block, private/deleted video, bad
+        URL). None of these are Anthias bugs, and the download task's
+        ``on_failure`` already records ``metadata.error_message`` so the
+        asset renders a "Failed" pill with the reason — the operator
+        gets the feedback without a Sentry page (Sentry ANTHIAS-3T).
+        Matched by name+module so we don't import yt_dlp here.
     """
     # Imported lazily — this runs only when an event is about to send,
     # well after Django is configured, and avoids an import cycle at
@@ -164,6 +171,12 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
             return None
         if isinstance(exc, socket.gaierror):
             return None
+        exc_cls = type(exc)
+        if (
+            exc_cls.__name__ == 'DownloadError'
+            and exc_cls.__module__.startswith('yt_dlp')
+        ):
+            return None
     return event
 
 
@@ -179,6 +192,15 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
 ignore_logger('celery.worker.consumer.consumer')
 ignore_logger('celery.beat')
 ignore_logger('celery.backends.redis')
+# The async result backend logs "Retry limit exceeded while trying to
+# reconnect to the Celery result store backend. The Celery application
+# must be restarted." at a fatal level when redis stays unreachable
+# past its reconnect budget — the same transient-redis outage as the
+# loggers above, just from the result-backend's polling side. It self-
+# heals once redis returns (celery re-establishes on the next result
+# fetch); a persistent outage still surfaces via the watchdog restart
+# loop. (Sentry ANTHIAS-3X.)
+ignore_logger('celery.backends.asynchronous')
 
 
 def get_sentry_release() -> str | None:

--- a/src/anthias_viewer/scheduling.py
+++ b/src/anthias_viewer/scheduling.py
@@ -137,7 +137,15 @@ class Scheduler:
                 self.current_asset_id = self.extra_asset
                 self.extra_asset = None
                 return asset
-            logging.error('Asset not found or processed')
+            # An operator asked to jump to a specific asset that has
+            # since been deleted or is still processing — a benign race
+            # between their action and the asset's state, not a bug.
+            # Warning (not error) so it doesn't page Sentry (ANTHIAS-3V).
+            logging.warning(
+                'Requested asset %s not found or still processing; '
+                'falling back to the playlist',
+                self.extra_asset,
+            )
             self.extra_asset = None
 
         self.refresh_playlist()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -168,6 +168,31 @@ def test_get_next_asset_should_be_y_and_x(
 
 
 @pytest.mark.django_db
+def test_get_next_asset_missing_extra_asset_warns_and_falls_back(
+    restore_shuffle_setting: None,
+) -> None:
+    """An operator jump to a since-deleted / still-processing asset is
+    a benign race, not a bug — it must log at warning (not error, which
+    pages Sentry) and fall back to the playlist (Sentry ANTHIAS-3V)."""
+    from unittest import mock
+
+    _create_assets([ASSET_X, ASSET_Y])
+    scheduler = Scheduler()
+    scheduler.extra_asset = 'nonexistent-asset-id'
+
+    with (
+        mock.patch('anthias_viewer.scheduling.logging.warning') as m_warn,
+        mock.patch('anthias_viewer.scheduling.logging.error') as m_error,
+    ):
+        result = scheduler.get_next_asset()
+
+    m_warn.assert_called_once()
+    m_error.assert_not_called()
+    assert scheduler.extra_asset is None
+    assert result in (ASSET_X, ASSET_Y)
+
+
+@pytest.mark.django_db
 def test_keep_same_position_on_playlist_update(
     restore_shuffle_setting: None,
 ) -> None:

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -195,6 +195,36 @@ class TestBeforeSendTransientNoise:
             }
         assert _sentry_before_send({'event_id': 'x'}, hint) is None
 
+    def test_drops_yt_dlp_download_error(self) -> None:
+        # A yt-dlp DownloadError (network timeout, geo-block, private/
+        # deleted video, bad URL) is operator-facing, not a bug — the
+        # download task's on_failure records error_message so the asset
+        # shows a "Failed" pill (Sentry ANTHIAS-3T). Synthesise the
+        # class so the test doesn't depend on importing yt_dlp.
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        download_error_cls = type(
+            'DownloadError', (Exception,), {'__module__': 'yt_dlp.utils'}
+        )
+        hint = self._hint_for(download_error_cls('read timed out'))
+        assert _sentry_before_send({'event_id': 'x'}, hint) is None
+
+    def test_keeps_non_ytdlp_download_error(self) -> None:
+        # The drop is scoped to yt_dlp by module — a same-named
+        # DownloadError from anywhere else must NOT be swallowed.
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        other_cls = type(
+            'DownloadError', (Exception,), {'__module__': 'some.other.pkg'}
+        )
+        event: Event = {'event_id': 'x'}
+        hint = self._hint_for(other_cls('a real bug'))
+        assert _sentry_before_send(event, hint) == event
+
     def test_keeps_ordinary_exceptions(self) -> None:
         from anthias_server.django_project.settings import (
             _sentry_before_send,
@@ -228,6 +258,10 @@ class TestBeforeSendTransientNoise:
         # ("Connection to Redis lost: Retry (4/20)") at ERROR
         # (Sentry ANTHIAS-2E).
         assert 'celery.backends.redis' in _IGNORED_LOGGERS
+        # The async result backend logs "Retry limit exceeded while
+        # trying to reconnect to the Celery result store backend" at a
+        # fatal level on a sustained redis outage (Sentry ANTHIAS-3X).
+        assert 'celery.backends.asynchronous' in _IGNORED_LOGGERS
 
 
 class TestGetBoardModel:

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -225,6 +225,21 @@ class TestBeforeSendTransientNoise:
         hint = self._hint_for(other_cls('a real bug'))
         assert _sentry_before_send(event, hint) == event
 
+    def test_keeps_lookalike_module_download_error(self) -> None:
+        # The module match is exact/prefix-scoped so a look-alike
+        # package (yt_dlp2, yt_dlp_fake) can't smuggle its own
+        # DownloadError through the drop.
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        lookalike_cls = type(
+            'DownloadError', (Exception,), {'__module__': 'yt_dlp2.utils'}
+        )
+        event: Event = {'event_id': 'x'}
+        hint = self._hint_for(lookalike_cls('not really yt-dlp'))
+        assert _sentry_before_send(event, hint) == event
+
     def test_keeps_ordinary_exceptions(self) -> None:
         from anthias_server.django_project.settings import (
             _sentry_before_send,

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2201,6 +2201,7 @@ def test_settings_recover_invalid_archive_warns_not_error(
     ANTHIAS-3W)."""
     import tarfile
 
+    from django.contrib.messages import get_messages
     from django.core.files.uploadedfile import SimpleUploadedFile
 
     with (
@@ -2227,6 +2228,8 @@ def test_settings_recover_invalid_archive_warns_not_error(
         )
 
     assert response.status_code in (200, 302)
+    messages = [str(m) for m in get_messages(response.wsgi_request)]
+    assert 'Invalid backup archive.' in messages
     mock_logger.warning.assert_called_once()
     mock_logger.exception.assert_not_called()
 

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2192,6 +2192,46 @@ def test_assets_upload_disk_full_during_write_cleans_up_partial(
 
 
 @pytest.mark.django_db
+def test_settings_recover_invalid_archive_warns_not_error(
+    client: Client,
+) -> None:
+    """A bad / non-backup upload to the HTML recover view is operator
+    input, not a bug — it must log at warning (not logger.exception,
+    which pages Sentry) and show the error message (Sentry
+    ANTHIAS-3W)."""
+    import tarfile
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    with (
+        mock.patch('anthias_server.app.views.ViewerPublisher'),
+        mock.patch(
+            'anthias_server.app.views.open', mock.mock_open(), create=True
+        ),
+        mock.patch('anthias_server.app.views.path.isfile', return_value=False),
+        mock.patch(
+            'anthias_server.app.views.backup_helper.recover',
+            side_effect=tarfile.ReadError('not a gzip file'),
+        ),
+        mock.patch('anthias_server.app.views.logger') as mock_logger,
+    ):
+        response = client.post(
+            reverse('anthias_app:settings_recover'),
+            data={
+                'backup_upload': SimpleUploadedFile(
+                    'backup.tar.gz',
+                    b'\n\nnot a real gzip',
+                    content_type='application/x-tar',
+                )
+            },
+        )
+
+    assert response.status_code in (200, 302)
+    mock_logger.warning.assert_called_once()
+    mock_logger.exception.assert_not_called()
+
+
+@pytest.mark.django_db
 def test_write_endpoint_fires_websocket_notify(
     client: Client, asset: Asset
 ) -> None:


### PR DESCRIPTION
### Issues Fixed

- Fixes #3140 (Sentry ANTHIAS-3W / 3V / 3T / 3X)

### Description

A second Sentry sweep surfaced four new noise-class issues on `2026.7.0` — all expected operator-input or transient conditions that were logged/captured as errors despite already having a proper user-facing outcome. Same theme as the AuthSettingsError (#3068) and gaierror (#3132) cleanups.

- **ANTHIAS-3W** — uploading a non-backup file to recover logged `logger.exception('Backup recovery failed')` while already returning an "Invalid backup archive" error to the operator. Fixed in **both** recover entry points that share this handling: the API view (`RecoverViewMixin`, `/api/v1|v2/recover`) and the HTML view (`settings_recover`). → warning.
- **ANTHIAS-3V** — the viewer's `Scheduler.get_next_asset` logged `error('Asset not found or processed')` on a benign race (operator jumps to a since-deleted / still-processing asset). → warning + names the asset + falls back to the playlist.
- **ANTHIAS-3T** — a yt-dlp `DownloadError` (network timeout, geo-block, private/deleted video, bad URL) was captured by the Celery Sentry integration. The download task's `on_failure` already records `metadata.error_message`, so the operator sees a "Failed" pill. → dropped in `before_send`, matched by name + `yt_dlp`/`yt_dlp.` module so a look-alike package can't smuggle its own `DownloadError` through (and yt_dlp isn't imported there).
- **ANTHIAS-3X** — `celery.backends.asynchronous` logs "Retry limit exceeded while trying to reconnect to the Celery result store backend" at a fatal level during a sustained redis outage — the same transient-redis noise as the loggers already ignored. → `ignore_logger`.

Each change has a regression test (including both recover entry points). Separately resolved **ANTHIAS-3S** (`No module named 'channels'` from a non-device `session-*` context) as environmental.

> Note: the specific 3W event that started this was a 1.4 KB curl upload of a non-gzip file — unrelated operator input. The separate large-backup **restore OOM** it prompted a look at is fixed in #3143 (stream the upload instead of `read()`-ing it into RAM), with deeper restore follow-ups tracked in #3142.

### Validation on real hardware

The `before_send` drops and `ignore_logger` registration were confirmed in the real server container on the x86 testbed during the first sweep's validation pass; these are the same mechanism extended to two more exception/logger names. Server-side and arch-independent.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices. <!-- server-side + viewer log-level change, arch-independent -->
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
