### PR TITLE
feat(import): add Xibo CMS (REST) provider to the import framework

### DIFF
--- a/src/anthias_server/api/tests/_graphql_helpers.py
+++ b/src/anthias_server/api/tests/_graphql_helpers.py
@@ -1,8 +1,9 @@
-"""Shared response fakes for GraphQL provider tests.
+"""Shared response fakes for import-provider tests.
 
-Used by the ScreenCloud and OptiSigns import-provider test modules so the
-canned-response boilerplate lives in one place. Not a test module (no
-``test_`` prefix), so pytest doesn't collect it.
+Used by the provider test modules (GraphQL: ScreenCloud/OptiSigns; REST:
+Yodeck/piSignage/Xibo) so the canned-response boilerplate lives in one
+place. Not a test module (no ``test_`` prefix), so pytest doesn't collect
+it.
 """
 
 from __future__ import annotations
@@ -11,6 +12,19 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import requests
+
+
+def json_response(status: int, json_body: Any = None) -> MagicMock:
+    """A fake ``requests.Response`` for a plain-JSON REST call."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    resp.json.return_value = json_body
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            f'HTTP {status}', response=resp
+        )
+    return resp
 
 
 def gql_response(

--- a/src/anthias_server/api/tests/test_pisignage_import.py
+++ b/src/anthias_server/api/tests/test_pisignage_import.py
@@ -16,6 +16,10 @@ import pytest
 import requests
 
 from anthias_server.app.models import Asset
+from anthias_server.api.tests._graphql_helpers import (
+    json_response as _resp,
+    stream_response as _stream,
+)
 from anthias_server.lib.integrations import pisignage
 from anthias_server.lib.integrations.base import ProviderImportError
 from anthias_server.lib.integrations.registry import (
@@ -26,28 +30,6 @@ from anthias_server.settings import settings
 
 PROVIDER = pisignage.PiSignageProvider()
 TOKEN = 'mysite:user@example.com:secret'
-
-
-def _resp(status: int, json_body: Any = None) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status
-    resp.ok = 200 <= status < 400
-    resp.json.return_value = json_body
-    if not resp.ok:
-        resp.raise_for_status.side_effect = requests.HTTPError(
-            f'HTTP {status}', response=resp
-        )
-    return resp
-
-
-def _stream(status: int, chunks: list[bytes]) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status
-    resp.ok = 200 <= status < 400
-    resp.iter_content.return_value = iter(chunks)
-    resp.__enter__.return_value = resp
-    resp.__exit__.return_value = False
-    return resp
 
 
 def _login_ok() -> MagicMock:

--- a/src/anthias_server/api/tests/test_xibo_import.py
+++ b/src/anthias_server/api/tests/test_xibo_import.py
@@ -1,0 +1,196 @@
+"""Unit tests for the Xibo (REST) import provider.
+
+Never touches the network: the provider's module-level ``_session`` is
+patched. Covers credential parsing, OAuth token exchange, library listing
++ classification, and per-item import (Bearer token attached to the
+same-host download).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from anthias_server.app.models import Asset
+from anthias_server.lib.integrations import xibo
+from anthias_server.lib.integrations.base import ProviderImportError
+from anthias_server.lib.integrations.registry import (
+    get_provider,
+    list_provider_meta,
+)
+from anthias_server.settings import settings
+
+PROVIDER = xibo.XiboProvider()
+TOKEN = 'cms.xibosignage.com:client123:secret456'
+
+
+def _resp(status: int, json_body: Any = None) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    resp.json.return_value = json_body
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            f'HTTP {status}', response=resp
+        )
+    return resp
+
+
+def _stream(status: int, chunks: list[bytes]) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.ok = 200 <= status < 400
+    resp.iter_content.return_value = iter(chunks)
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _token_ok() -> MagicMock:
+    return _resp(200, {'access_token': 'bearer-xyz'})
+
+
+class TestTokenAndSession:
+    def test_parse_token(self) -> None:
+        assert xibo._parse_token('h:cid:sec') == ('h', 'cid', 'sec')
+
+    def test_parse_token_malformed(self) -> None:
+        with pytest.raises(ProviderImportError):
+            xibo._parse_token('only:two')
+
+    def test_map_type(self) -> None:
+        assert xibo._map_type('image') == 'image'
+        assert xibo._map_type('video') == 'video'
+        assert xibo._map_type('audio') is None
+        assert xibo._map_type(None) is None
+
+
+class TestValidateToken:
+    @patch('anthias_server.lib.integrations.xibo._session.post')
+    def test_true(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _token_ok()
+        assert PROVIDER.validate_token(TOKEN) is True
+
+    @patch('anthias_server.lib.integrations.xibo._session.post')
+    def test_false_on_bad_credentials(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _resp(400, {'error': 'invalid_client'})
+        assert PROVIDER.validate_token(TOKEN) is False
+
+    def test_false_on_malformed(self) -> None:
+        assert PROVIDER.validate_token('nope') is False
+
+    @patch('anthias_server.lib.integrations.xibo._session.post')
+    def test_raises_on_5xx(self, post_mock: MagicMock) -> None:
+        post_mock.return_value = _resp(503)
+        with pytest.raises(requests.HTTPError):
+            PROVIDER.validate_token(TOKEN)
+
+
+class TestListMedia:
+    @patch('anthias_server.lib.integrations.xibo._session.get')
+    @patch('anthias_server.lib.integrations.xibo._session.post')
+    def test_classifies_library(
+        self, post_mock: MagicMock, get_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _token_ok()
+        get_mock.return_value = _resp(
+            200,
+            [
+                {'mediaId': 1, 'name': 'Pic', 'mediaType': 'image'},
+                {'mediaId': 2, 'name': 'Clip', 'mediaType': 'video'},
+                {'mediaId': 3, 'name': 'Song', 'mediaType': 'audio'},
+            ],
+        )
+        items = PROVIDER.list_media(TOKEN)
+        by_id = {i.remote_id: i for i in items}
+        assert by_id['1'].media_type == 'image' and by_id['1'].importable
+        assert by_id['2'].importable
+        assert by_id['3'].importable is False
+
+    @patch('anthias_server.lib.integrations.xibo._session.post')
+    def test_bad_credentials_surface_as_transport_error(
+        self, post_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _resp(401, {})
+        with pytest.raises(requests.RequestException):
+            PROVIDER.list_media(TOKEN)
+
+
+class TestRegistry:
+    def test_registered(self) -> None:
+        assert isinstance(get_provider('xibo'), xibo.XiboProvider)
+        assert 'xibo' in {m['key'] for m in list_provider_meta()}
+
+
+@pytest.mark.django_db
+class TestImportItem:
+    def test_idempotent_reimport_skips(self) -> None:
+        Asset.objects.create(
+            asset_id='xibo-existing',
+            name='Pic',
+            uri='/data/x.png',
+            mimetype='image',
+            duration=10,
+            metadata={'import_source': {'provider': 'xibo', 'remote_id': '1'}},
+        )
+        with patch(
+            'anthias_server.lib.integrations.xibo._session.post'
+        ) as post_mock:
+            outcome = PROVIDER.import_item(TOKEN, '1')
+        post_mock.assert_not_called()
+        assert outcome.skipped is True and outcome.success is True
+
+    @patch('anthias_server.lib.integrations.xibo._session.get')
+    @patch('anthias_server.lib.integrations.xibo._session.post')
+    def test_import_image_attaches_bearer_on_same_host(
+        self,
+        post_mock: MagicMock,
+        get_mock: MagicMock,
+        tmp_path: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setitem(settings, 'assetdir', str(tmp_path))
+        post_mock.return_value = _token_ok()
+        captured: dict[str, str] = {}
+
+        def _get(url: str, **kwargs: Any) -> MagicMock:
+            if kwargs.get('stream'):
+                captured.update(kwargs.get('headers') or {})
+                return _stream(200, [b'\x89PNG\r\n'])
+            return _resp(
+                200,
+                [
+                    {
+                        'mediaId': 1,
+                        'name': 'Pic',
+                        'mediaType': 'image',
+                        'fileName': 'pic.png',
+                        'duration': 20,
+                    }
+                ],
+            )
+
+        get_mock.side_effect = _get
+
+        outcome = PROVIDER.import_item(TOKEN, '1', enable=False)
+        assert outcome.success is True and not outcome.skipped
+        asset = Asset.objects.get(asset_id=outcome.asset_id)
+        assert asset.mimetype == 'image'
+        assert (tmp_path / f'{asset.asset_id}.png').is_file()
+        # CMS-hosted download → the Bearer token IS attached.
+        assert captured.get('Authorization') == 'Bearer bearer-xyz'
+
+    @patch('anthias_server.lib.integrations.xibo._session.get')
+    @patch('anthias_server.lib.integrations.xibo._session.post')
+    def test_import_audio_skipped(
+        self, post_mock: MagicMock, get_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _token_ok()
+        get_mock.return_value = _resp(
+            200, [{'mediaId': 3, 'name': 'Song', 'mediaType': 'audio'}]
+        )
+        outcome = PROVIDER.import_item(TOKEN, '3')
+        assert outcome.skipped is True

--- a/src/anthias_server/api/tests/test_xibo_import.py
+++ b/src/anthias_server/api/tests/test_xibo_import.py
@@ -15,6 +15,10 @@ import pytest
 import requests
 
 from anthias_server.app.models import Asset
+from anthias_server.api.tests._graphql_helpers import (
+    json_response as _resp,
+    stream_response as _stream,
+)
 from anthias_server.lib.integrations import xibo
 from anthias_server.lib.integrations.base import ProviderImportError
 from anthias_server.lib.integrations.registry import (
@@ -25,28 +29,6 @@ from anthias_server.settings import settings
 
 PROVIDER = xibo.XiboProvider()
 TOKEN = 'https://cms.xibosignage.com client123 secret456'
-
-
-def _resp(status: int, json_body: Any = None) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status
-    resp.ok = 200 <= status < 400
-    resp.json.return_value = json_body
-    if not resp.ok:
-        resp.raise_for_status.side_effect = requests.HTTPError(
-            f'HTTP {status}', response=resp
-        )
-    return resp
-
-
-def _stream(status: int, chunks: list[bytes]) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status
-    resp.ok = 200 <= status < 400
-    resp.iter_content.return_value = iter(chunks)
-    resp.__enter__.return_value = resp
-    resp.__exit__.return_value = False
-    return resp
 
 
 def _token_ok() -> MagicMock:
@@ -62,9 +44,10 @@ class TestTokenAndSession:
         )
 
     def test_parse_token_self_hosted_with_port(self) -> None:
-        base, cid, sec = xibo._parse_token(
+        base, client_id, client_secret = xibo._parse_token(
             'https://signage.example.com:8080 cid sec'
         )
+        assert (client_id, client_secret) == ('cid', 'sec')
         assert base == 'https://signage.example.com:8080'
         # auth-host scoping must include the port so the download matches.
         assert xibo._host(base) == 'signage.example.com:8080'

--- a/src/anthias_server/api/tests/test_xibo_import.py
+++ b/src/anthias_server/api/tests/test_xibo_import.py
@@ -24,7 +24,7 @@ from anthias_server.lib.integrations.registry import (
 from anthias_server.settings import settings
 
 PROVIDER = xibo.XiboProvider()
-TOKEN = 'cms.xibosignage.com:client123:secret456'
+TOKEN = 'https://cms.xibosignage.com client123 secret456'
 
 
 def _resp(status: int, json_body: Any = None) -> MagicMock:
@@ -54,12 +54,28 @@ def _token_ok() -> MagicMock:
 
 
 class TestTokenAndSession:
-    def test_parse_token(self) -> None:
-        assert xibo._parse_token('h:cid:sec') == ('h', 'cid', 'sec')
+    def test_parse_token_cloud(self) -> None:
+        assert xibo._parse_token('https://h.x/ cid sec') == (
+            'https://h.x',
+            'cid',
+            'sec',
+        )
+
+    def test_parse_token_self_hosted_with_port(self) -> None:
+        base, cid, sec = xibo._parse_token(
+            'https://signage.example.com:8080 cid sec'
+        )
+        assert base == 'https://signage.example.com:8080'
+        # auth-host scoping must include the port so the download matches.
+        assert xibo._host(base) == 'signage.example.com:8080'
 
     def test_parse_token_malformed(self) -> None:
         with pytest.raises(ProviderImportError):
-            xibo._parse_token('only:two')
+            xibo._parse_token('only two')
+
+    def test_parse_token_non_url(self) -> None:
+        with pytest.raises(ProviderImportError):
+            xibo._parse_token('not-a-url cid sec')
 
     def test_map_type(self) -> None:
         assert xibo._map_type('image') == 'image'

--- a/src/anthias_server/api/tests/test_yodeck_import.py
+++ b/src/anthias_server/api/tests/test_yodeck_import.py
@@ -27,6 +27,10 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from anthias_server.app.models import Asset
+from anthias_server.api.tests._graphql_helpers import (
+    json_response as _fake_response,
+    stream_response as _fake_stream_response,
+)
 from anthias_server.lib.integrations import ingest, yodeck
 from anthias_server.lib.integrations.base import (
     ImportOutcome,
@@ -45,34 +49,6 @@ from anthias_server.settings import settings
 # ``pytest.raises`` blocks also means each of those blocks has a single
 # throwing invocation (Sonar S5778).
 PROVIDER = yodeck.YodeckProvider()
-
-
-# ---------------------------------------------------------------------------
-# Fake HTTP responses
-# ---------------------------------------------------------------------------
-
-
-def _fake_response(status_code: int, json_body: Any = None) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status_code
-    resp.ok = 200 <= status_code < 400
-    resp.json.return_value = json_body
-    if not resp.ok:
-        resp.raise_for_status.side_effect = requests.HTTPError(
-            f'HTTP {status_code}', response=resp
-        )
-    return resp
-
-
-def _fake_stream_response(status_code: int, chunks: list[bytes]) -> MagicMock:
-    """A streaming response usable as a context manager (``with ... as``)."""
-    resp = MagicMock(spec=requests.Response)
-    resp.status_code = status_code
-    resp.ok = 200 <= status_code < 400
-    resp.iter_content.return_value = iter(chunks)
-    resp.__enter__.return_value = resp
-    resp.__exit__.return_value = False
-    return resp
 
 
 # ---------------------------------------------------------------------------

--- a/src/anthias_server/lib/integrations/registry.py
+++ b/src/anthias_server/lib/integrations/registry.py
@@ -14,6 +14,7 @@ from .base import ImportProvider
 from .optisigns import OptiSignsProvider
 from .pisignage import PiSignageProvider
 from .screencloud import ScreenCloudProvider
+from .xibo import XiboProvider
 from .yodeck import YodeckProvider
 
 # Providers are stateless (their HTTP session is module-level), so a
@@ -25,6 +26,7 @@ _PROVIDERS: dict[str, ImportProvider] = {
         ScreenCloudProvider(),
         OptiSignsProvider(),
         PiSignageProvider(),
+        XiboProvider(),
     )
 }
 

--- a/src/anthias_server/lib/integrations/xibo.py
+++ b/src/anthias_server/lib/integrations/xibo.py
@@ -1,11 +1,15 @@
 """Xibo import provider — REST (Xibo CMS API).
 
-Xibo runs per-CMS (Xibo Cloud gives each account a host such as
-``<name>.xibosignage.com``) and authenticates with OAuth2
-client-credentials: an API application's ``client_id`` / ``client_secret``
-are exchanged for a Bearer token at ``POST /api/authorize/access_token``.
-Because the CMS host and both credentials are needed, the operator's
-"token" is ``host:client_id:client_secret`` (hostname only, no scheme).
+Works with both Xibo Cloud (``https://<name>.xibosignage.com``) and
+self-hosted CMS instances (any URL, including a custom host, port or
+sub-path). Authenticates with OAuth2 client-credentials: an API
+application's ``client_id`` / ``client_secret`` are exchanged for a Bearer
+token at ``POST <cms>/api/authorize/access_token``.
+
+Because a self-hosted CMS URL can contain ``:`` (scheme, port), the
+operator's "token" is whitespace-separated:
+``<cms-url> <client_id> <client_secret>`` — e.g.
+``https://signage.example.com:8080 abc123 secretxyz``.
 
 Media is the CMS library (``GET /library``): images and videos are
 imported, everything else (audio, documents, module widgets) is skipped.
@@ -21,6 +25,7 @@ Swagger spec and worth confirming against a live CMS.
 from __future__ import annotations
 
 from typing import Any, Iterator
+from urllib.parse import urlparse
 
 import requests
 
@@ -42,24 +47,40 @@ _LIST_TIMEOUT_S = 30.0
 _session = new_import_session()
 
 
-def _base_url(host: str) -> str:
-    return f'https://{host}/api'
-
-
 def _parse_token(token: str) -> tuple[str, str, str]:
-    """Split ``host:client_id:client_secret`` (hostname only, no scheme)."""
-    parts = (token or '').split(':', 2)
-    if len(parts) != 3 or not all(p.strip() for p in parts):
+    """Split ``<cms-url> <client_id> <client_secret>`` (whitespace-separated).
+
+    The CMS URL is validated as http(s); any trailing slash is trimmed so
+    ``<base>/api/...`` is well-formed for cloud and self-hosted alike.
+    """
+    parts = (token or '').split()
+    if len(parts) != 3:
         raise ProviderImportError(
-            'Xibo token must be "cms-host:client_id:client_secret".'
+            'Xibo token must be "<cms-url> <client_id> <client_secret>".'
         )
-    return parts[0].strip(), parts[1].strip(), parts[2].strip()
+    base, client_id, client_secret = parts
+    parsed = urlparse(base)
+    if parsed.scheme not in ('http', 'https') or not parsed.netloc:
+        raise ProviderImportError(
+            'Xibo CMS URL must be a full http(s) URL, e.g. '
+            'https://name.xibosignage.com.'
+        )
+    return base.rstrip('/'), client_id, client_secret
 
 
-def _authorize(host: str, client_id: str, client_secret: str) -> str | None:
+def _api_url(base: str, path: str) -> str:
+    return f'{base}/api{path}'
+
+
+def _host(base: str) -> str:
+    """Host (with port, if any) the CMS is served from."""
+    return urlparse(base).netloc.lower()
+
+
+def _authorize(base: str, client_id: str, client_secret: str) -> str | None:
     """Exchange client credentials for a Bearer token, or None if rejected."""
     response = _session.post(
-        f'{_base_url(host)}/authorize/access_token',
+        _api_url(base, '/authorize/access_token'),
         data={
             'grant_type': 'client_credentials',
             'client_id': client_id,
@@ -75,16 +96,16 @@ def _authorize(host: str, client_id: str, client_secret: str) -> str | None:
 
 
 def _login_or_raise(token: str) -> tuple[str, dict[str, str]]:
-    """Return (host, auth-headers) after authorizing.
+    """Return (cms-base-url, auth-headers) after authorizing.
 
     Raises ``ProviderImportError`` for a malformed token or rejected
     credentials; transport errors propagate.
     """
-    host, client_id, client_secret = _parse_token(token)
-    access = _authorize(host, client_id, client_secret)
+    base, client_id, client_secret = _parse_token(token)
+    access = _authorize(base, client_id, client_secret)
     if not access:
         raise ProviderImportError('Xibo rejected these API credentials.')
-    return host, {'Authorization': f'Bearer {access}'}
+    return base, {'Authorization': f'Bearer {access}'}
 
 
 def _map_type(media_type: Any) -> str | None:
@@ -100,36 +121,38 @@ class XiboProvider(ImportProvider):
     key = PROVIDER_KEY
     label = 'Xibo'
     description = (
-        'Copy images and videos from a Xibo CMS library into this player.'
+        'Copy images and videos from a Xibo CMS library into this player '
+        '(Xibo Cloud or self-hosted).'
     )
     token_help = (
         'In your Xibo CMS create an API application (Applications → Add), '
-        'then enter "cms-host:client_id:client_secret" — the host is the '
-        'CMS hostname (e.g. name.xibosignage.com). Used only for this import '
-        'and never stored.'
+        'then enter "<cms-url> <client_id> <client_secret>" (space '
+        'separated) — the CMS URL is your Xibo address, e.g. '
+        'https://name.xibosignage.com, or your self-hosted CMS URL. Used '
+        'only for this import and never stored.'
     )
 
     # -- token / listing ---------------------------------------------------
 
     def validate_token(self, token: str) -> bool:
         try:
-            host, client_id, client_secret = _parse_token(token)
+            base, client_id, client_secret = _parse_token(token)
         except ProviderImportError:
             return False
-        return _authorize(host, client_id, client_secret) is not None
+        return _authorize(base, client_id, client_secret) is not None
 
     def list_media(
         self, token: str, *, workspace: str | None = None
     ) -> list[RemoteMediaItem]:
         try:
-            host, headers = _login_or_raise(token)
+            base, headers = _login_or_raise(token)
         except ProviderImportError as error:
             # list_media's caller handles transport errors, not
             # ProviderImportError — surface bad creds as a controlled 502.
             raise requests.RequestException(error.user_message) from error
 
         items: list[RemoteMediaItem] = []
-        for media in self._paginate(host, headers):
+        for media in self._paginate(base, headers):
             media_id = media.get('mediaId')
             if media_id is None:
                 continue
@@ -154,13 +177,13 @@ class XiboProvider(ImportProvider):
         return items
 
     def _paginate(
-        self, host: str, headers: dict[str, str]
+        self, base: str, headers: dict[str, str]
     ) -> Iterator[dict[str, Any]]:
         start = 0
         seen: set[Any] = set()
         while True:
             batch = self._library(
-                host, headers, {'start': start, 'length': _PAGE_SIZE}
+                base, headers, {'start': start, 'length': _PAGE_SIZE}
             )
             fresh = [
                 media
@@ -179,10 +202,10 @@ class XiboProvider(ImportProvider):
             start += _PAGE_SIZE
 
     def _library(
-        self, host: str, headers: dict[str, str], params: dict[str, Any]
+        self, base: str, headers: dict[str, str], params: dict[str, Any]
     ) -> list[Any]:
         response = _session.get(
-            f'{_base_url(host)}/library',
+            _api_url(base, '/library'),
             headers=headers,
             params=params,
             timeout=_LIST_TIMEOUT_S,
@@ -205,8 +228,8 @@ class XiboProvider(ImportProvider):
                 reason='Already imported.',
             )
 
-        host, headers = _login_or_raise(token)
-        matches = self._library(host, headers, {'mediaId': remote_id})
+        base, headers = _login_or_raise(token)
+        matches = self._library(base, headers, {'mediaId': remote_id})
         media = (
             matches[0] if matches and isinstance(matches[0], dict) else None
         )
@@ -221,9 +244,9 @@ class XiboProvider(ImportProvider):
                 reason="This Xibo library item isn't an image or video.",
             )
 
-        file_url = (
-            f'{_base_url(host)}/library/download/{remote_id}/'
-            f'{media.get("mediaType")}'
+        file_url = _api_url(
+            base,
+            f'/library/download/{remote_id}/{media.get("mediaType")}',
         )
         start_date, end_date = ingest.default_window()
         asset = ingest.create_file_asset(
@@ -231,7 +254,7 @@ class XiboProvider(ImportProvider):
             headers=headers,
             # The download is on the CMS host, so the Bearer token IS
             # attached (scoped to that host by ingest).
-            auth_host=host,
+            auth_host=_host(base),
             provider_key=PROVIDER_KEY,
             remote_id=remote_id,
             name=str(media.get('name') or media.get('fileName') or remote_id),

--- a/src/anthias_server/lib/integrations/xibo.py
+++ b/src/anthias_server/lib/integrations/xibo.py
@@ -18,8 +18,8 @@ attached to the download (scoped to that host by the shared ingest layer).
 
 TODO(confirm-with-live-token): Xibo web pages live on layouts as widgets,
 not in the library, so they aren't imported here. The
-``/library/download/{mediaId}/{mediaType}`` download shape is from the
-Swagger spec and worth confirming against a live CMS.
+``<cms>/api/library/download/{mediaId}/{mediaType}`` download shape is from
+the Swagger spec and worth confirming against a live CMS.
 """
 
 from __future__ import annotations
@@ -244,9 +244,11 @@ class XiboProvider(ImportProvider):
                 reason="This Xibo library item isn't an image or video.",
             )
 
+        # Use the normalised ``media_type`` (not the raw field) so casing
+        # variance in the API response can't produce a wrong download URL.
         file_url = _api_url(
             base,
-            f'/library/download/{remote_id}/{media.get("mediaType")}',
+            f'/library/download/{remote_id}/{media_type}',
         )
         start_date, end_date = ingest.default_window()
         asset = ingest.create_file_asset(

--- a/src/anthias_server/lib/integrations/xibo.py
+++ b/src/anthias_server/lib/integrations/xibo.py
@@ -1,0 +1,251 @@
+"""Xibo import provider — REST (Xibo CMS API).
+
+Xibo runs per-CMS (Xibo Cloud gives each account a host such as
+``<name>.xibosignage.com``) and authenticates with OAuth2
+client-credentials: an API application's ``client_id`` / ``client_secret``
+are exchanged for a Bearer token at ``POST /api/authorize/access_token``.
+Because the CMS host and both credentials are needed, the operator's
+"token" is ``host:client_id:client_secret`` (hostname only, no scheme).
+
+Media is the CMS library (``GET /library``): images and videos are
+imported, everything else (audio, documents, module widgets) is skipped.
+Files download from the same host as the API, so the Bearer token is
+attached to the download (scoped to that host by the shared ingest layer).
+
+TODO(confirm-with-live-token): Xibo web pages live on layouts as widgets,
+not in the library, so they aren't imported here. The
+``/library/download/{mediaId}/{mediaType}`` download shape is from the
+Swagger spec and worth confirming against a live CMS.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+import requests
+
+from . import ingest
+from .base import (
+    ImportOutcome,
+    ImportProvider,
+    ProviderImportError,
+    RemoteMediaItem,
+)
+from .http import new_import_session
+
+PROVIDER_KEY = 'xibo'
+
+_PAGE_SIZE = 100
+_VALIDATE_TIMEOUT_S = 15.0
+_LIST_TIMEOUT_S = 30.0
+
+_session = new_import_session()
+
+
+def _base_url(host: str) -> str:
+    return f'https://{host}/api'
+
+
+def _parse_token(token: str) -> tuple[str, str, str]:
+    """Split ``host:client_id:client_secret`` (hostname only, no scheme)."""
+    parts = (token or '').split(':', 2)
+    if len(parts) != 3 or not all(p.strip() for p in parts):
+        raise ProviderImportError(
+            'Xibo token must be "cms-host:client_id:client_secret".'
+        )
+    return parts[0].strip(), parts[1].strip(), parts[2].strip()
+
+
+def _authorize(host: str, client_id: str, client_secret: str) -> str | None:
+    """Exchange client credentials for a Bearer token, or None if rejected."""
+    response = _session.post(
+        f'{_base_url(host)}/authorize/access_token',
+        data={
+            'grant_type': 'client_credentials',
+            'client_id': client_id,
+            'client_secret': client_secret,
+        },
+        timeout=_VALIDATE_TIMEOUT_S,
+    )
+    if response.status_code in (400, 401, 403):
+        return None
+    response.raise_for_status()
+    token = response.json().get('access_token')
+    return token if isinstance(token, str) and token else None
+
+
+def _login_or_raise(token: str) -> tuple[str, dict[str, str]]:
+    """Return (host, auth-headers) after authorizing.
+
+    Raises ``ProviderImportError`` for a malformed token or rejected
+    credentials; transport errors propagate.
+    """
+    host, client_id, client_secret = _parse_token(token)
+    access = _authorize(host, client_id, client_secret)
+    if not access:
+        raise ProviderImportError('Xibo rejected these API credentials.')
+    return host, {'Authorization': f'Bearer {access}'}
+
+
+def _map_type(media_type: Any) -> str | None:
+    value = media_type.lower() if isinstance(media_type, str) else ''
+    if value == 'image':
+        return 'image'
+    if value == 'video':
+        return 'video'
+    return None
+
+
+class XiboProvider(ImportProvider):
+    key = PROVIDER_KEY
+    label = 'Xibo'
+    description = (
+        'Copy images and videos from a Xibo CMS library into this player.'
+    )
+    token_help = (
+        'In your Xibo CMS create an API application (Applications → Add), '
+        'then enter "cms-host:client_id:client_secret" — the host is the '
+        'CMS hostname (e.g. name.xibosignage.com). Used only for this import '
+        'and never stored.'
+    )
+
+    # -- token / listing ---------------------------------------------------
+
+    def validate_token(self, token: str) -> bool:
+        try:
+            host, client_id, client_secret = _parse_token(token)
+        except ProviderImportError:
+            return False
+        return _authorize(host, client_id, client_secret) is not None
+
+    def list_media(
+        self, token: str, *, workspace: str | None = None
+    ) -> list[RemoteMediaItem]:
+        try:
+            host, headers = _login_or_raise(token)
+        except ProviderImportError as error:
+            # list_media's caller handles transport errors, not
+            # ProviderImportError — surface bad creds as a controlled 502.
+            raise requests.RequestException(error.user_message) from error
+
+        items: list[RemoteMediaItem] = []
+        for media in self._paginate(host, headers):
+            media_id = media.get('mediaId')
+            if media_id is None:
+                continue
+            media_type = _map_type(media.get('mediaType'))
+            importable = media_type in ('image', 'video')
+            items.append(
+                RemoteMediaItem(
+                    remote_id=str(media_id),
+                    name=str(
+                        media.get('name')
+                        or media.get('fileName')
+                        or f'Xibo media {media_id}'
+                    ),
+                    media_type=media_type or 'unsupported',
+                    importable=importable,
+                    skip_reason=None
+                    if importable
+                    else "This Xibo library item isn't an image or video.",
+                    raw=media,
+                )
+            )
+        return items
+
+    def _paginate(
+        self, host: str, headers: dict[str, str]
+    ) -> Iterator[dict[str, Any]]:
+        start = 0
+        seen: set[Any] = set()
+        while True:
+            batch = self._library(
+                host, headers, {'start': start, 'length': _PAGE_SIZE}
+            )
+            fresh = [
+                media
+                for media in batch
+                if isinstance(media, dict) and media.get('mediaId') not in seen
+            ]
+            # No new rows means the CMS ignored our paging (returned the
+            # same set) or we're done — either way, stop.
+            if not fresh:
+                break
+            for media in fresh:
+                seen.add(media.get('mediaId'))
+                yield media
+            if len(batch) < _PAGE_SIZE:
+                break
+            start += _PAGE_SIZE
+
+    def _library(
+        self, host: str, headers: dict[str, str], params: dict[str, Any]
+    ) -> list[Any]:
+        response = _session.get(
+            f'{_base_url(host)}/library',
+            headers=headers,
+            params=params,
+            timeout=_LIST_TIMEOUT_S,
+        )
+        response.raise_for_status()
+        body = response.json()
+        return body if isinstance(body, list) else []
+
+    # -- import ------------------------------------------------------------
+
+    def import_item(
+        self, token: str, remote_id: str, *, enable: bool = True
+    ) -> ImportOutcome:
+        existing = ingest.find_imported_asset(PROVIDER_KEY, remote_id)
+        if existing is not None:
+            return ImportOutcome(
+                success=True,
+                asset_id=existing.asset_id,
+                skipped=True,
+                reason='Already imported.',
+            )
+
+        host, headers = _login_or_raise(token)
+        matches = self._library(host, headers, {'mediaId': remote_id})
+        media = (
+            matches[0] if matches and isinstance(matches[0], dict) else None
+        )
+        if media is None:
+            raise ProviderImportError('Media no longer exists in Xibo.')
+
+        media_type = _map_type(media.get('mediaType'))
+        if media_type not in ('image', 'video'):
+            return ImportOutcome(
+                success=False,
+                skipped=True,
+                reason="This Xibo library item isn't an image or video.",
+            )
+
+        file_url = (
+            f'{_base_url(host)}/library/download/{remote_id}/'
+            f'{media.get("mediaType")}'
+        )
+        start_date, end_date = ingest.default_window()
+        asset = ingest.create_file_asset(
+            session=_session,
+            headers=headers,
+            # The download is on the CMS host, so the Bearer token IS
+            # attached (scoped to that host by ingest).
+            auth_host=host,
+            provider_key=PROVIDER_KEY,
+            remote_id=remote_id,
+            name=str(media.get('name') or media.get('fileName') or remote_id),
+            mimetype=media_type,
+            file_url=file_url,
+            ext=ingest.file_ext_from(None, media.get('fileName') or ''),
+            # Video duration is probed server-side; images use Xibo's value.
+            duration=(
+                0
+                if media_type == 'video'
+                else ingest.duration_or_default(media.get('duration'))
+            ),
+            start_date=start_date,
+            end_date=end_date,
+            enable=enable,
+        )
+        return ImportOutcome(success=True, asset_id=asset.asset_id)


### PR DESCRIPTION
### Issues Fixed

Stacked on #3148 (piSignage). Fifth provider in the import series.

> **Base branch:** `feat/import-content-pisignage` — review after the earlier PRs. Retarget to `master` as the stack merges.

### Description

- **Xibo provider** (REST, Xibo CMS API): imports images and videos from a CMS library over the same `ImportProvider` interface, wizard, and CLI.
- **Auth**: OAuth2 client-credentials — an API application's `client_id`/`client_secret` are exchanged for a Bearer token at `POST /api/authorize/access_token`. Per-CMS host, so the operator token is `cms-host:client_id:client_secret`.
- **Content + filter**: lists `GET /library`, imports `mediaType` image/video, skips everything else (audio, documents, module widgets).
- **Download**: `/library/download/{mediaId}/{type}` on the CMS host — the Bearer token is attached (shared ingest auth-scoping).
- Unit tests (no network).

**Follow-ups (flagged in `xibo.py`):** Xibo web pages are layout widgets, not library media, so aren't imported; confirm the download-path shape against a live CMS.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)