### PR TITLE
feat(bulk-edit): add No cache & Skip asset check to mass edit; restore nocache in viewer

### DIFF
--- a/src/anthias_server/app/static/sass/_styles.scss
+++ b/src/anthias_server/app/static/sass/_styles.scss
@@ -2599,6 +2599,42 @@ body.auth-body {
 }
 .bulk-field__toggle { cursor: pointer; }
 
+// On/Off selector for the boolean flag groups (No cache / Skip asset
+// check) in the bulk-edit modal (#3137). A two-pill radio group makes
+// the target state explicit and keeps it visually distinct from the
+// group's opt-in switch above it — two identical switches would read as
+// duplicates. Shares the weekday pill vocabulary for a consistent look.
+.bulk-flag-choice {
+  display: inline-flex;
+  gap: var(--space-2);
+
+  &__pill {
+    --bg: var(--color-surface-tint);
+    --fg: var(--color-text);
+    border: 1px solid var(--color-border);
+    background: var(--bg);
+    color: var(--fg);
+    font-weight: 600;
+    padding: 0.4rem 1.1rem;
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    user-select: none;
+    transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+    input { position: absolute; opacity: 0; pointer-events: none; }
+  }
+  &__pill:has(input:checked) {
+    --bg: #{$anthias-yellow-3};
+    --fg: var(--color-accent-text);
+    border-color: $anthias-yellow-2;
+  }
+  // Keyboard focus lands on the hidden radio — surface it on the pill so
+  // the control is navigable without a mouse.
+  &__pill:has(input:focus-visible) {
+    outline: 2px solid var(--color-accent-edge);
+    outline-offset: 2px;
+  }
+}
+
 // Reserve room at the bottom of the page while a selection is active so
 // the fixed bulk bar never covers the last rows or their action
 // buttons (it floats over them otherwise, blocking clicks on the very

--- a/src/anthias_server/app/templates/_bulk_edit_modal.html
+++ b/src/anthias_server/app/templates/_bulk_edit_modal.html
@@ -36,7 +36,7 @@
         hx-target="#asset-table"
         hx-swap="outerHTML"
         hx-on::after-request="if (window.bulkSucceeded(event)) window.dispatchEvent(new CustomEvent('bulk-done', {detail: {closeEdit: true}}))"
-        x-data="{ applyDates: false, applyDuration: false, applyTime: false, applyDays: false }"
+        x-data="{ applyDates: false, applyDuration: false, applyTime: false, applyDays: false, applyNocache: false, applySkip: false }"
       >
         {% csrf_token %}
         <input type="hidden" name="ids" :value="selectedIds.join(',')">
@@ -122,12 +122,61 @@
               </div>
             </div>
           </section>
