### PR TITLE
fix(viewer): bound AnthiasViewer output instead of buffering it in RAM

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -4,6 +4,7 @@ import logging
 import os
 import subprocess
 import sys
+from collections import deque
 from collections.abc import Callable
 from os import getenv, path
 from signal import SIGALRM, signal
@@ -681,13 +682,24 @@ class _BoundedWebviewOutput:
 
     We keep the last ``maxlen`` characters: the handshake line is emitted
     early (well inside the window) and a crash tail is the most recent
-    output, so both survive while everything older is dropped. sh invokes
-    ``__call__`` from its stdout reader thread, so access is lock-guarded.
+    output, so both survive while everything older is dropped.
+
+    Retention is a deque of raw chunks, not a growing-then-sliced string:
+    a chatty decoder can call ``__call__`` per audio frame for the life of
+    the process, and ``buf += chunk`` + slice would re-copy ~``maxlen``
+    characters on *every* such call once the window is full — steady CPU
+    burn on a weak Pi, against the spirit of this fix. Appending a chunk
+    and dropping whole oldest chunks is amortized O(1); the join to a
+    single string happens only in ``text()``, which is read rarely (the
+    startup handshake poll, where the buffer is still small, and
+    ``WEBVIEW_DEBUG``). sh invokes ``__call__`` from its stdout reader
+    thread, so access is lock-guarded.
     """
 
     def __init__(self, maxlen: int = WEBVIEW_OUTPUT_BUFFER_CHARS) -> None:
         self._maxlen = maxlen
-        self._buf = ''
+        self._chunks: deque[str] = deque()
+        self._size = 0
         self._lock = Lock()
 
     def __call__(self, chunk: str | bytes) -> None:
@@ -699,21 +711,30 @@ class _BoundedWebviewOutput:
         if isinstance(chunk, bytes):
             chunk = chunk.decode('utf-8', errors='replace')
         # A single chunk larger than the window (a big unbuffered write
-        # from the child) would otherwise force a ``buf + chunk``
-        # allocation proportional to the chunk, spiking well past
-        # ``maxlen`` — the very thing this sink exists to prevent. Slice
-        # it to its tail first (same tail-retention result), so both the
-        # retained buffer and the transient stay within ~2x maxlen.
+        # from the child) can't add more than the tail we'd keep anyway,
+        # so slice it up front — bounds both the stored chunk and the
+        # transient at ``maxlen``.
         if len(chunk) > self._maxlen:
             chunk = chunk[-self._maxlen :]
         with self._lock:
-            self._buf += chunk
-            if len(self._buf) > self._maxlen:
-                self._buf = self._buf[-self._maxlen :]
+            self._chunks.append(chunk)
+            self._size += len(chunk)
+            # Drop whole oldest chunks while the remainder still covers
+            # the window, so retained size stays within [maxlen,
+            # maxlen + newest-dropped-chunk) < 2x maxlen — without ever
+            # re-copying the kept data.
+            while (
+                self._chunks
+                and self._size - len(self._chunks[0]) >= self._maxlen
+            ):
+                self._size -= len(self._chunks.popleft())
 
     def text(self) -> str:
         with self._lock:
-            return self._buf
+            joined = ''.join(self._chunks)
+        # Trim to the exact tail: the front chunk may push the join a
+        # little over ``maxlen`` (see the drop condition above).
+        return joined[-self._maxlen :]
 
 
 def _spawn_webview_once(startup_timeout: float) -> Any:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -7,6 +7,7 @@ import sys
 from collections.abc import Callable
 from os import getenv, path
 from signal import SIGALRM, signal
+from threading import Lock
 from time import monotonic, sleep
 from typing import Any
 
@@ -74,6 +75,11 @@ current_browser_url: str | None = None
 # viewer anyway; that resets the cache.
 _webview_supports_set_reload_interval: bool = True
 browser: Any = None
+# Bounded sink for the current AnthiasViewer's merged stdout+stderr. See
+# _BoundedWebviewOutput / _spawn_webview_once (issue #3138). Mirrors
+# ``browser``: replaced on every (re)spawn, so it always refers to the
+# live process's output.
+_webview_output: Any = None
 loop_is_stopped: bool = False
 # Set by the ``blank`` command: pauses the asset loop (via
 # loop_is_stopped) and signals the main thread to paint a black screen.
@@ -653,6 +659,48 @@ def _wait_for_wayland_socket(deadline: float) -> None:
     )
 
 
+# Upper bound on the AnthiasViewer output we retain in memory. sh
+# otherwise keeps the whole stdout+stderr stream for the life of the
+# background process (issue #3138); we keep only the most recent slice —
+# large enough that the startup handshake and any crash tail fall inside
+# the window, small enough to never pressure a 1-2 GB board.
+WEBVIEW_OUTPUT_BUFFER_CHARS = 64 * 1024
+
+
+class _BoundedWebviewOutput:
+    """``_out`` sink that retains only the tail of AnthiasViewer's output.
+
+    Passed as ``_out`` to the background ``sh`` command so sh streams each
+    chunk here instead of aggregating the entire merged stdout+stderr in
+    the viewer process's RAM for the whole session. Without it, a chatty
+    decoder — e.g. ffmpeg's AAC path spamming ``channel element 0.0
+    duplicate`` on every audio frame for certain files — grows the
+    viewer's RSS without bound until a low-memory board (the 2 GB Pi4 in
+    issue #3138) swaps itself to a standstill and the screen sits blank
+    for minutes between assets.
+
+    We keep the last ``maxlen`` characters: the handshake line is emitted
+    early (well inside the window) and a crash tail is the most recent
+    output, so both survive while everything older is dropped. sh invokes
+    ``__call__`` from its stdout reader thread, so access is lock-guarded.
+    """
+
+    def __init__(self, maxlen: int = WEBVIEW_OUTPUT_BUFFER_CHARS) -> None:
+        self._maxlen = maxlen
+        self._buf = ''
+        self._lock = Lock()
+
+    def __call__(self, chunk: str) -> None:
+        with self._lock:
+            self._buf += chunk
+            if len(self._buf) > self._maxlen:
+                self._buf = self._buf[-self._maxlen :]
+
+    def text(self) -> str:
+        with self._lock:
+            return self._buf
+
+
 def _spawn_webview_once(startup_timeout: float) -> Any:
     """Spawn AnthiasViewer once and block until it registers on D-Bus.
 
