### PR TITLE
feat(import): add ScreenCloud (GraphQL) provider to the import framework

### DIFF
--- a/src/anthias_server/api/tests/test_screencloud_import.py
+++ b/src/anthias_server/api/tests/test_screencloud_import.py
@@ -1,0 +1,348 @@
+"""Unit tests for the ScreenCloud (GraphQL) import provider.
+
+Never touches the network: the provider's module-level ``_session`` is
+patched so each GraphQL query and file download is driven deterministically
+— token validation, region parsing, file/link listing (with the
+``linkType`` and mimetype filters), and per-item import.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from anthias_server.app.models import Asset
+from anthias_server.lib.integrations import screencloud
+from anthias_server.lib.integrations.registry import (
+    get_provider,
+    list_provider_meta,
+)
+from anthias_server.settings import settings
+
+PROVIDER = screencloud.ScreenCloudProvider()
+
+
+def _gql(
+    status: int,
+    data: Any = None,
+    errors: Any = None,
+) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    body: dict[str, Any] = {}
+    if data is not None:
+        body['data'] = data
+    if errors is not None:
+        body['errors'] = errors
+    resp.json.return_value = body
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            f'HTTP {status}', response=resp
+        )
+    return resp
+
+
+def _stream(status: int, chunks: list[bytes]) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    resp.iter_content.return_value = iter(chunks)
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _router(routes: dict[str, MagicMock]) -> Any:
+    """Route a GraphQL POST to a canned response by query substring."""
+
+    def _post(url: str, **kwargs: Any) -> MagicMock:
+        query = kwargs['json']['query']
+        for needle, resp in routes.items():
+            if needle in query:
+                return resp
+        return _gql(200, data={})
+
+    return _post
+
+
+class TestAuthAndSession:
+    def test_bearer_header(self) -> None:
+        assert screencloud._auth_headers('abc') == {
+            'Authorization': 'Bearer abc',
+            'Content-Type': 'application/json',
+        }
+
+    def test_session_not_anthias_ua(self) -> None:
+        ua = screencloud._session.headers['User-Agent']
+        assert isinstance(ua, str)
+        assert not ua.startswith('Anthias/')
+        assert 'anthias' not in ua.lower()
+
+
+class TestTokenRegion:
+    def test_default_region(self) -> None:
+        assert screencloud._parse_token('abc') == ('eu', 'abc')
+
+    def test_explicit_us(self) -> None:
+        assert screencloud._parse_token('us:abc') == ('us', 'abc')
+
+    def test_endpoint_for_us(self) -> None:
+        endpoint, bearer = screencloud._endpoint_for('us:secret')
+        assert bearer == 'secret'
+        assert '.us.' in endpoint
+
+
+class TestValidateToken:
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_true_on_current_org(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _gql(200, data={'currentOrg': {'id': 'x'}})
+        assert PROVIDER.validate_token('tok') is True
+
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_false_on_errors(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _gql(200, errors=[{'message': 'bad token'}])
+        assert PROVIDER.validate_token('tok') is False
+
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_false_on_401(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _gql(401)
+        assert PROVIDER.validate_token('tok') is False
+
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_raises_on_5xx(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _gql(503)
+        with pytest.raises(requests.HTTPError):
+            PROVIDER.validate_token('tok')
+
+
+class TestListMedia:
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_files_and_links_filtered(self, post_mock: MagicMock) -> None:
+        files = _gql(
+            200,
+            data={
+                'allFiles': {
+                    'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                    'nodes': [
+                        {'id': 'f1', 'name': 'Pic', 'mimetype': 'image/png'},
+                        {'id': 'f2', 'name': 'Clip', 'mimetype': 'video/mp4'},
+                        {'id': 'f3', 'name': 'Song', 'mimetype': 'audio/mp3'},
+                    ],
+                }
+            },
+        )
+        links = _gql(
+            200,
+            data={
+                'allLinks': {
+                    'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                    'nodes': [
+                        {'id': 'l1', 'name': 'Site', 'linkType': 'STANDARD'},
+                        {'id': 'l2', 'name': 'Dash', 'linkType': 'INTERNAL'},
+                    ],
+                }
+            },
+        )
+        post_mock.side_effect = _router({'allFiles': files, 'allLinks': links})
+
+        items = PROVIDER.list_media('tok')
+        by_id = {item.remote_id: item for item in items}
+
+        assert by_id['file:f1'].media_type == 'image'
+        assert by_id['file:f1'].importable
+        assert by_id['file:f2'].media_type == 'video'
+        assert by_id['file:f2'].importable
+        # Audio isn't supported.
+        assert by_id['file:f3'].importable is False
+        # Only STANDARD links import; INTERNAL is filtered out.
+        assert by_id['link:l1'].importable is True
+        assert by_id['link:l2'].importable is False
+        assert by_id['link:l2'].skip_reason
+
+
+class TestHelpers:
+    def test_media_type_from_mimetype(self) -> None:
+        assert screencloud._file_media_type('image/png') == 'image'
+        assert screencloud._file_media_type('video/mp4') == 'video'
+        assert screencloud._file_media_type('audio/mp3') == 'audio'
+        assert screencloud._file_media_type('application/pdf') == 'document'
+
+    def test_download_url_prefers_matching_mimetype(self) -> None:
+        file_obj = {
+            'mimetype': 'video/mp4',
+            'fileOutputsByFileId': {
+                'nodes': [
+                    {'url': 'https://cdn/thumb.jpg', 'mimetype': 'image/jpeg'},
+                    {'url': 'https://cdn/orig.mp4', 'mimetype': 'video/mp4'},
+                ]
+            },
+        }
+        assert (
+            screencloud._file_download_url(file_obj) == 'https://cdn/orig.mp4'
+        )
+
+
+class TestRegistry:
+    def test_registered(self) -> None:
+        assert isinstance(
+            get_provider('screencloud'), screencloud.ScreenCloudProvider
+        )
+        keys = {meta['key'] for meta in list_provider_meta()}
+        assert 'screencloud' in keys
+
+
+@pytest.mark.django_db
+class TestImportItem:
+    def test_idempotent_reimport_skips(self) -> None:
+        Asset.objects.create(
+            asset_id='sc-existing',
+            name='Existing',
+            uri='https://example.com/',
+            mimetype='webpage',
+            duration=10,
+            metadata={
+                'import_source': {
+                    'provider': 'screencloud',
+                    'remote_id': 'link:l1',
+                }
+            },
+        )
+        with patch(
+            'anthias_server.lib.integrations.screencloud._session.post'
+        ) as post_mock:
+            outcome = PROVIDER.import_item('tok', 'link:l1')
+        post_mock.assert_not_called()
+        assert outcome.skipped is True and outcome.success is True
+
+    def test_unrecognised_id_skipped(self) -> None:
+        outcome = PROVIDER.import_item('tok', 'bogus:1')
+        assert outcome.skipped is True
+
+    @patch(
+        'anthias_server.api.serializers.mixins.url_fails', return_value=False
+    )
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_import_standard_link(
+        self, post_mock: MagicMock, _url_fails: MagicMock
+    ) -> None:
+        post_mock.side_effect = _router(
+            {
+                'linkById': _gql(
+                    200,
+                    data={
+                        'linkById': {
+                            'id': 'l1',
+                            'name': 'Wireload',
+                            'url': 'https://wireload.net/',
+                            'linkType': 'STANDARD',
+                        }
+                    },
+                )
+            }
+        )
+        outcome = PROVIDER.import_item('tok', 'link:l1', enable=True)
+        assert outcome.success is True and not outcome.skipped
+
+        asset = Asset.objects.get(asset_id=outcome.asset_id)
+        assert asset.mimetype == 'webpage'
+        assert asset.uri == 'https://wireload.net/'
+        assert asset.metadata['import_source'] == {
+            'provider': 'screencloud',
+            'remote_id': 'link:l1',
+        }
+
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_import_internal_link_skipped(self, post_mock: MagicMock) -> None:
+        post_mock.side_effect = _router(
+            {
+                'linkById': _gql(
+                    200,
+                    data={
+                        'linkById': {
+                            'id': 'l2',
+                            'name': 'Dashboard',
+                            'url': 'https://studio.internal/x',
+                            'linkType': 'INTERNAL',
+                        }
+                    },
+                )
+            }
+        )
+        outcome = PROVIDER.import_item('tok', 'link:l2')
+        assert outcome.skipped is True
+        assert Asset.objects.count() == 0
+
+    @patch('anthias_server.lib.integrations.screencloud._session.get')
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_import_file_image_downloads_without_auth(
+        self,
+        post_mock: MagicMock,
+        get_mock: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setitem(settings, 'assetdir', str(tmp_path))
+        post_mock.side_effect = _router(
+            {
+                'fileById': _gql(
+                    200,
+                    data={
+                        'fileById': {
+                            'id': 'f1',
+                            'name': 'Pic',
+                            'mimetype': 'image/png',
+                            'availableAt': None,
+                            'expireAt': None,
+                            'fileOutputsByFileId': {
+                                'nodes': [
+                                    {
+                                        'url': 'https://cdn.sc/x.png',
+                                        'mimetype': 'image/png',
+                                    }
+                                ]
+                            },
+                        }
+                    },
+                )
+            }
+        )
+        captured: dict[str, str] = {}
+
+        def _get(url: str, **kwargs: Any) -> MagicMock:
+            captured.update(kwargs.get('headers') or {})
+            return _stream(200, [b'\x89PNG\r\n'])
+
+        get_mock.side_effect = _get
+
+        outcome = PROVIDER.import_item('tok', 'file:f1', enable=False)
+        assert outcome.success is True and not outcome.skipped
+
+        asset = Asset.objects.get(asset_id=outcome.asset_id)
+        assert asset.mimetype == 'image'
+        assert (tmp_path / f'{asset.asset_id}.png').is_file()
+        # Pre-signed CDN original — the bearer token must NOT be sent.
+        assert 'Authorization' not in captured
+
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_import_audio_file_skipped(self, post_mock: MagicMock) -> None:
+        post_mock.side_effect = _router(
+            {
+                'fileById': _gql(
+                    200,
+                    data={
+                        'fileById': {
+                            'id': 'f3',
+                            'name': 'Song',
+                            'mimetype': 'audio/mp3',
+                            'fileOutputsByFileId': {'nodes': []},
+                        }
+                    },
+                )
+            }
+        )
+        outcome = PROVIDER.import_item('tok', 'file:f3')
+        assert outcome.skipped is True

--- a/src/anthias_server/api/tests/test_screencloud_import.py
+++ b/src/anthias_server/api/tests/test_screencloud_import.py
@@ -163,6 +163,16 @@ class TestListMedia:
         assert by_id['link:l2'].importable is False
         assert by_id['link:l2'].skip_reason
 
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_graphql_error_surfaces_as_transport_error(
+        self, post_mock: MagicMock
+    ) -> None:
+        # A GraphQL errors[] during listing must become a RequestException
+        # so the API view returns a controlled 502, not a 500.
+        post_mock.return_value = _gql(200, errors=[{'message': 'boom'}])
+        with pytest.raises(requests.RequestException):
+            PROVIDER.list_media('tok')
+
 
 class TestHelpers:
     def test_media_type_from_mimetype(self) -> None:

--- a/src/anthias_server/api/tests/test_yodeck_import.py
+++ b/src/anthias_server/api/tests/test_yodeck_import.py
@@ -27,7 +27,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from anthias_server.app.models import Asset
-from anthias_server.lib.integrations import yodeck
+from anthias_server.lib.integrations import ingest, yodeck
 from anthias_server.lib.integrations.base import (
     ImportOutcome,
     ProviderImportError,
@@ -284,9 +284,9 @@ class TestFieldMapping:
     def test_first_http_url_rejects_stream_scheme(self) -> None:
         # validate_url accepts rtsp://, but this helper feeds webpage URIs
         # and requests.get downloads — http(s) only.
-        assert yodeck._first_http_url(['rtsp://cam/stream']) is None
+        assert ingest.first_http_url(['rtsp://cam/stream']) is None
         assert (
-            yodeck._first_http_url(['rtsp://cam/stream', 'https://ok/x'])
+            ingest.first_http_url(['rtsp://cam/stream', 'https://ok/x'])
             == 'https://ok/x'
         )
 

--- a/src/anthias_server/lib/integrations/http.py
+++ b/src/anthias_server/lib/integrations/http.py
@@ -1,0 +1,30 @@
+"""Shared outbound HTTP helper for import providers.
+
+Import providers talk to a third-party signage vendor's own API during a
+migration *away* from that vendor. A self-identifying ``Anthias/<version>``
+User-Agent (what :class:`anthias_common.http.AnthiasSession` sends) invites
+vendor-side blocking, so these calls deliberately do **not** use it — they
+carry a neutral browser-like UA instead, the same blend-in rationale as the
+anti-bot probe in ``anthias_common.utils.url_fails``.
+
+Every provider builds its session through :func:`new_import_session` so the
+UA policy lives in exactly one place.
+"""
+
+from __future__ import annotations
+
+import requests
+
+# Neutral, non-Anthias User-Agent. See the module docstring for why we don't
+# use AnthiasSession here.
+IMPORT_USER_AGENT = (
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+)
+
+
+def new_import_session() -> requests.Session:
+    """Return a ``requests.Session`` carrying the neutral import UA."""
+    session = requests.Session()
+    session.headers['User-Agent'] = IMPORT_USER_AGENT
+    return session

--- a/src/anthias_server/lib/integrations/ingest.py
+++ b/src/anthias_server/lib/integrations/ingest.py
@@ -20,6 +20,7 @@ from uploaded ones at playback time.
 from __future__ import annotations
 
 import os
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
@@ -45,28 +46,50 @@ _DOWNLOAD_TIMEOUT_S = 120.0
 
 
 def first_http_url(candidates: Iterable[Any]) -> str | None:
-    """Return the first candidate that is a real http(s) URL."""
+    """Return the first candidate that is a real http(s) URL.
+
+    ``validate_url`` also accepts streaming schemes (rtsp/rtmp/…); this
+    helper feeds webpage URIs and ``requests.get`` downloads, so it is
+    restricted to http(s) to avoid picking a stream endpoint out of a
+    field bag or handing an rtsp URL to ``requests``.
+    """
     for value in candidates:
-        if isinstance(value, str) and value and validate_url(value):
+        if not isinstance(value, str) or not value:
+            continue
+        if validate_url(value) and urlparse(value).scheme in (
+            'http',
+            'https',
+        ):
             return value
     return None
+
+
+def _sanitise_ext(raw: str) -> str:
+    """Reduce a candidate extension to a safe ``.<alnum>`` token.
+
+    The value comes from a third-party API response or a URL path, so it
+    is stripped to alphanumerics and capped — otherwise something like
+    ``"/../../etc/passwd"`` could escape the asset directory when the
+    staged filename is built.
+    """
+    cleaned = re.sub(r'[^A-Za-z0-9]', '', (raw or '').strip().lstrip('.'))
+    cleaned = cleaned[:16]
+    return f'.{cleaned}' if cleaned else ''
 
 
 def file_ext_from(ext_hint: str | None, url: str) -> str:
     """Best on-disk extension for a downloaded original.
 
     Prefers an explicit provider hint ("mp4"), falls back to the
