### PR TITLE
feat(import): import content from Yodeck via an extensible import-provider framework

### DIFF
--- a/src/anthias_server/api/helpers.py
+++ b/src/anthias_server/api/helpers.py
@@ -6,7 +6,10 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
+from anthias_common.remote_video import dispatch_remote_video_download
+from anthias_common.youtube import dispatch_download
 from anthias_server.app.models import Asset
+from anthias_server.processing import dispatch_pending_normalize
 from anthias_server.settings import ViewerPublisher
 
 
@@ -55,6 +58,57 @@ def custom_exception_handler(
     return Response(
         {'error': str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
     )
+
+
+def persist_new_asset(serializer: Any) -> Asset:
+    """Persist a validated Create*Serializer into an ``Asset`` and fire
+    the deferred pipelines it flagged, then splice the row into the
+    active play ordering.
+
+    Extracted from ``AssetListViewV2.post`` so the v2 create endpoint and
+    the content importer (``lib.integrations``) create assets through one
+    code path: the YouTube / remote-video download hand-off, the
+    image/video normalise dispatch, the post-create ``metadata`` apply
+    and the active-ordering insert must stay identical for both, or an
+    imported asset would behave subtly differently from an uploaded one.
+
+    Expects an already-validated serializer (``is_valid()`` called) that
+    mixes in ``CreateAssetSerializerMixin`` — the ``_pending_*`` hand-off
+    attributes are read here.
+    """
+    active_asset_ids = get_active_asset_ids()
+    asset = Asset.objects.create(**serializer.data)
+
+    # Apply ``metadata`` (set by the create serializer's validate() when
+    # the operator passes ``refresh_interval_s``). It lives in
+    # ``validated_data`` rather than ``serializer.data`` because
+    # ``metadata`` isn't a declared field on the create serializer —
+    # surfacing it as one would open the upload-pipeline-owned bag
+    # (original_ext, transcoded, error_message) for arbitrary writes.
+    post_create_metadata = serializer.validated_data.get('metadata')
+    if post_create_metadata:
+        existing = dict(asset.metadata or {})
+        existing.update(post_create_metadata)
+        asset.metadata = existing
+        asset.save(update_fields=['metadata'])
+    asset.refresh_from_db()
+
+    # Kick off any out-of-band work the serializer flagged. The row is
+    # already persisted with is_processing=True where relevant; the task
+    # fills in the file/duration and clears the flag.
+    if serializer._pending_youtube_uri:
+        dispatch_download(asset.asset_id, serializer._pending_youtube_uri)
+    if serializer._pending_remote_video_uri:
+        dispatch_remote_video_download(
+            asset.asset_id, serializer._pending_remote_video_uri
+        )
+    dispatch_pending_normalize(serializer, asset.asset_id)
+
+    if asset.is_active():
+        active_asset_ids.insert(asset.play_order, asset.asset_id)
+    save_active_assets_ordering(active_asset_ids)
+    asset.refresh_from_db()
+    return asset
 
 
 def get_active_asset_ids() -> list[str]:

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -412,3 +412,22 @@ class ScreenlyMigrateAssetSerializerV2(Serializer[Any]):
     token = CharField(write_only=True)
     asset_id = CharField()
     asset_group_id = CharField(required=False, allow_blank=True)
+
+
+class ImportValidateSerializerV2(Serializer[Any]):
+    """Request body for validating an import provider's token."""
+
+    token = CharField(write_only=True)
+
+
+class ImportItemSerializerV2(Serializer[Any]):
+    """Request body for importing a single remote media item.
+
+    ``enable`` defaults to True so the wizard's per-item calls don't have
+    to send it on every request; the operator toggles it once and it
+    rides on each item POST.
+    """
+
+    token = CharField(write_only=True)
+    remote_id = CharField()
+    enable = BooleanField(required=False, default=True)

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -87,7 +87,11 @@ def _patched_youtube_dispatch() -> Iterator[dict[str, Any]]:
             'anthias_server.api.views.v1_2.dispatch_download'
         ) as v1_2_dispatch,
         mock.patch(
-            'anthias_server.api.views.v2.dispatch_download'
+            # v2's create view delegates persistence + dispatch to
+            # ``api.helpers.persist_new_asset`` (shared with the content
+            # importer), so the download hand-off is patched there rather
+            # than in the view module.
+            'anthias_server.api.helpers.dispatch_download'
         ) as v2_dispatch,
         mock.patch(
             'anthias_server.api.serializers.mixins.url_fails',
@@ -1060,7 +1064,9 @@ def test_create_remote_video_url_dispatches_download_task(
     }
     asset_list_url = reverse(f'api:asset_list_{version}')
     dispatch_target = (
-        f'anthias_server.api.views.{version}.dispatch_remote_video_download'
+        'anthias_server.api.helpers.dispatch_remote_video_download'
+        if version == 'v2'
+        else f'anthias_server.api.views.{version}.dispatch_remote_video_download'
     )
     with (
         mock.patch(dispatch_target) as mock_dispatch,
@@ -1162,7 +1168,9 @@ def test_create_stream_uri_stays_as_literal(
     }
     asset_list_url = reverse(f'api:asset_list_{version}')
     dispatch_target = (
-        f'anthias_server.api.views.{version}.dispatch_remote_video_download'
+        'anthias_server.api.helpers.dispatch_remote_video_download'
+        if version == 'v2'
+        else f'anthias_server.api.views.{version}.dispatch_remote_video_download'
     )
     with (
         mock.patch(dispatch_target) as mock_dispatch,

--- a/src/anthias_server/api/tests/test_yodeck_import.py
+++ b/src/anthias_server/api/tests/test_yodeck_import.py
@@ -464,6 +464,66 @@ class TestImportItem:
         assert not list(tmp_path.glob('.import-*'))
         assert Asset.objects.count() == 0
 
+    def _capture_download_headers(
+        self,
+        get_mock: MagicMock,
+        detail: dict[str, Any],
+    ) -> dict[str, str]:
+        captured: dict[str, str] = {}
+
+        def _get(url: str, **kwargs: Any) -> MagicMock:
+            if kwargs.get('stream'):
+                captured.update(kwargs.get('headers') or {})
+                return _fake_stream_response(200, [b'\x89PNG\r\n'])
+            return self._detail_response(detail)
+
+        get_mock.side_effect = _get
+        return captured
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_download_omits_token_for_foreign_host(
+        self,
+        get_mock: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A pre-signed CDN original on a non-Yodeck host must NOT receive
+        # the Yodeck API token.
+        monkeypatch.setitem(settings, 'assetdir', str(tmp_path))
+        detail = {
+            'id': 1,
+            'name': 'Pic',
+            'media_origin': {'type': 'image'},
+            'file_extension': 'png',
+            'arguments': {
+                'download_from_url': 'https://cdn.example.com/x.png'
+            },
+        }
+        captured = self._capture_download_headers(get_mock, detail)
+        PROVIDER.import_item('tok', '1')
+        assert 'Authorization' not in captured
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_download_sends_token_for_yodeck_host(
+        self,
+        get_mock: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setitem(settings, 'assetdir', str(tmp_path))
+        detail = {
+            'id': 1,
+            'name': 'Pic',
+            'media_origin': {'type': 'image'},
+            'file_extension': 'png',
+            'arguments': {
+                'download_from_url': 'https://app.yodeck.com/media/orig/x.png'
+            },
+        }
+        captured = self._capture_download_headers(get_mock, detail)
+        PROVIDER.import_item('tok', '1')
+        assert captured.get('Authorization') == 'Token tok'
+
 
 # ---------------------------------------------------------------------------
 # HTTP endpoints (provider layer mocked)

--- a/src/anthias_server/api/tests/test_yodeck_import.py
+++ b/src/anthias_server/api/tests/test_yodeck_import.py
@@ -272,6 +272,24 @@ class TestFieldMapping:
     def test_file_ext_from_url_when_field_missing(self) -> None:
         assert yodeck._file_ext({}, 'https://x/y.png?v=1') == '.png'
 
+    def test_file_ext_sanitises_path_traversal(self) -> None:
+        # A hostile file_extension must not escape the asset directory.
+        assert (
+            yodeck._file_ext(
+                {'file_extension': '/../../etc/passwd'}, 'https://x/y'
+            )
+            == '.etcpasswd'
+        )
+
+    def test_first_http_url_rejects_stream_scheme(self) -> None:
+        # validate_url accepts rtsp://, but this helper feeds webpage URIs
+        # and requests.get downloads — http(s) only.
+        assert yodeck._first_http_url(['rtsp://cam/stream']) is None
+        assert (
+            yodeck._first_http_url(['rtsp://cam/stream', 'https://ok/x'])
+            == 'https://ok/x'
+        )
+
 
 # ---------------------------------------------------------------------------
 # Registry

--- a/src/anthias_server/api/tests/test_yodeck_import.py
+++ b/src/anthias_server/api/tests/test_yodeck_import.py
@@ -345,6 +345,24 @@ class TestImportItem:
         assert outcome.skipped is True
 
     @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_internal_yodeck_app_webpage_skipped(
+        self, get_mock: MagicMock
+    ) -> None:
+        # A webpage whose URL is Yodeck-hosted is an internal app/widget
+        # and must not be imported as a (broken) webpage asset.
+        get_mock.return_value = self._detail_response(
+            {
+                'id': 3,
+                'name': 'Weather widget',
+                'media_origin': {'type': 'webpage'},
+                'arguments': {'url': 'https://app.yodeck.com/widgets/weather'},
+            }
+        )
+        outcome = PROVIDER.import_item('tok', '3')
+        assert outcome.skipped is True
+        assert 'app' in (outcome.reason or '').lower()
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
     def test_image_without_file_url_skipped(self, get_mock: MagicMock) -> None:
         get_mock.return_value = self._detail_response(
             {

--- a/src/anthias_server/api/tests/test_yodeck_import.py
+++ b/src/anthias_server/api/tests/test_yodeck_import.py
@@ -1,0 +1,640 @@
+"""Unit tests for the Yodeck import provider + generic import endpoints.
+
+These tests never reach the network. The Yodeck provider's module-level
+``_session`` is patched on ``anthias_server.lib.integrations.yodeck`` so
+each branch is driven deterministically — token validation, media
+listing/pagination, field mapping, and the per-item import (webpage,
+image download, idempotency, skips, cleanup-on-failure).
+
+The HTTP-level tests use DRF's ``APIClient`` against the registered v2
+routes with the provider layer mocked, so the serializer + view wiring
+is under test independently of Yodeck's real API.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from django.test import Client
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from anthias_server.app.models import Asset
+from anthias_server.lib.integrations import yodeck
+from anthias_server.lib.integrations.base import (
+    ImportOutcome,
+    ProviderImportError,
+    RemoteMediaItem,
+)
+from anthias_server.lib.integrations.registry import (
+    get_provider,
+    list_provider_meta,
+)
+from anthias_server.settings import settings
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP responses
+# ---------------------------------------------------------------------------
+
+
+def _fake_response(status_code: int, json_body: Any = None) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 400
+    resp.json.return_value = json_body
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            f'HTTP {status_code}', response=resp
+        )
+    return resp
+
+
+def _fake_stream_response(status_code: int, chunks: list[bytes]) -> MagicMock:
+    """A streaming response usable as a context manager (``with ... as``)."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 400
+    resp.iter_content.return_value = iter(chunks)
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Auth / session
+# ---------------------------------------------------------------------------
+
+
+class TestAuthAndSession:
+    def test_auth_header_token_scheme(self) -> None:
+        assert yodeck._auth_headers('label:secret') == {
+            'Authorization': 'Token label:secret'
+        }
+
+    def test_session_does_not_use_anthias_user_agent(self) -> None:
+        # Migration traffic hits a competitor's API; a self-identifying
+        # ``Anthias/<ver>`` UA invites vendor-side blocking, so these
+        # calls must NOT carry it.
+        ua = yodeck._session.headers['User-Agent']
+        assert isinstance(ua, str)
+        assert not ua.startswith('Anthias/')
+        assert 'anthias' not in ua.lower()
+
+
+# ---------------------------------------------------------------------------
+# validate_token
+# ---------------------------------------------------------------------------
+
+
+class TestValidateToken:
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_returns_true_on_200(self, get_mock: MagicMock) -> None:
+        get_mock.return_value = _fake_response(200, {'results': []})
+        assert yodeck.YodeckProvider().validate_token('good') is True
+        _, kwargs = get_mock.call_args
+        assert kwargs['headers']['Authorization'] == 'Token good'
+        assert kwargs['params']['limit'] == 1
+
+    @pytest.mark.parametrize('code', [401, 403])
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_returns_false_on_auth_failure(
+        self, get_mock: MagicMock, code: int
+    ) -> None:
+        get_mock.return_value = _fake_response(code, {'detail': 'no'})
+        assert yodeck.YodeckProvider().validate_token('bad') is False
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_raises_on_5xx(self, get_mock: MagicMock) -> None:
+        get_mock.return_value = _fake_response(503)
+        with pytest.raises(requests.HTTPError):
+            yodeck.YodeckProvider().validate_token('x')
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_propagates_network_error(self, get_mock: MagicMock) -> None:
+        get_mock.side_effect = requests.ConnectionError('boom')
+        with pytest.raises(requests.ConnectionError):
+            yodeck.YodeckProvider().validate_token('x')
+
+
+# ---------------------------------------------------------------------------
+# list_media
+# ---------------------------------------------------------------------------
+
+
+class TestListMedia:
+    def _pages(
+        self, pages_by_type: dict[str, dict[int, dict[str, Any]]]
+    ) -> Any:
+        """side_effect that serves list pages keyed on media_type+offset."""
+
+        def _get(url: str, **kwargs: Any) -> MagicMock:
+            params = kwargs['params']
+            media_type = params['media_type']
+            offset = params['offset']
+            body = pages_by_type.get(media_type, {}).get(
+                offset, {'results': [], 'next': None}
+            )
+            return _fake_response(200, body)
+
+        return _get
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_maps_types_and_flags_unsupported(
+        self, get_mock: MagicMock
+    ) -> None:
+        get_mock.side_effect = self._pages(
+            {
+                'image': {
+                    0: {'results': [{'id': 1, 'name': 'Pic'}], 'next': None}
+                },
+                'video': {
+                    0: {'results': [{'id': 2, 'name': 'Clip'}], 'next': None}
+                },
+                'webpage': {
+                    0: {'results': [{'id': 3, 'name': 'Site'}], 'next': None}
+                },
+                'audio': {
+                    0: {'results': [{'id': 4, 'name': 'Song'}], 'next': None}
+                },
+                'document': {
+                    0: {'results': [{'id': 5, 'name': 'PDF'}], 'next': None}
+                },
+            }
+        )
+        items = yodeck.YodeckProvider().list_media('tok')
+        by_id = {item.remote_id: item for item in items}
+
+        assert by_id['1'].media_type == 'image' and by_id['1'].importable
+        assert by_id['2'].media_type == 'video' and by_id['2'].importable
+        assert by_id['3'].media_type == 'webpage' and by_id['3'].importable
+        assert by_id['4'].importable is False
+        assert by_id['4'].skip_reason
+        assert by_id['5'].importable is False
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_follows_pagination(self, get_mock: MagicMock) -> None:
+        get_mock.side_effect = self._pages(
+            {
+                'image': {
+                    0: {
+                        'results': [
+                            {'id': 1, 'name': 'A'},
+                            {'id': 2, 'name': 'B'},
+                        ],
+                        'next': 'http://x/?offset=2',
+                    },
+                    2: {'results': [{'id': 3, 'name': 'C'}], 'next': None},
+                },
+            }
+        )
+        items = yodeck.YodeckProvider().list_media('tok')
+        image_ids = sorted(
+            i.remote_id for i in items if i.media_type == 'image'
+        )
+        assert image_ids == ['1', '2', '3']
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_names_fallback_when_missing(self, get_mock: MagicMock) -> None:
+        get_mock.side_effect = self._pages(
+            {'image': {0: {'results': [{'id': 9}], 'next': None}}}
+        )
+        items = yodeck.YodeckProvider().list_media('tok')
+        item = next(i for i in items if i.remote_id == '9')
+        assert 'Yodeck media 9' == item.name
+
+
+# ---------------------------------------------------------------------------
+# Pure field-mapping helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFieldMapping:
+    def test_availability_window_uses_schedule(self) -> None:
+        detail = {
+            'availability_schedule': {
+                'enable': True,
+                'available_after': '2024-05-20T12:38:00Z',
+                'available_before': '2024-06-21T12:38:00Z',
+            }
+        }
+        start, end = yodeck._availability_window(detail)
+        assert start == datetime(2024, 5, 20, 12, 38, tzinfo=timezone.utc)
+        assert end == datetime(2024, 6, 21, 12, 38, tzinfo=timezone.utc)
+
+    def test_availability_window_defaults_when_disabled(self) -> None:
+        start, end = yodeck._availability_window({'availability_schedule': {}})
+        assert end > start
+
+    def test_default_duration_prefers_media_value(self) -> None:
+        assert yodeck._default_duration({'default_duration': 42}) == 42
+
+    def test_default_duration_falls_back_to_settings(self) -> None:
+        expected = int(settings['default_duration'])
+        assert yodeck._default_duration({'default_duration': 0}) == expected
+
+    def test_webpage_url_read_from_arguments(self) -> None:
+        detail = {'arguments': {'url': 'https://example.com/page'}}
+        assert yodeck._webpage_url(detail) == 'https://example.com/page'
+
+    def test_webpage_url_scans_argument_values(self) -> None:
+        # Unknown key, but the value is a URL — the value scan finds it.
+        detail = {'arguments': {'target_location': 'https://example.com/x'}}
+        assert yodeck._webpage_url(detail) == 'https://example.com/x'
+
+    def test_file_url_read_from_download_from_url(self) -> None:
+        detail = {'arguments': {'download_from_url': 'https://cdn/x.mp4'}}
+        assert yodeck._file_url(detail) == 'https://cdn/x.mp4'
+
+    def test_file_url_none_when_absent(self) -> None:
+        assert yodeck._file_url({'arguments': {}}) is None
+
+    def test_file_ext_prefers_field(self) -> None:
+        assert (
+            yodeck._file_ext({'file_extension': 'mp4'}, 'https://x/y')
+            == '.mp4'
+        )
+
+    def test_file_ext_from_url_when_field_missing(self) -> None:
+        assert yodeck._file_ext({}, 'https://x/y.png?v=1') == '.png'
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_get_provider_known(self) -> None:
+        assert isinstance(get_provider('yodeck'), yodeck.YodeckProvider)
+
+    def test_get_provider_unknown(self) -> None:
+        assert get_provider('nope') is None
+
+    def test_list_provider_meta_includes_yodeck(self) -> None:
+        keys = {meta['key'] for meta in list_provider_meta()}
+        assert 'yodeck' in keys
+
+
+# ---------------------------------------------------------------------------
+# import_item (DB-backed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestImportItem:
+    def _detail_response(self, detail: dict[str, Any]) -> MagicMock:
+        return _fake_response(200, detail)
+
+    def test_idempotent_reimport_skips(self) -> None:
+        asset = Asset.objects.create(
+            asset_id='already',
+            name='Existing',
+            uri='https://example.com/',
+            mimetype='webpage',
+            duration=10,
+            metadata={
+                'import_source': {'provider': 'yodeck', 'remote_id': '77'}
+            },
+        )
+        with patch(
+            'anthias_server.lib.integrations.yodeck._session.get'
+        ) as get_mock:
+            outcome = yodeck.YodeckProvider().import_item('tok', '77')
+        # Short-circuits before any HTTP call.
+        get_mock.assert_not_called()
+        assert outcome.skipped is True
+        assert outcome.success is True
+        assert outcome.asset_id == asset.asset_id
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_unsupported_type_skipped(self, get_mock: MagicMock) -> None:
+        get_mock.return_value = self._detail_response(
+            {'id': 5, 'name': 'Song', 'media_origin': {'type': 'audio'}}
+        )
+        outcome = yodeck.YodeckProvider().import_item('tok', '5')
+        assert outcome.skipped is True
+        assert outcome.success is False
+        assert 'supported' in (outcome.reason or '').lower()
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_webpage_without_url_skipped(self, get_mock: MagicMock) -> None:
+        get_mock.return_value = self._detail_response(
+            {
+                'id': 3,
+                'name': 'Site',
+                'media_origin': {'type': 'webpage'},
+                'arguments': {},
+            }
+        )
+        outcome = yodeck.YodeckProvider().import_item('tok', '3')
+        assert outcome.skipped is True
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_image_without_file_url_skipped(self, get_mock: MagicMock) -> None:
+        get_mock.return_value = self._detail_response(
+            {
+                'id': 1,
+                'name': 'Pic',
+                'media_origin': {'type': 'image'},
+                'arguments': {},
+            }
+        )
+        outcome = yodeck.YodeckProvider().import_item('tok', '1')
+        assert outcome.skipped is True
+        assert 're-upload' in (outcome.reason or '')
+
+    @patch(
+        'anthias_server.api.serializers.mixins.url_fails', return_value=False
+    )
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_webpage_import_creates_asset(
+        self, get_mock: MagicMock, _url_fails: MagicMock
+    ) -> None:
+        get_mock.return_value = self._detail_response(
+            {
+                'id': 3,
+                'name': 'Wireload',
+                'media_origin': {'type': 'webpage'},
+                'default_duration': 15,
+                'arguments': {'url': 'https://wireload.net/'},
+                'availability_schedule': {
+                    'enable': True,
+                    'available_after': '2024-05-20T12:38:00Z',
+                    'available_before': '2024-06-21T12:38:00Z',
+                },
+            }
+        )
+        outcome = yodeck.YodeckProvider().import_item('tok', '3', enable=True)
+        assert outcome.success is True and not outcome.skipped
+
+        asset = Asset.objects.get(asset_id=outcome.asset_id)
+        assert asset.mimetype == 'webpage'
+        assert asset.uri == 'https://wireload.net/'
+        assert asset.is_enabled is True
+        assert asset.duration == 15
+        assert asset.metadata['import_source'] == {
+            'provider': 'yodeck',
+            'remote_id': '3',
+        }
+        assert asset.start_date == datetime(
+            2024, 5, 20, 12, 38, tzinfo=timezone.utc
+        )
+        assert asset.end_date == datetime(
+            2024, 6, 21, 12, 38, tzinfo=timezone.utc
+        )
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_image_import_downloads_and_creates_asset(
+        self,
+        get_mock: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setitem(settings, 'assetdir', str(tmp_path))
+        detail = {
+            'id': 1,
+            'name': 'Pic',
+            'media_origin': {'type': 'image'},
+            'file_extension': 'png',
+            'default_duration': 20,
+            'arguments': {'download_from_url': 'https://cdn/x.png'},
+            'availability_schedule': {},
+        }
+
+        def _get(url: str, **kwargs: Any) -> MagicMock:
+            if kwargs.get('stream'):
+                return _fake_stream_response(200, [b'\x89PNG\r\n\x1a\n'])
+            return self._detail_response(detail)
+
+        get_mock.side_effect = _get
+
+        outcome = yodeck.YodeckProvider().import_item('tok', '1', enable=False)
+        assert outcome.success is True and not outcome.skipped
+
+        asset = Asset.objects.get(asset_id=outcome.asset_id)
+        assert asset.mimetype == 'image'
+        assert asset.uri == str(tmp_path / f'{asset.asset_id}.png')
+        assert (tmp_path / f'{asset.asset_id}.png').is_file()
+        assert asset.is_enabled is False
+        # No staged temp files left behind.
+        assert not list(tmp_path.glob('.import-*'))
+
+    @patch('anthias_server.lib.integrations.yodeck._session.get')
+    def test_image_download_failure_cleans_up(
+        self,
+        get_mock: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setitem(settings, 'assetdir', str(tmp_path))
+        detail = {
+            'id': 1,
+            'name': 'Pic',
+            'media_origin': {'type': 'image'},
+            'file_extension': 'png',
+            'arguments': {'download_from_url': 'https://cdn/x.png'},
+        }
+
+        def _get(url: str, **kwargs: Any) -> MagicMock:
+            if kwargs.get('stream'):
+                return _fake_stream_response(404, [])
+            return self._detail_response(detail)
+
+        get_mock.side_effect = _get
+
+        with pytest.raises(ProviderImportError):
+            yodeck.YodeckProvider().import_item('tok', '1')
+
+        # Neither the .part nor the staged file survive a failed download.
+        assert not list(tmp_path.glob('.import-*'))
+        assert Asset.objects.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoints (provider layer mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture
+def validate_url() -> str:
+    return reverse('api:import_validate_v2', kwargs={'provider': 'yodeck'})
+
+
+@pytest.fixture
+def item_url() -> str:
+    return reverse('api:import_item_v2', kwargs={'provider': 'yodeck'})
+
+
+@pytest.mark.django_db
+class TestImportValidateEndpoint:
+    @mock.patch('anthias_server.api.views.v2.get_provider')
+    def test_valid_token_returns_items(
+        self,
+        provider_mock: MagicMock,
+        api_client: APIClient,
+        validate_url: str,
+    ) -> None:
+        provider = MagicMock()
+        provider.validate_token.return_value = True
+        provider.list_media.return_value = [
+            RemoteMediaItem('1', 'Pic', 'image', True),
+            RemoteMediaItem('4', 'Song', 'audio', False, 'unsupported'),
+        ]
+        provider_mock.return_value = provider
+
+        response = api_client.post(
+            validate_url, {'token': 'good'}, format='json'
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body['valid'] is True
+        assert len(body['items']) == 2
+        assert body['items'][0]['media_type'] == 'image'
+        # ``raw`` must not leak to the browser.
+        assert 'raw' not in body['items'][0]
+
+    @mock.patch('anthias_server.api.views.v2.get_provider')
+    def test_invalid_token(
+        self,
+        provider_mock: MagicMock,
+        api_client: APIClient,
+        validate_url: str,
+    ) -> None:
+        provider = MagicMock()
+        provider.validate_token.return_value = False
+        provider_mock.return_value = provider
+        response = api_client.post(
+            validate_url, {'token': 'bad'}, format='json'
+        )
+        assert response.status_code == 200
+        assert response.json() == {'valid': False}
+        provider.list_media.assert_not_called()
+
+    @mock.patch('anthias_server.api.views.v2.get_provider')
+    def test_network_error_returns_502(
+        self,
+        provider_mock: MagicMock,
+        api_client: APIClient,
+        validate_url: str,
+    ) -> None:
+        provider = MagicMock()
+        provider.validate_token.side_effect = requests.ConnectionError('x')
+        provider_mock.return_value = provider
+        response = api_client.post(validate_url, {'token': 'x'}, format='json')
+        assert response.status_code == 502
+        assert response.json()['valid'] is False
+
+    @mock.patch('anthias_server.api.views.v2.get_provider', return_value=None)
+    def test_unknown_provider_404(
+        self,
+        _provider_mock: MagicMock,
+        api_client: APIClient,
+    ) -> None:
+        url = reverse('api:import_validate_v2', kwargs={'provider': 'nope'})
+        response = api_client.post(url, {'token': 'x'}, format='json')
+        assert response.status_code == 404
+
+    def test_missing_token_400(
+        self, api_client: APIClient, validate_url: str
+    ) -> None:
+        # get_provider('yodeck') resolves; serializer rejects empty body.
+        response = api_client.post(validate_url, {}, format='json')
+        assert response.status_code == 400
+
+
+@pytest.mark.django_db
+class TestImportItemEndpoint:
+    @mock.patch('anthias_server.api.views.v2.get_provider')
+    def test_success(
+        self,
+        provider_mock: MagicMock,
+        api_client: APIClient,
+        item_url: str,
+    ) -> None:
+        provider = MagicMock()
+        provider.import_item.return_value = ImportOutcome(
+            success=True, asset_id='new-asset'
+        )
+        provider_mock.return_value = provider
+
+        response = api_client.post(
+            item_url,
+            {'token': 'tok', 'remote_id': '1', 'enable': True},
+            format='json',
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body['success'] is True
+        assert body['asset_id'] == 'new-asset'
+        _, kwargs = provider.import_item.call_args
+        assert kwargs['enable'] is True
+
+    @mock.patch('anthias_server.api.views.v2.get_provider')
+    def test_provider_error_returns_per_item_error(
+        self,
+        provider_mock: MagicMock,
+        api_client: APIClient,
+        item_url: str,
+    ) -> None:
+        provider = MagicMock()
+        provider.import_item.side_effect = ProviderImportError('nope')
+        provider_mock.return_value = provider
+
+        response = api_client.post(
+            item_url,
+            {'token': 'tok', 'remote_id': '1'},
+            format='json',
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body['success'] is False
+        assert body['error'] == 'nope'
+
+    @mock.patch('anthias_server.api.views.v2.get_provider')
+    def test_network_error_returns_502(
+        self,
+        provider_mock: MagicMock,
+        api_client: APIClient,
+        item_url: str,
+    ) -> None:
+        provider = MagicMock()
+        provider.import_item.side_effect = requests.ConnectionError('x')
+        provider_mock.return_value = provider
+
+        response = api_client.post(
+            item_url,
+            {'token': 'tok', 'remote_id': '1'},
+            format='json',
+        )
+        assert response.status_code == 502
+        assert response.json()['success'] is False
+
+
+# ---------------------------------------------------------------------------
+# Wizard page + settings entry (template rendering)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestImportWizardPage:
+    def test_wizard_unknown_provider_404(self) -> None:
+        # The view resolves the provider from the registry before
+        # rendering, so an unknown key 404s without touching a template
+        # (and without the redis-backed base layout the full-page render
+        # would pull in — that path is exercised in the dev stack).
+        url = reverse(
+            'anthias_app:import_content', kwargs={'provider': 'nope'}
+        )
+        response = Client().get(url)
+        assert response.status_code == 404

--- a/src/anthias_server/api/tests/test_yodeck_import.py
+++ b/src/anthias_server/api/tests/test_yodeck_import.py
@@ -14,12 +14,14 @@ is under test independently of Yodeck's real API.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from io import StringIO
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from django.core.management import call_command
 from django.test import Client
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -36,6 +38,13 @@ from anthias_server.lib.integrations.registry import (
     list_provider_meta,
 )
 from anthias_server.settings import settings
+
+
+# Stateless provider (its HTTP session is module-level), so one shared
+# instance is reused across tests. Keeping construction out of the
+# ``pytest.raises`` blocks also means each of those blocks has a single
+# throwing invocation (Sonar S5778).
+PROVIDER = yodeck.YodeckProvider()
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +105,7 @@ class TestValidateToken:
     @patch('anthias_server.lib.integrations.yodeck._session.get')
     def test_returns_true_on_200(self, get_mock: MagicMock) -> None:
         get_mock.return_value = _fake_response(200, {'results': []})
-        assert yodeck.YodeckProvider().validate_token('good') is True
+        assert PROVIDER.validate_token('good') is True
         _, kwargs = get_mock.call_args
         assert kwargs['headers']['Authorization'] == 'Token good'
         assert kwargs['params']['limit'] == 1
@@ -107,19 +116,19 @@ class TestValidateToken:
         self, get_mock: MagicMock, code: int
     ) -> None:
         get_mock.return_value = _fake_response(code, {'detail': 'no'})
-        assert yodeck.YodeckProvider().validate_token('bad') is False
+        assert PROVIDER.validate_token('bad') is False
 
     @patch('anthias_server.lib.integrations.yodeck._session.get')
     def test_raises_on_5xx(self, get_mock: MagicMock) -> None:
         get_mock.return_value = _fake_response(503)
         with pytest.raises(requests.HTTPError):
-            yodeck.YodeckProvider().validate_token('x')
+            PROVIDER.validate_token('x')
 
     @patch('anthias_server.lib.integrations.yodeck._session.get')
     def test_propagates_network_error(self, get_mock: MagicMock) -> None:
         get_mock.side_effect = requests.ConnectionError('boom')
         with pytest.raises(requests.ConnectionError):
-            yodeck.YodeckProvider().validate_token('x')
+            PROVIDER.validate_token('x')
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +176,7 @@ class TestListMedia:
                 },
             }
         )
-        items = yodeck.YodeckProvider().list_media('tok')
+        items = PROVIDER.list_media('tok')
         by_id = {item.remote_id: item for item in items}
 
         assert by_id['1'].media_type == 'image' and by_id['1'].importable
@@ -187,13 +196,13 @@ class TestListMedia:
                             {'id': 1, 'name': 'A'},
                             {'id': 2, 'name': 'B'},
                         ],
-                        'next': 'http://x/?offset=2',
+                        'next': 'https://x/?offset=2',
                     },
                     2: {'results': [{'id': 3, 'name': 'C'}], 'next': None},
                 },
             }
         )
-        items = yodeck.YodeckProvider().list_media('tok')
+        items = PROVIDER.list_media('tok')
         image_ids = sorted(
             i.remote_id for i in items if i.media_type == 'image'
         )
@@ -204,7 +213,7 @@ class TestListMedia:
         get_mock.side_effect = self._pages(
             {'image': {0: {'results': [{'id': 9}], 'next': None}}}
         )
-        items = yodeck.YodeckProvider().list_media('tok')
+        items = PROVIDER.list_media('tok')
         item = next(i for i in items if i.remote_id == '9')
         assert 'Yodeck media 9' == item.name
 
@@ -305,7 +314,7 @@ class TestImportItem:
         with patch(
             'anthias_server.lib.integrations.yodeck._session.get'
         ) as get_mock:
-            outcome = yodeck.YodeckProvider().import_item('tok', '77')
+            outcome = PROVIDER.import_item('tok', '77')
         # Short-circuits before any HTTP call.
         get_mock.assert_not_called()
         assert outcome.skipped is True
@@ -317,7 +326,7 @@ class TestImportItem:
         get_mock.return_value = self._detail_response(
             {'id': 5, 'name': 'Song', 'media_origin': {'type': 'audio'}}
         )
-        outcome = yodeck.YodeckProvider().import_item('tok', '5')
+        outcome = PROVIDER.import_item('tok', '5')
         assert outcome.skipped is True
         assert outcome.success is False
         assert 'supported' in (outcome.reason or '').lower()
@@ -332,7 +341,7 @@ class TestImportItem:
                 'arguments': {},
             }
         )
-        outcome = yodeck.YodeckProvider().import_item('tok', '3')
+        outcome = PROVIDER.import_item('tok', '3')
         assert outcome.skipped is True
 
     @patch('anthias_server.lib.integrations.yodeck._session.get')
@@ -345,7 +354,7 @@ class TestImportItem:
                 'arguments': {},
             }
         )
-        outcome = yodeck.YodeckProvider().import_item('tok', '1')
+        outcome = PROVIDER.import_item('tok', '1')
         assert outcome.skipped is True
         assert 're-upload' in (outcome.reason or '')
 
@@ -370,7 +379,7 @@ class TestImportItem:
                 },
             }
         )