@@ -668,12 +716,20 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
     socket and the handshake, so the socket wait can't pile on top of
     ``startup_timeout``.
     """
+    global _webview_output
     deadline = monotonic() + startup_timeout
     # On cage boards, don't race the Wayland socket — a spawn before
     # it exists dies instantly with "Failed to create wl_display" and
     # wastes a retry attempt (Sentry ANTHIAS-19). No-op elsewhere and
     # when the socket is already up (the common case).
     _wait_for_wayland_socket(deadline)
+    # Bounded ``_out`` sink instead of sh's default: sh would otherwise
+    # retain the process's entire stdout+stderr in RAM forever, and a
+    # chatty decoder then leaks the viewer to death on a low-memory board
+    # (issue #3138). With an ``_out`` handler sh stops aggregating
+    # ``.process.stdout`` (it stays empty), so the handshake scan and the
+    # failure message below read the sink instead.
+    output = _BoundedWebviewOutput()
     try:
         # _bg_exc=False: with the default (True), sh re-raises the exit
         # error (e.g. SignalException_SIGABRT on a Qt init crash, or
@@ -686,6 +742,7 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
             _bg=True,
             _bg_exc=False,
             _err_to_out=True,
+            _out=output,
             _env=_build_webview_env(),
         )
     except sh.CommandNotFound as exc:
@@ -697,15 +754,13 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
     # so the whole attempt — socket wait plus handshake — is bounded by
     # ``startup_timeout`` rather than the two stacking.
     while monotonic() < deadline:
-        if BROWSER_HANDSHAKE_LINE in candidate.process.stdout.decode(
-            'utf-8', errors='replace'
-        ):
+        if BROWSER_HANDSHAKE_LINE in output.text():
+            _webview_output = output
             return candidate
         if not candidate.is_alive():
             raise WebviewLaunchError(
                 'AnthiasViewer exited before emitting D-Bus handshake; '
-                'stdout: '
-                + candidate.process.stdout.decode('utf-8', errors='replace')
+                'stdout: ' + output.text()
             )
         sleep(BROWSER_POLL_INTERVAL_SECONDS)
 
@@ -1021,8 +1076,8 @@ def view_image(uri: str) -> None:
         current_browser_url = uri
     logging.info('Current url is {0}'.format(current_browser_url))
 
-    if string_to_bool(getenv('WEBVIEW_DEBUG', '0')):
-        logging.info(browser.process.stdout)
+    if string_to_bool(getenv('WEBVIEW_DEBUG', '0')) and _webview_output:
+        logging.info(_webview_output.text())
 
 
 def view_video(uri: str, duration: int | str) -> None:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -690,7 +690,14 @@ class _BoundedWebviewOutput:
         self._buf = ''
         self._lock = Lock()
 
-    def __call__(self, chunk: str) -> None:
+    def __call__(self, chunk: str | bytes) -> None:
+        # sh decodes to ``str`` for an ``_out`` callback under the default
+        # encoding (verified with the shipped sh 2.3.0 on a Pi4), but
+        # coerce defensively so an ``_encoding=None`` / raw-bytes
+        # configuration can never turn ``str + bytes`` into a TypeError
+        # that would silently break the handshake scan.
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode('utf-8', errors='replace')
         with self._lock:
             self._buf += chunk
             if len(self._buf) > self._maxlen:
@@ -729,7 +736,12 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
     # (issue #3138). With an ``_out`` handler sh stops aggregating
     # ``.process.stdout`` (it stays empty), so the handshake scan and the
     # failure message below read the sink instead.
+    #
+    # Publish the sink now, before the spawn: ``_webview_output`` then
+    # mirrors ``browser`` for the live attempt, so a WEBVIEW_DEBUG read
+    # during launch/retry can't surface a previous process's stale tail.
     output = _BoundedWebviewOutput()
+    _webview_output = output
     try:
         # _bg_exc=False: with the default (True), sh re-raises the exit
         # error (e.g. SignalException_SIGABRT on a Qt init crash, or
@@ -755,7 +767,6 @@ def _spawn_webview_once(startup_timeout: float) -> Any:
     # ``startup_timeout`` rather than the two stacking.
     while monotonic() < deadline:
         if BROWSER_HANDSHAKE_LINE in output.text():
-            _webview_output = output
             return candidate
         if not candidate.is_alive():
             raise WebviewLaunchError(

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -698,6 +698,14 @@ class _BoundedWebviewOutput:
         # that would silently break the handshake scan.
         if isinstance(chunk, bytes):
             chunk = chunk.decode('utf-8', errors='replace')
+        # A single chunk larger than the window (a big unbuffered write
+        # from the child) would otherwise force a ``buf + chunk``
+        # allocation proportional to the chunk, spiking well past
+        # ``maxlen`` — the very thing this sink exists to prevent. Slice
+        # it to its tail first (same tail-retention result), so both the
+        # retained buffer and the transient stay within ~2x maxlen.
+        if len(chunk) > self._maxlen:
+            chunk = chunk[-self._maxlen :]
         with self._lock:
             self._buf += chunk
             if len(self._buf) > self._maxlen:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -168,40 +168,48 @@ def test_setup_reraises_unrelated_busget_error(
     assert viewer_fixtures.m_loadb.call_count == 1
 
 
-def _stub_browser_stdout_static(
+def _capture_out_sink(
+    viewer_fixtures: _ViewerFixtures,
     browser_proc: mock.Mock,
-    value: bytes,
-) -> None:
-    """
-    sh.RunningCommand.process.stdout is a @property that returns the
-    latest accumulated buffer on each access. Use PropertyMock so
-    the test exercises the same poll-and-decode pattern as the
-    production loop. Static variant: every read returns the same
-    bytes value, suitable for cases where the loop doesn't depend
-    on stdout changing across iterations (early-exit, timeout).
-    """
-    type(browser_proc.process).stdout = mock.PropertyMock(return_value=value)
+    seed: str = '',
+) -> dict[str, Any]:
+    """Wire the mocked sh command so the ``_BoundedWebviewOutput`` it is
+    handed as ``_out`` is captured for the test to drive.
 