-    extension on the download URL's path, and finally to none. The
-    leading dot is normalised so ``CreateAssetSerializerV2`` renames the
-    file to ``<asset_id>.mp4`` and ffprobe can identify the container.
+    extension on the download URL's path, and finally to none. Both
+    sources are sanitised (see ``_sanitise_ext``) so a hostile value
+    can't escape the asset directory when the staged filename is built.
     """
-    raw = (ext_hint or '').strip().lstrip('.')
-    if raw:
-        return f'.{raw}'
-    _stem, ext = os.path.splitext(url.split('?', 1)[0])
-    if ext and len(ext) <= 8:
+    ext = _sanitise_ext(ext_hint or '')
+    if ext:
         return ext
-    return ''
+    _stem, url_ext = os.path.splitext(url.split('?', 1)[0])
+    return _sanitise_ext(url_ext)
 
 
 def default_window() -> tuple[datetime, datetime]:

--- a/src/anthias_server/lib/integrations/ingest.py
+++ b/src/anthias_server/lib/integrations/ingest.py
@@ -1,0 +1,288 @@
+"""Provider-agnostic asset ingestion for import providers.
+
+Every provider maps its own API's media object onto a handful of neutral
+values (name, a URL or a downloadable file, a duration, a start/end
+window) and then hands them here. This module owns the parts that must
+behave identically no matter which platform the media came from:
+
+* downloading an original file into the asset directory under a size cap,
+* creating the ``Asset`` through the same ``CreateAssetSerializerV2``
+  pipeline the web UI and REST API use (rename → normalise → duration
+  probe), and
+* idempotency — stamping ``Asset.metadata['import_source']`` and looking
+  it up so a re-import returns the existing row instead of duplicating.
+
+Keeping this in one place means a new provider only writes API-specific
+field mapping, and every provider's imported assets are indistinguishable
+from uploaded ones at playback time.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+import requests
+
+from anthias_common.utils import validate_url
+from anthias_server.api.helpers import AssetCreationError, persist_new_asset
+from anthias_server.api.serializers.v2 import CreateAssetSerializerV2
+from anthias_server.app.models import Asset
+from anthias_server.settings import settings
+
+from .base import ProviderImportError
+
+# Same 5 GiB ceiling the Celery remote-video downloader enforces
+# (``celery_tasks.REMOTE_VIDEO_MAX_BYTES``). Duplicated as a literal
+# rather than imported so this request-path module doesn't pull in the
+# whole Celery app.
+MAX_DOWNLOAD_BYTES = 5 * 1024**3
+_DOWNLOAD_CHUNK = 1024 * 1024
+_DOWNLOAD_TIMEOUT_S = 120.0
+
+
+def first_http_url(candidates: Iterable[Any]) -> str | None:
+    """Return the first candidate that is a real http(s) URL."""
+    for value in candidates:
+        if isinstance(value, str) and value and validate_url(value):
+            return value
+    return None
+
+
+def file_ext_from(ext_hint: str | None, url: str) -> str:
+    """Best on-disk extension for a downloaded original.
+
+    Prefers an explicit provider hint ("mp4"), falls back to the
+    extension on the download URL's path, and finally to none. The
+    leading dot is normalised so ``CreateAssetSerializerV2`` renames the
+    file to ``<asset_id>.mp4`` and ffprobe can identify the container.
+    """
+    raw = (ext_hint or '').strip().lstrip('.')
+    if raw:
+        return f'.{raw}'
+    _stem, ext = os.path.splitext(url.split('?', 1)[0])
+    if ext and len(ext) <= 8:
+        return ext
+    return ''
+
+
+def default_window() -> tuple[datetime, datetime]:
+    """The always-on window used when a provider gives no schedule.
+
+    Modelled as "now → +10 years" — the same wide window the schedule UI
+    treats as unbounded.
+    """
+    now = datetime.now(timezone.utc)
+    return now, now + timedelta(days=3650)
+
+
+def find_imported_asset(provider_key: str, remote_id: str) -> Asset | None:
+    """Return a previously-imported asset for this provider+remote id."""
+    return Asset.objects.filter(
+        metadata__import_source__provider=provider_key,
+        metadata__import_source__remote_id=str(remote_id),
+    ).first()
+
+
+def _stamp_import_source(
+    asset: Asset, provider_key: str, remote_id: str
+) -> None:
+    metadata = dict(asset.metadata or {})
+    metadata['import_source'] = {
+        'provider': provider_key,
+        'remote_id': str(remote_id),
+    }
+    asset.metadata = metadata
+    asset.save(update_fields=['metadata'])
+
+
+def _stringify_errors(errors: Any) -> str:
+    """Collapse a serializer error bag into one operator-facing line."""
+    if isinstance(errors, str):
+        return errors
+    if isinstance(errors, dict):
+        for value in errors.values():
+            if isinstance(value, (list, tuple)) and value:
+                return str(value[0])
+            if value:
+                return str(value)
+    if isinstance(errors, (list, tuple)) and errors:
+        return str(errors[0])
+    return 'Anthias rejected the imported asset.'
+
+
+def _safe_unlink(path: str | None) -> None:
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _create_via_serializer(
+    *,
+    uri: str,
+    ext: str | None,
+    mimetype: str,
+    name: str,
+    start_date: datetime,
+    end_date: datetime,
+    duration: int,
+    enable: bool,
+) -> Asset:
+    data: dict[str, Any] = {
+        'name': name,
+        'uri': uri,
+        'mimetype': mimetype,
+        'start_date': start_date,
+        'end_date': end_date,
+        'duration': duration,
+        'is_enabled': enable,
+    }
+    if ext:
+        data['ext'] = ext
+    serializer = CreateAssetSerializerV2(data=data, unique_name=True)
+    # ``prepare_asset`` raises ``AssetCreationError`` (not a DRF
+    # ValidationError) for reachability / duration failures, which
+    # ``is_valid()`` does not catch — hence the explicit guard, matching
+    # ``AssetListViewV2.post``.
+    try:
+        valid = serializer.is_valid()
+    except AssetCreationError as error:
+        raise ProviderImportError(_stringify_errors(error.errors))
+    if not valid:
+        raise ProviderImportError(_stringify_errors(serializer.errors))
+    return persist_new_asset(serializer)
+
+
+def _download_to_assetdir(
+    session: requests.Session,
+    url: str,
+    headers: dict[str, str],
+    ext: str,
+    auth_host: str | None,
+) -> str:
+    assetdir = settings['assetdir']
+    staged = os.path.join(assetdir, f'.import-{uuid.uuid4().hex}{ext}')
+    part = f'{staged}.part'
+    # Only attach the provider's auth headers when the download stays on
+    # the host they're scoped to — original-file URLs are frequently
+    # pre-signed CDN links on a different host, and forwarding the API
+    # token there would leak the credential and can break the signed
+    # request. No ``auth_host`` (or a foreign host) → send no auth.
+    send_auth = bool(auth_host) and (
+        urlparse(url).netloc.lower() == (auth_host or '').lower()
+    )
+    request_headers = headers if send_auth else {}
+    try:
+        with session.get(
+            url,
+            headers=request_headers,
+            stream=True,
+            timeout=_DOWNLOAD_TIMEOUT_S,
+        ) as response:
+            if not response.ok:
+                raise ProviderImportError(
+                    f'Download failed ({response.status_code}).'
+                )
+            written = 0
+            with open(part, 'wb') as handle:
+                for chunk in response.iter_content(_DOWNLOAD_CHUNK):
+                    if not chunk:
+                        continue
+                    written += len(chunk)
+                    if written > MAX_DOWNLOAD_BYTES:
+                        raise ProviderImportError(
+                            'File exceeds the 5 GiB import size limit.'
+                        )
+                    handle.write(chunk)
+        if written == 0:
+            raise ProviderImportError('The provider returned an empty file.')
+        # Atomic move into the final staged name only once the whole body
+        # landed, so a truncated download can't be handed to the serializer.
+        os.replace(part, staged)
+        return staged
+    except Exception:
+        _safe_unlink(part)
+        _safe_unlink(staged)
+        raise
+
+
+def create_webpage_asset(
+    *,
+    provider_key: str,
+    remote_id: str,
+    name: str,
+    url: str,
+    duration: int,
+    start_date: datetime,
+    end_date: datetime,
+    enable: bool,
+) -> Asset:
+    """Create a webpage asset whose ``uri`` is the destination URL."""
+    asset = _create_via_serializer(
+        uri=url,
+        ext=None,
+        mimetype='webpage',
+        name=name,
+        start_date=start_date,
+        end_date=end_date,
+        duration=duration,
+        enable=enable,
+    )
+    _stamp_import_source(asset, provider_key, remote_id)
+    return asset
+
+
+def create_file_asset(
+    *,
+    session: requests.Session,
+    provider_key: str,
+    remote_id: str,
+    name: str,
+    mimetype: str,
+    file_url: str,
+    ext: str,
+    duration: int,
+    start_date: datetime,
+    end_date: datetime,
+    enable: bool,
+    headers: dict[str, str] | None = None,
+    auth_host: str | None = None,
+) -> Asset:
+    """Download an original file and create an image/video asset.
+
+    The file is staged inside the asset directory and handed to
+    ``CreateAssetSerializerV2`` like a local upload. ``duration`` must be
+    0 for video (probed server-side); images carry the provider's value.
+
+    ``headers`` are attached to the download only when ``file_url`` is on
+    ``auth_host`` — so an API token is never forwarded to a pre-signed CDN
+    original on a different host.
+    """
+    staged_path = _download_to_assetdir(
+        session, file_url, headers or {}, ext, auth_host
+    )
+    try:
+        asset = _create_via_serializer(
+            uri=staged_path,
+            ext=ext,
+            mimetype=mimetype,
+            name=name,
+            start_date=start_date,
+            end_date=end_date,
+            duration=duration,
+            enable=enable,
+        )
+    except Exception:
+        # ``prepare_asset`` renames the staged file into place only once
+        # validation passes, so on failure it's still at ``staged_path``
+        # — remove it rather than leaving an orphan for the hourly sweep.
+        _safe_unlink(staged_path)
+        raise
+    _stamp_import_source(asset, provider_key, remote_id)
+    return asset