+
+          {% comment %} No cache & Skip asset check (#3137). Both are
+             boolean flags, so — unlike the date/duration groups — the
+             operator picks the target state with an On/Off segmented
+             control once the group is ticked. A segmented radio (rather
+             than a second switch) keeps the value control visually
+             distinct from the group's own opt-in switch above it: two
+             identical switches would read as duplicates. The radios are
+             disabled while the group is unticked so nothing is POSTed and
+             assets_bulk_update leaves the flag untouched.
+          {% endcomment %}
+          <section class="bulk-field" :class="applyNocache && 'is-on'">
+            <label class="app-check app-switch bulk-field__toggle m-0">
+              <input type="checkbox" class="app-check-input" name="apply_nocache" value="true" x-model="applyNocache">
+              <span class="app-check-label ml-2">No cache</span>
+            </label>
+            <div class="mt-3" x-show="applyNocache" x-cloak>
+              <div class="bulk-flag-choice" role="radiogroup" aria-label="No cache value">
+                <label class="bulk-flag-choice__pill">
+                  <input type="radio" name="nocache" value="true" checked :disabled="!applyNocache">
+                  <span>On</span>
+                </label>
+                <label class="bulk-flag-choice__pill">
+                  <input type="radio" name="nocache" value="false" :disabled="!applyNocache">
+                  <span>Off</span>
+                </label>
+              </div>
+            </div>
+          </section>
+
+          {# ---- Skip asset check ---- #}
+          <section class="bulk-field" :class="applySkip && 'is-on'">
+            <label class="app-check app-switch bulk-field__toggle m-0">
+              <input type="checkbox" class="app-check-input" name="apply_skip_asset_check" value="true" x-model="applySkip">
+              <span class="app-check-label ml-2">Skip asset check</span>
+            </label>
+            <div class="mt-3" x-show="applySkip" x-cloak>
+              <div class="bulk-flag-choice" role="radiogroup" aria-label="Skip asset check value">
+                <label class="bulk-flag-choice__pill">
+                  <input type="radio" name="skip_asset_check" value="true" checked :disabled="!applySkip">
+                  <span>On</span>
+                </label>
+                <label class="bulk-flag-choice__pill">
+                  <input type="radio" name="skip_asset_check" value="false" :disabled="!applySkip">
+                  <span>Off</span>
+                </label>
+              </div>
+            </div>
+          </section>
         </div>
 
         <div class="modal-card__footer">
           <button type="button" class="app-btn app-btn-link" @click="closeBulkEdit()">Cancel</button>
           <button type="submit" class="app-btn app-btn-primary"
-            :disabled="!(applyDates || applyDuration || applyTime || applyDays)">
+            :disabled="!(applyDates || applyDuration || applyTime || applyDays || applyNocache || applySkip)">
             <i class="ti ti-check"></i><span>Apply to selected</span>
           </button>
         </div>

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1042,11 +1042,12 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
     """Apply common schedule fields to a set of assets at once.
 
     Mirrors the per-asset ``assets_update`` parsing for dates,
-    duration, time-of-day, and weekday filters, but each group is
-    opt-in via an ``apply_*`` flag so an operator only overwrites the
-    fields they ticked — an unticked group is left untouched on every
-    selected asset. Everything is parsed before any row is mutated so a
-    bad date/time toasts without leaving a half-applied batch (#3046).
+    duration, time-of-day, weekday filters, and the No cache /
+    Skip asset check flags (#3137), but each group is opt-in via an
+    ``apply_*`` flag so an operator only overwrites the fields they
+    ticked — an unticked group is left untouched on every selected
+    asset. Everything is parsed before any row is mutated so a bad
+    date/time toasts without leaving a half-applied batch (#3046).
     """
     import json as _json
 
@@ -1078,8 +1079,17 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
     apply_duration = request.POST.get('apply_duration') == 'true'
     apply_time = request.POST.get('apply_time') == 'true'
     apply_days = request.POST.get('apply_days') == 'true'
+    apply_nocache = request.POST.get('apply_nocache') == 'true'
+    apply_skip = request.POST.get('apply_skip_asset_check') == 'true'
 
-    if not (apply_dates or apply_duration or apply_time or apply_days):
+    if not (
+        apply_dates
+        or apply_duration
+        or apply_time
+        or apply_days
+        or apply_nocache
+        or apply_skip
+    ):
         return _asset_table_response(
             request,
             toast=('info', 'Nothing to change — pick a field to edit'),
@@ -1196,6 +1206,15 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
         shared['play_time_to'] = None if clear_time else new_time_to
     if apply_days and new_play_days is not None:
         shared['play_days'] = new_play_days
+    # Boolean flags: the group being ticked means "set this flag on every
+    # selected asset to the switch's state" — an absent/off checkbox POSTs
+    # 'false', so a group can clear the flag as well as set it.
+    if apply_nocache:
+        shared['nocache'] = request.POST.get('nocache') == 'true'
+    if apply_skip:
+        shared['skip_asset_check'] = (
+            request.POST.get('skip_asset_check') == 'true'
+        )
 
     if not shared and not apply_duration:
         # e.g. apply_dates ticked but both date fields left blank.

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1206,9 +1206,10 @@ def assets_bulk_update(request: HttpRequest) -> HttpResponse:
         shared['play_time_to'] = None if clear_time else new_time_to
     if apply_days and new_play_days is not None:
         shared['play_days'] = new_play_days
-    # Boolean flags: the group being ticked means "set this flag on every
-    # selected asset to the switch's state" — an absent/off checkbox POSTs
-    # 'false', so a group can clear the flag as well as set it.
+    # Boolean flags: when a group is applied, its On/Off segmented radio
+    # POSTs the target state ('true'/'false'), so a group can clear the
+    # flag as well as set it. When the group isn't applied the field is
+    # absent (radios disabled) and the stored value is left untouched.
     if apply_nocache:
         shared['nocache'] = request.POST.get('nocache') == 'true'
     if apply_skip:

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -9,7 +9,7 @@ from os import getenv, path
 from signal import SIGALRM, signal
 from time import monotonic, sleep, time
 from typing import Any
-from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse
 
 import django
 import pydbus
@@ -945,13 +945,15 @@ def _cache_busted_url(uri: str) -> str:
 
     The token is wall-clock milliseconds, matching the original
     implementation; the key is namespaced so it can't clobber a query
-    parameter the page itself relies on, and any existing query string
-    is preserved.
+    parameter the page itself relies on. The existing query string is
+    appended to verbatim — NOT decoded and re-encoded — so a signed or
+    pre-encoded URL (presigned S3, dashboard auth tokens, ``%20`` vs
+    ``+`` distinctions) reaches the origin byte-for-byte as stored.
     """
     parts = urlparse(uri)
-    query = parse_qsl(parts.query, keep_blank_values=True)
-    query.append(('_anthias_nc', str(int(time() * 1000))))
-    return urlunparse(parts._replace(query=urlencode(query)))
+    token = f'_anthias_nc={int(time() * 1000)}'
+    new_query = f'{parts.query}&{token}' if parts.query else token
+    return urlunparse(parts._replace(query=new_query))
 
 
 def view_webpage(

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -7,8 +7,9 @@ import sys
 from collections.abc import Callable
 from os import getenv, path
 from signal import SIGALRM, signal
-from time import monotonic, sleep
+from time import monotonic, sleep, time
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import django
 import pydbus
@@ -929,7 +930,33 @@ def _send_to_webview(send: Callable[[], Any]) -> None:
     send()
 
 
-def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
+def _cache_busted_url(uri: str) -> str:
+    """Append a unique query parameter so a ``nocache`` webpage is
+    refetched fresh on every rotation.
+
+    Two things otherwise serve stale content for a ``nocache`` asset:
+    QtWebEngine's in-memory HTTP cache (which honours the response's
+    own cache-control headers, so a page that ships a long max-age is
+    reused for the whole session), and view_webpage's unchanged-URL
+    short-circuit (which skips the loadPage D-Bus call entirely when the
+    asset comes back around in the loop). A distinct URL per display
+    defeats both. This restores the per-asset nocache behaviour (refs
+    #11) that the Uzbl→webview migration silently dropped.
+
+    The token is wall-clock milliseconds, matching the original
+    implementation; the key is namespaced so it can't clobber a query
+    parameter the page itself relies on, and any existing query string
+    is preserved.
+    """
+    parts = urlparse(uri)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    query.append(('_anthias_nc', str(int(time() * 1000))))
+    return urlunparse(parts._replace(query=urlencode(query)))
+
+
+def view_webpage(
+    uri: str, reload_interval_s: int = 0, nocache: bool = False
+) -> None:
     """Display a webpage and arm its per-asset auto-refresh timer.
 
     ``reload_interval_s`` mirrors ``Asset.metadata['refresh_interval_s']``:
@@ -940,8 +967,16 @@ def view_webpage(uri: str, reload_interval_s: int = 0) -> None:
     when the URL is unchanged from the previous tick — so an edit that
     only flips the interval (no URI change) takes effect on the next
     asset_loop iteration.
+
+    ``nocache`` mirrors ``Asset.nocache``: when set, the URL is
+    cache-busted (see _cache_busted_url) so the page is fetched fresh
+    each time the asset is shown rather than served from QtWebEngine's
+    HTTP cache or skipped by the unchanged-URL short-circuit below.
     """
     global current_browser_url
+
+    if nocache:
+        uri = _cache_busted_url(uri)
 
     if browser is None or not browser.is_alive():
         # Mid-playback respawn on the asset_loop thread: small, short
@@ -1434,7 +1469,11 @@ def asset_loop(scheduler: Any) -> None:
             interval = clamp_refresh_interval(
                 metadata.get('refresh_interval_s')
             )
-            view_webpage(uri, reload_interval_s=interval)
+            view_webpage(
+                uri,
+                reload_interval_s=interval,
+                nocache=bool(asset.get('nocache')),
+            )
         elif 'video' in mime or 'streaming' in mime:
             # ``'video' or 'streaming' in mime`` parses as ``'video'
             # or ('streaming' in mime)`` — the truthy literal short-

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1900,7 +1900,7 @@ def test_assets_bulk_update_days(
 def test_assets_bulk_update_nocache_sets_flag(
     client: Client, bulk_assets: list[Asset]
 ) -> None:
-    """Ticking the No cache group with the switch on sets nocache on
+    """Ticking the No cache group with the On radio sets nocache on
     every selected asset, videos included (#3137)."""
     with mock.patch(
         'anthias_server.settings.ViewerPublisher.send_to_viewer',
@@ -1923,7 +1923,7 @@ def test_assets_bulk_update_nocache_sets_flag(
 def test_assets_bulk_update_nocache_off_clears_flag(
     client: Client, bulk_assets: list[Asset]
 ) -> None:
-    """The group can clear as well as set: an off switch POSTs
+    """The group can clear as well as set: the Off radio POSTs
     nocache=false and turns the flag off on every selected asset (#3137).
     """
     Asset.objects.filter(
@@ -1950,7 +1950,7 @@ def test_assets_bulk_update_nocache_off_clears_flag(
 def test_assets_bulk_update_skip_asset_check_sets_flag(
     client: Client, bulk_assets: list[Asset]
 ) -> None:
-    """Ticking the Skip asset check group with the switch on sets
+    """Ticking the Skip asset check group with the On radio sets
     skip_asset_check on every selected asset (#3137)."""
     with mock.patch(
         'anthias_server.settings.ViewerPublisher.send_to_viewer',

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -1897,6 +1897,136 @@ def test_assets_bulk_update_days(
 
 
 @pytest.mark.django_db
+def test_assets_bulk_update_nocache_sets_flag(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """Ticking the No cache group with the switch on sets nocache on
+    every selected asset, videos included (#3137)."""
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_nocache': 'true',
+                'nocache': 'true',
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.nocache is True
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_nocache_off_clears_flag(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """The group can clear as well as set: an off switch POSTs
+    nocache=false and turns the flag off on every selected asset (#3137).
+    """
+    Asset.objects.filter(
+        asset_id__in=[a.asset_id for a in bulk_assets]
+    ).update(nocache=True)
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_nocache': 'true',
+                'nocache': 'false',
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.nocache is False
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_skip_asset_check_sets_flag(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """Ticking the Skip asset check group with the switch on sets
+    skip_asset_check on every selected asset (#3137)."""
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_skip_asset_check': 'true',
+                'skip_asset_check': 'true',
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.skip_asset_check is True
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_flag_untouched_when_group_off(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """A flag value POSTed without its apply_* toggle is ignored — an
+    unticked group never overwrites the stored flag (#3137)."""
+    Asset.objects.filter(
+        asset_id__in=[a.asset_id for a in bulk_assets]
+    ).update(nocache=True, skip_asset_check=True)
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                # Duration group is the only one ticked; the stray flag
+                # values below must be ignored.
+                'apply_duration': 'true',
+                'duration': '42',
+                'nocache': 'false',
+                'skip_asset_check': 'false',
+            },
+        )
+    for a in bulk_assets:
+        a.refresh_from_db()
+        assert a.nocache is True
+        assert a.skip_asset_check is True
+
+
+@pytest.mark.django_db
+def test_assets_bulk_update_flag_only_counts_all_matched(
+    client: Client, bulk_assets: list[Asset]
+) -> None:
+    """A flag-only edit touches every matched row (videos included), so
+    the success toast reports the full selection count, not the
+    non-video subset the duration rule uses (#3137)."""
+    import json as _json
+
+    with mock.patch(
+        'anthias_server.settings.ViewerPublisher.send_to_viewer',
+        return_value=None,
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_bulk_update'),
+            data={
+                'ids': _bulk_ids_csv(bulk_assets),
+                'apply_nocache': 'true',
+                'nocache': 'true',
+            },
+            HTTP_HX_REQUEST='true',
+        )
+    trigger = _json.loads(response['HX-Trigger'])
+    assert trigger['toast']['message'] == '3 assets updated'
+
+
+@pytest.mark.django_db
 def test_assets_bulk_update_no_flags_is_noop(
     client: Client, bulk_assets: list[Asset]
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -482,6 +482,29 @@ def test_view_webpage_nocache_preserves_existing_query(
     assert '_anthias_nc=2000' in loaded
 
 
+def test_view_webpage_nocache_preserves_encoded_query_verbatim(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """The existing query string must reach the origin byte-for-byte —
+    a signed/pre-encoded URL breaks if %20/+ or percent-encoding is
+    normalised. The buster appends, it must not decode/re-encode."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    signed = 'https://s3.example/o?X-Sig=a%2Bb%2Fc%3D&name=q%20r'
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'time', return_value=3.0),
+    ):
+        viewer_fixtures.u.view_webpage(signed, nocache=True)
+
+    (loaded,), _ = fake_bus.loadPage.call_args
+    assert loaded == signed + '&_anthias_nc=3000'
+
+
 def test_view_webpage_nocache_reloads_each_display(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -432,6 +432,101 @@ def test_view_webpage_default_zero_interval(
     fake_bus.setReloadInterval.assert_called_once_with(0)
 
 
+def test_view_webpage_nocache_busts_url(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """A ``nocache`` webpage is loaded with a unique query token so it's
+    fetched fresh instead of served from QtWebEngine's HTTP cache
+    (#3137, restoring refs #11). setReloadInterval still fires."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'time', return_value=1234.567),
+    ):
+        viewer_fixtures.u.view_webpage('https://example.com', 30, nocache=True)
+
+    fake_bus.loadPage.assert_called_once_with(
+        'https://example.com?_anthias_nc=1234567'
+    )
+    fake_bus.setReloadInterval.assert_called_once_with(30)
+
+
+def test_view_webpage_nocache_preserves_existing_query(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """Cache-busting must merge into an existing query string, not
+    replace it — a dashboard URL's own parameters have to survive."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'time', return_value=2.0),
+    ):
+        viewer_fixtures.u.view_webpage(
+            'https://example.com/dash?tab=sales&x=1', nocache=True
+        )
+
+    (loaded,), _ = fake_bus.loadPage.call_args
+    assert loaded.startswith('https://example.com/dash?')
+    assert 'tab=sales' in loaded
+    assert 'x=1' in loaded
+    assert '_anthias_nc=2000' in loaded
+
+
+def test_view_webpage_nocache_reloads_each_display(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """The unique token per display defeats the unchanged-URL
+    short-circuit: showing the same nocache asset twice must issue two
+    distinct loadPage calls (a fresh fetch each rotation), unlike a
+    cached webpage which would skip the second load."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'time', side_effect=[10.0, 20.0]),
+    ):
+        viewer_fixtures.u.view_webpage('https://example.com', nocache=True)
+        viewer_fixtures.u.view_webpage('https://example.com', nocache=True)
+
+    assert fake_bus.loadPage.call_count == 2
+    first = fake_bus.loadPage.call_args_list[0].args[0]
+    second = fake_bus.loadPage.call_args_list[1].args[0]
+    assert first != second
+
+
+def test_view_webpage_without_nocache_leaves_url_untouched(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """The default (nocache=False) path must load the exact URL — no
+    stray cache-busting parameter for ordinary webpage assets."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+    ):
+        viewer_fixtures.u.view_webpage('https://example.com/dash?tab=1')
+
+    fake_bus.loadPage.assert_called_once_with('https://example.com/dash?tab=1')
+
+
 @pytest.mark.parametrize(
     'error_message,expected_call_count',
     [
@@ -895,6 +990,33 @@ def test_asset_loop_rechecks_unreachable_remote_asset() -> None:
     ):
         viewer.asset_loop(scheduler)
     trigger.assert_called_once_with('remote')
+
+
+def test_asset_loop_passes_nocache_flag_to_view_webpage() -> None:
+    """A webpage asset with ``nocache`` set must reach view_webpage with
+    nocache=True so the URL is fetched fresh (#3137). The default-False
+    case is guarded by the non-nocache webpage path."""
+    scheduler = mock.Mock()
+    scheduler.get_next_asset.return_value = {
+        'asset_id': 'web',
+        'name': 'dashboard',
+        'uri': 'https://example.com/dash',
+        'mimetype': 'webpage',
+        'duration': 10,
+        'skip_asset_check': True,
+        'is_reachable': True,
+        'nocache': True,
+        'metadata': {},
+    }
+    skip_event = mock.Mock()
+    skip_event.wait.return_value = False
+    with (
+        mock.patch('anthias_viewer.view_webpage') as view_webpage,
+        mock.patch('anthias_viewer.get_skip_event', return_value=skip_event),
+    ):
+        viewer.asset_loop(scheduler)
+    _, kwargs = view_webpage.call_args
+    assert kwargs['nocache'] is True
 
 
 def test_asset_loop_clamps_out_of_range_duration() -> None:


### PR DESCRIPTION
### Issues Fixed

Fixes #3137

### Description

Adds the **No cache** and **Skip asset check** flags to the mass-edit ("Edit N assets") modal, so operators can set or clear them across a whole selection instead of one asset at a time. Each flag is opt-in via the existing per-group toggle (unticked groups are left untouched) and picks its target state with an On/Off segmented control — visually distinct from the group's opt-in switch and consistent with the modal's existing pill styling.

While wiring this up I found `nocache` was a **no-op** in the current viewer stack — it was silently dropped in the Uzbl→webview migration. Since there is no point exposing a dead flag, this PR also restores it:

- `view_webpage` now cache-busts the URL for `nocache` assets (namespaced `_anthias_nc` token appended to the raw query string, so signed / pre-encoded URLs are preserved byte-for-byte), so the page is refetched fresh instead of being served from QtWebEngine's in-memory HTTP cache or skipped by the unchanged-URL short-circuit.
- `asset_loop` passes the asset's `nocache` flag through to `view_webpage`.
- `assets_bulk_update` writes both boolean flags as opt-in shared fields.

`skip_asset_check` was already honoured by the viewer, so it needed only the UI/endpoint wiring.

### Validation

**Unit:** 279 tests pass (10 new: bulk-edit endpoint + viewer cache-busting/dispatch/byte-preservation); `ruff check` and `ruff format --check` clean.

**End-to-end on a real x86 device** (overlaid the changed source onto the running `latest-x86` stack, real Qt6 QtWebEngine viewer, pointed webpage assets at a logging HTTP server that returns `Cache-Control: max-age=3600`):

- _Bulk edit_ — drove the real web UI in a browser: selected assets → opened the modal → No cache = On → Apply → toast "2 assets updated", and the device DB flipped both rows to `nocache=1`.
- _Viewer, single looping asset (8s), watched 45s:_

  | nocache | Network fetches | Behaviour |
  | --- | --- | --- |
  | OFF | 1 | Loads once, never refetches (stale — the bug) |
  | ON | 6 | Fresh fetch every rotation, distinct `_anthias_nc` token each time |

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [x] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).