-        outcome = yodeck.YodeckProvider().import_item('tok', '3', enable=True)
+        outcome = PROVIDER.import_item('tok', '3', enable=True)
         assert outcome.success is True and not outcome.skipped
 
         asset = Asset.objects.get(asset_id=outcome.asset_id)
@@ -414,7 +423,7 @@ class TestImportItem:
 
         get_mock.side_effect = _get
 
-        outcome = yodeck.YodeckProvider().import_item('tok', '1', enable=False)
+        outcome = PROVIDER.import_item('tok', '1', enable=False)
         assert outcome.success is True and not outcome.skipped
 
         asset = Asset.objects.get(asset_id=outcome.asset_id)
@@ -449,7 +458,7 @@ class TestImportItem:
         get_mock.side_effect = _get
 
         with pytest.raises(ProviderImportError):
-            yodeck.YodeckProvider().import_item('tok', '1')
+            PROVIDER.import_item('tok', '1')
 
         # Neither the .part nor the staged file survive a failed download.
         assert not list(tmp_path.glob('.import-*'))
@@ -624,6 +633,74 @@ class TestImportItemEndpoint:
 # ---------------------------------------------------------------------------
 # Wizard page + settings entry (template rendering)
 # ---------------------------------------------------------------------------
+
+
+_COMMAND_PROVIDER = (
+    'anthias_server.app.management.commands.import_content.get_provider'
+)
+
+
+class TestImportContentCommand:
+    def _provider(self, items: list[RemoteMediaItem]) -> MagicMock:
+        provider = MagicMock()
+        provider.label = 'Yodeck'
+        provider.validate_token.return_value = True
+        provider.list_media.return_value = items
+        return provider
+
+    @mock.patch(_COMMAND_PROVIDER)
+    def test_dry_run_lists_without_importing(
+        self, provider_mock: MagicMock
+    ) -> None:
+        provider = self._provider(
+            [
+                RemoteMediaItem('1', 'Pic', 'image', True),
+                RemoteMediaItem('4', 'Song', 'audio', False, 'unsupported'),
+            ]
+        )
+        provider_mock.return_value = provider
+        out = StringIO()
+        call_command(
+            'import_content',
+            '--provider',
+            'yodeck',
+            '--token',
+            'x',
+            '--dry-run',
+            stdout=out,
+        )
+        provider.import_item.assert_not_called()
+        assert '1 importable' in out.getvalue()
+
+    @mock.patch(_COMMAND_PROVIDER)
+    def test_import_runs_and_reports_counts(
+        self, provider_mock: MagicMock
+    ) -> None:
+        provider = self._provider([RemoteMediaItem('1', 'Pic', 'image', True)])
+        provider.import_item.return_value = ImportOutcome(
+            success=True, asset_id='a'
+        )
+        provider_mock.return_value = provider
+        out = StringIO()
+        call_command(
+            'import_content',
+            '--provider',
+            'yodeck',
+            '--token',
+            'x',
+            stdout=out,
+        )
+        provider.import_item.assert_called_once()
+        assert '1 imported' in out.getvalue()
+
+    @mock.patch(_COMMAND_PROVIDER, return_value=None)
+    def test_unknown_provider_errors(self, _provider_mock: MagicMock) -> None:
+        from django.core.management.base import CommandError
+
+        with pytest.raises(CommandError):
+            call_command(
+                'import_content', '--provider', 'nope', '--token', 'x'
+            )
 
 
 @pytest.mark.django_db