--- a/src/anthias_server/lib/integrations/registry.py
+++ b/src/anthias_server/lib/integrations/registry.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 from typing import Any
 
 from .base import ImportProvider
+from .screencloud import ScreenCloudProvider
 from .yodeck import YodeckProvider
 
 # Providers are stateless (their HTTP session is module-level), so a
 # single shared instance each is fine.
 _PROVIDERS: dict[str, ImportProvider] = {
-    provider.key: provider for provider in (YodeckProvider(),)
+    provider.key: provider
+    for provider in (YodeckProvider(), ScreenCloudProvider())
 }
 
 

--- a/src/anthias_server/lib/integrations/screencloud.py
+++ b/src/anthias_server/lib/integrations/screencloud.py
@@ -1,0 +1,446 @@
+"""ScreenCloud (Studio) import provider — GraphQL.
+
+ScreenCloud's Signage/Studio API is a PostGraphile GraphQL endpoint (not
+REST), which is exactly why the provider interface is transport-agnostic:
+this module speaks GraphQL behind the same
+``validate_token`` / ``list_media`` / ``import_item`` contract, and reuses
+:mod:`anthias_server.lib.integrations.ingest` for the download + asset
+creation + idempotency that every provider shares.
+
+Media is split across two GraphQL types:
+
+* ``File``  → uploaded images and videos (distinguished by ``mimetype``).
+  The downloadable original comes from ``fileOutputsByFileId``.
+* ``Link``  → web pages / URLs (imported as Anthias ``webpage`` assets).
+
+Remote ids are namespaced ``file:<uuid>`` / ``link:<uuid>`` so a single
+``import_item`` call knows which GraphQL type to fetch.
+
+Endpoint / region: ScreenCloud endpoints are per-organization and region
+(``eu`` / ``us``). The operator can prefix the token with a region
+(``eu:<token>`` / ``us:<token>``); without a prefix the EU endpoint is
+used. See ``token_help``.
+
+TODO(confirm-with-live-token): the production regional hostnames, the
+``fileById`` / ``linkById`` field names, and which ``FileOutput`` is the
+durable original vs a thumbnail are documented behind a ScreenCloud login
+and should be verified against a real account before GA. The resolution
+points are isolated in ``_endpoint_for`` / ``_file_download_url`` /
+``_FILE_BY_ID`` so confirming them is a localized change.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterator
+
+from . import ingest
+from .base import (
+    ImportOutcome,
+    ImportProvider,
+    ProviderImportError,
+    RemoteMediaItem,
+)
+from .http import new_import_session
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_KEY = 'screencloud'
+
+# Region → GraphQL endpoint. The staging EU host is the only one the
+# public docs state outright; the production hosts follow the documented
+# ``*.next.sc/graphql`` pattern but are unconfirmed (read the exact value
+# from Studio → Account Settings → DEVELOPER). Kept in one map so a
+# correction is a one-line change.
+_REGION_ENDPOINTS = {
+    'eu': 'https://graphql.eu.next.sc/graphql',
+    'us': 'https://graphql.us.next.sc/graphql',
+}
+_DEFAULT_REGION = 'eu'
+
+_LIST_PAGE_SIZE = 100
+_VALIDATE_TIMEOUT_S = 15.0
+_QUERY_TIMEOUT_S = 30.0
+
+_session = new_import_session()
+
+# --- GraphQL documents ------------------------------------------------------
+
+_VALIDATE_QUERY = '{ currentOrg { id } }'
+
+_ALL_FILES = """
+query($first: Int!, $after: Cursor) {
+  allFiles(first: $first, after: $after, orderBy: [CREATED_AT_DESC]) {
+    pageInfo { hasNextPage endCursor }
+    nodes { id name mimetype }
+  }
+}
+"""
+
+# ``linkType`` filters out non-portable links: only STANDARD is a real
+# external URL. INTERNAL / CLOUD are ScreenCloud-hosted content (apps,
+# dashboards, cloud integrations) that would not render outside Studio.
+_STANDARD_LINK = 'STANDARD'
+
+_ALL_LINKS = """
+query($first: Int!, $after: Cursor) {
+  allLinks(first: $first, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes { id name linkType }
+  }
+}
+"""
+
+_FILE_BY_ID = """
+query($id: UUID!) {
+  fileById(id: $id) {
+    id name mimetype availableAt expireAt
+    fileOutputsByFileId { nodes { url mimetype } }
+  }
+}
+"""
+
+_LINK_BY_ID = """
+query($id: UUID!) {
+  linkById(id: $id) { id name url linkType }
+}
+"""
+
+
+def _parse_token(token: str) -> tuple[str, str]:
+    """Split an optional ``<region>:`` prefix off the bearer token."""
+    raw = (token or '').strip()
+    prefix, sep, rest = raw.partition(':')
+    if sep and prefix.lower() in _REGION_ENDPOINTS:
+        return prefix.lower(), rest
+    return _DEFAULT_REGION, raw
+
+
+def _endpoint_for(token: str) -> tuple[str, str]:
+    region, bearer = _parse_token(token)
+    return _REGION_ENDPOINTS[region], bearer
+
+
+def _auth_headers(bearer: str) -> dict[str, str]:
+    return {
+        'Authorization': f'Bearer {bearer}',
+        'Content-Type': 'application/json',
+    }
+
+
+def _post(
+    token: str,
+    query: str,
+    variables: dict[str, Any] | None,
+    timeout: float,
+) -> Any:
+    """Low-level GraphQL POST. Returns the raw ``requests`` response."""
+    endpoint, bearer = _endpoint_for(token)
+    return _session.post(
+        endpoint,
+        headers=_auth_headers(bearer),
+        json={'query': query, 'variables': variables or {}},
+        timeout=timeout,
+    )
+
+
+def _graphql(
+    token: str,
+    query: str,
+    variables: dict[str, Any] | None = None,
+    *,
+    timeout: float = _QUERY_TIMEOUT_S,
+) -> dict[str, Any]:
+    """Execute a query and return ``data``.
+
+    GraphQL answers 200 even on failure, so the ``errors`` array is
+    checked explicitly. HTTP-level and GraphQL errors both raise
+    ``ProviderImportError`` with the first message — callers that need
+    the transport error to propagate (``validate_token``) don't use this.
+    """
+    response = _post(token, query, variables, timeout)
+    response.raise_for_status()
+    body = response.json()
+    errors = body.get('errors')
+    if errors:
+        message = 'ScreenCloud query failed.'
+        if isinstance(errors, list) and errors:
+            first = errors[0]
+            if isinstance(first, dict) and first.get('message'):
+                message = str(first['message'])
+        raise ProviderImportError(message)
+    data = body.get('data')
+    if not isinstance(data, dict):
+        raise ProviderImportError('Unexpected response from ScreenCloud.')
+    return data
+
+
+def _file_media_type(mimetype: str | None) -> str:
+    mt = (mimetype or '').lower()
+    if mt.startswith('image/'):
+        return 'image'
+    if mt.startswith('video/'):
+        return 'video'
+    if mt.startswith('audio/'):
+        return 'audio'
+    return 'document'
+
+
+def _file_download_url(file_obj: dict[str, Any]) -> str | None:
+    """Pick the downloadable original URL from a File's outputs.
+
+    Prefers a ``FileOutput`` whose mimetype matches the file's top-level
+    type (image/video), falling back to the first valid URL. Which output
+    is the durable original vs a thumbnail isn't documented — see the
+    module TODO.
+    """
+    mimetype = file_obj.get('mimetype') or ''
+    top = mimetype.split('/', 1)[0]
+    outputs = (file_obj.get('fileOutputsByFileId') or {}).get('nodes') or []
+    for output in outputs:
+        if not isinstance(output, dict):
+            continue
+        url = output.get('url')
+        out_top = (output.get('mimetype') or '').split('/', 1)[0]
+        if out_top and out_top == top and ingest.first_http_url([url]):
+            return url
+    return ingest.first_http_url(
+        output.get('url') for output in outputs if isinstance(output, dict)
+    )
+
+
+def _default_duration() -> int:
+    from anthias_server.settings import settings
+
+    return int(settings['default_duration'])
+
+
+class ScreenCloudProvider(ImportProvider):
+    key = PROVIDER_KEY
+    label = 'ScreenCloud'
+    description = (
+        'Copy images, videos and web pages from a ScreenCloud (Studio) '
+        'account into this player using a ScreenCloud API token.'
+    )
+    token_help = (
+        'Create an API token in ScreenCloud Studio under Account Settings '
+        '→ Developer → New Token. Paste it here; if your account is in the '
+        'US region, prefix the token with "us:" (EU is the default). It is '
+        'used only for this import and is never stored.'
+    )
+
+    # -- token / listing ---------------------------------------------------
+
+    def validate_token(self, token: str) -> bool:
+        response = _post(token, _VALIDATE_QUERY, None, _VALIDATE_TIMEOUT_S)
+        if response.status_code in (401, 403):
+            return False
+        response.raise_for_status()
+        body = response.json()
+        # A minimal ``currentOrg`` query returns data for a good token; an
+        # errors[] here means the token was rejected.
+        if body.get('errors'):
+            return False
+        data = body.get('data') or {}
+        return bool(data.get('currentOrg'))
+
+    def list_media(
+        self, token: str, *, workspace: str | None = None
+    ) -> list[RemoteMediaItem]:
+        items: list[RemoteMediaItem] = []
+        for node in self._paginate(token, _ALL_FILES, 'allFiles'):
+            remote_id = node.get('id')
+            if not remote_id:
+                continue
+            media_type = _file_media_type(node.get('mimetype'))
+            importable = media_type in ('image', 'video')
+            items.append(
+                RemoteMediaItem(
+                    remote_id=f'file:{remote_id}',
+                    name=node.get('name') or f'ScreenCloud file {remote_id}',
+                    media_type=media_type,
+                    importable=importable,
+                    skip_reason=None
+                    if importable
+                    else (
+                        f"{media_type.capitalize()} media isn't supported by "
+                        'Anthias and was skipped.'
+                    ),
+                    raw=node,
+                )
+            )
+        for node in self._paginate(token, _ALL_LINKS, 'allLinks'):
+            remote_id = node.get('id')
+            if not remote_id:
+                continue
+            importable = node.get('linkType') == _STANDARD_LINK
+            items.append(
+                RemoteMediaItem(
+                    remote_id=f'link:{remote_id}',
+                    name=node.get('name') or f'ScreenCloud link {remote_id}',
+                    media_type='webpage',
+                    importable=importable,
+                    skip_reason=None
+                    if importable
+                    else (
+                        'Internal ScreenCloud content (not a standard web '
+                        'link) and was skipped.'
+                    ),
+                    raw=node,
+                )
+            )
+        return items
+
+    def _paginate(
+        self, token: str, query: str, connection: str
+    ) -> Iterator[dict[str, Any]]:
+        after: str | None = None
+        while True:
+            data = _graphql(
+                token,
+                query,
+                {'first': _LIST_PAGE_SIZE, 'after': after},
+            )
+            block = data.get(connection) or {}
+            for node in block.get('nodes') or []:
+                if isinstance(node, dict):
+                    yield node
+            page_info = block.get('pageInfo') or {}
+            if not page_info.get('hasNextPage'):
+                break
+            after = page_info.get('endCursor')
+            if not after:
+                break
+
+    # -- import ------------------------------------------------------------
+
+    def import_item(
+        self, token: str, remote_id: str, *, enable: bool = True
+    ) -> ImportOutcome:
+        existing = ingest.find_imported_asset(PROVIDER_KEY, remote_id)
+        if existing is not None:
+            return ImportOutcome(
+                success=True,
+                asset_id=existing.asset_id,
+                skipped=True,
+                reason='Already imported.',
+            )
+
+        kind, _sep, native_id = remote_id.partition(':')
+        if kind == 'link':
+            return self._import_link(token, remote_id, native_id, enable)
+        if kind == 'file':
+            return self._import_file(token, remote_id, native_id, enable)
+        return ImportOutcome(
+            success=False,
+            skipped=True,
+            reason=f'Unrecognised ScreenCloud id: {remote_id}.',
+        )
+
+    def _import_link(
+        self, token: str, remote_id: str, native_id: str, enable: bool
+    ) -> ImportOutcome:
+        data = _graphql(token, _LINK_BY_ID, {'id': native_id})
+        link = data.get('linkById')
+        if not isinstance(link, dict):
+            raise ProviderImportError('Link no longer exists in ScreenCloud.')
+        if link.get('linkType') != _STANDARD_LINK:
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason=(
+                    'Internal ScreenCloud content (not a standard web link) '
+                    'cannot be imported.'
+                ),
+            )
+        url = ingest.first_http_url([link.get('url')])
+        if not url:
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason='ScreenCloud link has no URL.',
+            )
+        start_date, end_date = ingest.default_window()
+        asset = ingest.create_webpage_asset(
+            provider_key=PROVIDER_KEY,
+            remote_id=remote_id,
+            name=(link.get('name') or f'ScreenCloud link {native_id}').strip(),
+            url=url,
+            duration=_default_duration(),
+            start_date=start_date,
+            end_date=end_date,
+            enable=enable,
+        )
+        return ImportOutcome(success=True, asset_id=asset.asset_id)
+
+    def _import_file(
+        self, token: str, remote_id: str, native_id: str, enable: bool
+    ) -> ImportOutcome:
+        data = _graphql(token, _FILE_BY_ID, {'id': native_id})
+        file_obj = data.get('fileById')
+        if not isinstance(file_obj, dict):
+            raise ProviderImportError('File no longer exists in ScreenCloud.')
+
+        media_type = _file_media_type(file_obj.get('mimetype'))
+        if media_type not in ('image', 'video'):
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason=(
+                    f"{media_type.capitalize()} media isn't supported by "
+                    'Anthias.'
+                ),
+            )
+
+        file_url = _file_download_url(file_obj)
+        if not file_url:
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason=(
+                    "ScreenCloud didn't expose a downloadable original for "
+                    f'this {media_type}; re-upload it manually.'
+                ),
+            )
+
+        start_date, end_date = _file_window(file_obj)
+        # No auth on the download: ScreenCloud FileOutput URLs are
+        # pre-signed CDN links, so forwarding the bearer token would leak
+        # it and can break the signed request.
+        asset = ingest.create_file_asset(
+            session=_session,
+            provider_key=PROVIDER_KEY,
+            remote_id=remote_id,
+            name=(
+                file_obj.get('name') or f'ScreenCloud file {native_id}'
+            ).strip(),
+            mimetype=media_type,
+            file_url=file_url,
+            ext=ingest.file_ext_from(None, file_url),
+            # Video duration is probed server-side; images use the default.
+            duration=0 if media_type == 'video' else _default_duration(),
+            start_date=start_date,
+            end_date=end_date,
+            enable=enable,
+        )
+        return ImportOutcome(success=True, asset_id=asset.asset_id)
+
+
+def _parse_dt(value: Any) -> Any:
+    from datetime import datetime
+
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
+def _file_window(file_obj: dict[str, Any]) -> tuple[Any, Any]:
+    now, far_future = ingest.default_window()
+    start = _parse_dt(file_obj.get('availableAt')) or now
+    end = _parse_dt(file_obj.get('expireAt')) or far_future
+    if end <= start:
+        return now, far_future
+    return start, end

--- a/src/anthias_server/lib/integrations/screencloud.py
+++ b/src/anthias_server/lib/integrations/screencloud.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Iterator
 
+import requests
+
 from . import ingest
 from .base import (
     ImportOutcome,
@@ -283,8 +285,8 @@ class ScreenCloudProvider(ImportProvider):
                     skip_reason=None
                     if importable
                     else (
-                        'Internal ScreenCloud content (not a standard web '
-                        'link) and was skipped.'
+                        'Internal ScreenCloud content, not a standard web '
+                        'link.'
                     ),
                     raw=node,
                 )
@@ -296,11 +298,19 @@ class ScreenCloudProvider(ImportProvider):
     ) -> Iterator[dict[str, Any]]:
         after: str | None = None
         while True:
-            data = _graphql(
-                token,
-                query,
-                {'first': _LIST_PAGE_SIZE, 'after': after},
-            )
+            try:
+                data = _graphql(
+                    token,
+                    query,
+                    {'first': _LIST_PAGE_SIZE, 'after': after},
+                )
+            except ProviderImportError as error:
+                # ``_paginate`` is only used by ``list_media``, whose caller
+                # (the validate API view) handles transport errors but not
+                # ``ProviderImportError`` — surface a GraphQL-level failure
+                # as a transport error so it becomes a controlled 502
+                # rather than a 500.
+                raise requests.RequestException(error.user_message) from error
             block = data.get(connection) or {}
             for node in block.get('nodes') or []:
                 if isinstance(node, dict):

--- a/src/anthias_server/lib/integrations/yodeck.py
+++ b/src/anthias_server/lib/integrations/yodeck.py
@@ -11,35 +11,27 @@ Anthias ``Asset``:
 * ``audio`` / ``document`` → surfaced as skipped-with-reason (Anthias has
   no viewer path for either).
 
-Re-imports are idempotent: each created asset is stamped with its Yodeck
-id in ``Asset.metadata['import_source']`` and a second run of the same
-item returns the existing asset instead of duplicating it.
+Only the Yodeck-specific API shape lives here (endpoints, auth header,
+pagination, and mapping a media object's fields). The provider-agnostic
+work — downloading the original, creating the asset, and idempotency —
+is delegated to :mod:`anthias_server.lib.integrations.ingest`.
 """
 
 from __future__ import annotations
 
 import logging
