### PR TITLE
feat(import): add OptiSigns (GraphQL) provider to the import framework

### DIFF
--- a/src/anthias_server/api/tests/_graphql_helpers.py
+++ b/src/anthias_server/api/tests/_graphql_helpers.py
@@ -1,0 +1,44 @@
+"""Shared response fakes for GraphQL provider tests.
+
+Used by the ScreenCloud and OptiSigns import-provider test modules so the
+canned-response boilerplate lives in one place. Not a test module (no
+``test_`` prefix), so pytest doesn't collect it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import requests
+
+
+def gql_response(
+    status: int, data: Any = None, errors: Any = None
+) -> MagicMock:
+    """A fake ``requests.Response`` for a GraphQL POST."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    body: dict[str, Any] = {}
+    if data is not None:
+        body['data'] = data
+    if errors is not None:
+        body['errors'] = errors
+    resp.json.return_value = body
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            f'HTTP {status}', response=resp
+        )
+    return resp
+
+
+def stream_response(status: int, chunks: list[bytes]) -> MagicMock:
+    """A fake streaming response usable as a context manager."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    resp.iter_content.return_value = iter(chunks)
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp

--- a/src/anthias_server/api/tests/test_optisigns_import.py
+++ b/src/anthias_server/api/tests/test_optisigns_import.py
@@ -1,0 +1,326 @@
+"""Unit tests for the OptiSigns (GraphQL) import provider.
+
+Never touches the network: the provider's module-level ``_session`` is
+patched. Covers token validation, asset listing + classification (files
+vs external web links vs apps/YouTube/internal content), and per-item
+import.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from anthias_server.app.models import Asset
+from anthias_server.lib.integrations import optisigns
+from anthias_server.lib.integrations.registry import (
+    get_provider,
+    list_provider_meta,
+)
+from anthias_server.settings import settings
+
+PROVIDER = optisigns.OptiSignsProvider()
+
+
+def _gql(status: int, data: Any = None, errors: Any = None) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    body: dict[str, Any] = {}
+    if data is not None:
+        body['data'] = data
+    if errors is not None:
+        body['errors'] = errors
+    resp.json.return_value = body
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            f'HTTP {status}', response=resp
+        )
+    return resp
+
+
+def _stream(status: int, chunks: list[bytes]) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    resp.iter_content.return_value = iter(chunks)
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _assets(nodes: list[dict[str, Any]]) -> MagicMock:
+    edges = [{'cursor': n['_id'], 'node': n} for n in nodes]
+    return _gql(200, data={'assets': {'page': {'edges': edges}}})
+
+
+def _router(
+    by_id: dict[str, dict[str, Any]] | None = None,
+    listing: MagicMock | None = None,
+) -> Any:
+    def _post(url: str, **kwargs: Any) -> MagicMock:
+        query = kwargs['json']['query']
+        variables = kwargs['json'].get('variables') or {}
+        if '_id: $id' in query:
+            node = (by_id or {}).get(str(variables.get('id') or ''))
+            return _assets([node] if node else [])
+        if '$first' in query:
+            return listing if listing is not None else _assets([])
+        return _gql(200, data={'assets': {'page': {'edges': []}}})
+
+    return _post
+
+
+class TestAuthAndSession:
+    def test_bearer_header(self) -> None:
+        assert optisigns._auth_headers('abc') == {
+            'Authorization': 'Bearer abc',
+            'Content-Type': 'application/json',
+        }
+
+    def test_session_not_anthias_ua(self) -> None:
+        ua = optisigns._session.headers['User-Agent']
+        assert not ua.startswith('Anthias/')
+        assert 'anthias' not in ua.lower()
+
+
+class TestValidateToken:
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_true(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _assets([])
+        assert PROVIDER.validate_token('tok') is True
+
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_false_on_errors(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _gql(200, errors=[{'message': 'bad'}])
+        assert PROVIDER.validate_token('tok') is False
+
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_false_on_401(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _gql(401)
+        assert PROVIDER.validate_token('tok') is False
+
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_raises_on_5xx(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _gql(503)
+        with pytest.raises(requests.HTTPError):
+            PROVIDER.validate_token('tok')
+
+
+class TestClassify:
+    def test_image_and_video(self) -> None:
+        assert optisigns._classify({'fileType': 'image'}) == 'image'
+        assert optisigns._classify({'fileType': 'video'}) == 'video'
+
+    def test_external_weblink_is_webpage(self) -> None:
+        assert (
+            optisigns._classify({'webLink': 'https://example.com/'})
+            == 'webpage'
+        )
+
+    def test_youtube_and_internal_excluded(self) -> None:
+        assert (
+            optisigns._classify(
+                {'webLink': 'https://youtube.com/watch', 'youtubeType': 'v'}
+            )
+            is None
+        )
+        assert (
+            optisigns._classify({'webLink': 'https://app.optisigns.com/x'})
+            is None
+        )
+
+    def test_app_without_media_excluded(self) -> None:
+        assert optisigns._classify({'appType': 'dashboard'}) is None
+
+    def test_file_download_url_prefers_video_1080p(self) -> None:
+        node = {
+            'fileType': 'video',
+            'video_1080p': 'https://cdn/v.mp4',
+            'path': 'https://cdn/orig',
+        }
+        assert optisigns._file_download_url(node) == 'https://cdn/v.mp4'
+
+    def test_file_download_url_none_for_relative_path(self) -> None:
+        assert (
+            optisigns._file_download_url(
+                {'fileType': 'image', 'path': '/relative/x.png'}
+            )
+            is None
+        )
+
+
+class TestListMedia:
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_classifies_and_filters(self, post_mock: MagicMock) -> None:
+        post_mock.side_effect = _router(
+            listing=_assets(
+                [
+                    {'_id': 'a1', 'name': 'Pic', 'fileType': 'image'},
+                    {'_id': 'a2', 'name': 'Clip', 'fileType': 'video'},
+                    {
+                        '_id': 'a3',
+                        'name': 'Site',
+                        'webLink': 'https://example.com/',
+                    },
+                    {
+                        '_id': 'a4',
+                        'name': 'YT',
+                        'webLink': 'https://youtube.com/w',
+                        'youtubeType': 'v',
+                    },
+                    {'_id': 'a5', 'name': 'Dash', 'appType': 'dashboard'},
+                    {
+                        '_id': 'a6',
+                        'name': 'Int',
+                        'webLink': 'https://app.optisigns.com/x',
+                    },
+                ]
+            )
+        )
+        items = PROVIDER.list_media('tok')
+        by_id = {i.remote_id: i for i in items}
+        assert by_id['a1'].media_type == 'image' and by_id['a1'].importable
+        assert by_id['a2'].media_type == 'video' and by_id['a2'].importable
+        assert by_id['a3'].media_type == 'webpage' and by_id['a3'].importable
+        assert by_id['a4'].importable is False
+        assert by_id['a5'].importable is False
+        assert by_id['a6'].importable is False
+        assert by_id['a4'].skip_reason
+
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_graphql_error_surfaces_as_transport_error(
+        self, post_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _gql(200, errors=[{'message': 'boom'}])
+        with pytest.raises(requests.RequestException):
+            PROVIDER.list_media('tok')
+
+
+class TestRegistry:
+    def test_registered(self) -> None:
+        assert isinstance(
+            get_provider('optisigns'), optisigns.OptiSignsProvider
+        )
+        assert 'optisigns' in {m['key'] for m in list_provider_meta()}
+
+
+@pytest.mark.django_db
+class TestImportItem:
+    def test_idempotent_reimport_skips(self) -> None:
+        Asset.objects.create(
+            asset_id='opti-existing',
+            name='Existing',
+            uri='https://example.com/',
+            mimetype='webpage',
+            duration=10,
+            metadata={
+                'import_source': {
+                    'provider': 'optisigns',
+                    'remote_id': 'a1',
+                }
+            },
+        )
+        with patch(
+            'anthias_server.lib.integrations.optisigns._session.post'
+        ) as post_mock:
+            outcome = PROVIDER.import_item('tok', 'a1')
+        post_mock.assert_not_called()
+        assert outcome.skipped is True and outcome.success is True
+
+    @patch(
+        'anthias_server.api.serializers.mixins.url_fails', return_value=False
+    )
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_import_external_webpage(
+        self, post_mock: MagicMock, _url_fails: MagicMock
+    ) -> None:
+        post_mock.side_effect = _router(
+            by_id={
+                'a3': {
+                    '_id': 'a3',
+                    'name': 'Wireload',
+                    'webLink': 'https://wireload.net/',
+                    'duration': 12,
+                }
+            }
+        )
+        outcome = PROVIDER.import_item('tok', 'a3', enable=True)
+        assert outcome.success is True and not outcome.skipped
+        asset = Asset.objects.get(asset_id=outcome.asset_id)
+        assert asset.mimetype == 'webpage'
+        assert asset.uri == 'https://wireload.net/'
+        assert asset.metadata['import_source'] == {
+            'provider': 'optisigns',
+            'remote_id': 'a3',
+        }
+
+    @patch('anthias_server.lib.integrations.optisigns._session.get')
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_import_image_downloads_without_auth(
+        self,
+        post_mock: MagicMock,
+        get_mock: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setitem(settings, 'assetdir', str(tmp_path))
+        post_mock.side_effect = _router(
+            by_id={
+                'a1': {
+                    '_id': 'a1',
+                    'name': 'Pic',
+                    'fileType': 'image',
+                    'fileExtension': 'png',
+                    'path': 'https://cdn.optisigns.com/x.png',
+                }
+            }
+        )
+        captured: dict[str, str] = {}
+
+        def _get(url: str, **kwargs: Any) -> MagicMock:
+            captured.update(kwargs.get('headers') or {})
+            return _stream(200, [b'\x89PNG\r\n'])
+
+        get_mock.side_effect = _get
+
+        outcome = PROVIDER.import_item('tok', 'a1', enable=False)
+        assert outcome.success is True and not outcome.skipped
+        asset = Asset.objects.get(asset_id=outcome.asset_id)
+        assert asset.mimetype == 'image'
+        assert (tmp_path / f'{asset.asset_id}.png').is_file()
+        assert 'Authorization' not in captured
+
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_import_relative_path_skipped(self, post_mock: MagicMock) -> None:
+        post_mock.side_effect = _router(
+            by_id={
+                'a1': {
+                    '_id': 'a1',
+                    'name': 'Pic',
+                    'fileType': 'image',
+                    'path': '/relative/x.png',
+                }
+            }
+        )
+        outcome = PROVIDER.import_item('tok', 'a1')
+        assert outcome.skipped is True
+        assert 're-upload' in (outcome.reason or '')
+
+    @patch('anthias_server.lib.integrations.optisigns._session.post')
+    def test_import_youtube_skipped(self, post_mock: MagicMock) -> None:
+        post_mock.side_effect = _router(
+            by_id={
+                'a4': {
+                    '_id': 'a4',
+                    'name': 'YT',
+                    'webLink': 'https://youtube.com/watch?v=x',
+                    'youtubeType': 'video',
+                }
+            }
+        )
+        outcome = PROVIDER.import_item('tok', 'a4')
+        assert outcome.skipped is True

--- a/src/anthias_server/api/tests/test_optisigns_import.py
+++ b/src/anthias_server/api/tests/test_optisigns_import.py
@@ -15,7 +15,11 @@ import pytest
 import requests
 
 from anthias_server.app.models import Asset
-from anthias_server.lib.integrations import optisigns
+from anthias_server.api.tests._graphql_helpers import (
+    gql_response as _gql,
+    stream_response as _stream,
+)
+from anthias_server.lib.integrations import graphql, optisigns
 from anthias_server.lib.integrations.registry import (
     get_provider,
     list_provider_meta,
@@ -23,33 +27,6 @@ from anthias_server.lib.integrations.registry import (
 from anthias_server.settings import settings
 
 PROVIDER = optisigns.OptiSignsProvider()
-
-
-def _gql(status: int, data: Any = None, errors: Any = None) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status
-    resp.ok = 200 <= status < 400
-    body: dict[str, Any] = {}
-    if data is not None:
-        body['data'] = data
-    if errors is not None:
-        body['errors'] = errors
-    resp.json.return_value = body
-    if not resp.ok:
-        resp.raise_for_status.side_effect = requests.HTTPError(
-            f'HTTP {status}', response=resp
-        )
-    return resp
-
-
-def _stream(status: int, chunks: list[bytes]) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status
-    resp.ok = 200 <= status < 400
-    resp.iter_content.return_value = iter(chunks)
-    resp.__enter__.return_value = resp
-    resp.__exit__.return_value = False
-    return resp
 
 
 def _assets(nodes: list[dict[str, Any]]) -> MagicMock:
@@ -76,7 +53,7 @@ def _router(
 
 class TestAuthAndSession:
     def test_bearer_header(self) -> None:
-        assert optisigns._auth_headers('abc') == {
+        assert graphql.bearer_headers('abc') == {
             'Authorization': 'Bearer abc',
             'Content-Type': 'application/json',
         }

--- a/src/anthias_server/api/tests/test_screencloud_import.py
+++ b/src/anthias_server/api/tests/test_screencloud_import.py
@@ -15,7 +15,11 @@ import pytest
 import requests
 
 from anthias_server.app.models import Asset
-from anthias_server.lib.integrations import screencloud
+from anthias_server.api.tests._graphql_helpers import (
+    gql_response as _gql,
+    stream_response as _stream,
+)
+from anthias_server.lib.integrations import graphql, screencloud
 from anthias_server.lib.integrations.registry import (
     get_provider,
     list_provider_meta,
@@ -23,37 +27,6 @@ from anthias_server.lib.integrations.registry import (
 from anthias_server.settings import settings
 
 PROVIDER = screencloud.ScreenCloudProvider()
-
-
-def _gql(
-    status: int,
-    data: Any = None,
-    errors: Any = None,
-) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status
-    resp.ok = 200 <= status < 400
-    body: dict[str, Any] = {}
-    if data is not None:
-        body['data'] = data
-    if errors is not None:
-        body['errors'] = errors
-    resp.json.return_value = body
-    if not resp.ok:
-        resp.raise_for_status.side_effect = requests.HTTPError(
-            f'HTTP {status}', response=resp
-        )
-    return resp
-
-
-def _stream(status: int, chunks: list[bytes]) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status
-    resp.ok = 200 <= status < 400
-    resp.iter_content.return_value = iter(chunks)
-    resp.__enter__.return_value = resp
-    resp.__exit__.return_value = False
-    return resp
 
 
 def _router(routes: dict[str, MagicMock]) -> Any:
@@ -71,7 +44,7 @@ def _router(routes: dict[str, MagicMock]) -> Any:
 
 class TestAuthAndSession:
     def test_bearer_header(self) -> None:
-        assert screencloud._auth_headers('abc') == {
+        assert graphql.bearer_headers('abc') == {
             'Authorization': 'Bearer abc',
             'Content-Type': 'application/json',
         }

--- a/src/anthias_server/lib/integrations/graphql.py
+++ b/src/anthias_server/lib/integrations/graphql.py
@@ -1,0 +1,67 @@
+"""Shared GraphQL helpers for import providers.
+
+The GraphQL-backed providers (ScreenCloud, OptiSigns) all talk the same
+shape: a Bearer token, a POST of ``{query, variables}``, and a response
+that returns HTTP 200 even on failure (errors surfaced in an ``errors``
+array). This centralises that boilerplate so each provider owns only its
+endpoint, queries, and field mapping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from .base import ProviderImportError
+
+
+def bearer_headers(token: str) -> dict[str, str]:
+    return {
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/json',
+    }
+
+
+def post(
+    session: requests.Session,
+    endpoint: str,
+    headers: dict[str, str],
+    query: str,
+    variables: dict[str, Any] | None,
+    timeout: float,
+) -> requests.Response:
+    """Low-level GraphQL POST. Returns the raw ``requests`` response."""
+    return session.post(
+        endpoint,
+        headers=headers,
+        json={'query': query, 'variables': variables or {}},
+        timeout=timeout,
+    )
+
+
+def data_or_raise(
+    response: requests.Response, *, source: str
+) -> dict[str, Any]:
+    """Return ``data`` from a GraphQL response, raising on any error.
+
+    GraphQL answers 200 even on failure, so the ``errors`` array is checked
+    explicitly. HTTP-level and GraphQL errors both raise
+    ``ProviderImportError`` with the first message; ``source`` names the
+    provider for the fallback messages. Callers that need the transport
+    error to propagate (e.g. ``validate_token``) don't use this.
+    """
+    response.raise_for_status()
+    body = response.json()
+    errors = body.get('errors')
+    if errors:
+        message = f'{source} query failed.'
+        if isinstance(errors, list) and errors:
+            first = errors[0]
+            if isinstance(first, dict) and first.get('message'):
+                message = str(first['message'])
+        raise ProviderImportError(message)
+    data = body.get('data')
+    if not isinstance(data, dict):
+        raise ProviderImportError(f'Unexpected response from {source}.')
+    return data

--- a/src/anthias_server/lib/integrations/ingest.py
+++ b/src/anthias_server/lib/integrations/ingest.py
@@ -92,6 +92,20 @@ def file_ext_from(ext_hint: str | None, url: str) -> str:
     return _sanitise_ext(url_ext)
 
 
+def duration_or_default(raw: Any) -> int:
+    """Return a positive integer duration (seconds), or the device default.
+
+    Providers pass whatever their API gave (int/float/None); a missing or
+    non-positive value falls back to the operator's configured
+    ``default_duration``.
+    """
+    from anthias_server.settings import settings
+
+    if isinstance(raw, (int, float)) and raw > 0:
+        return int(raw)
+    return int(settings['default_duration'])
+
+
 def default_window() -> tuple[datetime, datetime]:
     """The always-on window used when a provider gives no schedule.
 

--- a/src/anthias_server/lib/integrations/optisigns.py
+++ b/src/anthias_server/lib/integrations/optisigns.py
@@ -22,13 +22,12 @@ against a live account. Resolution points are isolated in
 
 from __future__ import annotations
 
-import logging
 from typing import Any, Iterator
 from urllib.parse import urlparse
 
 import requests
 
-from . import ingest
+from . import graphql, ingest
 from .base import (
     ImportOutcome,
     ImportProvider,
@@ -36,8 +35,6 @@ from .base import (
     RemoteMediaItem,
 )
 from .http import new_import_session
-
-logger = logging.getLogger(__name__)
 
 PROVIDER_KEY = 'optisigns'
 OPTISIGNS_ENDPOINT = 'https://graphql-gateway.optisigns.com/graphql'
@@ -90,24 +87,19 @@ query($id: String!) {
 """
 
 
-def _auth_headers(token: str) -> dict[str, str]:
-    return {
-        'Authorization': f'Bearer {token}',
-        'Content-Type': 'application/json',
-    }
-
-
 def _post(
     token: str,
     query: str,
     variables: dict[str, Any] | None,
     timeout: float,
 ) -> Any:
-    return _session.post(
+    return graphql.post(
+        _session,
         OPTISIGNS_ENDPOINT,
-        headers=_auth_headers(token),
-        json={'query': query, 'variables': variables or {}},
-        timeout=timeout,
+        graphql.bearer_headers(token),
+        query,
+        variables,
+        timeout,
     )
 
 
@@ -118,22 +110,9 @@ def _graphql(
     *,
     timeout: float = _QUERY_TIMEOUT_S,
 ) -> dict[str, Any]:
-    """Execute a query and return ``data`` (raises on HTTP / GraphQL errors)."""
-    response = _post(token, query, variables, timeout)
-    response.raise_for_status()
-    body = response.json()
-    errors = body.get('errors')
-    if errors:
-        message = 'OptiSigns query failed.'
-        if isinstance(errors, list) and errors:
-            first = errors[0]
-            if isinstance(first, dict) and first.get('message'):
-                message = str(first['message'])
-        raise ProviderImportError(message)
-    data = body.get('data')
-    if not isinstance(data, dict):
-        raise ProviderImportError('Unexpected response from OptiSigns.')
-    return data
+    return graphql.data_or_raise(
+        _post(token, query, variables, timeout), source='OptiSigns'
+    )
 
 
 def _edges(data: dict[str, Any]) -> list[dict[str, Any]]:
@@ -166,7 +145,9 @@ def _webpage_url(node: dict[str, Any]) -> str | None:
     url = ingest.first_http_url([node.get('webLink')])
     if not url:
         return None
-    host = urlparse(url).netloc.lower()
+    # ``hostname`` (not ``netloc``) so an explicit port or userinfo can't
+    # dodge the internal-host match.
+    host = (urlparse(url).hostname or '').lower()
     if any(
         host == internal or host.endswith(f'.{internal}')
         for internal in _INTERNAL_WEB_HOSTS
@@ -190,21 +171,19 @@ def _file_download_url(node: dict[str, Any]) -> str | None:
 
 
 def _default_duration(node: dict[str, Any]) -> int:
-    from anthias_server.settings import settings
-
-    raw = node.get('duration')
-    if isinstance(raw, (int, float)) and raw > 0:
-        return int(raw)
-    return int(settings['default_duration'])
+    return ingest.duration_or_default(node.get('duration'))
 
 
 def _asset_name(node: dict[str, Any]) -> str:
-    return (
+    # Coerce to str: OptiSigns fields are typed loosely, and a non-string
+    # (or falsy non-None) name would otherwise break ``.strip()``.
+    name = (
         node.get('name')
         or node.get('originalFileName')
         or node.get('filename')
         or f'OptiSigns asset {node.get("_id")}'
-    ).strip()
+    )
+    return str(name).strip()
 
 
 class OptiSignsProvider(ImportProvider):

--- a/src/anthias_server/lib/integrations/optisigns.py
+++ b/src/anthias_server/lib/integrations/optisigns.py
@@ -1,0 +1,377 @@
+"""OptiSigns import provider — GraphQL.
+
+OptiSigns' API is a single GraphQL endpoint. Media lives under one
+``assets`` connection (there is no per-type query and no single-item
+query — a lookup is a filtered ``assets(query: {_id: …})``). Each asset's
+kind is read from ``fileType`` (image/video) or a populated external
+``webLink`` (web pages); apps, widgets, YouTube and other
+internally-generated content are filtered out.
+
+Reuses the shared ingest layer for download + asset creation +
+idempotency, behind the same ``ImportProvider`` interface as the other
+providers.
+
+TODO(confirm-with-live-token): the exact downloadable original-file field
+is undocumented — ``path`` (and ``video_1080p`` for video) are the
+candidates but may be CDN-relative, in which case the item is skipped
+rather than guessed at. The ``QueryAssetInput`` ``_id`` filter shape and
+the ``fileType``/``appType`` vocabularies are also worth confirming
+against a live account. Resolution points are isolated in
+``_file_download_url`` / ``_ASSET_BY_ID`` / ``_classify``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterator
+from urllib.parse import urlparse
+
+import requests
+
+from . import ingest
+from .base import (
+    ImportOutcome,
+    ImportProvider,
+    ProviderImportError,
+    RemoteMediaItem,
+)
+from .http import new_import_session
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_KEY = 'optisigns'
+OPTISIGNS_ENDPOINT = 'https://graphql-gateway.optisigns.com/graphql'
+
+_LIST_PAGE_SIZE = 100
+_VALIDATE_TIMEOUT_S = 15.0
+_QUERY_TIMEOUT_S = 30.0
+
+# Hosts whose web links are internal/app content, not portable external
+# URLs (OptiSigns-hosted apps/dashboards, and YouTube handled as an app).
+_INTERNAL_WEB_HOSTS = ('optisigns.com', 'youtube.com', 'youtu.be')
+
+_session = new_import_session()
+
+# --- GraphQL documents ------------------------------------------------------
+
+_VALIDATE_QUERY = (
+    'query { assets(first: 1, query: {}) { page { edges { cursor } } } }'
+)
+
+# Only the fields needed to classify a row (id/name + type discriminators);
+# the full field set is fetched per item on import.
+_ASSETS = """
+query($first: Int!, $after: String) {
+  assets(first: $first, after: $after, query: {}) {
+    page {
+      edges {
+        cursor
+        node { _id name fileType appType webType webLink youtubeType }
+      }
+    }
+  }
+}
+"""
+
+_ASSET_BY_ID = """
+query($id: String!) {
+  assets(first: 1, query: { _id: $id }) {
+    page {
+      edges {
+        node {
+          _id name fileType appType webType webLink youtubeType embedLink
+          duration path thumbnail video_1080p fileExtension
+          originalFileExtension originalFileName filename
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/json',
+    }
+
+
+def _post(
+    token: str,
+    query: str,
+    variables: dict[str, Any] | None,
+    timeout: float,
+) -> Any:
+    return _session.post(
+        OPTISIGNS_ENDPOINT,
+        headers=_auth_headers(token),
+        json={'query': query, 'variables': variables or {}},
+        timeout=timeout,
+    )
+
+
+def _graphql(
+    token: str,
+    query: str,
+    variables: dict[str, Any] | None = None,
+    *,
+    timeout: float = _QUERY_TIMEOUT_S,
+) -> dict[str, Any]:
+    """Execute a query and return ``data`` (raises on HTTP / GraphQL errors)."""
+    response = _post(token, query, variables, timeout)
+    response.raise_for_status()
+    body = response.json()
+    errors = body.get('errors')
+    if errors:
+        message = 'OptiSigns query failed.'
+        if isinstance(errors, list) and errors:
+            first = errors[0]
+            if isinstance(first, dict) and first.get('message'):
+                message = str(first['message'])
+        raise ProviderImportError(message)
+    data = body.get('data')
+    if not isinstance(data, dict):
+        raise ProviderImportError('Unexpected response from OptiSigns.')
+    return data
+
+
+def _edges(data: dict[str, Any]) -> list[dict[str, Any]]:
+    page = (data.get('assets') or {}).get('page') or {}
+    edges = page.get('edges') or []
+    return [edge for edge in edges if isinstance(edge, dict)]
+
+
+def _classify(node: dict[str, Any]) -> str | None:
+    """Return 'image' | 'video' | 'webpage', or None for unsupported.
+
+    Files are keyed off ``fileType``; a genuine external ``webLink`` (not
+    an OptiSigns/YouTube app) is a web page. Everything else — apps,
+    widgets, YouTube, audio, documents — is unsupported.
+    """
+    file_type = (node.get('fileType') or '').lower()
+    if file_type == 'image':
+        return 'image'
+    if file_type == 'video':
+        return 'video'
+    if _webpage_url(node):
+        return 'webpage'
+    return None
+
+
+def _webpage_url(node: dict[str, Any]) -> str | None:
+    """Return a genuine external web URL, or None for internal/app content."""
+    if node.get('youtubeType'):
+        return None
+    url = ingest.first_http_url([node.get('webLink')])
+    if not url:
+        return None
+    host = urlparse(url).netloc.lower()
+    if any(
+        host == internal or host.endswith(f'.{internal}')
+        for internal in _INTERNAL_WEB_HOSTS
+    ):
+        return None
+    return url
+
+
+def _file_download_url(node: dict[str, Any]) -> str | None:
+    """Pick the downloadable original URL (absolute http(s) only).
+
+    ``video_1080p`` is preferred for video; otherwise ``path``. If neither
+    is an absolute URL (e.g. a CDN-relative path), None is returned and the
+    item is skipped rather than guessed at — see the module TODO.
+    """
+    candidates = []
+    if (node.get('fileType') or '').lower() == 'video':
+        candidates.append(node.get('video_1080p'))
+    candidates.append(node.get('path'))
+    return ingest.first_http_url(candidates)
+
+
+def _default_duration(node: dict[str, Any]) -> int:
+    from anthias_server.settings import settings
+
+    raw = node.get('duration')
+    if isinstance(raw, (int, float)) and raw > 0:
+        return int(raw)
+    return int(settings['default_duration'])
+
+
+def _asset_name(node: dict[str, Any]) -> str:
+    return (
+        node.get('name')
+        or node.get('originalFileName')
+        or node.get('filename')
+        or f'OptiSigns asset {node.get("_id")}'
+    ).strip()
+
+
+class OptiSignsProvider(ImportProvider):
+    key = PROVIDER_KEY
+    label = 'OptiSigns'
+    description = (
+        'Copy images, videos and web pages from an OptiSigns account into '
+        'this player using an OptiSigns API key.'
+    )
+    token_help = (
+        'Create an API key in OptiSigns under Account Settings → API Keys → '
+        'New API Key. Paste it here; it is used only for this import and is '
+        'never stored.'
+    )
+
+    # -- token / listing ---------------------------------------------------
+
+    def validate_token(self, token: str) -> bool:
+        response = _post(token, _VALIDATE_QUERY, None, _VALIDATE_TIMEOUT_S)
+        if response.status_code in (401, 403):
+            return False
+        response.raise_for_status()
+        body = response.json()
+        if body.get('errors'):
+            return False
+        data = body.get('data') or {}
+        return isinstance(data.get('assets'), dict)
+
+    def list_media(
+        self, token: str, *, workspace: str | None = None
+    ) -> list[RemoteMediaItem]:
+        items: list[RemoteMediaItem] = []
+        for node in self._paginate(token):
+            remote_id = node.get('_id')
+            if not remote_id:
+                continue
+            media_type = _classify(node)
+            importable = media_type is not None
+            items.append(
+                RemoteMediaItem(
+                    remote_id=str(remote_id),
+                    name=_asset_name(node),
+                    media_type=media_type or 'unsupported',
+                    importable=importable,
+                    skip_reason=None
+                    if importable
+                    else (
+                        "This OptiSigns asset isn't a supported image, video "
+                        'or web page (app, widget or other content).'
+                    ),
+                    raw=node,
+                )
+            )
+        return items
+
+    def _paginate(self, token: str) -> Iterator[dict[str, Any]]:
+        after: str | None = None
+        while True:
+            try:
+                data = _graphql(
+                    token, _ASSETS, {'first': _LIST_PAGE_SIZE, 'after': after}
+                )
+            except ProviderImportError as error:
+                # list_media's caller (the API view) handles transport
+                # errors but not ProviderImportError; surface a GraphQL
+                # failure as one so it becomes a controlled 502, not a 500.
+                raise requests.RequestException(error.user_message) from error
+            edges = _edges(data)
+            for edge in edges:
+                node = edge.get('node')
+                if isinstance(node, dict):
+                    yield node
+            # OptiSigns' PageInfo field names aren't documented, so stop on a
+            # short page (or a missing cursor) rather than trusting a
+            # hasNextPage flag.
+            if len(edges) < _LIST_PAGE_SIZE:
+                break
+            after = edges[-1].get('cursor')
+            if not after:
+                break
+
+    # -- import ------------------------------------------------------------
+
+    def import_item(
+        self, token: str, remote_id: str, *, enable: bool = True
+    ) -> ImportOutcome:
+        existing = ingest.find_imported_asset(PROVIDER_KEY, remote_id)
+        if existing is not None:
+            return ImportOutcome(
+                success=True,
+                asset_id=existing.asset_id,
+                skipped=True,
+                reason='Already imported.',
+            )
+
+        node = self._get_asset(token, remote_id)
+        media_type = _classify(node)
+        if media_type is None:
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason=(
+                    "This OptiSigns asset isn't a supported image, video or "
+                    'web page.'
+                ),
+            )
+
+        name = _asset_name(node)
+        start_date, end_date = ingest.default_window()
+
+        if media_type == 'webpage':
+            url = _webpage_url(node)
+            if not url:
+                return ImportOutcome(
+                    success=False,
+                    skipped=True,
+                    reason='Could not determine an external URL for this asset.',
+                )
+            asset = ingest.create_webpage_asset(
+                provider_key=PROVIDER_KEY,
+                remote_id=remote_id,
+                name=name,
+                url=url,
+                duration=_default_duration(node),
+                start_date=start_date,
+                end_date=end_date,
+                enable=enable,
+            )
+            return ImportOutcome(success=True, asset_id=asset.asset_id)
+
+        file_url = _file_download_url(node)
+        if not file_url:
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason=(
+                    "OptiSigns didn't expose a downloadable original for this "
+                    f'{media_type}; re-upload it manually.'
+                ),
+            )
+        ext_hint = node.get('fileExtension') or node.get(
+            'originalFileExtension'
+        )
+        # No auth on the download: OptiSigns files are CDN/S3-served, so the
+        # bearer token must not be forwarded.
+        asset = ingest.create_file_asset(
+            session=_session,
+            provider_key=PROVIDER_KEY,
+            remote_id=remote_id,
+            name=name,
+            mimetype=media_type,
+            file_url=file_url,
+            ext=ingest.file_ext_from(ext_hint, file_url),
+            # Video duration is probed server-side; images use the default.
+            duration=0 if media_type == 'video' else _default_duration(node),
+            start_date=start_date,
+            end_date=end_date,
+            enable=enable,
+        )
+        return ImportOutcome(success=True, asset_id=asset.asset_id)
+
+    def _get_asset(self, token: str, remote_id: str) -> dict[str, Any]:
+        data = _graphql(token, _ASSET_BY_ID, {'id': remote_id})
+        edges = _edges(data)
+        if not edges:
+            raise ProviderImportError('Asset no longer exists in OptiSigns.')
+        node = edges[0].get('node')
+        if not isinstance(node, dict):
+            raise ProviderImportError('Unexpected response from OptiSigns.')
+        return node

--- a/src/anthias_server/lib/integrations/registry.py
+++ b/src/anthias_server/lib/integrations/registry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 from .base import ImportProvider
+from .optisigns import OptiSignsProvider
 from .screencloud import ScreenCloudProvider
 from .yodeck import YodeckProvider
 
@@ -18,7 +19,11 @@ from .yodeck import YodeckProvider
 # single shared instance each is fine.
 _PROVIDERS: dict[str, ImportProvider] = {
     provider.key: provider
-    for provider in (YodeckProvider(), ScreenCloudProvider())
+    for provider in (
+        YodeckProvider(),
+        ScreenCloudProvider(),
+        OptiSignsProvider(),
+    )
 }
 
 

--- a/src/anthias_server/lib/integrations/screencloud.py
+++ b/src/anthias_server/lib/integrations/screencloud.py
@@ -36,7 +36,7 @@ from typing import Any, Iterator
 
 import requests
 
-from . import ingest
+from . import graphql, ingest
 from .base import (
     ImportOutcome,
     ImportProvider,
@@ -123,26 +123,20 @@ def _endpoint_for(token: str) -> tuple[str, str]:
     return _REGION_ENDPOINTS[region], bearer
 
 
-def _auth_headers(bearer: str) -> dict[str, str]:
-    return {
-        'Authorization': f'Bearer {bearer}',
-        'Content-Type': 'application/json',
-    }
-
-
 def _post(
     token: str,
     query: str,
     variables: dict[str, Any] | None,
     timeout: float,
 ) -> Any:
-    """Low-level GraphQL POST. Returns the raw ``requests`` response."""
     endpoint, bearer = _endpoint_for(token)
-    return _session.post(
+    return graphql.post(
+        _session,
         endpoint,
-        headers=_auth_headers(bearer),
-        json={'query': query, 'variables': variables or {}},
-        timeout=timeout,
+        graphql.bearer_headers(bearer),
+        query,
+        variables,
+        timeout,
     )
 
 
@@ -153,28 +147,9 @@ def _graphql(
     *,
     timeout: float = _QUERY_TIMEOUT_S,
 ) -> dict[str, Any]:
-    """Execute a query and return ``data``.
-
-    GraphQL answers 200 even on failure, so the ``errors`` array is
-    checked explicitly. HTTP-level and GraphQL errors both raise
-    ``ProviderImportError`` with the first message — callers that need
-    the transport error to propagate (``validate_token``) don't use this.
-    """
-    response = _post(token, query, variables, timeout)
-    response.raise_for_status()
-    body = response.json()
-    errors = body.get('errors')
-    if errors:
-        message = 'ScreenCloud query failed.'
-        if isinstance(errors, list) and errors:
-            first = errors[0]
-            if isinstance(first, dict) and first.get('message'):
-                message = str(first['message'])
-        raise ProviderImportError(message)
-    data = body.get('data')
-    if not isinstance(data, dict):
-        raise ProviderImportError('Unexpected response from ScreenCloud.')
-    return data
+    return graphql.data_or_raise(
+        _post(token, query, variables, timeout), source='ScreenCloud'
+    )
 
 
 def _file_media_type(mimetype: str | None) -> str:
@@ -212,9 +187,9 @@ def _file_download_url(file_obj: dict[str, Any]) -> str | None:
 
 
 def _default_duration() -> int:
-    from anthias_server.settings import settings
-
-    return int(settings['default_duration'])
+    # ScreenCloud files/links don't expose a per-item display duration, so
+    # imported assets always use the device default.
+    return ingest.duration_or_default(None)
 
 
 class ScreenCloudProvider(ImportProvider):


### PR DESCRIPTION
### Issues Fixed

Stacked on #3145 (ScreenCloud). Third provider in the import series.

> **Base branch:** `feat/import-content-screencloud` — review after #3144 and #3145. Retarget to `master` as the stack merges.

### Description

- **OptiSigns provider** (GraphQL, `graphql-gateway.optisigns.com`): validates an API key (Bearer), pages the single `assets` connection, and imports via the same `ImportProvider` interface, wizard, and CLI. No per-type or single-item query exists, so a lookup is a filtered `assets(query: {_id: …})`.
- **Content classification + non-portable filter** (as requested): image/video from `fileType`; a genuine external `webLink` → web page. Apps/widgets (`appType`), YouTube (`youtubeType`), and OptiSigns-hosted internal links are skipped-with-reason.
- Reuses the shared **ingest/http** layer — download auth stays off the CDN original, list-level GraphQL errors surface as controlled 502s, extensions are sanitised.
- Unit tests (GraphQL mocked; no network).

**Follow-ups (isolated, flagged in `optisigns.py`):** the exact downloadable original-file field (`path`/`video_1080p` — may be CDN-relative), the `QueryAssetInput._id` filter shape, and the `fileType`/`appType` vocabularies are undocumented — to confirm against a live OptiSigns account; unresolved originals are skipped rather than guessed.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)