### PR TITLE
fix(api): stream the recover upload to disk instead of read()

### DIFF
--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -309,15 +309,22 @@ def test_file_asset_content_range_truncates_stale_tmp(
 @pytest.mark.django_db
 def test_recover_streams_large_upload_to_disk(
     api_client: APIClient,
+    tmp_path: Path,
+    monkeypatch: Any,
 ) -> None:
     """The restore endpoint must stream the uploaded backup to disk in
     chunks, not ``read()`` the whole archive into RAM (which OOM-kills
     the worker on a Pi restoring a multi-GB backup). Upload content
     larger than one chunk and assert the staged file the recover step
-    sees is the complete, byte-identical upload."""
-    import os
+    sees is the complete, byte-identical upload.
 
+    The view stages under a relative ``static/`` dir, so run from a tmp
+    cwd that pytest cleans up rather than polluting the checkout.
+    """
     from django.core.files.uploadedfile import SimpleUploadedFile
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / 'static').mkdir()
 
     # > 64 KiB so file_upload.chunks() yields multiple chunks and the
     # streaming loop is actually exercised.
@@ -328,7 +335,6 @@ def test_recover_streams_large_upload_to_disk(
         with open(location, 'rb') as staged:
             captured['content'] = staged.read()
 
-    os.makedirs('static', exist_ok=True)
     with (
         mock.patch('anthias_server.api.views.mixins.ViewerPublisher'),
         mock.patch(

--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -307,6 +307,51 @@ def test_file_asset_content_range_truncates_stale_tmp(
 
 
 @pytest.mark.django_db
+def test_recover_streams_large_upload_to_disk(
+    api_client: APIClient,
+) -> None:
+    """The restore endpoint must stream the uploaded backup to disk in
+    chunks, not ``read()`` the whole archive into RAM (which OOM-kills
+    the worker on a Pi restoring a multi-GB backup). Upload content
+    larger than one chunk and assert the staged file the recover step
+    sees is the complete, byte-identical upload."""
+    import os
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    # > 64 KiB so file_upload.chunks() yields multiple chunks and the
+    # streaming loop is actually exercised.
+    payload = bytes(range(256)) * 1024  # 256 KiB, non-trivial content
+    captured: dict[str, bytes] = {}
+
+    def fake_recover(location: str) -> None:
+        with open(location, 'rb') as staged:
+            captured['content'] = staged.read()
+
+    os.makedirs('static', exist_ok=True)
+    with (
+        mock.patch('anthias_server.api.views.mixins.ViewerPublisher'),
+        mock.patch(
+            'anthias_server.api.views.mixins.backup_helper.recover',
+            side_effect=fake_recover,
+        ),
+    ):
+        response = api_client.post(
+            reverse('api:recover_v1'),
+            data={
+                'backup_upload': SimpleUploadedFile(
+                    'backup.tar.gz',
+                    payload,
+                    content_type='application/x-tar',
+                )
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert captured['content'] == payload
+
+
+@pytest.mark.django_db
 def test_playlist_order(
     api_client: APIClient, cleanup_asset_dir: None
 ) -> None:

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -123,8 +123,15 @@ class RecoverViewMixin(APIView):
         try:
             publisher.send_to_viewer('stop')
 
+            # Stream the upload to disk in chunks — ``file_upload.read()``
+            # pulls the whole archive into RAM, and a backup is every
+            # image + video asset on the device, so a multi-GB restore
+            # OOM-kills the worker on a 1 GB Pi. The HTML recover view
+            # (settings_recover) already streams; this brings the API
+            # path in line.
             with open(location, 'wb') as f:
-                f.write(file_upload.read())
+                for chunk in file_upload.chunks():
+                    f.write(chunk)
 
             try:
                 backup_helper.recover(location)


### PR DESCRIPTION
### Issues Fixed

- Fixes #3142

### Description

Prompted by a question on whether the recover failures relate to large backups — they do, and here's the concrete bug.

The API restore endpoint (`RecoverViewMixin.post`, `/api/v1|v2/recover`) staged the uploaded backup with `file_upload.read()`, pulling the **entire** archive into RAM before writing it to disk. A backup contains every image and video asset on the device, so a multi-GB restore allocates a multi-GB `bytes` object and OOM-kills the worker on a 1 GB Pi. Because it's an OOM (process killed), it surfaces as "restore doesn't work" rather than a clean Sentry stack.

The **HTML** recover view (`settings_recover`) was already fixed to stream via `file_upload.chunks()`; this brings the API path in line — a flat memory footprint regardless of backup size.

Two related restore weaknesses are documented in #3142 as follow-ups (not addressed here to keep this focused): the extraction is still **synchronous in the request** (can time out on a multi-GB library, the restore equivalent of the download-side #2987/#3073 work), and there's no **ENOSPC** handling if the SD card fills mid-restore.

The download/generate side is already hardened (`astream_backup`, #2987/#3073).

### Validation

New test uploads a >64 KiB (multi-chunk) payload through the real `recover` endpoint and asserts the staged file the recover step sees is byte-identical to the upload — proving the streamed write reassembles correctly. Note: the specific Sentry event that started this (ANTHIAS-3W) was a 1.4 KB curl upload of a non-gzip file — unrelated operator input; this fix is for the large-backup OOM the question surfaced.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices. <!-- server-side, arch-independent; memory-footprint fix -->
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)