-import os
-import re
-import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Any, Iterator
 from urllib.parse import urlparse
 
-import requests
-
-from anthias_common.utils import validate_url
-from anthias_server.api.helpers import AssetCreationError, persist_new_asset
-from anthias_server.api.serializers.v2 import CreateAssetSerializerV2
-from anthias_server.app.models import Asset
-from anthias_server.settings import settings
-
+from . import ingest
 from .base import (
     ImportOutcome,
     ImportProvider,
     ProviderImportError,
     RemoteMediaItem,
 )
+from .http import new_import_session
 
 logger = logging.getLogger(__name__)
 
@@ -58,17 +50,9 @@ _IMPORTABLE_TYPES = ('image', 'video', 'webpage')
 _UNSUPPORTED_TYPES = ('audio', 'document')
 _ALL_TYPES = _IMPORTABLE_TYPES + _UNSUPPORTED_TYPES
 
-# Same 5 GiB ceiling the Celery remote-video downloader enforces
-# (``celery_tasks.REMOTE_VIDEO_MAX_BYTES``). Duplicated as a literal
-# rather than imported so this request-path module doesn't pull in the
-# whole Celery app.
-_MAX_DOWNLOAD_BYTES = 5 * 1024**3
-_DOWNLOAD_CHUNK = 1024 * 1024
-
 _LIST_PAGE_SIZE = 100
 _VALIDATE_TIMEOUT_S = 10.0
 _LIST_TIMEOUT_S = 30.0