+    Production no longer reads ``.process.stdout`` (sh stops aggregating
+    it once an ``_out`` handler is set — that's the issue #3138 fix);
+    instead the handshake scan and failure message read the bounded sink.
+    When ``seed`` is given it is fed into the sink as the command is
+    invoked, so the handshake is present on the first poll. Returns a
+    holder dict whose ``'sink'`` key is populated when the command runs.
+    """
+    holder: dict[str, Any] = {}
 
-def _stub_browser_stdout_chunks(
-    browser_proc: mock.Mock,
-    chunks: list[bytes],
-) -> None:
-    """As above, but advance through `chunks` across reads — for
-    the success case where the handshake appears in a later poll."""
-    type(browser_proc.process).stdout = mock.PropertyMock(side_effect=chunks)
+    def capture(*args: Any, **kwargs: Any) -> mock.Mock:
+        holder['sink'] = kwargs['_out']
+        if seed:
+            kwargs['_out'](seed)
+        return browser_proc
+
+    viewer_fixtures.m_cmd.return_value.side_effect = capture
+    return holder
 
 
 def test_load_browser(viewer_fixtures: _ViewerFixtures) -> None:
     browser_proc = viewer_fixtures.m_cmd.return_value.return_value
-    # Two stdout reads: an empty buffer on the first poll, then the
-    # handshake line appended on the second. Verifies that the
-    # polling loop actually re-reads stdout each iteration.
-    _stub_browser_stdout_chunks(
-        browser_proc,
-        [b'starting up\n', b'starting up\nAnthias service start\n'],
-    )
     browser_proc.is_alive.return_value = True
+
+    # The handshake line must arrive across polls, not before the first:
+    # capture the _out sink, leave it empty for the first poll, then feed
+    # the handshake on the first mocked sleep so the second poll finds it
+    # — verifying the loop re-reads the sink each iteration.
+    holder = _capture_out_sink(viewer_fixtures, browser_proc)
+
+    def feed_handshake(*args: Any, **kwargs: Any) -> None:
+        holder['sink']('starting up\nAnthias service start\n')
+
+    viewer_fixtures.m_sleep.side_effect = feed_handshake
+
     viewer_fixtures.p_cmd.start()
     viewer_fixtures.p_sleep.start()
     try:
@@ -218,6 +226,12 @@ def test_load_browser(viewer_fixtures: _ViewerFixtures) -> None:
     launch_kwargs = viewer_fixtures.m_cmd.return_value.call_args.kwargs
     assert launch_kwargs['_bg'] is True
     assert launch_kwargs['_bg_exc'] is False
+    # _out must be the bounded sink, not sh's default unbounded stdout
+    # aggregation that leaks the viewer's RAM on a chatty decoder
+    # (issue #3138).
+    assert isinstance(
+        launch_kwargs['_out'], viewer_fixtures.u._BoundedWebviewOutput
+    )
 
 
 def test_spawn_webview_once_raises_on_early_exit(
@@ -227,8 +241,8 @@ def test_spawn_webview_once_raises_on_early_exit(
     WebviewLaunchError (a RuntimeError subclass) and does NOT terminate
     (it's already dead)."""
     browser_proc = viewer_fixtures.m_cmd.return_value.return_value
-    # The error message also reads stdout, so use the static stub.
-    _stub_browser_stdout_static(browser_proc, b'')
+    # No output is fed, so the bounded _out sink stays empty and the
+    # failure message reads it as such.
     browser_proc.is_alive.return_value = False
     viewer_fixtures.p_cmd.start()
     viewer_fixtures.p_sleep.start()
@@ -249,7 +263,6 @@ def test_spawn_webview_once_terminates_on_timeout(
     would leak a second AnthiasViewer contending for the framebuffer /
     D-Bus name."""
     browser_proc = viewer_fixtures.m_cmd.return_value.return_value
-    _stub_browser_stdout_static(browser_proc, b'irrelevant noise')
     # is_alive False so _terminate_webview reaps immediately without a
     # busy-wait; the 0s timeout drives the deadline straight past.
     browser_proc.is_alive.return_value = False
@@ -278,6 +291,35 @@ def test_spawn_webview_once_missing_binary(
             viewer_fixtures.u._spawn_webview_once(30)
     finally:
         viewer_fixtures.p_cmd.stop()
+
+
+def test_bounded_webview_output_discards_old_data(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """The _out sink retains only the most recent maxlen chars, so a
+    chatty AnthiasViewer (e.g. ffmpeg spamming 'channel element 0.0
+    duplicate' every frame) can't grow the viewer's RSS without bound —
+    the root cause of issue #3138."""
+    sink = viewer_fixtures.u._BoundedWebviewOutput(maxlen=100)
+    for _ in range(1000):
+        sink('channel element 0.0 duplicate\n')
+    text = sink.text()
+    assert len(text) <= 100
+    # What survives is the tail of the stream, not the head.
+    assert text.endswith('duplicate\n')
+
+
+def test_bounded_webview_output_preserves_handshake_in_window(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """The handshake line is emitted early, within the retained window,
+    so it stays visible to the startup scan even after later output and
+    across chunk boundaries."""
+    sink = viewer_fixtures.u._BoundedWebviewOutput(maxlen=1024)
+    sink('booting\nAnthias service ')
+    sink('start\n')
+    sink('more logs after handshake\n')
+    assert viewer_fixtures.u.BROWSER_HANDSHAKE_LINE in sink.text()
 
 
 def test_load_browser_retries_then_succeeds(
@@ -488,9 +530,8 @@ def test_load_browser_resets_set_reload_interval_capability(
     and we shouldn't leave auto-refresh permanently disabled because
     the *old* process didn't have it."""
     browser_proc = viewer_fixtures.m_cmd.return_value.return_value
-    _stub_browser_stdout_chunks(
-        browser_proc,
-        [b'Anthias service start\n'],
+    _capture_out_sink(
+        viewer_fixtures, browser_proc, seed='Anthias service start\n'
     )
     browser_proc.is_alive.return_value = True
     viewer_fixtures.p_cmd.start()
@@ -673,9 +714,8 @@ def test_load_browser_resets_current_browser_url(
     unchanged URL (single-asset playlist) the respawned webview would
     otherwise stay blank forever."""
     browser_proc = viewer_fixtures.m_cmd.return_value.return_value
-    _stub_browser_stdout_chunks(
-        browser_proc,
-        [b'Anthias service start\n'],
+    _capture_out_sink(
+        viewer_fixtures, browser_proc, seed='Anthias service start\n'
     )
     browser_proc.is_alive.return_value = True
     viewer_fixtures.p_cmd.start()

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -36,7 +36,19 @@ class _ViewerFixtures:
 
 
 @pytest.fixture
-def viewer_fixtures() -> Iterator[_ViewerFixtures]:
+def viewer_fixtures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[_ViewerFixtures]:
+    # Keep every spawn/handshake test hermetic against the host's Wayland
+    # env. _spawn_webview_once calls _wait_for_wayland_socket before the
+    # mocked command runs; with sleep mocked, a set-but-dangling
+    # WAYLAND_DISPLAY (some CI/dev containers, or a Wayland desktop whose
+    # socket path doesn't resolve here) would make that wait busy-loop for
+    # the whole startup budget or fire a sleep side effect before the
+    # spawn. Clearing it makes _wayland_socket_path() return None so the
+    # wait is a no-op. The dedicated _wait_for_wayland_socket tests set
+    # their own env and don't use this fixture.
+    monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
     fixtures = _ViewerFixtures()
     original_splash_delay = viewer.SPLASH_DELAY
     viewer.SPLASH_DELAY = 0
@@ -195,20 +207,13 @@ def _capture_out_sink(
     return holder
 
 
-def test_load_browser(
-    viewer_fixtures: _ViewerFixtures, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_load_browser(viewer_fixtures: _ViewerFixtures) -> None:
     browser_proc = viewer_fixtures.m_cmd.return_value.return_value
     browser_proc.is_alive.return_value = True
 
-    # Keep the pre-spawn Wayland-socket wait a no-op regardless of the
-    # host: _spawn_webview_once calls _wait_for_wayland_socket before the
-    # command runs, and on a Wayland desktop (WAYLAND_DISPLAY set) that
-    # wait would call the mocked sleep — firing feed_handshake before the
-    # _out sink is captured. Clearing it makes _wayland_socket_path()
-    # return None, so sleep is exercised only by the handshake poll loop.
-    monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
-
+    # (viewer_fixtures clears WAYLAND_DISPLAY, so the pre-spawn
+    # _wait_for_wayland_socket is a no-op and sleep is exercised only by
+    # the handshake poll loop below.)
     # The handshake line must arrive across polls, not before the first:
     # capture the _out sink, leave it empty for the first poll, then feed
     # the handshake on the first mocked sleep so the second poll finds it

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -309,6 +309,20 @@ def test_bounded_webview_output_discards_old_data(
     assert text.endswith('duplicate\n')
 
 
+def test_bounded_webview_output_slices_oversized_chunk(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """A single chunk larger than the window is sliced to its tail before
+    being buffered, so a big unbuffered write from the child can't spike a
+    ``buf + chunk`` allocation far past maxlen — the retained buffer never
+    exceeds maxlen and keeps the most recent bytes."""
+    sink = viewer_fixtures.u._BoundedWebviewOutput(maxlen=100)
+    sink('x' * 10000 + 'TAIL')
+    text = sink.text()
+    assert len(text) <= 100
+    assert text.endswith('TAIL')
+
+
 def test_bounded_webview_output_coerces_bytes(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -309,6 +309,27 @@ def test_bounded_webview_output_discards_old_data(
     assert text.endswith('duplicate\n')
 
 
+def test_bounded_webview_output_write_is_amortized_cheap(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """Once the window is full, a new chunk must not re-copy the retained
+    data: retention is a deque of chunks, not a grow-then-slice string, so
+    a per-frame chatty decoder doesn't burn CPU recopying ~maxlen chars on
+    every call. Assert the write path stores whole chunks (bounded count)
+    and never materializes maxlen-sized strings on append."""
+    sink = viewer_fixtures.u._BoundedWebviewOutput(maxlen=100)
+    # 10k tiny writes; if each recopied the buffer this would be O(n*maxlen).
+    for i in range(10000):
+        sink(f'line {i}\n')
+    # The kept data is bounded, holds the most recent lines, and the
+    # number of retained chunks is small (only enough to cover the window,
+    # not one per write).
+    text = sink.text()
+    assert len(text) <= 100
+    assert text.endswith('line 9999\n')
+    assert len(sink._chunks) < 50
+
+
 def test_bounded_webview_output_slices_oversized_chunk(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -309,6 +309,21 @@ def test_bounded_webview_output_discards_old_data(
     assert text.endswith('duplicate\n')
 
 
+def test_bounded_webview_output_coerces_bytes(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """sh hands the _out callback str under the default encoding, but the
+    sink coerces bytes defensively so an _encoding=None / raw-bytes
+    configuration can't turn ``str + bytes`` into a TypeError that would
+    silently break the handshake scan."""
+    sink = viewer_fixtures.u._BoundedWebviewOutput(maxlen=1024)
+    sink(b'booting\n')
+    sink('Anthias service start\n')
+    text = sink.text()
+    assert viewer_fixtures.u.BROWSER_HANDSHAKE_LINE in text
+    assert isinstance(text, str)
+
+
 def test_bounded_webview_output_preserves_handshake_in_window(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -195,9 +195,19 @@ def _capture_out_sink(
     return holder
 
 
-def test_load_browser(viewer_fixtures: _ViewerFixtures) -> None:
+def test_load_browser(
+    viewer_fixtures: _ViewerFixtures, monkeypatch: pytest.MonkeyPatch
+) -> None:
     browser_proc = viewer_fixtures.m_cmd.return_value.return_value
     browser_proc.is_alive.return_value = True
+
+    # Keep the pre-spawn Wayland-socket wait a no-op regardless of the
+    # host: _spawn_webview_once calls _wait_for_wayland_socket before the
+    # command runs, and on a Wayland desktop (WAYLAND_DISPLAY set) that
+    # wait would call the mocked sleep — firing feed_handshake before the
+    # _out sink is captured. Clearing it makes _wayland_socket_path()
+    # return None, so sleep is exercised only by the handshake poll loop.
+    monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
 
     # The handshake line must arrive across polls, not before the first:
     # capture the _out sink, leave it empty for the first poll, then feed
@@ -206,7 +216,10 @@ def test_load_browser(viewer_fixtures: _ViewerFixtures) -> None:
     holder = _capture_out_sink(viewer_fixtures, browser_proc)
 
     def feed_handshake(*args: Any, **kwargs: Any) -> None:
-        holder['sink']('starting up\nAnthias service start\n')
+        # Only the post-spawn poll loop should drive this; guard so a
+        # stray pre-spawn sleep can never KeyError on an uncaptured sink.
+        if 'sink' in holder:
+            holder['sink']('starting up\nAnthias service start\n')
 
     viewer_fixtures.m_sleep.side_effect = feed_handshake
 


### PR DESCRIPTION
## Problem

Fixes https://github.com/Screenly/Anthias/issues/3138.

On a 2 GB Raspberry Pi 4 with large MP4s, moving to the next asset blanks the screen for minutes and the viewer can wedge until the next asset is forced in the UI.

**Root cause:** the viewer spawns `AnthiasViewer` via the `sh` library with `_bg=True, _err_to_out=True` and **no output sink**. `sh` therefore aggregates the process's *entire* merged stdout+stderr in the viewer process's RAM for the whole session, and nothing ever drains `browser.process.stdout` after the D-Bus handshake. When a file's audio makes ffmpeg's AAC decoder spam `channel element 0.0 duplicate` on every frame (245k lines / 203 MB in the reporter's attached debug log), that in-RAM buffer grows without bound. On a 2 GB board it exhausts memory and drives the box into swap — hence the multi-minute blank transitions and the "device unresponsive for ~5 min" reports. With `debug_logging` on, `sh`'s own per-chunk DEBUG logging multiplies it into the 203 MB log.

## Fix

Pass a bounded `_BoundedWebviewOutput` sink as `_out`. `sh` then streams each chunk to it instead of retaining the stream — and, importantly, **stops aggregating `.process.stdout`** — so we keep only the last 64 KiB, which is enough for the startup-handshake scan and any crash tail. The handshake scan and the launch-failure message now read the bounded sink; `WEBVIEW_DEBUG` reads it too.

## Verification

**On the real Pi 4 (arm64), inside the viewer container, exact shipped `sh` 2.3.0** — feeding a fixed 28.6 MB of decoder-style spam through the two spawn variants:

| Scenario | Subprocess output | Viewer RSS delta | sh aggregated stdout |
|---|---|---|---|
| current (no `_out` sink) | 28.6 MB | **+192 MB** | 28.6 MB retained |
| this PR (`_out` bounded sink) | 28.6 MB | **0.0 MB** | **0.0 MB** |

Same result reproduced on x86 (23 MB → 670 MB RSS in 24 s of continuous spam under the old flags; flat 23 MB with the sink). The bounded probe left the board healthy (no wedge).

**Unit tests:** added a direct regression test that the sink discards old data (bounded) and preserves the handshake in its window; reworked the spawn/handshake tests to drive the new sink. Full non-integration suite: **1245 passed**. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)