### PR TITLE
feat(import): add piSignage (REST) provider to the import framework

### DIFF
--- a/src/anthias_server/api/tests/test_pisignage_import.py
+++ b/src/anthias_server/api/tests/test_pisignage_import.py
@@ -1,0 +1,275 @@
+"""Unit tests for the piSignage (REST) import provider.
+
+Never touches the network: the provider's module-level ``_session`` is
+patched. Covers credential parsing, login/validation, file listing +
+classification, and per-item import (with the token attached to the
+same-host media download).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+from urllib.parse import unquote
+
+import pytest
+import requests
+
+from anthias_server.app.models import Asset
+from anthias_server.lib.integrations import pisignage
+from anthias_server.lib.integrations.base import ProviderImportError
+from anthias_server.lib.integrations.registry import (
+    get_provider,
+    list_provider_meta,
+)
+from anthias_server.settings import settings
+
+PROVIDER = pisignage.PiSignageProvider()
+TOKEN = 'mysite:user@example.com:secret'
+
+
+def _resp(status: int, json_body: Any = None) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    resp.json.return_value = json_body
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            f'HTTP {status}', response=resp
+        )
+    return resp
+
+
+def _stream(status: int, chunks: list[bytes]) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    resp.iter_content.return_value = iter(chunks)
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _login_ok() -> MagicMock:
+    return _resp(200, {'token': 'jwt-123'})
+
+
+def _get_router(
+    *,
+    listing: MagicMock | None = None,
+    details: dict[str, MagicMock] | None = None,
+    download: MagicMock | None = None,
+) -> Any:
+    def _get(url: str, **kwargs: Any) -> MagicMock:
+        if kwargs.get('stream'):
+            return download or _stream(200, [b'\x89PNG'])
+        if url.endswith('/api/files'):
+            return listing or _resp(200, {'data': {}})
+        name = unquote(url.rsplit('/api/files/', 1)[-1])
+        return (details or {}).get(name) or _resp(404, {})
+
+    return _get
+
+
+class TestTokenAndSession:
+    def test_parse_token(self) -> None:
+        assert pisignage._parse_token('sub:user@x.com:p:w') == (
+            'sub',
+            'user@x.com',
+            'p:w',
+        )
+
+    def test_parse_token_malformed(self) -> None:
+        with pytest.raises(ProviderImportError):
+            pisignage._parse_token('just-one-part')
+
+    def test_session_not_anthias_ua(self) -> None:
+        ua = pisignage._session.headers['User-Agent']
+        assert not ua.startswith('Anthias/')
+        assert 'anthias' not in ua.lower()
+
+
+class TestValidateToken:
+    @patch('anthias_server.lib.integrations.pisignage._session.post')
+    def test_true(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _login_ok()
+        assert PROVIDER.validate_token(TOKEN) is True
+
+    @patch('anthias_server.lib.integrations.pisignage._session.post')
+    def test_false_on_401(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _resp(401, {})
+        assert PROVIDER.validate_token(TOKEN) is False
+
+    def test_false_on_malformed(self) -> None:
+        assert PROVIDER.validate_token('nope') is False
+
+    @patch('anthias_server.lib.integrations.pisignage._session.post')
+    def test_raises_on_5xx(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _resp(503)
+        with pytest.raises(requests.HTTPError):
+            PROVIDER.validate_token(TOKEN)
+
+
+class TestHelpers:
+    def test_map_type(self) -> None:
+        assert pisignage._map_type('image/png') == 'image'
+        assert pisignage._map_type('video') == 'video'
+        assert pisignage._map_type('audio/mp3') == 'audio'
+        assert pisignage._map_type(None) is None
+
+    def test_type_from_name(self) -> None:
+        assert pisignage._type_from_name('a.PNG') == 'image'
+        assert pisignage._type_from_name('b.mp4') == 'video'
+        assert pisignage._type_from_name('c.pdf') is None
+
+
+class TestListMedia:
+    @patch('anthias_server.lib.integrations.pisignage._session.get')
+    @patch('anthias_server.lib.integrations.pisignage._session.post')
+    def test_classifies_files(
+        self, post_mock: MagicMock, get_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _login_ok()
+        get_mock.side_effect = _get_router(
+            listing=_resp(
+                200,
+                {
+                    'data': {
+                        'dbdata': [
+                            {'name': 'pic.png', 'type': 'image'},
+                            {'name': 'clip.mp4', 'type': 'video'},
+                            {'name': 'song.mp3', 'type': 'audio'},
+                        ],
+                        'files': ['extra.jpg'],
+                    }
+                },
+            )
+        )
+        items = PROVIDER.list_media(TOKEN)
+        by_id = {i.remote_id: i for i in items}
+        assert by_id['pic.png'].media_type == 'image'
+        assert by_id['pic.png'].importable
+        assert by_id['clip.mp4'].importable
+        assert by_id['song.mp3'].importable is False
+        # ``files``-only entry classified by extension.
+        assert by_id['extra.jpg'].media_type == 'image'
+
+    @patch('anthias_server.lib.integrations.pisignage._session.post')
+    def test_bad_credentials_surface_as_transport_error(
+        self, post_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _resp(401, {})
+        with pytest.raises(requests.RequestException):
+            PROVIDER.list_media(TOKEN)
+
+
+class TestRegistry:
+    def test_registered(self) -> None:
+        assert isinstance(
+            get_provider('pisignage'), pisignage.PiSignageProvider
+        )
+        assert 'pisignage' in {m['key'] for m in list_provider_meta()}
+
+
+@pytest.mark.django_db
+class TestImportItem:
+    def test_idempotent_reimport_skips(self) -> None:
+        Asset.objects.create(
+            asset_id='pi-existing',
+            name='pic.png',
+            uri='/data/x.png',
+            mimetype='image',
+            duration=10,
+            metadata={
+                'import_source': {
+                    'provider': 'pisignage',
+                    'remote_id': 'pic.png',
+                }
+            },
+        )
+        with patch(
+            'anthias_server.lib.integrations.pisignage._session.post'
+        ) as post_mock:
+            outcome = PROVIDER.import_item(TOKEN, 'pic.png')
+        post_mock.assert_not_called()
+        assert outcome.skipped is True and outcome.success is True
+
+    @patch('anthias_server.lib.integrations.pisignage._session.get')
+    @patch('anthias_server.lib.integrations.pisignage._session.post')
+    def test_import_image_attaches_token_on_same_host(
+        self,
+        post_mock: MagicMock,
+        get_mock: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setitem(settings, 'assetdir', str(tmp_path))
+        post_mock.return_value = _login_ok()
+        captured: dict[str, str] = {}
+        detail = _resp(
+            200,
+            {
+                'data': {
+                    'name': 'pic.png',
+                    'type': 'image',
+                    'path': '/media/acct/pic.png',
+                    'dbdata': {'duration': '15'},
+                }
+            },
+        )
+
+        def _get(url: str, **kwargs: Any) -> MagicMock:
+            if kwargs.get('stream'):
+                captured.update(kwargs.get('headers') or {})
+                return _stream(200, [b'\x89PNG\r\n'])
+            return detail
+
+        get_mock.side_effect = _get
+
+        outcome = PROVIDER.import_item(TOKEN, 'pic.png', enable=False)
+        assert outcome.success is True and not outcome.skipped
+        asset = Asset.objects.get(asset_id=outcome.asset_id)
+        assert asset.mimetype == 'image'
+        assert (tmp_path / f'{asset.asset_id}.png').is_file()
+        # Media is on the piSignage host, so the token IS attached.
+        assert captured.get('x-access-token') == 'jwt-123'
+
+    @patch('anthias_server.lib.integrations.pisignage._session.get')
+    @patch('anthias_server.lib.integrations.pisignage._session.post')
+    def test_import_audio_skipped(
+        self, post_mock: MagicMock, get_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _login_ok()
+        get_mock.side_effect = _get_router(
+            details={
+                'song.mp3': _resp(
+                    200,
+                    {
+                        'data': {
+                            'name': 'song.mp3',
+                            'type': 'audio',
+                            'path': '/media/acct/song.mp3',
+                        }
+                    },
+                )
+            }
+        )
+        outcome = PROVIDER.import_item(TOKEN, 'song.mp3')
+        assert outcome.skipped is True
+
+    @patch('anthias_server.lib.integrations.pisignage._session.get')
+    @patch('anthias_server.lib.integrations.pisignage._session.post')
+    def test_import_missing_path_skipped(
+        self, post_mock: MagicMock, get_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _login_ok()
+        get_mock.side_effect = _get_router(
+            details={
+                'pic.png': _resp(
+                    200,
+                    {'data': {'name': 'pic.png', 'type': 'image'}},
+                )
+            }
+        )
+        outcome = PROVIDER.import_item(TOKEN, 'pic.png')
+        assert outcome.skipped is True

--- a/src/anthias_server/lib/integrations/pisignage.py
+++ b/src/anthias_server/lib/integrations/pisignage.py
@@ -170,11 +170,14 @@ class PiSignageProvider(ImportProvider):
         for entry in dbdata:
             if not isinstance(entry, dict):
                 continue
-            name = entry.get('name')
-            if not name:
+            raw_name = entry.get('name')
+            if not raw_name:
                 continue
+            # Coerce to str so the de-dupe check against the string-only
+            # ``files`` list below is reliable.
+            name = str(raw_name)
             seen.add(name)
-            yield self._item(str(name), _map_type(entry.get('type')))
+            yield self._item(name, _map_type(entry.get('type')))
         for name in data.get('files') or []:
             if isinstance(name, str) and name not in seen:
                 yield self._item(name, _type_from_name(name))
@@ -226,7 +229,9 @@ class PiSignageProvider(ImportProvider):
                 skipped=True,
                 reason='piSignage did not expose a download path for this file.',
             )
-        file_url = f'https://{_media_host(subdomain)}{path}'
+        # Guarantee a single leading slash so the URL is well-formed even if
+        # the API ever returns a path without one.
+        file_url = f'https://{_media_host(subdomain)}/{path.lstrip("/")}'
         start_date, end_date = ingest.default_window()
         asset = ingest.create_file_asset(
             session=_session,
@@ -257,7 +262,7 @@ class PiSignageProvider(ImportProvider):
         self, subdomain: str, headers: dict[str, str], filename: str
     ) -> dict[str, Any]:
         response = _session.get(
-            f'{_base_url(subdomain)}/files/{quote(filename)}',
+            f'{_base_url(subdomain)}/files/{quote(filename, safe="")}',
             headers=headers,
             timeout=_LIST_TIMEOUT_S,
         )

--- a/src/anthias_server/lib/integrations/pisignage.py
+++ b/src/anthias_server/lib/integrations/pisignage.py
@@ -1,0 +1,267 @@
+"""piSignage import provider — REST.
+
+piSignage is hosted per-account on a subdomain (``<account>.pisignage.com``)
+and authenticates by exchanging credentials for a JWT at ``POST /session``,
+then passing it as an ``x-access-token`` header. Because both the subdomain
+and the login are needed, the operator's "token" is
+``subdomain:email:password`` (email may be a username; password may itself
+contain ``:``).
+
+Media is the account's uploaded files (``GET /files``): images and videos
+are imported, audio is skipped. Files download from the same host as the
+API, so the token is attached to the download (scoped to that host by the
+shared ingest layer). Reuses the ingest/http layer for download + asset
+creation + idempotency.
+
+TODO(confirm-with-live-token): piSignage web-link assets are not part of
+``/files`` and aren't imported here; the media ``path`` → download URL
+mapping (``https://<sub>.pisignage.com<path>``) and whether the media host
+needs the token are worth confirming against a live hosted account.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterator
+from urllib.parse import quote
+
+import requests
+
+from . import ingest
+from .base import (
+    ImportOutcome,
+    ImportProvider,
+    ProviderImportError,
+    RemoteMediaItem,
+)
+from .http import new_import_session
+
+PROVIDER_KEY = 'pisignage'
+_PISIGNAGE_DOMAIN = 'pisignage.com'
+
+_VALIDATE_TIMEOUT_S = 15.0
+_LIST_TIMEOUT_S = 30.0
+
+_session = new_import_session()
+
+
+def _base_url(subdomain: str) -> str:
+    return f'https://{subdomain}.{_PISIGNAGE_DOMAIN}/api'
+
+
+def _media_host(subdomain: str) -> str:
+    return f'{subdomain}.{_PISIGNAGE_DOMAIN}'
+
+
+def _parse_token(token: str) -> tuple[str, str, str]:
+    """Split ``subdomain:email:password`` (password may contain ``:``)."""
+    parts = (token or '').split(':', 2)
+    if len(parts) != 3 or not parts[0].strip() or not parts[1].strip():
+        raise ProviderImportError(
+            'piSignage token must be "subdomain:email:password".'
+        )
+    return parts[0].strip(), parts[1].strip(), parts[2]
+
+
+def _login(subdomain: str, email: str, password: str) -> str | None:
+    """Exchange credentials for a JWT, or None if they're rejected."""
+    response = _session.post(
+        f'{_base_url(subdomain)}/session',
+        json={'email': email, 'password': password, 'getToken': True},
+        timeout=_VALIDATE_TIMEOUT_S,
+    )
+    if response.status_code == 401:
+        return None
+    response.raise_for_status()
+    token = response.json().get('token')
+    return token if isinstance(token, str) and token else None
+
+
+def _login_or_raise(token: str) -> tuple[str, dict[str, str]]:
+    """Return (subdomain, auth-headers) after logging in.
+
+    Raises ``ProviderImportError`` for a malformed token or rejected
+    credentials; transport errors propagate.
+    """
+    subdomain, email, password = _parse_token(token)
+    jwt = _login(subdomain, email, password)
+    if not jwt:
+        raise ProviderImportError('piSignage rejected these credentials.')
+    return subdomain, {'x-access-token': jwt}
+
+
+def _map_type(raw: Any) -> str | None:
+    value = raw.lower() if isinstance(raw, str) else ''
+    if value.startswith('image'):
+        return 'image'
+    if value.startswith('video'):
+        return 'video'
+    if value.startswith('audio'):
+        return 'audio'
+    return None
+
+
+def _type_from_name(filename: str) -> str | None:
+    ext = ingest.file_ext_from(None, filename).lstrip('.').lower()
+    if ext in ('jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp'):
+        return 'image'
+    if ext in ('mp4', 'mov', 'mkv', 'webm', 'avi', 'flv', 'm4v'):
+        return 'video'
+    return None
+
+
+def _duration(dbdata: dict[str, Any]) -> int | None:
+    raw = dbdata.get('duration')
+    if isinstance(raw, (int, str)):
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+class PiSignageProvider(ImportProvider):
+    key = PROVIDER_KEY
+    label = 'piSignage'
+    description = (
+        'Copy images and videos from a piSignage account into this player.'
+    )
+    token_help = (
+        'Enter your piSignage account as "subdomain:email:password" — the '
+        'subdomain is the "<name>" in <name>.pisignage.com, followed by your '
+        'login email (or username) and password. It is used only for this '
+        'import and is never stored.'
+    )
+
+    # -- token / listing ---------------------------------------------------
+
+    def validate_token(self, token: str) -> bool:
+        try:
+            subdomain, email, password = _parse_token(token)
+        except ProviderImportError:
+            return False
+        return _login(subdomain, email, password) is not None
+
+    def list_media(
+        self, token: str, *, workspace: str | None = None
+    ) -> list[RemoteMediaItem]:
+        try:
+            subdomain, headers = _login_or_raise(token)
+        except ProviderImportError as error:
+            # list_media's caller handles transport errors, not
+            # ProviderImportError — surface bad creds as a controlled 502.
+            raise requests.RequestException(error.user_message) from error
+
+        response = _session.get(
+            f'{_base_url(subdomain)}/files',
+            headers=headers,
+            timeout=_LIST_TIMEOUT_S,
+        )
+        response.raise_for_status()
+        data = (response.json() or {}).get('data') or {}
+        return list(self._items_from_listing(data))
+
+    def _items_from_listing(
+        self, data: dict[str, Any]
+    ) -> Iterator[RemoteMediaItem]:
+        # ``dbdata`` (hosted service) carries the type; fall back to the
+        # bare ``files`` name list and infer the type from the extension.
+        dbdata = data.get('dbdata') or []
+        seen: set[str] = set()
+        for entry in dbdata:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get('name')
+            if not name:
+                continue
+            seen.add(name)
+            yield self._item(str(name), _map_type(entry.get('type')))
+        for name in data.get('files') or []:
+            if isinstance(name, str) and name not in seen:
+                yield self._item(name, _type_from_name(name))
+
+    def _item(self, name: str, media_type: str | None) -> RemoteMediaItem:
+        importable = media_type in ('image', 'video')
+        return RemoteMediaItem(
+            remote_id=name,
+            name=name,
+            media_type=media_type or 'unsupported',
+            importable=importable,
+            skip_reason=None
+            if importable
+            else "This piSignage file isn't a supported image or video.",
+        )
+
+    # -- import ------------------------------------------------------------
+
+    def import_item(
+        self, token: str, remote_id: str, *, enable: bool = True
+    ) -> ImportOutcome:
+        existing = ingest.find_imported_asset(PROVIDER_KEY, remote_id)
+        if existing is not None:
+            return ImportOutcome(
+                success=True,
+                asset_id=existing.asset_id,
+                skipped=True,
+                reason='Already imported.',
+            )
+
+        subdomain, headers = _login_or_raise(token)
+        detail = self._get_file(subdomain, headers, remote_id)
+
+        dbdata = detail.get('dbdata') or {}
+        media_type = _map_type(detail.get('type')) or _map_type(
+            dbdata.get('type')
+        )
+        if media_type not in ('image', 'video'):
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason="This piSignage file isn't a supported image or video.",
+            )
+
+        path = detail.get('path')
+        if not isinstance(path, str) or not path:
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason='piSignage did not expose a download path for this file.',
+            )
+        file_url = f'https://{_media_host(subdomain)}{path}'
+        start_date, end_date = ingest.default_window()
+        asset = ingest.create_file_asset(
+            session=_session,
+            headers=headers,
+            # Media is served from the same host as the API, so the token is
+            # attached to the download (scoped to that host).
+            auth_host=_media_host(subdomain),
+            provider_key=PROVIDER_KEY,
+            remote_id=remote_id,
+            name=str(detail.get('name') or remote_id),
+            mimetype=media_type,
+            file_url=file_url,
+            ext=ingest.file_ext_from(None, file_url),
+            # Video duration is probed server-side; images use piSignage's
+            # value or the device default.
+            duration=(
+                0
+                if media_type == 'video'
+                else ingest.duration_or_default(_duration(dbdata))
+            ),
+            start_date=start_date,
+            end_date=end_date,
+            enable=enable,
+        )
+        return ImportOutcome(success=True, asset_id=asset.asset_id)
+
+    def _get_file(
+        self, subdomain: str, headers: dict[str, str], filename: str
+    ) -> dict[str, Any]:
+        response = _session.get(
+            f'{_base_url(subdomain)}/files/{quote(filename)}',
+            headers=headers,
+            timeout=_LIST_TIMEOUT_S,
+        )
+        if response.status_code == 404:
+            raise ProviderImportError('File no longer exists in piSignage.')
+        response.raise_for_status()
+        return (response.json() or {}).get('data') or {}