-_DOWNLOAD_TIMEOUT_S = 120.0
 
 # Candidate fields that may carry a downloadable ORIGINAL file URL for an
 # image/video, in priority order — first at the top level, then inside
@@ -86,18 +70,9 @@ _ARGUMENT_FILE_KEYS = ('download_from_url', 'source_url', 'file', 'url')
 # inside ``arguments``).
 _WEBPAGE_URL_KEYS = ('url', 'website_url', 'source_url', 'link', 'address')
 
-# Deliberately NOT ``AnthiasSession``: these calls hit a third-party
-# vendor's API during a migration away from them, and a self-identifying
-# ``Anthias/<version>`` User-Agent invites vendor-side blocking. A
-# neutral browser-like UA lets import traffic look like an ordinary API
-# client. (Same blend-in rationale as the anti-bot probe in
-# ``anthias_common.utils.url_fails``.)
-_IMPORT_USER_AGENT = (
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
-    '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
-)
-_session = requests.Session()
-_session.headers['User-Agent'] = _IMPORT_USER_AGENT
+# Neutral (non-Anthias) session — see ``integrations.http`` for why import
+# traffic must not carry the ``Anthias/<version>`` User-Agent.
+_session = new_import_session()
 
 
 def _auth_headers(token: str) -> dict[str, str]:
@@ -109,25 +84,6 @@ def _auth_headers(token: str) -> dict[str, str]:
     return {'Authorization': f'Token {token}'}
 
 
-def _first_http_url(candidates: Iterator[Any] | list[Any]) -> str | None:
-    """Return the first candidate that is a real http(s) URL.
-
-    ``validate_url`` also accepts streaming schemes (rtsp/rtmp/…); this
-    helper feeds webpage URIs and ``requests.get`` downloads, so it is
-    restricted to http(s) to avoid picking a stream endpoint out of the
-    argument bag or handing an rtsp URL to ``requests``.
-    """
-    for value in candidates:
-        if not isinstance(value, str) or not value:
-            continue
-        if validate_url(value) and urlparse(value).scheme in (
-            'http',
-            'https',
-        ):
-            return value
-    return None
-
-
 def _webpage_url(detail: dict[str, Any]) -> str | None:
     arguments = detail.get('arguments') or {}
     top = (detail.get(k) for k in _WEBPAGE_URL_KEYS)
@@ -135,14 +91,14 @@ def _webpage_url(detail: dict[str, Any]) -> str | None:
     # Fall back to any http(s) value anywhere in ``arguments`` — Yodeck
     # webpage media keep the destination URL there under a key we may not
     # have enumerated above.