--- a/src/anthias_server/api/urls/v2.py
+++ b/src/anthias_server/api/urls/v2.py
@@ -10,6 +10,8 @@ from anthias_server.api.views.v2 import (
     DeviceSettingsViewV2,
     DisplayPowerViewV2,
     FileAssetViewV2,
+    ImportItemViewV2,
+    ImportValidateViewV2,
     InfoViewV2,
     IntegrationsViewV2,
     NetworkIpAddressesViewV2,
@@ -86,6 +88,16 @@ def get_url_patterns() -> list[URLPattern | URLResolver]:
             'v2/integrations/screenly/migrate',
             ScreenlyMigrateAssetViewV2.as_view(),
             name='screenly_migrate_asset_v2',
+        ),
+        path(
+            'v2/integrations/import/<str:provider>/validate',
+            ImportValidateViewV2.as_view(),
+            name='import_validate_v2',
+        ),
+        path(
+            'v2/integrations/import/<str:provider>/item',
+            ImportItemViewV2.as_view(),
+            name='import_item_v2',
         ),
         path(
             'v2/network/ip-addresses',

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -27,8 +27,7 @@ from anthias_server.app.models import Asset
 from anthias_server.api.helpers import (
     AssetCreationError,
     finalize_asset_update,
-    get_active_asset_ids,
-    save_active_assets_ordering,
+    persist_new_asset,
 )
 from anthias_server.lib.auth import (
     AuthSettingsError,
@@ -36,13 +35,12 @@ from anthias_server.lib.auth import (
     operator_username,
 )
 from anthias_common.internal_auth import is_internal_request
-from anthias_common.remote_video import dispatch_remote_video_download
-from anthias_common.youtube import dispatch_download
-from anthias_server.processing import dispatch_pending_normalize
 from anthias_server.api.serializers.v2 import (
     AssetSerializerV2,
     CreateAssetSerializerV2,
     DeviceSettingsSerializerV2,
+    ImportItemSerializerV2,
+    ImportValidateSerializerV2,
     IntegrationsSerializerV2,
     ScreenlyMigrateAssetSerializerV2,
     ScreenlyTokenSerializerV2,
@@ -51,6 +49,8 @@ from anthias_server.api.serializers.v2 import (
     ViewerPlaylistSerializerV2,
     ViewerSettingsSerializerV2,
 )
+from anthias_server.lib.integrations.base import ProviderImportError
+from anthias_server.lib.integrations.registry import get_provider
 from anthias_server.lib.screenly_migration import (
     MIGRATION_ASSET_GROUP_TITLE,
     ScreenlyMigrationError,
@@ -96,6 +96,14 @@ logger = logging.getLogger(__name__)
 # — see CodeQL's information-exposure rule.
 _SCREENLY_NETWORK_USER_MESSAGE = (
     "Could not reach Screenly. Check this device's internet "
+    'connection and try again.'
+)
+
+# Same posture for inbound content-import providers: one canonical
+# message in place of the raw transport error, so an import provider
+# being unreachable never leaks socket/DNS/proxy state into a response.
+_IMPORT_NETWORK_USER_MESSAGE = (
+    "Could not reach the import provider. Check this device's internet "
     'connection and try again.'
 )
 
@@ -366,59 +374,11 @@ class AssetListViewV2(APIView):
         except AssetCreationError as error:
             return Response(error.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        active_asset_ids = get_active_asset_ids()
-        asset = Asset.objects.create(**serializer.data)
-        # Apply ``metadata`` (set by CreateAssetSerializerV2.validate()
-        # when the operator passes ``refresh_interval_s``). It lives in
-        # ``validated_data`` rather than ``serializer.data`` because
-        # ``metadata`` isn't a declared field on the create serializer
-        # — surfacing it as one would open the upload-pipeline-owned
-        # bag (original_ext, transcoded, error_message) for arbitrary
-        # client writes. Pulling it from validated_data and applying
-        # post-create keeps the read-only stance on metadata while
-        # still letting the dedicated refresh_interval_s knob round-
-        # trip on POST.
-        post_create_metadata = serializer.validated_data.get('metadata')
-        if post_create_metadata:
-            existing = dict(asset.metadata or {})
-            existing.update(post_create_metadata)
-            asset.metadata = existing
-            asset.save(update_fields=['metadata'])
-        asset.refresh_from_db()
-
-        # Kick off the YouTube download out of band when the
-        # serializer flagged a youtube_asset. The row is already
-        # persisted with is_processing=True; the task fills in the
-        # title + duration once yt-dlp finishes.
-        if serializer._pending_youtube_uri:
-            dispatch_download(asset.asset_id, serializer._pending_youtube_uri)
-
-        # Generic remote video URLs get the same hand-off: the
-        # serializer pointed Asset.uri at a local destination path
-        # and flipped is_processing; the Celery task downloads via
-        # requests and chains into normalize_video_asset. Live
-        # streams (RTSP / HLS / DASH) are excluded by the
-        # serializer's ``is_downloadable_remote_video`` classify.
-        if serializer._pending_remote_video_uri:
-            dispatch_remote_video_download(
-                asset.asset_id, serializer._pending_remote_video_uri
-            )
-
-        # Normalisation pipeline: HEIC/HEIF/TIFF → WebP, exotic video
-        # → H.264 MP4. Dispatched after persistence (same pattern as
-        # the YouTube hop above) so the row's ``asset_id`` is already
-        # written to the DB by the time the worker picks it up. The
-        # row was set ``is_processing=True`` by ``prepare_asset``;
-        # the task clears it once the file lands. Shared with
-        # v1/v1.1/v1.2 via dispatch_pending_normalize so adding a
-        # new API version can't re-open GH #2870.
-        dispatch_pending_normalize(serializer, asset.asset_id)
-
-        if asset.is_active():
-            active_asset_ids.insert(asset.play_order, asset.asset_id)
-
-        save_active_assets_ordering(active_asset_ids)
-        asset.refresh_from_db()
+        # Persist + fire the deferred download / normalise pipelines and
+        # splice into the active ordering. Shared with the content
+        # importer (lib.integrations) so imported and uploaded assets
+        # travel exactly one create path.
+        asset = persist_new_asset(serializer)
 
         return Response(
             AssetSerializerV2(asset).data,
@@ -1235,3 +1195,137 @@ class ScreenlyMigrateAssetViewV2(APIView):
                 'screenly_asset_id': screenly_asset_id,
             }
         )
+
+
+class ImportValidateViewV2(APIView):
+    """Validate an import provider's token and enumerate its media.
+
+    Inbound counterpart to ``ScreenlyValidateTokenViewV2``: validation
+    and listing happen in one round-trip so the wizard's Continue button
+    goes straight from the token field to the item picker. The token is
+    not stored; each request forwards it inline. ``provider`` is the
+    registry key from the URL (``yodeck``, later ``screencloud`` …).
+    """
+
+    serializer_class = ImportValidateSerializerV2
+
+    @extend_schema(
+        summary='Validate an import provider token and list its media',
+        request=ImportValidateSerializerV2,
+        responses={
+            200: {
+                'type': 'object',
+                'properties': {
+                    'valid': {'type': 'boolean'},
+                    'items': {'type': 'array', 'items': {'type': 'object'}},
+                    'error': {'type': 'string', 'nullable': True},
+                },
+            },
+        },
+    )
+    @authorized
+    def post(self, request: Request, provider: str) -> Response:
+        provider_impl = get_provider(provider)
+        if provider_impl is None:
+            return Response(
+                {'valid': False, 'error': 'Unknown import provider.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        token = serializer.validated_data['token']
+
+        try:
+            valid = provider_impl.validate_token(token)
+        except requests.RequestException:
+            # Log transport detail server-side only — see
+            # ScreenlyValidateTokenViewV2.post for the CodeQL rationale.
+            logger.warning('%s token validate failed', provider, exc_info=True)
+            return Response(
+                {'valid': False, 'error': _IMPORT_NETWORK_USER_MESSAGE},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        if not valid:
+            return Response({'valid': False})
+
+        try:
+            items = provider_impl.list_media(token)
+        except requests.RequestException:
+            logger.warning('%s list_media failed', provider, exc_info=True)
+            return Response(
+                {'valid': False, 'error': _IMPORT_NETWORK_USER_MESSAGE},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(
+            {'valid': True, 'items': [item.as_dict() for item in items]}
+        )
+
+
+class ImportItemViewV2(APIView):
+    """Import a single remote media item as an Anthias asset.
+
+    Per-item (not batch) for the same reason as
+    ``ScreenlyMigrateAssetViewV2``: the wizard shows live progress and
+    keeps going past individual failures. Known per-item failures return
+    200 with ``success: False`` so the queue keeps advancing; only a
+    transport failure is a 502.
+    """
+
+    serializer_class = ImportItemSerializerV2
+
+    @extend_schema(
+        summary='Import one media item from a provider',
+        request=ImportItemSerializerV2,
+        responses={
+            200: {
+                'type': 'object',
+                'properties': {
+                    'success': {'type': 'boolean'},
+                    'asset_id': {'type': 'string', 'nullable': True},
+                    'skipped': {'type': 'boolean'},
+                    'reason': {'type': 'string', 'nullable': True},
+                    'error': {'type': 'string', 'nullable': True},
+                },
+            },
+        },
+    )
+    @authorized
+    def post(self, request: Request, provider: str) -> Response:
+        provider_impl = get_provider(provider)
+        if provider_impl is None:
+            return Response(
+                {'success': False, 'error': 'Unknown import provider.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        token = serializer.validated_data['token']
+        remote_id = serializer.validated_data['remote_id']
+        enable = serializer.validated_data.get('enable', True)
+
+        try:
+            outcome = provider_impl.import_item(
+                token, remote_id, enable=enable
+            )
+        except ProviderImportError as error:
+            # .user_message is the operator-display string we composed in
+            # the provider — using it (not str(error)) keeps the response
+            # free of exception state.
+            return Response({'success': False, 'error': error.user_message})
+        except requests.RequestException:
+            logger.warning(
+                '%s import_item failed for %s',
+                provider,
+                remote_id,
+                exc_info=True,
+            )
+            return Response(
+                {'success': False, 'error': _IMPORT_NETWORK_USER_MESSAGE},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(outcome.as_dict())

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -108,6 +108,22 @@ _IMPORT_NETWORK_USER_MESSAGE = (
 )
 
 
+def _import_error_body(message: str) -> dict[str, Any]:
+    """Uniform error body for the import-item endpoint.
+
+    Same keys as ``ImportOutcome.as_dict()`` plus ``error`` so every
+    response from the endpoint has one shape regardless of outcome —
+    easier for non-wizard clients and matches the declared schema.
+    """
+    return {
+        'success': False,
+        'asset_id': None,
+        'skipped': False,
+        'reason': None,
+        'error': message,
+    }
+
+
 # Bounded HTTP timeout for the Balena supervisor lookup below. Hit by
 # every poll on Balena devices, so it must stay well under the JS
 # poll cadence (2s) to keep request workers free. A real supervisor
@@ -1314,8 +1330,10 @@ class ImportItemViewV2(APIView):
         except ProviderImportError as error:
             # .user_message is the operator-display string we composed in
             # the provider — using it (not str(error)) keeps the response
-            # free of exception state.
-            return Response({'success': False, 'error': error.user_message})
+            # free of exception state. Keep the same key shape as the
+            # success path (ImportOutcome.as_dict) plus ``error`` so every
+            # response is uniform for non-wizard clients.
+            return Response(_import_error_body(error.user_message))
         except requests.RequestException:
             logger.warning(
                 '%s import_item failed for %s',
@@ -1324,8 +1342,8 @@ class ImportItemViewV2(APIView):
                 exc_info=True,
             )
             return Response(
-                {'success': False, 'error': _IMPORT_NETWORK_USER_MESSAGE},
+                _import_error_body(_IMPORT_NETWORK_USER_MESSAGE),
                 status=status.HTTP_502_BAD_GATEWAY,
             )
 
-        return Response(outcome.as_dict())
+        return Response({**outcome.as_dict(), 'error': None})

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -1312,8 +1312,10 @@ class ImportItemViewV2(APIView):
     def post(self, request: Request, provider: str) -> Response:
         provider_impl = get_provider(provider)
         if provider_impl is None:
+            # Keep the uniform shape (asset_id/skipped/reason/error) so a
+            # client can read the same keys on every response.
             return Response(
-                {'success': False, 'error': 'Unknown import provider.'},
+                _import_error_body('Unknown import provider.'),
                 status=status.HTTP_404_NOT_FOUND,
             )
 

--- a/src/anthias_server/app/management/commands/import_content.py
+++ b/src/anthias_server/app/management/commands/import_content.py
@@ -1,0 +1,116 @@
+"""Headless content import from a third-party signage provider.
+
+Drives the same import-provider registry the wizard and API use, so a
+support engineer can run a migration (or a dry-run manifest) over SSH
+without the browser:
+
+    manage.py import_content --provider yodeck --token '<label:secret>'
+    manage.py import_content --provider yodeck --token '…' --dry-run
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from django.core.management.base import (
+    BaseCommand,
+    CommandError,
+    CommandParser,
+)
+
+from anthias_server.lib.integrations.base import ProviderImportError
+from anthias_server.lib.integrations.registry import get_provider
+
+
+class Command(BaseCommand):
+    help = 'Import media from a third-party signage provider.'
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            '--provider',
+            required=True,
+            help='Provider key (e.g. "yodeck").',
+        )
+        parser.add_argument(
+            '--token',
+            required=True,
+            help="The provider's API token. Used only for this run.",
+        )
+        parser.add_argument(
+            '--workspace',
+            default=None,
+            help='Optional provider workspace/account id to scope the import.',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='List the media that would be imported without importing.',
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        provider = get_provider(options['provider'])
+        if provider is None:
+            raise CommandError(f'Unknown provider: {options["provider"]!r}')
+
+        token = options['token']
+        workspace = options['workspace']
+
+        try:
+            if not provider.validate_token(token):
+                raise CommandError('The provider rejected this API token.')
+            items = provider.list_media(token, workspace=workspace)
+        except requests.RequestException as error:
+            raise CommandError(f'Could not reach {provider.label}: {error}')
+
+        importable = [item for item in items if item.importable]
+        self.stdout.write(
+            f'{len(items)} media found in {provider.label}; '
+            f'{len(importable)} importable.'
+        )
+
+        if options['dry_run']:
+            for item in items:
+                mark = '✓' if item.importable else '–'
+                reason = f'  ({item.skip_reason})' if item.skip_reason else ''
+                self.stdout.write(
+                    f'  [{mark}] {item.media_type:8} {item.name}{reason}'
+                )
+            return
+
+        imported = skipped = failed = 0
+        for item in importable:
+            try:
+                outcome = provider.import_item(token, item.remote_id)
+            except ProviderImportError as error:
+                failed += 1
+                self.stderr.write(
+                    self.style.ERROR(f'  ✗ {item.name}: {error.user_message}')
+                )
+                continue
+            except requests.RequestException as error:
+                failed += 1
+                self.stderr.write(
+                    self.style.ERROR(f'  ✗ {item.name}: {error}')
+                )
+                continue
+
+            if outcome.skipped:
+                skipped += 1
+                self.stdout.write(f'  – {item.name}: {outcome.reason}')
+            elif outcome.success:
+                imported += 1
+                self.stdout.write(self.style.SUCCESS(f'  ✓ {item.name}'))
+            else:
+                failed += 1
+                self.stderr.write(
+                    self.style.ERROR(
+                        f'  ✗ {item.name}: {outcome.reason or "failed"}'
+                    )
+                )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Done. {imported} imported, {skipped} skipped, {failed} failed.'
+            )
+        )

--- a/src/anthias_server/app/management/commands/import_content.py
+++ b/src/anthias_server/app/management/commands/import_content.py
@@ -19,7 +19,11 @@ from django.core.management.base import (
     CommandParser,
 )
 
-from anthias_server.lib.integrations.base import ProviderImportError
+from anthias_server.lib.integrations.base import (
+    ImportProvider,
+    ProviderImportError,
+    RemoteMediaItem,
+)
 from anthias_server.lib.integrations.registry import get_provider
 
 
@@ -54,15 +58,7 @@ class Command(BaseCommand):
             raise CommandError(f'Unknown provider: {options["provider"]!r}')
 
         token = options['token']
-        workspace = options['workspace']
-
-        try:
-            if not provider.validate_token(token):
-                raise CommandError('The provider rejected this API token.')
-            items = provider.list_media(token, workspace=workspace)
-        except requests.RequestException as error:
-            raise CommandError(f'Could not reach {provider.label}: {error}')
-
+        items = self._fetch(provider, token, options['workspace'])
         importable = [item for item in items if item.importable]
         self.stdout.write(
             f'{len(items)} media found in {provider.label}; '
@@ -70,47 +66,60 @@ class Command(BaseCommand):
         )
 
         if options['dry_run']:
-            for item in items:
-                mark = '✓' if item.importable else '–'
-                reason = f'  ({item.skip_reason})' if item.skip_reason else ''
-                self.stdout.write(
-                    f'  [{mark}] {item.media_type:8} {item.name}{reason}'
-                )
+            self._print_manifest(items)
             return
 
         imported = skipped = failed = 0
         for item in importable:
-            try:
-                outcome = provider.import_item(token, item.remote_id)
-            except ProviderImportError as error:
-                failed += 1
-                self.stderr.write(
-                    self.style.ERROR(f'  ✗ {item.name}: {error.user_message}')
-                )
-                continue
-            except requests.RequestException as error:
-                failed += 1
-                self.stderr.write(
-                    self.style.ERROR(f'  ✗ {item.name}: {error}')
-                )
-                continue
-
-            if outcome.skipped:
-                skipped += 1
-                self.stdout.write(f'  – {item.name}: {outcome.reason}')
-            elif outcome.success:
-                imported += 1
-                self.stdout.write(self.style.SUCCESS(f'  ✓ {item.name}'))
-            else:
-                failed += 1
-                self.stderr.write(
-                    self.style.ERROR(
-                        f'  ✗ {item.name}: {outcome.reason or "failed"}'
-                    )
-                )
+            status = self._import_one(provider, token, item)
+            imported += status == 'imported'
+            skipped += status == 'skipped'
+            failed += status == 'failed'
 
         self.stdout.write(
             self.style.SUCCESS(
-                f'Done. {imported} imported, {skipped} skipped, {failed} failed.'
+                f'Done. {imported} imported, {skipped} skipped, '
+                f'{failed} failed.'
             )
         )
+
+    def _fetch(
+        self, provider: ImportProvider, token: str, workspace: str | None
+    ) -> list[RemoteMediaItem]:
+        try:
+            if not provider.validate_token(token):
+                raise CommandError('The provider rejected this API token.')
+            return provider.list_media(token, workspace=workspace)
+        except requests.RequestException as error:
+            raise CommandError(f'Could not reach {provider.label}: {error}')
+
+    def _print_manifest(self, items: list[RemoteMediaItem]) -> None:
+        for item in items:
+            mark = '✓' if item.importable else '–'
+            reason = f'  ({item.skip_reason})' if item.skip_reason else ''
+            self.stdout.write(
+                f'  [{mark}] {item.media_type:8} {item.name}{reason}'
+            )
+
+    def _import_one(
+        self, provider: ImportProvider, token: str, item: RemoteMediaItem
+    ) -> str:
+        """Import one item; return 'imported' | 'skipped' | 'failed'."""
+        try:
+            outcome = provider.import_item(token, item.remote_id)
+        except ProviderImportError as error:
+            return self._fail(item, error.user_message)
+        except requests.RequestException as error:
+            return self._fail(item, str(error))
+
+        if outcome.skipped:
+            self.stdout.write(f'  – {item.name}: {outcome.reason}')
+            return 'skipped'
+        if outcome.success:
+            self.stdout.write(self.style.SUCCESS(f'  ✓ {item.name}'))
+            return 'imported'
+        return self._fail(item, outcome.reason or 'failed')
+
+    def _fail(self, item: RemoteMediaItem, message: str) -> str:
+        self.stderr.write(self.style.ERROR(f'  ✗ {item.name}: {message}'))
+        return 'failed'

--- a/src/anthias_server/app/templates/import_content.html
+++ b/src/anthias_server/app/templates/import_content.html
@@ -1,0 +1,493 @@
+{% extends "_layout.html" %}
+{% load static %}
+
+{% block title %}{% if player_name %}{{ player_name }} · {% endif %}Import from {{ provider.label }}{% endblock %}
+
+{% block main %}
+<style>
+  /*
+    Native <progress> styled to match the surface, mirroring the
+    Migrate-to-Screenly wizard. The element (rather than a div with
+    role="progressbar") is used so the completion state is announced
+    consistently by assistive tech. Pseudoelement names are
+    vendor-prefixed and can't be set via inline styles, hence the rule
+    block.
+  */
+  .content-import-progress {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    display: block;
+    width: 100%;
+    height: 0.5rem;
+    border: none;
+    border-radius: 0.25rem;
+    overflow: hidden;
+    background: #e5e7eb;
+  }
+  .content-import-progress::-webkit-progress-bar {
+    background: #e5e7eb;
+    border-radius: 0.25rem;
+  }
+  .content-import-progress::-webkit-progress-value {
+    background: #2563eb;
+    border-radius: 0.25rem;
+    transition: width 0.2s linear;
+  }
+  .content-import-progress::-moz-progress-bar {
+    background: #2563eb;
+    border-radius: 0.25rem;
+  }
+</style>
+<div class="app-container" x-data="importContent()" x-init="init()">
+  {# Hidden form just for the CSRF token — the wizard does everything in JS. #}
+  <form style="display:none">{% csrf_token %}</form>
+
+  <div class="page-header-bar">
+    <div class="page-header-bar__title">
+      <h1 class="page-header">Import from {{ provider.label }}</h1>
+      <p class="page-header-bar__lede">
+        Copy media from a {{ provider.label }} account into this player. Existing assets are left alone.
+      </p>
+    </div>
+  </div>
+
+  {# ===== Step 1: Token paste + validate ===== #}
+  <section class="surface" x-show="step === 'token'" x-cloak>
+    <header class="surface__header">
+      <h2><i class="ti ti-key mr-2"></i>{{ provider.label }} API token</h2>
+    </header>
+    <div class="settings-stack">
+      <p class="muted-label m-0">{{ provider.token_help }}</p>
+      <div class="app-floating" style="position: relative;">
+        <input
+          :type="showToken ? 'text' : 'password'"
+          class="app-input"
+          id="import_token"
+          x-model="token"
+          @keydown.enter.prevent="validate()"
+          autocomplete="off"
+          placeholder=" "
+          style="padding-right: 3rem;"
+        >
+        <label for="import_token">API token</label>
+        <button
+          type="button"
+          class="app-btn-icon"
+          @click="showToken = !showToken"
+          :aria-label="showToken ? 'Hide token' : 'Show token'"
+          :aria-pressed="showToken"
+          style="position: absolute; right: 0.5rem; top: 50%; transform: translateY(-50%);"
+        >
+          <i class="ti" :class="showToken ? 'ti-eye-off' : 'ti-eye'"></i>
+        </button>
+      </div>
+      <div
+        x-show="tokenError"
+        x-cloak
+        class="text-red-600"
+        role="alert"
+        aria-live="assertive"
+      >
+        <i class="ti ti-alert-triangle"></i>
+        <span x-text="tokenError"></span>
+      </div>
+      <div class="flex justify-between">
+        <a href="{% url 'anthias_app:settings' %}" class="app-btn app-btn-link">
+          <i class="ti ti-arrow-left"></i><span>Back to Settings</span>
+        </a>
+        <button
+          type="button"
+          class="app-btn app-btn-primary"
+          :disabled="!token || validating"
+          @click="validate()"
+        >
+          <i class="ti" :class="validating ? 'ti-loader animate-spin' : 'ti-check'"></i>
+          <span x-text="validating ? 'Checking…' : 'Continue'"></span>
+        </button>
+      </div>
+    </div>
+  </section>
+
+  {# ===== Step 2: Media selection ===== #}
+  <section class="surface" x-show="step === 'select'" x-cloak>
+    <header class="surface__header">
+      <h2><i class="ti ti-list mr-2"></i>Choose media to import</h2>
+      <p class="muted-label m-0" x-show="items.length">
+        <span x-text="selectedCount()"></span> of <span x-text="importableCount()"></span> importable selected
+        <template x-if="skippedCount()">
+          <span>&middot; <span x-text="skippedCount()"></span> unsupported</span>
+        </template>
+      </p>
+    </header>
+
+    <div class="settings-stack" x-show="loadingItems" x-cloak>
+      <p class="muted-label"><i class="ti ti-loader animate-spin"></i> Loading media…</p>
+    </div>
+
+    <div
+      class="settings-stack"
+      x-show="!loadingItems && !items.length"
+      x-cloak
+    >
+      <div class="empty-state">
+        <div class="empty-state__icon"><i class="ti ti-photo-off"></i></div>
+        <p class="empty-state__title">No media to import</p>
+        <p class="empty-state__description">This {{ provider.label }} account has no media yet.</p>
+      </div>
+      <div class="flex justify-start">
+        <button type="button" class="app-btn app-btn-link" @click="step = 'token'">
+          <i class="ti ti-arrow-left"></i><span>Back</span>
+        </button>
+      </div>
+    </div>
+
+    <div x-show="!loadingItems && items.length" x-cloak>
+      <div class="settings-section__actions mb-3">
+        <button type="button" class="app-btn app-btn-link" @click="selectAll(true)">Select all</button>
+        <button type="button" class="app-btn app-btn-link" @click="selectAll(false)">Select none</button>
+      </div>
+
+      <label class="flex items-center mb-3" style="gap: 0.5rem;">
+        <input type="checkbox" x-model="enableImported">
+        <span>Enable imported assets so they play immediately</span>
+      </label>
+
+      <table class="asset-table">
+        <thead>
+          <tr>
+            <th scope="col" style="width: 3rem"></th>
+            <th scope="col">Name</th>
+            <th scope="col" style="width: 8rem">Type</th>
+            <th scope="col">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="item in items" :key="item.remote_id">
+            <tr :style="item.importable ? '' : 'opacity: 0.55;'">
+              <td>
+                <input
+                  type="checkbox"
+                  :id="`m-${item.remote_id}`"
+                  x-model="selected[item.remote_id]"
+                  :disabled="!item.importable"
+                >
+              </td>
+              <td>
+                <label :for="`m-${item.remote_id}`" x-text="item.name || item.remote_id"></label>
+              </td>
+              <td><span class="muted-label" x-text="item.media_type || '—'"></span></td>
+              <td>
+                <template x-if="item.importable">
+                  <span class="muted-label">Ready to import</span>
+                </template>
+                <template x-if="!item.importable">
+                  <span class="muted-label" x-text="item.skip_reason || 'Not supported'"></span>
+                </template>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+
+      <div class="flex justify-between mt-3">
+        <button type="button" class="app-btn app-btn-link" @click="step = 'token'">
+          <i class="ti ti-arrow-left"></i><span>Back</span>
+        </button>
+        <button
+          type="button"
+          class="app-btn app-btn-primary"
+          :disabled="!selectedCount()"
+          @click="startImport()"
+        >
+          <i class="ti ti-download"></i>
+          <span>Import <span x-text="selectedCount()"></span> item<span x-show="selectedCount() !== 1">s</span></span>
+        </button>
+      </div>
+    </div>
+  </section>
+
+  {# ===== Step 3 + 4: Progress and summary share the same surface ===== #}
+  <section class="surface" x-show="step === 'running' || step === 'done'" x-cloak>
+    <header class="surface__header">
+      <h2 x-show="step === 'running'"><i class="ti ti-download mr-2"></i>Importing…</h2>
+      <h2 x-show="step === 'done' && failureCount() === 0">
+        <i class="ti ti-circle-check mr-2" style="color:#16a34a"></i>Import complete
+      </h2>
+      <h2 x-show="step === 'done' && failureCount() > 0">
+        <i class="ti ti-alert-triangle mr-2" style="color:#d97706"></i>Import finished with errors
+      </h2>
+      <p class="muted-label m-0">
+        <span x-text="completedCount()"></span> of <span x-text="results.length"></span> done
+        &middot; <span x-text="successCount()"></span> imported
+        <template x-if="skippedResultCount()">
+          <span>&middot; <span x-text="skippedResultCount() + ' skipped'"></span></span>
+        </template>
+        <template x-if="failureCount()">
+          <span>&middot; <span class="text-red-600" x-text="failureCount() + ' failed'"></span></span>
+        </template>
+      </p>
+    </header>
+
+    <div class="settings-stack">
+      <progress
+        class="content-import-progress"
+        :value="progressPercent()"
+        max="100"
+      ></progress>
+
+      <table class="asset-table">
+        <thead>
+          <tr>
+            <th scope="col" style="width: 8rem">Status</th>
+            <th scope="col">Media</th>
+            <th scope="col">Detail</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="row in results" :key="row.remote_id">
+            <tr>
+              <td>
+                <template x-if="row.status === 'pending'">
+                  <span class="muted-label">Queued</span>
+                </template>
+                <template x-if="row.status === 'running'">
+                  <span><i class="ti ti-loader animate-spin"></i> Importing…</span>
+                </template>
+                <template x-if="row.status === 'success'">
+                  <span style="color:#16a34a"><i class="ti ti-check"></i> Imported</span>
+                </template>
+                <template x-if="row.status === 'skipped'">
+                  <span class="muted-label"><i class="ti ti-minus"></i> Skipped</span>
+                </template>
+                <template x-if="row.status === 'failed'">
+                  <span class="text-red-600"><i class="ti ti-x"></i> Failed</span>
+                </template>
+              </td>
+              <td x-text="row.name || row.remote_id"></td>
+              <td>
+                <template x-if="row.status === 'skipped'">
+                  <span class="muted-label" x-text="row.detail"></span>
+                </template>
+                <template x-if="row.status === 'failed'">
+                  <span class="text-red-600" x-text="row.detail"></span>
+                </template>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+
+      <div class="flex justify-end" x-show="step === 'done'" x-cloak>
+        <a href="{% url 'anthias_app:home' %}" class="app-btn app-btn-outline-dark mr-2">
+          <i class="ti ti-list"></i><span>View schedule</span>
+        </a>
+        <button
+          type="button"
+          class="app-btn app-btn-primary"
+          x-show="failureCount() > 0"
+          @click="retryFailed()"
+        >
+          <i class="ti ti-refresh"></i>
+          <span>Retry <span x-text="failureCount()"></span> failed</span>
+        </button>
+      </div>
+    </div>
+  </section>
+</div>
+
+<script>
+const CONTENT_IMPORT_PROVIDER = '{{ provider.key|escapejs }}'
+const CONTENT_IMPORT_ENDPOINTS = {
+  validate: `/api/v2/integrations/import/${CONTENT_IMPORT_PROVIDER}/validate`,
+  item: `/api/v2/integrations/import/${CONTENT_IMPORT_PROVIDER}/item`,
+}
+
+function contentImportCsrfToken() {
+  const el = document.querySelector('input[name=csrfmiddlewaretoken]')
+  if (el) return el.value
+  const m = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/)
+  return m ? decodeURIComponent(m[1]) : ''
+}
+
+async function contentImportPostJson(url, body) {
+  const response = await fetch(url, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': contentImportCsrfToken(),
+    },
+    body: JSON.stringify(body),
+  })
+  let payload = {}
+  try { payload = await response.json() } catch { /* empty body */ }
+  return { ok: response.ok, status: response.status, payload }
+}
+
+function importContent() {
+  const ENDPOINTS = CONTENT_IMPORT_ENDPOINTS
+  const postJson = contentImportPostJson
+
+  return {
+    step: 'token',
+    token: '',
+    showToken: false,
+    tokenError: '',
+    validating: false,
+    loadingItems: false,
+    items: [],
+    selected: {},
+    enableImported: true,
+    results: [],
+
+    init() {
+      // No-op; media is fetched on demand at the validate step.
+    },
+
+    async validate() {
+      // Re-entrancy guard: the button is disabled while validating, but
+      // @keydown.enter still fires. First call wins.
+      if (this.validating) return
+      this.tokenError = ''
+      const token = (this.token || '').trim()
+      if (!token) {
+        this.tokenError = 'Paste your {{ provider.label|escapejs }} API token first.'
+        return
+      }
+      this.token = token
+      this.validating = true
+      this.loadingItems = true
+      try {
+        const { ok, status, payload } = await postJson(ENDPOINTS.validate, { token })
+
+        if (status >= 500) {
+          this.tokenError = payload.error
+            || 'Anthias couldn\'t reach {{ provider.label|escapejs }}. Check the device\'s internet connection and try again.'
+          return
+        }
+        if (status === 400) {
+          this.tokenError = 'That token looks malformed. Double-check the value you pasted.'
+          return
+        }
+        if (status === 404) {
+          this.tokenError = 'This import provider is not available.'
+          return
+        }
+        if (!ok) {
+          this.tokenError = payload.error
+            || `Anthias returned HTTP ${status} from the validate endpoint.`
+          return
+        }
+        if (!payload.valid) {
+          this.tokenError = payload.error
+            || '{{ provider.label|escapejs }} rejected this token. Double-check it in your dashboard.'
+          return
+        }
+
+        this.items = Array.isArray(payload.items) ? payload.items : []
+        this.selected = {}
+        for (const item of this.items) {
+          // Pre-select importable items only; unsupported ones stay
+          // disabled so the operator can't queue a guaranteed skip.
+          this.selected[item.remote_id] = !!item.importable
+        }
+        this.step = 'select'
+      } catch (e) {
+        this.tokenError = String(e)
+      } finally {
+        this.validating = false
+        this.loadingItems = false
+      }
+    },
+
+    importableCount() {
+      return this.items.filter(i => i.importable).length
+    },
+    skippedCount() {
+      return this.items.filter(i => !i.importable).length
+    },
+    selectedCount() {
+      return this.items.filter(i => i.importable && this.selected[i.remote_id]).length
+    },
+
+    selectAll(value) {
+      for (const item of this.items) {
+        if (item.importable) this.selected[item.remote_id] = value
+      }
+    },
+
+    async startImport() {
+      const queue = this.items.filter(i => i.importable && this.selected[i.remote_id])
+      this.results = queue.map(i => ({
+        remote_id: i.remote_id,
+        name: i.name || i.remote_id,
+        status: 'pending',
+        detail: '',
+      }))
+      this.step = 'running'
+      await this.runQueue()
+      this.step = 'done'
+    },
+
+    async runQueue() {
+      // Sequential on purpose: importing downloads each file through the
+      // device, and N parallel downloads on a slow link would stall.
+      for (const row of this.results) {
+        if (row.status === 'success' || row.status === 'skipped') continue
+        row.status = 'running'
+        try {
+          const { ok, payload } = await postJson(ENDPOINTS.item, {
+            token: this.token,
+            remote_id: row.remote_id,
+            enable: this.enableImported,
+          })
+          if (payload.skipped) {
+            row.status = 'skipped'
+            row.detail = payload.reason || 'Skipped'
+          } else if (ok && payload.success) {
+            row.status = 'success'
+          } else {
+            row.status = 'failed'
+            row.detail = payload.error || payload.reason
+              || `HTTP error (${ok ? 'app-level' : 'transport'})`
+          }
+        } catch (e) {
+          row.status = 'failed'
+          row.detail = String(e)
+        }
+      }
+    },
+
+    async retryFailed() {
+      for (const row of this.results) {
+        if (row.status === 'failed') {
+          row.status = 'pending'
+          row.detail = ''
+        }
+      }
+      this.step = 'running'
+      await this.runQueue()
+      this.step = 'done'
+    },
+
+    completedCount() {
+      return this.results.filter(r => ['success', 'skipped', 'failed'].includes(r.status)).length
+    },
+    successCount() {
+      return this.results.filter(r => r.status === 'success').length
+    },
+    skippedResultCount() {
+      return this.results.filter(r => r.status === 'skipped').length
+    },
+    failureCount() {
+      return this.results.filter(r => r.status === 'failed').length
+    },
+    progressPercent() {
+      if (!this.results.length) return 0
+      return Math.round((this.completedCount() / this.results.length) * 100)
+    },
+  }
+}
+</script>
+{% endblock %}

--- a/src/anthias_server/app/templates/settings.html
+++ b/src/anthias_server/app/templates/settings.html
@@ -165,6 +165,36 @@
     </header>
   </section>
 
+  {% comment %}
+    Import content — one card per registered provider (Yodeck today;
+    ScreenCloud / OptiSign / NoviSign / PiSignage as they land). The list
+    comes from the import-provider registry via the settings view, so a
+    new provider appears here with no template edit.
+  {% endcomment %}
+  {% if import_providers %}
+  <section class="settings-section mt-4">
+    <header>
+      <div>
+        <h2>Import content</h2>
+        <p class="settings-section__lede">Bring media in from another digital signage platform.</p>
+      </div>
+    </header>
+    {% for provider in import_providers %}
+    <div class="settings-section__row">
+      <div>
+        <strong>{{ provider.label }}</strong>
+        <p class="settings-section__lede">{{ provider.description }}</p>
+      </div>
+      <div class="settings-section__actions">
+        <a href="{% url 'anthias_app:import_content' provider.key %}" class="app-btn app-btn-outline-dark">
+          <i class="ti ti-download"></i><span>Import from {{ provider.label }}</span>
+        </a>
+      </div>
+    </div>
+    {% endfor %}
+  </section>
+  {% endif %}
+
   {# ===== Backup & restore ===== #}
   <section class="settings-section mt-4">
     <header>

--- a/src/anthias_server/app/urls.py
+++ b/src/anthias_server/app/urls.py
@@ -40,6 +40,11 @@ urlpatterns = [
         name='migrate_to_screenly',
     ),
     path(
+        'settings/import/<str:provider>/',
+        views.import_content,
+        name='import_content',
+    ),
+    path(
         '_partials/asset-table/',
         views.assets_table_partial,
         name='assets_table',

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -14,6 +14,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth import login as django_login
 from django.http import (
     FileResponse,
+    Http404,
     HttpRequest,
     HttpResponse,
     StreamingHttpResponse,
@@ -171,6 +172,27 @@ def migrate_to_screenly(request: HttpRequest) -> HttpResponse:
         request,
         'migrate_to_screenly.html',
         {'active_nav': 'settings'},
+    )
+
+
+@authorized
+@require_http_methods(['GET'])
+def import_content(request: HttpRequest, provider: str) -> HttpResponse:
+    """Render the import wizard for a given provider.
+
+    Provider display copy (label, token help) comes from the registry so
+    the same template serves every provider — Yodeck today, ScreenCloud
+    / OptiSign / NoviSign as they land. An unknown key 404s.
+    """
+    from anthias_server.lib.integrations.registry import get_provider_meta
+
+    meta = get_provider_meta(provider)
+    if meta is None:
+        raise Http404('Unknown import provider.')
+    return template(
+        request,
+        'import_content.html',
+        {'active_nav': 'settings', 'provider': meta},
     )
 
 
@@ -1551,8 +1573,13 @@ def review_cta_snooze(request: HttpRequest) -> HttpResponse:
 @authorized
 @require_http_methods(['GET'])
 def settings_view(request: HttpRequest) -> HttpResponse:
+    from anthias_server.lib.integrations.registry import list_provider_meta
+
     context = page_context.device_settings()
     context['active_nav'] = 'settings'
+    # Data-driven so a newly registered provider appears in Settings with
+    # no template edit.
+    context['import_providers'] = list_provider_meta()
     return template(request, 'settings.html', context)
 
 

--- a/src/anthias_server/lib/integrations/__init__.py
+++ b/src/anthias_server/lib/integrations/__init__.py
@@ -1,0 +1,17 @@
+"""Inbound content-import providers.
+
+The mirror image of ``lib.screenly_migration`` (which pushes Anthias
+assets *out* to Screenly): these providers pull media *in* from a
+third-party signage platform and recreate each item as an Anthias
+``Asset``.
+
+Every provider implements the transport-agnostic ``ImportProvider``
+interface (``base.py``) and is registered in ``registry.py``. The API
+views, the settings wizard and the ``import_content`` management command
+all speak only that interface + the neutral ``RemoteMediaItem`` /
+``ImportOutcome`` dataclasses, so adding a provider (ScreenCloud,
+OptiSign, NoviSign, PiSignage, …) is a new module plus one registry
+entry — no change to the endpoints, UI, or CLI. Providers may be REST
+*or* GraphQL backed; nothing outside a provider module assumes a
+transport.
+"""

--- a/src/anthias_server/lib/integrations/base.py
+++ b/src/anthias_server/lib/integrations/base.py
@@ -1,0 +1,139 @@
+"""Provider-neutral contract for inbound content import.
+
+An ``ImportProvider`` knows how to talk to one third-party signage
+platform's API. The three methods are the whole surface the rest of
+Anthias depends on:
+
+* ``validate_token``  — is this API token accepted?
+* ``list_media``      — what's importable, and what has to be skipped?
+* ``import_item``     — pull one item in and create the Anthias ``Asset``.
+
+Errors follow the same split as ``lib.screenly_migration``:
+``validate_token`` / ``list_media`` let ``requests.RequestException``
+(or a provider's transport equivalent) propagate so the view can answer
+502; ``import_item`` raises :class:`ProviderImportError` for per-item
+failures the wizard shows in its error column, and lets transport
+errors bubble.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ProviderImportError(Exception):
+    """A per-item import failure with an operator-facing message.
+
+    Mirrors ``ScreenlyMigrationError``: the message is written for
+    display in the wizard's per-item error column, so keep it short and
+    concrete ("Yodeck download failed (404)"). ``user_message`` lets the
+    view echo it into API responses without going through ``str(exc)`` —
+    that keeps CodeQL's information-exposure rule quiet, since the
+    attribute traces to a string we composed, not to exception/stack
+    state.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.user_message: str = message
+
+
+@dataclass
+class RemoteMediaItem:
+    """One media item on the remote platform, before import.
+
+    ``importable`` is False for media Anthias has no viewer path for
+    (audio, documents); ``skip_reason`` then carries the operator-facing
+    explanation. ``raw`` keeps the provider's original payload so a later
+    ``import_item`` needn't re-fetch the list row.
+    """
+
+    remote_id: str
+    name: str
+    media_type: str
+    importable: bool
+    skip_reason: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        # ``raw`` is intentionally omitted — it can carry provider
+        # internals (and, for URL-ingested media, source URLs) that the
+        # browser has no need to see.
+        return {
+            'remote_id': self.remote_id,
+            'name': self.name,
+            'media_type': self.media_type,
+            'importable': self.importable,
+            'skip_reason': self.skip_reason,
+        }
+
+
+@dataclass
+class ImportOutcome:
+    """Result of importing a single item.
+
+    ``skipped`` distinguishes "deliberately not imported" (unsupported
+    type, already imported) from a hard failure — the wizard and CLI
+    tally the two separately. A skip is reported with ``success=False``
+    unless it's an idempotent re-run of an item Anthias already holds,
+    in which case ``success=True`` + ``asset_id`` point at the existing
+    row.
+    """
+
+    success: bool
+    asset_id: str | None = None
+    skipped: bool = False
+    reason: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            'success': self.success,
+            'asset_id': self.asset_id,
+            'skipped': self.skipped,
+            'reason': self.reason,
+        }
+
+
+class ImportProvider(ABC):
+    """Base class every import provider implements.
+
+    The class attributes drive the settings page and wizard copy so the
+    UI stays data-driven — a new provider appears in Settings by virtue
+    of being registered, with no template edit.
+    """
+
+    #: URL-safe identifier used in routes (``/settings/import/<key>/``)
+    #: and the registry. Lowercase, no spaces.
+    key: str = ''
+    #: Display name shown in the UI ("Yodeck").
+    label: str = ''
+    #: One-line description for the settings card.
+    description: str = ''
+    #: Guidance shown next to the token field in the wizard.
+    token_help: str = ''
+
+    @abstractmethod
+    def validate_token(self, token: str) -> bool:
+        """Return True if the token is accepted, False if rejected.
+
+        Transport errors (network down, 5xx) propagate to the caller so
+        "your token is bad" stays distinct from "the platform is down".
+        """
+
+    @abstractmethod
+    def list_media(
+        self, token: str, *, workspace: str | None = None
+    ) -> list[RemoteMediaItem]:
+        """Enumerate the account's media as ``RemoteMediaItem`` rows."""
+
+    @abstractmethod
+    def import_item(
+        self, token: str, remote_id: str, *, enable: bool = True
+    ) -> ImportOutcome:
+        """Import one item and create the Anthias ``Asset``.
+
+        Raises :class:`ProviderImportError` for per-item failures;
+        transport errors propagate.
+        """

--- a/src/anthias_server/lib/integrations/registry.py
+++ b/src/anthias_server/lib/integrations/registry.py
@@ -1,0 +1,45 @@
+"""Registry of available import providers.
+
+Adding a provider is a two-line change here (import it, add an instance
+to ``_PROVIDERS``); the API views, settings page and CLI discover it
+through :func:`get_provider` / :func:`list_provider_meta` without any
+further edits.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ImportProvider
+from .yodeck import YodeckProvider
+
+# Providers are stateless (their HTTP session is module-level), so a
+# single shared instance each is fine.
+_PROVIDERS: dict[str, ImportProvider] = {
+    provider.key: provider for provider in (YodeckProvider(),)
+}
+
+
+def get_provider(key: str) -> ImportProvider | None:
+    """Return the provider registered under ``key``, or None."""
+    return _PROVIDERS.get(key)
+
+
+def _meta(provider: ImportProvider) -> dict[str, Any]:
+    return {
+        'key': provider.key,
+        'label': provider.label,
+        'description': provider.description,
+        'token_help': provider.token_help,
+    }
+
+
+def get_provider_meta(key: str) -> dict[str, Any] | None:
+    """Return display metadata for ``key`` (for the wizard), or None."""
+    provider = _PROVIDERS.get(key)
+    return _meta(provider) if provider is not None else None
+
+
+def list_provider_meta() -> list[dict[str, Any]]:
+    """Return display metadata for every provider (for the settings page)."""
+    return [_meta(provider) for provider in _PROVIDERS.values()]

--- a/src/anthias_server/lib/integrations/yodeck.py
+++ b/src/anthias_server/lib/integrations/yodeck.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterator
@@ -108,9 +109,20 @@ def _auth_headers(token: str) -> dict[str, str]:
 
 
 def _first_http_url(candidates: Iterator[Any] | list[Any]) -> str | None:
-    """Return the first candidate that is a real http(s) URL."""
+    """Return the first candidate that is a real http(s) URL.
+
+    ``validate_url`` also accepts streaming schemes (rtsp/rtmp/…); this
+    helper feeds webpage URIs and ``requests.get`` downloads, so it is
+    restricted to http(s) to avoid picking a stream endpoint out of the
+    argument bag or handing an rtsp URL to ``requests``.
+    """
     for value in candidates:
-        if isinstance(value, str) and value and validate_url(value):
+        if not isinstance(value, str) or not value:
+            continue
+        if validate_url(value) and urlparse(value).scheme in (
+            'http',
+            'https',
+        ):
             return value
     return None
 
@@ -144,22 +156,33 @@ def _is_internal_yodeck_url(url: str) -> bool:
     return host == 'yodeck.com' or host.endswith('.yodeck.com')
 
 
+def _sanitise_ext(raw: str) -> str:
+    """Reduce a candidate extension to a safe ``.<alnum>`` token.
+
+    The value comes from a third-party API (Yodeck's ``file_extension``)
+    or a URL path, so it is stripped to alphanumerics and capped —
+    otherwise ``"/../../etc/passwd"`` could escape the asset directory
+    when the staged filename is built.
+    """
+    cleaned = re.sub(r'[^A-Za-z0-9]', '', (raw or '').strip().lstrip('.'))
+    cleaned = cleaned[:16]
+    return f'.{cleaned}' if cleaned else ''
+
+
 def _file_ext(detail: dict[str, Any], url: str) -> str:
     """Best on-disk extension for a downloaded original.
 
     Prefers Yodeck's ``file_extension`` field ("mp4"), falls back to the
     extension on the download URL's path, and finally to no extension.
-    The leading dot is normalised so ``CreateAssetSerializerV2`` renames
-    the file to ``<asset_id>.mp4`` and ffprobe can identify the
-    container.
+    Both sources are sanitised (see ``_sanitise_ext``) so
+    ``CreateAssetSerializerV2`` renames the file to a safe
+    ``<asset_id>.mp4`` and ffprobe can identify the container.
     """
-    raw = (detail.get('file_extension') or '').strip().lstrip('.')
-    if raw:
-        return f'.{raw}'
-    _stem, ext = os.path.splitext(url.split('?', 1)[0])
-    if ext and len(ext) <= 8:
+    ext = _sanitise_ext(detail.get('file_extension') or '')
+    if ext:
         return ext
-    return ''
+    _stem, url_ext = os.path.splitext(url.split('?', 1)[0])
+    return _sanitise_ext(url_ext)
 
 
 def _parse_dt(value: Any) -> datetime | None:

--- a/src/anthias_server/lib/integrations/yodeck.py
+++ b/src/anthias_server/lib/integrations/yodeck.py
@@ -132,6 +132,18 @@ def _file_url(detail: dict[str, Any]) -> str | None:
     return _first_http_url([*top, *inner])
 
 
+def _is_internal_yodeck_url(url: str) -> bool:
+    """True when a webpage URL points back at Yodeck-hosted content.
+
+    Yodeck apps/widgets (weather, RSS, dashboards) surface as webpage
+    media whose URL is rendered inside Yodeck. Those only work within
+    Yodeck, so they're filtered out of the import rather than recreated
+    as broken webpage assets.
+    """
+    host = urlparse(url).netloc.lower()
+    return host == 'yodeck.com' or host.endswith('.yodeck.com')
+
+
 def _file_ext(detail: dict[str, Any], url: str) -> str:
     """Best on-disk extension for a downloaded original.
 
@@ -364,6 +376,19 @@ class YodeckProvider(ImportProvider):
                     success=False,
                     skipped=True,
                     reason='Could not determine the web page URL from Yodeck.',
+                )
+            if _is_internal_yodeck_url(url):
+                # A "webpage" that resolves to Yodeck-hosted content is an
+                # internally-rendered app/widget (weather, RSS, dashboards,
+                # …). Its URL only works inside Yodeck, so importing it
+                # would create a broken asset — skip with a clear reason.
+                return ImportOutcome(
+                    success=False,
+                    skipped=True,
+                    reason=(
+                        'This is internally-hosted Yodeck content (an app '
+                        'or widget) and cannot be imported.'
+                    ),
                 )
             asset = self._create_via_serializer(
                 uri=url,

--- a/src/anthias_server/lib/integrations/yodeck.py
+++ b/src/anthias_server/lib/integrations/yodeck.py
@@ -23,6 +23,7 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterator
+from urllib.parse import urlparse
 
 import requests
 
@@ -42,6 +43,11 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 YODECK_API_BASE = 'https://app.yodeck.com/api/v2'
+# Host the API token is scoped to. Original-file URLs are frequently
+# pre-signed CDN links on a different host; sending the Yodeck token to
+# those would leak the credential and can break the signed request, so
+# auth is attached only when downloading from Yodeck itself.
+_YODECK_HOST = urlparse(YODECK_API_BASE).netloc.lower()
 PROVIDER_KEY = 'yodeck'
 
 # Anthias renders images, videos and web pages. Yodeck audio/document
@@ -309,8 +315,8 @@ class YodeckProvider(ImportProvider):
             for item in results:
                 if isinstance(item, dict):
                     yield item
-            # Stop when the page was short or the API reports no ``next``
-            # cursor — either signals the last page.
+            # Stop when the page came back empty or the API reports no
+            # ``next`` cursor — either signals the last page.
             if not results or not body.get('next'):
                 break
             offset += len(results)
@@ -445,10 +451,17 @@ class YodeckProvider(ImportProvider):
         assetdir = settings['assetdir']
         staged = os.path.join(assetdir, f'.import-{uuid.uuid4().hex}{ext}')
         part = f'{staged}.part'
+        # Only attach the Yodeck token when the download stays on the
+        # Yodeck host — never forward it to a pre-signed CDN original.
+        download_headers = (
+            _auth_headers(token)
+            if urlparse(url).netloc.lower() == _YODECK_HOST
+            else {}
+        )
         try:
             with _session.get(
                 url,
-                headers=_auth_headers(token),
+                headers=download_headers,
                 stream=True,
                 timeout=_DOWNLOAD_TIMEOUT_S,
             ) as response:

--- a/src/anthias_server/lib/integrations/yodeck.py
+++ b/src/anthias_server/lib/integrations/yodeck.py
@@ -1,0 +1,514 @@
+"""Yodeck import provider (REST, ``https://app.yodeck.com/api/v2``).
+
+Pulls media out of a Yodeck account and recreates each item as an
+Anthias ``Asset``:
+
+* ``webpage`` → a webpage asset whose ``uri`` is the destination URL.
+* ``image`` / ``video`` → the original file is downloaded into the asset
+  directory and handed to ``CreateAssetSerializerV2`` exactly like a
+  local upload, so it flows through the same rename + normalise +
+  duration-probe pipeline the web UI and API already use.
+* ``audio`` / ``document`` → surfaced as skipped-with-reason (Anthias has
+  no viewer path for either).
+
+Re-imports are idempotent: each created asset is stamped with its Yodeck
+id in ``Asset.metadata['import_source']`` and a second run of the same
+item returns the existing asset instead of duplicating it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterator
+
+import requests
+
+from anthias_common.utils import validate_url
+from anthias_server.api.helpers import AssetCreationError, persist_new_asset
+from anthias_server.api.serializers.v2 import CreateAssetSerializerV2
+from anthias_server.app.models import Asset
+from anthias_server.settings import settings
+
+from .base import (
+    ImportOutcome,
+    ImportProvider,
+    ProviderImportError,
+    RemoteMediaItem,
+)
+
+logger = logging.getLogger(__name__)
+
+YODECK_API_BASE = 'https://app.yodeck.com/api/v2'
+PROVIDER_KEY = 'yodeck'
+
+# Anthias renders images, videos and web pages. Yodeck audio/document
+# media have no viewer path, so they're surfaced as skipped-with-reason
+# rather than half-imported.
+_IMPORTABLE_TYPES = ('image', 'video', 'webpage')
+_UNSUPPORTED_TYPES = ('audio', 'document')
+_ALL_TYPES = _IMPORTABLE_TYPES + _UNSUPPORTED_TYPES
+
+# Same 5 GiB ceiling the Celery remote-video downloader enforces
+# (``celery_tasks.REMOTE_VIDEO_MAX_BYTES``). Duplicated as a literal
+# rather than imported so this request-path module doesn't pull in the
+# whole Celery app.
+_MAX_DOWNLOAD_BYTES = 5 * 1024**3
+_DOWNLOAD_CHUNK = 1024 * 1024
+
+_LIST_PAGE_SIZE = 100
+_VALIDATE_TIMEOUT_S = 10.0
+_LIST_TIMEOUT_S = 30.0
+_DOWNLOAD_TIMEOUT_S = 120.0
+
+# Candidate fields that may carry a downloadable ORIGINAL file URL for an
+# image/video, in priority order — first at the top level, then inside
+# ``arguments``. Yodeck's media detail schema is documented behind a
+# login; these cover the observed shape (``arguments.download_from_url``
+# for URL-ingested media) plus the common alternatives. This is the one
+# lookup that decides whether a directly-uploaded (``source: local``)
+# original can be pulled; if none resolves, the item is skipped with a
+# clear reason rather than guessed at.
+_FILE_URL_KEYS = ('file', 'media_file', 'source_url', 'original_url', 'url')
+_ARGUMENT_FILE_KEYS = ('download_from_url', 'source_url', 'file', 'url')
+
+# Candidate fields carrying a webpage's destination URL (top level, then
+# inside ``arguments``).
+_WEBPAGE_URL_KEYS = ('url', 'website_url', 'source_url', 'link', 'address')
+
+# Deliberately NOT ``AnthiasSession``: these calls hit a third-party
+# vendor's API during a migration away from them, and a self-identifying
+# ``Anthias/<version>`` User-Agent invites vendor-side blocking. A
+# neutral browser-like UA lets import traffic look like an ordinary API
+# client. (Same blend-in rationale as the anti-bot probe in
+# ``anthias_common.utils.url_fails``.)
+_IMPORT_USER_AGENT = (
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+)
+_session = requests.Session()
+_session.headers['User-Agent'] = _IMPORT_USER_AGENT
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    # Yodeck API tokens are issued as "<label>:<secret>" and passed in
+    # the Authorization header. "Token <value>" is the DRF-style scheme
+    # Yodeck's stack uses; a wrong scheme surfaces immediately via
+    # validate_token() as an invalid token rather than a silent 401 mid
+    # import.
+    return {'Authorization': f'Token {token}'}
+
+
+def _first_http_url(candidates: Iterator[Any] | list[Any]) -> str | None:
+    """Return the first candidate that is a real http(s) URL."""
+    for value in candidates:
+        if isinstance(value, str) and value and validate_url(value):
+            return value
+    return None
+
+
+def _webpage_url(detail: dict[str, Any]) -> str | None:
+    arguments = detail.get('arguments') or {}
+    top = (detail.get(k) for k in _WEBPAGE_URL_KEYS)
+    inner = (arguments.get(k) for k in _WEBPAGE_URL_KEYS)
+    # Fall back to any http(s) value anywhere in ``arguments`` — Yodeck
+    # webpage media keep the destination URL there under a key we may not
+    # have enumerated above.
+    inner_any = (v for v in arguments.values())
+    return _first_http_url([*top, *inner, *inner_any])
+
+
+def _file_url(detail: dict[str, Any]) -> str | None:
+    arguments = detail.get('arguments') or {}
+    top = (detail.get(k) for k in _FILE_URL_KEYS)
+    inner = (arguments.get(k) for k in _ARGUMENT_FILE_KEYS)
+    return _first_http_url([*top, *inner])
+
+
+def _file_ext(detail: dict[str, Any], url: str) -> str:
+    """Best on-disk extension for a downloaded original.
+
+    Prefers Yodeck's ``file_extension`` field ("mp4"), falls back to the
+    extension on the download URL's path, and finally to no extension.
+    The leading dot is normalised so ``CreateAssetSerializerV2`` renames
+    the file to ``<asset_id>.mp4`` and ffprobe can identify the
+    container.
+    """
+    raw = (detail.get('file_extension') or '').strip().lstrip('.')
+    if raw:
+        return f'.{raw}'
+    _stem, ext = os.path.splitext(url.split('?', 1)[0])
+    if ext and len(ext) <= 8:
+        return ext
+    return ''
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _availability_window(detail: dict[str, Any]) -> tuple[datetime, datetime]:
+    """Map Yodeck's availability schedule onto Anthias start/end dates.
+
+    When the schedule is enabled and carries both bounds we honour them;
+    otherwise the asset is always-on, modelled as "now → +10 years" (the
+    same wide window the schedule UI treats as unbounded).
+    """
+    now = datetime.now(timezone.utc)
+    far_future = now + timedelta(days=3650)
+    schedule = detail.get('availability_schedule') or {}
+    if schedule.get('enable'):
+        start = _parse_dt(schedule.get('available_after')) or now
+        end = _parse_dt(schedule.get('available_before')) or far_future
+        if end > start:
+            return start, end
+    return now, far_future
+
+
+def _default_duration(detail: dict[str, Any]) -> int:
+    raw = detail.get('default_duration')
+    try:
+        duration = int(raw)
+    except (TypeError, ValueError):
+        duration = 0
+    if duration > 0:
+        return duration
+    return int(settings['default_duration'])
+
+
+def _stringify_errors(errors: Any) -> str:
+    """Collapse a serializer error bag into one operator-facing line."""
+    if isinstance(errors, str):
+        return errors
+    if isinstance(errors, dict):
+        for value in errors.values():
+            if isinstance(value, (list, tuple)) and value:
+                return str(value[0])
+            if value:
+                return str(value)
+    if isinstance(errors, (list, tuple)) and errors:
+        return str(errors[0])
+    return 'Anthias rejected the imported asset.'
+
+
+def _safe_unlink(path: str | None) -> None:
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _find_imported_asset(remote_id: str) -> Asset | None:
+    return Asset.objects.filter(
+        metadata__import_source__provider=PROVIDER_KEY,
+        metadata__import_source__remote_id=str(remote_id),
+    ).first()
+
+
+def _stamp_import_source(asset: Asset, remote_id: str) -> None:
+    metadata = dict(asset.metadata or {})
+    metadata['import_source'] = {
+        'provider': PROVIDER_KEY,
+        'remote_id': str(remote_id),
+    }
+    asset.metadata = metadata
+    asset.save(update_fields=['metadata'])
+
+
+class YodeckProvider(ImportProvider):
+    key = PROVIDER_KEY
+    label = 'Yodeck'
+    description = (
+        'Copy images, videos and web pages from a Yodeck account into '
+        'this player using a Yodeck API token.'
+    )
+    token_help = (
+        'Create an API token in Yodeck under Account Settings → Advanced '
+        'Settings → API Tokens, then paste it here. It is used only for '
+        'this import and is never stored.'
+    )
+
+    # -- token / listing ---------------------------------------------------
+
+    def validate_token(self, token: str) -> bool:
+        response = _session.get(
+            f'{YODECK_API_BASE}/media/',
+            headers=_auth_headers(token),
+            params={'limit': 1},
+            timeout=_VALIDATE_TIMEOUT_S,
+        )
+        if response.status_code == 200:
+            return True
+        if response.status_code in (401, 403):
+            return False
+        response.raise_for_status()
+        return False
+
+    def list_media(
+        self, token: str, *, workspace: str | None = None
+    ) -> list[RemoteMediaItem]:
+        # List each media_type with its filter rather than one mixed
+        # page: it lets us tag every row with a known type without
+        # depending on the exact field name Yodeck uses for type inside a
+        # list row (only ``id`` + ``name`` are read there).
+        items: list[RemoteMediaItem] = []
+        for media_type in _ALL_TYPES:
+            importable = media_type in _IMPORTABLE_TYPES
+            skip_reason = None
+            if not importable:
+                skip_reason = (
+                    f"{media_type.capitalize()} media isn't supported by "
+                    'Anthias and was skipped.'
+                )
+            for obj in self._paginate(token, media_type, workspace):
+                remote_id = obj.get('id')
+                if remote_id is None:
+                    continue
+                items.append(
+                    RemoteMediaItem(
+                        remote_id=str(remote_id),
+                        name=(obj.get('name') or f'Yodeck media {remote_id}'),
+                        media_type=media_type,
+                        importable=importable,
+                        skip_reason=skip_reason,
+                        raw=obj,
+                    )
+                )
+        return items
+
+    def _paginate(
+        self, token: str, media_type: str, workspace: str | None
+    ) -> Iterator[dict[str, Any]]:
+        offset = 0
+        params: dict[str, Any] = {
+            'media_type': media_type,
+            'limit': _LIST_PAGE_SIZE,
+        }
+        if workspace:
+            params['workspace'] = workspace
+        while True:
+            response = _session.get(
+                f'{YODECK_API_BASE}/media/',
+                headers=_auth_headers(token),
+                params={**params, 'offset': offset},
+                timeout=_LIST_TIMEOUT_S,
+            )
+            response.raise_for_status()
+            body = response.json()
+            results = body.get('results') or []
+            for item in results:
+                if isinstance(item, dict):
+                    yield item
+            # Stop when the page was short or the API reports no ``next``
+            # cursor — either signals the last page.
+            if not results or not body.get('next'):
+                break
+            offset += len(results)
+
+    # -- import ------------------------------------------------------------
+
+    def import_item(
+        self, token: str, remote_id: str, *, enable: bool = True
+    ) -> ImportOutcome:
+        existing = _find_imported_asset(remote_id)
+        if existing is not None:
+            return ImportOutcome(
+                success=True,
+                asset_id=existing.asset_id,
+                skipped=True,
+                reason='Already imported.',
+            )
+
+        detail = self._get_detail(token, remote_id)
+        media_type = (detail.get('media_origin') or {}).get('type')
+
+        if media_type in _UNSUPPORTED_TYPES:
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason=(
+                    f"{str(media_type).capitalize()} media isn't supported "
+                    'by Anthias.'
+                ),
+            )
+        if media_type not in _IMPORTABLE_TYPES:
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason=f'Unsupported media type: {media_type or "unknown"}.',
+            )
+
+        name = (detail.get('name') or f'Yodeck media {remote_id}').strip()
+        start_date, end_date = _availability_window(detail)
+
+        if media_type == 'webpage':
+            url = _webpage_url(detail)
+            if not url:
+                return ImportOutcome(
+                    success=False,
+                    skipped=True,
+                    reason='Could not determine the web page URL from Yodeck.',
+                )
+            asset = self._create_via_serializer(
+                uri=url,
+                ext=None,
+                mimetype='webpage',
+                name=name,
+                start_date=start_date,
+                end_date=end_date,
+                duration=_default_duration(detail),
+                enable=enable,
+            )
+        else:
+            asset = self._import_file(
+                token, detail, media_type, name, start_date, end_date, enable
+            )
+            if asset is None:
+                return ImportOutcome(
+                    success=False,
+                    skipped=True,
+                    reason=(
+                        f"Yodeck didn't expose a downloadable original for "
+                        f'this {media_type}; re-upload it manually.'
+                    ),
+                )
+
+        _stamp_import_source(asset, remote_id)
+        return ImportOutcome(success=True, asset_id=asset.asset_id)
+
+    def _get_detail(self, token: str, remote_id: str) -> dict[str, Any]:
+        response = _session.get(
+            f'{YODECK_API_BASE}/media/{remote_id}/',
+            headers=_auth_headers(token),
+            timeout=_LIST_TIMEOUT_S,
+        )
+        if response.status_code == 404:
+            raise ProviderImportError('Media no longer exists in Yodeck.')
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict):
+            raise ProviderImportError('Unexpected response from Yodeck.')
+        return body
+
+    def _import_file(
+        self,
+        token: str,
+        detail: dict[str, Any],
+        media_type: str,
+        name: str,
+        start_date: datetime,
+        end_date: datetime,
+        enable: bool,
+    ) -> Asset | None:
+        url = _file_url(detail)
+        if not url:
+            return None
+        staged_path, ext = self._download_to_assetdir(token, url, detail)
+        try:
+            return self._create_via_serializer(
+                uri=staged_path,
+                ext=ext,
+                mimetype=media_type,
+                name=name,
+                start_date=start_date,
+                end_date=end_date,
+                # Video duration is probed server-side (the serializer
+                # requires 0 on input); images carry Yodeck's duration.
+                duration=0
+                if media_type == 'video'
+                else _default_duration(detail),
+                enable=enable,
+            )
+        except Exception:
+            # ``prepare_asset`` renames the staged file into place only
+            # once validation passes, so on failure it's still at
+            # ``staged_path`` — remove it rather than leaving an orphan
+            # for the hourly cleanup sweep.
+            _safe_unlink(staged_path)
+            raise
+
+    def _download_to_assetdir(
+        self, token: str, url: str, detail: dict[str, Any]
+    ) -> tuple[str, str]:
+        ext = _file_ext(detail, url)
+        assetdir = settings['assetdir']
+        staged = os.path.join(assetdir, f'.import-{uuid.uuid4().hex}{ext}')
+        part = f'{staged}.part'
+        try:
+            with _session.get(
+                url,
+                headers=_auth_headers(token),
+                stream=True,
+                timeout=_DOWNLOAD_TIMEOUT_S,
+            ) as response:
+                if not response.ok:
+                    raise ProviderImportError(
+                        f'Yodeck download failed ({response.status_code}).'
+                    )
+                written = 0
+                with open(part, 'wb') as handle:
+                    for chunk in response.iter_content(_DOWNLOAD_CHUNK):
+                        if not chunk:
+                            continue
+                        written += len(chunk)
+                        if written > _MAX_DOWNLOAD_BYTES:
+                            raise ProviderImportError(
+                                'File exceeds the 5 GiB import size limit.'
+                            )
+                        handle.write(chunk)
+            if written == 0:
+                raise ProviderImportError('Yodeck returned an empty file.')
+            # Atomic move into the final staged name only once the whole
+            # body landed, so a truncated download can't be handed to the
+            # serializer.
+            os.replace(part, staged)
+            return staged, ext
+        except Exception:
+            _safe_unlink(part)
+            _safe_unlink(staged)
+            raise
+
+    def _create_via_serializer(
+        self,
+        *,
+        uri: str,
+        ext: str | None,
+        mimetype: str,
+        name: str,
+        start_date: datetime,
+        end_date: datetime,
+        duration: int,
+        enable: bool,
+    ) -> Asset:
+        data: dict[str, Any] = {
+            'name': name,
+            'uri': uri,
+            'mimetype': mimetype,
+            'start_date': start_date,
+            'end_date': end_date,
+            'duration': duration,
+            'is_enabled': enable,
+        }
+        if ext:
+            data['ext'] = ext
+        serializer = CreateAssetSerializerV2(data=data, unique_name=True)
+        # ``prepare_asset`` raises ``AssetCreationError`` (not a DRF
+        # ValidationError) for reachability / duration failures, which
+        # ``is_valid()`` does not catch — hence the explicit guard,
+        # matching ``AssetListViewV2.post``.
+        try:
+            valid = serializer.is_valid()
+        except AssetCreationError as error:
+            raise ProviderImportError(_stringify_errors(error.errors))
+        if not valid:
+            raise ProviderImportError(_stringify_errors(serializer.errors))
+        return persist_new_asset(serializer)

--- a/src/anthias_server/lib/integrations/yodeck.py
+++ b/src/anthias_server/lib/integrations/yodeck.py
@@ -72,11 +72,12 @@ _DOWNLOAD_TIMEOUT_S = 120.0
 
 # Candidate fields that may carry a downloadable ORIGINAL file URL for an
 # image/video, in priority order — first at the top level, then inside
-# ``arguments``. Yodeck's media detail schema is documented behind a
-# login; these cover the observed shape (``arguments.download_from_url``
-# for URL-ingested media) plus the common alternatives. This is the one
-# lookup that decides whether a directly-uploaded (``source: local``)
-# original can be pulled; if none resolves, the item is skipped with a
+# ``arguments``. ``arguments.download_from_url`` is Yodeck's download link
+# for the original and is present for uploaded (``source: local``) media
+# too — it points at Yodeck (app.yodeck.com) and 302-redirects to a signed
+# S3 URL, so the token is attached for the Yodeck host and dropped by
+# ``requests`` on the cross-host redirect. The extra keys cover forward-
+# compatible alternatives; if none resolves, the item is skipped with a
 # clear reason rather than guessed at.
 _FILE_URL_KEYS = ('file', 'media_file', 'source_url', 'original_url', 'url')
 _ARGUMENT_FILE_KEYS = ('download_from_url', 'source_url', 'file', 'url')
@@ -275,8 +276,10 @@ class YodeckProvider(ImportProvider):
     )
     token_help = (
         'Create an API token in Yodeck under Account Settings → Advanced '
-        'Settings → API Tokens, then paste it here. It is used only for '
-        'this import and is never stored.'
+        'Settings → API Tokens. Enter it as "<label>:<token>" — the name '
+        'you gave the token, a colon, then the copied token value (e.g. '
+        '"mylabel:XXXXXXXX"). It is used only for this import and is never '
+        'stored.'
     )
 
     # -- token / listing ---------------------------------------------------

--- a/src/anthias_server/lib/integrations/yodeck.py
+++ b/src/anthias_server/lib/integrations/yodeck.py
@@ -116,8 +116,7 @@ def _webpage_url(detail: dict[str, Any]) -> str | None:
     # Fall back to any http(s) value anywhere in ``arguments`` — Yodeck
     # webpage media keep the destination URL there under a key we may not
     # have enumerated above.
-    inner_any = (v for v in arguments.values())
-    return _first_http_url([*top, *inner, *inner_any])
+    return _first_http_url([*top, *inner, *arguments.values()])
 
 
 def _file_url(detail: dict[str, Any]) -> str | None:
@@ -174,10 +173,12 @@ def _availability_window(detail: dict[str, Any]) -> tuple[datetime, datetime]:
 
 def _default_duration(detail: dict[str, Any]) -> int:
     raw = detail.get('default_duration')
-    try:
-        duration = int(raw)
-    except (TypeError, ValueError):
-        duration = 0
+    duration = 0
+    if isinstance(raw, (int, str)):
+        try:
+            duration = int(raw)
+        except (TypeError, ValueError):
+            duration = 0
     if duration > 0:
         return duration
     return int(settings['default_duration'])
@@ -369,10 +370,10 @@ class YodeckProvider(ImportProvider):
                 enable=enable,
             )
         else:
-            asset = self._import_file(
+            imported = self._import_file(
                 token, detail, media_type, name, start_date, end_date, enable
             )
-            if asset is None:
+            if imported is None:
                 return ImportOutcome(
                     success=False,
                     skipped=True,
@@ -381,6 +382,7 @@ class YodeckProvider(ImportProvider):
                         f'this {media_type}; re-upload it manually.'
                     ),
                 )
+            asset = imported
 
         _stamp_import_source(asset, remote_id)
         return ImportOutcome(success=True, asset_id=asset.asset_id)

--- a/website/content/docs/importing-content-from-other-platforms.md
+++ b/website/content/docs/importing-content-from-other-platforms.md
@@ -1,0 +1,77 @@
+---
+title: "Importing Content from Other Platforms"
+description: "Bring images, videos, and web pages into Anthias from another digital signage platform."
+slug: "import-content"
+aliases:
+  - "/docs/importing-content-from-other-platforms/"
+---
+
+Moving to Anthias from another digital signage platform? Anthias ships a
+built-in import wizard that copies your media across using the other
+platform's API — no SSH or scripts required. Your existing Anthias assets
+are left untouched, and re-running an import skips anything already brought
+over, so it is safe to run more than once.
+
+**Available now:** [Yodeck](https://www.yodeck.com/). Support for more
+platforms (ScreenCloud, OptiSign, NoviSign, and PiSignage) is on the way.
+
+## What gets imported
+
+Anthias imports the content types it can play natively:
+
+- **Images** and **videos** — the original file is downloaded onto your
+  player and added to the schedule.
+- **Web pages** — added as a web asset pointing at the same URL.
+
+Anything Anthias cannot play, or that would not work outside the source
+platform, is **skipped and reported** rather than imported half-way:
+
+- **Audio** and **documents** (PDF, PowerPoint, and similar).
+- **Apps and internally-generated content** — weather, clock, RSS, and
+  dashboard widgets render inside the source platform, so their internal
+  URLs would only produce broken assets on Anthias.
+- **Files the platform does not expose for download** — if the source only
+  offers a preview or thumbnail, the original cannot be copied; those items
+  are flagged so you can re-upload them manually.
+
+## Before you start
+
+You will need an API token for the platform you are importing from. For
+Yodeck:
+
+1. Sign in to Yodeck.
+2. Go to **Account Settings → Advanced Settings → API Tokens** and create a
+   new token.
+3. Keep the token handy. It is not stored on the device — it is only used to
+   talk to the platform's API while the import runs.
+
+## Run the import
+
+1. Open your Anthias web interface and go to **Settings**.
+2. In the **Import content** section, click **Import from Yodeck** (or the
+   platform you are moving from).
+3. Paste your API token and click **Continue**. Anthias validates the token
+   before listing your media.
+4. Review the list of media found. Supported items are selected by default;
+   unsupported items are shown with the reason they will be skipped. Use
+   **Select all** / **Select none** or the per-item checkboxes to adjust.
+5. Leave **Enable imported assets** ticked to have them start playing right
+   away, or untick it to import them disabled and enable them later.
+6. Click **Import _N_ items**. Each selected item is copied in turn, with
+   live per-item progress.
+7. When it finishes, any items that failed can be retried with the **Retry
+   _N_ failed** button, without repeating the ones that already succeeded.
+
+That's it — your imported media now lives on your Anthias player, ready to
+schedule like any other asset.
+
+## Prefer the command line?
+
+The same import runs headlessly for support and automation:
+
+```bash
+$ docker compose exec anthias-server \
+    python manage.py import_content --provider yodeck --token '<your-token>'
+```
+
+Add `--dry-run` to list what would be imported without copying anything.


### PR DESCRIPTION
### Issues Fixed

Not associated with a tracked issue. Adds a new capability: migrating content **into** Anthias from another digital signage platform (the inbound mirror of the existing Migrate-to-Screenly export wizard).

### Description

Adds an extensible **import-provider framework** with **Yodeck** as the first provider. Built as a framework because more providers are planned as stacked PRs (ScreenCloud, OptiSign, NoviSign, PiSignage) — each is a new module plus one registry entry, with no change to the endpoints, wizard, or CLI.

- **Framework** (`lib/integrations/`): a transport-agnostic `ImportProvider` ABC + neutral `RemoteMediaItem` / `ImportOutcome` dataclasses + a registry. Providers may be REST or GraphQL backed.
- **Yodeck provider**: validates an API token, pages through `/api/v2/media/`, and imports `image` / `video` / `webpage` media (`audio` / `document` are skipped with a reported reason). Image/video originals are downloaded into the asset dir and flow through the **existing** `CreateAssetSerializerV2` pipeline (rename → normalise → duration probe); webpages store the URL. Re-imports are idempotent via `metadata.import_source`.
- **API**: `POST /api/v2/integrations/import/<provider>/{validate,item}` (validate + enumerate in one call; per-item import with live progress), matching the Screenly endpoints' error hygiene.
- **UI**: a data-driven "Import content" section in Settings plus a wizard mirroring the Migrate-to-Screenly Alpine flow, with an "Enable imported assets" toggle.
- **CLI**: `manage.py import_content --provider yodeck --token … [--workspace] [--dry-run]`.
- **Refactor**: extracted the v2 create view's persist + dispatch logic into `api.helpers.persist_new_asset` so imported and uploaded assets share one code path.
- Import traffic deliberately does **not** send the Anthias User-Agent (a self-identifying UA on a competitor's API invites vendor-side blocking).

**Follow-ups before this is fully field-ready:** the resolver (`_resolve_source` in `yodeck.py`) is isolated and defensive but two Yodeck detail-object field names still need confirming against a live token — the key holding a webpage's destination URL, and whether a directly-uploaded image/video exposes an **original**-file URL (beyond `thumbnail_url`); if not, those are skipped-with-reason rather than guessed.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)