--- a/src/anthias_server/lib/integrations/registry.py
+++ b/src/anthias_server/lib/integrations/registry.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from .base import ImportProvider
 from .optisigns import OptiSignsProvider
+from .pisignage import PiSignageProvider
 from .screencloud import ScreenCloudProvider
 from .yodeck import YodeckProvider
 
@@ -23,6 +24,7 @@ _PROVIDERS: dict[str, ImportProvider] = {
         YodeckProvider(),
         ScreenCloudProvider(),
         OptiSignsProvider(),
+        PiSignageProvider(),
     )
 }
 


### PR DESCRIPTION
### Issues Fixed

Stacked on #3146 (OptiSigns). Fourth provider in the import series.

> **Base branch:** `feat/import-content-optisign` — review after the earlier PRs in the stack. Retarget to `master` as the stack merges.

### Description

- **piSignage provider** (REST): imports images and videos from a hosted piSignage account, over the same `ImportProvider` interface, wizard, and CLI as the others.
- **Auth**: piSignage is per-account on a subdomain and authenticates by exchanging credentials for a JWT (`POST /session`) sent as `x-access-token`. Because both the subdomain and login are needed, the operator's token is `subdomain:email:password`.
- **Content + filter**: lists the account's uploaded files (`GET /files`), imports image/video, skips audio. (Web-link assets aren't part of `/files`; noted as a follow-up.)
- **Download**: media is served from the same host as the API, so the token *is* attached to the download — the shared `ingest` auth-scoping handles this (token attached only for the matching host).
- Unit tests (no network).

**Follow-ups (flagged in `pisignage.py`):** confirm the `path` → download-URL mapping and whether the media host needs the token, against a live hosted account; web-link assets aren't imported.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)