-    return _first_http_url([*top, *inner, *arguments.values()])
+    return ingest.first_http_url([*top, *inner, *arguments.values()])
 
 
 def _file_url(detail: dict[str, Any]) -> str | None:
     arguments = detail.get('arguments') or {}
     top = (detail.get(k) for k in _FILE_URL_KEYS)
     inner = (arguments.get(k) for k in _ARGUMENT_FILE_KEYS)
-    return _first_http_url([*top, *inner])
+    return ingest.first_http_url([*top, *inner])
 
 
 def _is_internal_yodeck_url(url: str) -> bool:
@@ -157,33 +113,8 @@ def _is_internal_yodeck_url(url: str) -> bool:
     return host == 'yodeck.com' or host.endswith('.yodeck.com')
 
 
-def _sanitise_ext(raw: str) -> str:
-    """Reduce a candidate extension to a safe ``.<alnum>`` token.
-
-    The value comes from a third-party API (Yodeck's ``file_extension``)
-    or a URL path, so it is stripped to alphanumerics and capped —
-    otherwise ``"/../../etc/passwd"`` could escape the asset directory
-    when the staged filename is built.
-    """
-    cleaned = re.sub(r'[^A-Za-z0-9]', '', (raw or '').strip().lstrip('.'))
-    cleaned = cleaned[:16]
-    return f'.{cleaned}' if cleaned else ''
-
-
 def _file_ext(detail: dict[str, Any], url: str) -> str:
-    """Best on-disk extension for a downloaded original.
-
-    Prefers Yodeck's ``file_extension`` field ("mp4"), falls back to the
-    extension on the download URL's path, and finally to no extension.
-    Both sources are sanitised (see ``_sanitise_ext``) so
-    ``CreateAssetSerializerV2`` renames the file to a safe
-    ``<asset_id>.mp4`` and ffprobe can identify the container.
-    """
-    ext = _sanitise_ext(detail.get('file_extension') or '')
-    if ext:
-        return ext
-    _stem, url_ext = os.path.splitext(url.split('?', 1)[0])
-    return _sanitise_ext(url_ext)
+    return ingest.file_ext_from(detail.get('file_extension'), url)
 
 
 def _parse_dt(value: Any) -> datetime | None:
@@ -199,11 +130,9 @@ def _availability_window(detail: dict[str, Any]) -> tuple[datetime, datetime]:
     """Map Yodeck's availability schedule onto Anthias start/end dates.
 
     When the schedule is enabled and carries both bounds we honour them;
-    otherwise the asset is always-on, modelled as "now → +10 years" (the
-    same wide window the schedule UI treats as unbounded).
+    otherwise the asset is always-on (``ingest.default_window()``).
     """
-    now = datetime.now(timezone.utc)
-    far_future = now + timedelta(days=3650)
+    now, far_future = ingest.default_window()
     schedule = detail.get('availability_schedule') or {}
     if schedule.get('enable'):
         start = _parse_dt(schedule.get('available_after')) or now
@@ -214,6 +143,8 @@ def _availability_window(detail: dict[str, Any]) -> tuple[datetime, datetime]:
 
 
 def _default_duration(detail: dict[str, Any]) -> int:
+    from anthias_server.settings import settings
+
     raw = detail.get('default_duration')
     duration = 0
     if isinstance(raw, (int, str)):
@@ -224,47 +155,6 @@ def _default_duration(detail: dict[str, Any]) -> int:
     if duration > 0:
         return duration
     return int(settings['default_duration'])
-
-
-def _stringify_errors(errors: Any) -> str:
-    """Collapse a serializer error bag into one operator-facing line."""
-    if isinstance(errors, str):
-        return errors
-    if isinstance(errors, dict):
-        for value in errors.values():
-            if isinstance(value, (list, tuple)) and value:
-                return str(value[0])
-            if value:
-                return str(value)
-    if isinstance(errors, (list, tuple)) and errors:
-        return str(errors[0])
-    return 'Anthias rejected the imported asset.'
-
-
-def _safe_unlink(path: str | None) -> None:
-    if not path:
-        return
-    try:
-        os.unlink(path)
-    except OSError:
-        pass
-
-
-def _find_imported_asset(remote_id: str) -> Asset | None:
-    return Asset.objects.filter(
-        metadata__import_source__provider=PROVIDER_KEY,
-        metadata__import_source__remote_id=str(remote_id),
-    ).first()
-
-
-def _stamp_import_source(asset: Asset, remote_id: str) -> None:
-    metadata = dict(asset.metadata or {})
-    metadata['import_source'] = {
-        'provider': PROVIDER_KEY,
-        'remote_id': str(remote_id),
-    }
-    asset.metadata = metadata
-    asset.save(update_fields=['metadata'])
 
 
 class YodeckProvider(ImportProvider):
@@ -364,7 +254,7 @@ class YodeckProvider(ImportProvider):
     def import_item(
         self, token: str, remote_id: str, *, enable: bool = True
     ) -> ImportOutcome:
-        existing = _find_imported_asset(remote_id)
+        existing = ingest.find_imported_asset(PROVIDER_KEY, remote_id)
         if existing is not None:
             return ImportOutcome(
                 success=True,
@@ -416,21 +306,19 @@ class YodeckProvider(ImportProvider):
                         'or widget) and cannot be imported.'
                     ),
                 )
-            asset = self._create_via_serializer(
-                uri=url,
-                ext=None,
-                mimetype='webpage',
+            asset = ingest.create_webpage_asset(
+                provider_key=PROVIDER_KEY,
+                remote_id=remote_id,
                 name=name,
+                url=url,
+                duration=_default_duration(detail),
                 start_date=start_date,
                 end_date=end_date,
-                duration=_default_duration(detail),
                 enable=enable,
             )
         else:
-            imported = self._import_file(
-                token, detail, media_type, name, start_date, end_date, enable
-            )
-            if imported is None:
+            file_url = _file_url(detail)
+            if not file_url:
                 return ImportOutcome(
                     success=False,
                     skipped=True,
@@ -439,9 +327,28 @@ class YodeckProvider(ImportProvider):
                         f'this {media_type}; re-upload it manually.'
                     ),
                 )
-            asset = imported
+            asset = ingest.create_file_asset(
+                session=_session,
+                headers=_auth_headers(token),
+                # Scope the Yodeck token to the Yodeck host — never forward
+                # it to a pre-signed CDN original.
+                auth_host=_YODECK_HOST,
+                provider_key=PROVIDER_KEY,
+                remote_id=remote_id,
+                name=name,
+                mimetype=media_type,
+                file_url=file_url,
+                ext=_file_ext(detail, file_url),
+                # Video duration is probed server-side (the serializer
+                # requires 0 on input); images carry Yodeck's duration.
+                duration=(
+                    0 if media_type == 'video' else _default_duration(detail)
+                ),
+                start_date=start_date,
+                end_date=end_date,
+                enable=enable,
+            )
 
-        _stamp_import_source(asset, remote_id)
         return ImportOutcome(success=True, asset_id=asset.asset_id)
 
     def _get_detail(self, token: str, remote_id: str) -> dict[str, Any]:
@@ -457,124 +364,3 @@ class YodeckProvider(ImportProvider):
         if not isinstance(body, dict):
             raise ProviderImportError('Unexpected response from Yodeck.')
         return body
-
-    def _import_file(
-        self,
-        token: str,
-        detail: dict[str, Any],
-        media_type: str,
-        name: str,
-        start_date: datetime,
-        end_date: datetime,
-        enable: bool,
-    ) -> Asset | None:
-        url = _file_url(detail)
-        if not url:
-            return None
-        staged_path, ext = self._download_to_assetdir(token, url, detail)
-        try:
-            return self._create_via_serializer(
-                uri=staged_path,
-                ext=ext,
-                mimetype=media_type,
-                name=name,
-                start_date=start_date,
-                end_date=end_date,
-                # Video duration is probed server-side (the serializer
-                # requires 0 on input); images carry Yodeck's duration.
-                duration=0
-                if media_type == 'video'
-                else _default_duration(detail),
-                enable=enable,
-            )
-        except Exception:
-            # ``prepare_asset`` renames the staged file into place only
-            # once validation passes, so on failure it's still at
-            # ``staged_path`` — remove it rather than leaving an orphan
-            # for the hourly cleanup sweep.
-            _safe_unlink(staged_path)
-            raise
-
-    def _download_to_assetdir(
-        self, token: str, url: str, detail: dict[str, Any]
-    ) -> tuple[str, str]:
-        ext = _file_ext(detail, url)
-        assetdir = settings['assetdir']
-        staged = os.path.join(assetdir, f'.import-{uuid.uuid4().hex}{ext}')
-        part = f'{staged}.part'
-        # Only attach the Yodeck token when the download stays on the
-        # Yodeck host — never forward it to a pre-signed CDN original.
-        download_headers = (
-            _auth_headers(token)
-            if urlparse(url).netloc.lower() == _YODECK_HOST
-            else {}
-        )
-        try:
-            with _session.get(
-                url,
-                headers=download_headers,
-                stream=True,
-                timeout=_DOWNLOAD_TIMEOUT_S,
-            ) as response:
-                if not response.ok:
-                    raise ProviderImportError(
-                        f'Yodeck download failed ({response.status_code}).'
-                    )
-                written = 0
-                with open(part, 'wb') as handle:
-                    for chunk in response.iter_content(_DOWNLOAD_CHUNK):
-                        if not chunk:
-                            continue
-                        written += len(chunk)
-                        if written > _MAX_DOWNLOAD_BYTES:
-                            raise ProviderImportError(
-                                'File exceeds the 5 GiB import size limit.'
-                            )
-                        handle.write(chunk)
-            if written == 0:
-                raise ProviderImportError('Yodeck returned an empty file.')
-            # Atomic move into the final staged name only once the whole
-            # body landed, so a truncated download can't be handed to the
-            # serializer.
-            os.replace(part, staged)
-            return staged, ext
-        except Exception:
-            _safe_unlink(part)
-            _safe_unlink(staged)
-            raise
-
-    def _create_via_serializer(
-        self,
-        *,
-        uri: str,
-        ext: str | None,
-        mimetype: str,
-        name: str,
-        start_date: datetime,
-        end_date: datetime,
-        duration: int,
-        enable: bool,
-    ) -> Asset:
-        data: dict[str, Any] = {
-            'name': name,
-            'uri': uri,
-            'mimetype': mimetype,
-            'start_date': start_date,
-            'end_date': end_date,
-            'duration': duration,
-            'is_enabled': enable,
-        }
-        if ext:
-            data['ext'] = ext
-        serializer = CreateAssetSerializerV2(data=data, unique_name=True)
-        # ``prepare_asset`` raises ``AssetCreationError`` (not a DRF
-        # ValidationError) for reachability / duration failures, which
-        # ``is_valid()`` does not catch — hence the explicit guard,
-        # matching ``AssetListViewV2.post``.
-        try:
-            valid = serializer.is_valid()
-        except AssetCreationError as error:
-            raise ProviderImportError(_stringify_errors(error.errors))
-        if not valid:
-            raise ProviderImportError(_stringify_errors(serializer.errors))
-        return persist_new_asset(serializer)


### PR DESCRIPTION
### Issues Fixed

Stacked on #3144 (Yodeck import). Adds the second provider in the import series and the shared ingest layer that makes further providers small.

> **Base branch:** `feat/import-content-yodeck` — review after #3144. Will retarget to `master` once #3144 merges.

### Description

- **Shared ingest layer** (`ingest.py` + `http.py`): the provider-agnostic download → `CreateAssetSerializerV2` → idempotency logic and the neutral (non-Anthias) HTTP session are extracted out of the Yodeck provider so every provider reuses them. Yodeck now delegates to them; behaviour is unchanged and its tests still pass.
- **ScreenCloud provider** (GraphQL): validates a token, pages `allFiles` (images/videos by mimetype) and `allLinks`, and imports each via the same `ImportProvider` interface, wizard, and CLI. Namespaced remote ids (`file:` / `link:`) route `import_item`. Regional endpoint via an optional `eu:`/`us:` token prefix.
- **Non-portable content filter** (as requested): only **STANDARD** ScreenCloud links import (INTERNAL/CLOUD skipped); only image/video files (audio/documents skipped); `allApps`/`allEmbeds` are never queried. Yodeck likewise skips webpage media that resolves to Yodeck-hosted apps/widgets.
- **Download auth scoping**: the API token is attached only when the download stays on the provider's host — never forwarded to a pre-signed CDN original (also applied to Yodeck via the shared layer).
- Unit tests for the ScreenCloud provider (GraphQL mocked; no network).

**Follow-ups (isolated, flagged in `screencloud.py`):** the production regional hostnames, the `fileById`/`linkById` field names, and which `FileOutput` is the durable original vs a thumbnail are behind a ScreenCloud login — to be confirmed against a live token; the resolution points are isolated for a localized change.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)