### PR TITLE
fix(import): correct ScreenCloud endpoints/download; broaden Yodeck files

### DIFF
--- a/src/anthias_server/api/tests/test_screencloud_import.py
+++ b/src/anthias_server/api/tests/test_screencloud_import.py
@@ -29,11 +29,26 @@ from anthias_server.settings import settings
 PROVIDER = screencloud.ScreenCloudProvider()
 
 
+@pytest.fixture(autouse=True)
+def _clear_endpoint_cache() -> Any:
+    # The region cache is module-global; clear it so tests reusing the same
+    # token don't see a previously-resolved endpoint.
+    screencloud._endpoint_cache.clear()
+    yield
+    screencloud._endpoint_cache.clear()
+
+
 def _router(routes: dict[str, MagicMock]) -> Any:
-    """Route a GraphQL POST to a canned response by query substring."""
+    """Route a GraphQL POST to a canned response by query substring.
+
+    The region-detection probe (``currentOrg``) always resolves to a valid
+    org so ``_resolve`` picks the first region and the routed queries run.
+    """
 
     def _post(url: str, **kwargs: Any) -> MagicMock:
         query = kwargs['json']['query']
+        if 'currentOrg' in query:
+            return _gql(200, data={'currentOrg': {'id': 'x'}})
         for needle, resp in routes.items():
             if needle in query:
                 return resp
@@ -57,16 +72,30 @@ class TestAuthAndSession:
 
 
 class TestTokenRegion:
-    def test_default_region(self) -> None:
-        assert screencloud._parse_token('abc') == ('eu', 'abc')
+    def test_no_prefix_means_autodetect(self) -> None:
+        # No explicit region → region is None (auto-detected by probing).
+        assert screencloud._split_region('abc') == (None, 'abc')
 
-    def test_explicit_us(self) -> None:
-        assert screencloud._parse_token('us:abc') == ('us', 'abc')
+    def test_explicit_region_prefix(self) -> None:
+        assert screencloud._split_region('us:secret') == ('us', 'secret')
 
-    def test_endpoint_for_us(self) -> None:
-        endpoint, bearer = screencloud._endpoint_for('us:secret')
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_resolve_detects_region(self, post_mock: MagicMock) -> None:
+        # First region probed that returns currentOrg wins; endpoint host
+        # encodes the region.
+        post_mock.return_value = _gql(200, data={'currentOrg': {'id': 'x'}})
+        resolved = screencloud._resolve('secret')
+        assert resolved is not None
+        endpoint, bearer = resolved
         assert bearer == 'secret'
-        assert '.us.' in endpoint
+        assert 'screencloud.com/graphql' in endpoint
+
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_resolve_none_when_no_region_accepts(
+        self, post_mock: MagicMock
+    ) -> None:
+        post_mock.return_value = _gql(401)
+        assert screencloud._resolve('secret') is None
 
 
 class TestValidateToken:
@@ -154,18 +183,28 @@ class TestHelpers:
         assert screencloud._file_media_type('audio/mp3') == 'audio'
         assert screencloud._file_media_type('application/pdf') == 'document'
 
-    def test_download_url_prefers_matching_mimetype(self) -> None:
+    def test_download_url_prefers_file_source(self) -> None:
         file_obj = {
-            'mimetype': 'video/mp4',
+            'source': 'https://media.eu.screencloud.com/orig.jpg',
             'fileOutputsByFileId': {
-                'nodes': [
-                    {'url': 'https://cdn/thumb.jpg', 'mimetype': 'image/jpeg'},
-                    {'url': 'https://cdn/orig.mp4', 'mimetype': 'video/mp4'},
-                ]
+                'nodes': [{'url': 'https://cdn/thumb.jpg'}]
             },
         }
         assert (
-            screencloud._file_download_url(file_obj) == 'https://cdn/orig.mp4'
+            screencloud._file_download_url(file_obj)
+            == 'https://media.eu.screencloud.com/orig.jpg'
+        )
+
+    def test_download_url_falls_back_to_outputs(self) -> None:
+        file_obj = {
+            'source': None,
+            'fileOutputsByFileId': {
+                'nodes': [{'url': 'https://cdn/rendition.mp4'}]
+            },
+        }
+        assert (
+            screencloud._file_download_url(file_obj)
+            == 'https://cdn/rendition.mp4'
         )
 
 
@@ -280,14 +319,8 @@ class TestImportItem:
                             'mimetype': 'image/png',
                             'availableAt': None,
                             'expireAt': None,
-                            'fileOutputsByFileId': {
-                                'nodes': [
-                                    {
-                                        'url': 'https://cdn.sc/x.png',
-                                        'mimetype': 'image/png',
-                                    }
-                                ]
-                            },
+                            'source': 'https://media.us.screencloud.com/x.png',
+                            'fileOutputsByFileId': {'nodes': []},
                         }
                     },
                 )

--- a/src/anthias_server/api/tests/test_screencloud_import.py
+++ b/src/anthias_server/api/tests/test_screencloud_import.py
@@ -97,6 +97,19 @@ class TestTokenRegion:
         post_mock.return_value = _gql(401)
         assert screencloud._resolve('secret') is None
 
+    @patch('anthias_server.lib.integrations.screencloud._session.post')
+    def test_explicit_prefix_overrides_cached_region(
+        self, post_mock: MagicMock
+    ) -> None:
+        # A cached auto-detected region must not win over an explicit prefix.
+        screencloud._endpoint_cache[screencloud._cache_key('secret')] = (
+            screencloud._REGION_ENDPOINTS['eu']
+        )
+        post_mock.return_value = _gql(200, data={'currentOrg': {'id': 'x'}})
+        resolved = screencloud._resolve('us:secret')
+        assert resolved is not None
+        assert '.us.' in resolved[0]
+
 
 class TestValidateToken:
     @patch('anthias_server.lib.integrations.screencloud._session.post')

--- a/src/anthias_server/api/tests/test_yodeck_import.py
+++ b/src/anthias_server/api/tests/test_yodeck_import.py
@@ -232,12 +232,52 @@ class TestFieldMapping:
         detail = {'arguments': {'target_location': 'https://example.com/x'}}
         assert yodeck._webpage_url(detail) == 'https://example.com/x'
 
-    def test_file_url_read_from_download_from_url(self) -> None:
-        detail = {'arguments': {'download_from_url': 'https://cdn/x.mp4'}}
-        assert yodeck._file_url(detail) == 'https://cdn/x.mp4'
+    def test_resolve_file_download_from_url(self) -> None:
+        detail = {
+            'file_extension': 'mp4',
+            'arguments': {'download_from_url': 'https://cdn/x.mp4'},
+        }
+        assert yodeck._resolve_file(detail, 'video') == (
+            'https://cdn/x.mp4',
+            '.mp4',
+        )
 
-    def test_file_url_none_when_absent(self) -> None:
-        assert yodeck._file_url({'arguments': {}}) is None
+    def test_resolve_file_play_from_url_for_video(self) -> None:
+        # Uploaded videos expose the transcoded MP4 at play_from_url.
+        detail = {
+            'file_extension': 'mp4',
+            'arguments': {
+                'download_from_url': None,
+                'play_from_url': 'https://cdn/1080p.mp4',
+            },
+        }
+        assert yodeck._resolve_file(detail, 'video') == (
+            'https://cdn/1080p.mp4',
+            '.mp4',
+        )
+
+    def test_resolve_file_image_thumbnail_fallback(self) -> None:
+        # An uploaded image with no source URL falls back to the resized
+        # render; its extension comes from the URL (jpg), not the stored one.
+        detail = {
+            'file_extension': 'png',
+            'arguments': {'download_from_url': None},
+            'thumbnail_url': 'https://cdn/a/b/1/resized.jpg',
+        }
+        assert yodeck._resolve_file(detail, 'image') == (
+            'https://cdn/a/b/1/resized.jpg',
+            '.jpg',
+        )
+
+    def test_resolve_file_none_for_video_without_url(self) -> None:
+        # No file URL and no thumbnail fallback for video → skip.
+        assert (
+            yodeck._resolve_file(
+                {'arguments': {}, 'thumbnail_url': 'https://cdn/x/poster.jpg'},
+                'video',
+            )
+            is None
+        )
 
     def test_file_ext_prefers_field(self) -> None:
         assert (

--- a/src/anthias_server/lib/integrations/pisignage.py
+++ b/src/anthias_server/lib/integrations/pisignage.py
@@ -1,4 +1,4 @@
-"""piSignage import provider — REST.
+"""piSignage import provider (REST).
 
 piSignage is hosted per-account on a subdomain (``<account>.pisignage.com``)
 and authenticates by exchanging credentials for a JWT at ``POST /session``,

--- a/src/anthias_server/lib/integrations/pisignage.py
+++ b/src/anthias_server/lib/integrations/pisignage.py
@@ -126,7 +126,7 @@ class PiSignageProvider(ImportProvider):
         'Copy images and videos from a piSignage account into this player.'
     )
     token_help = (
-        'Enter your piSignage account as "subdomain:email:password" — the '
+        'Enter your piSignage account as "subdomain:email:password". The '
         'subdomain is the "<name>" in <name>.pisignage.com, followed by your '
         'login email (or username) and password. It is used only for this '
         'import and is never stored.'

--- a/src/anthias_server/lib/integrations/screencloud.py
+++ b/src/anthias_server/lib/integrations/screencloud.py
@@ -49,16 +49,19 @@ logger = logging.getLogger(__name__)
 
 PROVIDER_KEY = 'screencloud'
 
-# Region → GraphQL endpoint. The staging EU host is the only one the
-# public docs state outright; the production hosts follow the documented
-# ``*.next.sc/graphql`` pattern but are unconfirmed (read the exact value
-# from Studio → Account Settings → DEVELOPER). Kept in one map so a
-# correction is a one-line change.
+# ScreenCloud is regional; the endpoint host encodes the region
+# (``graphql.{eu,us}.screencloud.com``). An account lives in exactly one
+# region, so we probe both and use whichever accepts the token — the
+# operator shouldn't have to know their region.
 _REGION_ENDPOINTS = {
-    'eu': 'https://graphql.eu.next.sc/graphql',
-    'us': 'https://graphql.us.next.sc/graphql',
+    'eu': 'https://graphql.eu.screencloud.com/graphql',
+    'us': 'https://graphql.us.screencloud.com/graphql',
 }
-_DEFAULT_REGION = 'eu'
+
+# Cache the resolved endpoint per token so a wizard run (validate → N
+# item imports) probes only once. The token is already in memory for the
+# duration of the request; this just avoids re-probing every call.
+_endpoint_cache: dict[str, str] = {}
 
 _LIST_PAGE_SIZE = 100
 _VALIDATE_TIMEOUT_S = 15.0
@@ -96,7 +99,7 @@ query($first: Int!, $after: Cursor) {
 _FILE_BY_ID = """
 query($id: UUID!) {
   fileById(id: $id) {
-    id name mimetype availableAt expireAt
+    id name mimetype availableAt expireAt source
     fileOutputsByFileId { nodes { url mimetype } }
   }
 }
@@ -109,18 +112,55 @@ query($id: UUID!) {
 """
 
 
-def _parse_token(token: str) -> tuple[str, str]:
-    """Split an optional ``<region>:`` prefix off the bearer token."""
+def _split_region(token: str) -> tuple[str | None, str]:
+    """Split an optional explicit ``<region>:`` prefix off the token.
+
+    A prefix is an override; without one the region is auto-detected.
+    """
     raw = (token or '').strip()
     prefix, sep, rest = raw.partition(':')
     if sep and prefix.lower() in _REGION_ENDPOINTS:
         return prefix.lower(), rest
-    return _DEFAULT_REGION, raw
+    return None, raw
 
 
-def _endpoint_for(token: str) -> tuple[str, str]:
-    region, bearer = _parse_token(token)
-    return _REGION_ENDPOINTS[region], bearer
+def _accepts(endpoint: str, bearer: str) -> bool:
+    """True if this regional endpoint authenticates the token."""
+    response = graphql.post(
+        _session,
+        endpoint,
+        graphql.bearer_headers(bearer),
+        _VALIDATE_QUERY,
+        None,
+        _VALIDATE_TIMEOUT_S,
+    )
+    if response.status_code in (401, 403):
+        return False
+    response.raise_for_status()
+    body = response.json()
+    if body.get('errors'):
+        return False
+    return bool((body.get('data') or {}).get('currentOrg'))
+
+
+def _resolve(token: str) -> tuple[str, str] | None:
+    """Return (endpoint, bearer) for the region that accepts this token.
+
+    Honours an explicit region prefix; otherwise probes each region.
+    Returns None if no region accepts the token; transport errors
+    propagate so the caller can answer 502.
+    """
+    region, bearer = _split_region(token)
+    cached = _endpoint_cache.get(bearer)
+    if cached is not None:
+        return cached, bearer
+    regions = [region] if region else list(_REGION_ENDPOINTS)
+    for name in regions:
+        endpoint = _REGION_ENDPOINTS[name]
+        if _accepts(endpoint, bearer):
+            _endpoint_cache[bearer] = endpoint
+            return endpoint, bearer
+    return None
 
 
 def _post(
@@ -129,7 +169,10 @@ def _post(
     variables: dict[str, Any] | None,
     timeout: float,
 ) -> Any:
-    endpoint, bearer = _endpoint_for(token)
+    resolved = _resolve(token)
+    if resolved is None:
+        raise ProviderImportError('ScreenCloud rejected this token.')
+    endpoint, bearer = resolved
     return graphql.post(
         _session,
         endpoint,
@@ -164,26 +207,18 @@ def _file_media_type(mimetype: str | None) -> str:
 
 
 def _file_download_url(file_obj: dict[str, Any]) -> str | None:
-    """Pick the downloadable original URL from a File's outputs.
+    """Pick the downloadable original URL for a File.
 
-    Prefers a ``FileOutput`` whose mimetype matches the file's top-level
-    type (image/video), falling back to the first valid URL. Which output
-    is the durable original vs a thumbnail isn't documented — see the
-    module TODO.
+    ``File.source`` is the original on ``media.<region>.screencloud.com``.
+    The ``fileOutputsByFileId`` renditions are kept as a fallback but can
+    be empty.
     """
-    mimetype = file_obj.get('mimetype') or ''
-    top = mimetype.split('/', 1)[0]
+    candidates: list[Any] = [file_obj.get('source')]
     outputs = (file_obj.get('fileOutputsByFileId') or {}).get('nodes') or []
-    for output in outputs:
-        if not isinstance(output, dict):
-            continue
-        url = output.get('url')
-        out_top = (output.get('mimetype') or '').split('/', 1)[0]
-        if out_top and out_top == top and ingest.first_http_url([url]):
-            return url
-    return ingest.first_http_url(
+    candidates += [
         output.get('url') for output in outputs if isinstance(output, dict)
-    )
+    ]
+    return ingest.first_http_url(candidates)
 
 
 def _default_duration() -> int:
@@ -201,25 +236,17 @@ class ScreenCloudProvider(ImportProvider):
     )
     token_help = (
         'Create an API token in ScreenCloud Studio under Account Settings '
-        '→ Developer → New Token. Paste it here; if your account is in the '
-        'US region, prefix the token with "us:" (EU is the default). It is '
-        'used only for this import and is never stored.'
+        '→ Developer → New Token, then paste it here. The region (EU or '
+        'US) is detected automatically. It is used only for this import '
+        'and is never stored.'
     )
 
     # -- token / listing ---------------------------------------------------
 
     def validate_token(self, token: str) -> bool:
-        response = _post(token, _VALIDATE_QUERY, None, _VALIDATE_TIMEOUT_S)
-        if response.status_code in (401, 403):
-            return False
-        response.raise_for_status()
-        body = response.json()
-        # A minimal ``currentOrg`` query returns data for a good token; an
-        # errors[] here means the token was rejected.
-        if body.get('errors'):
-            return False
-        data = body.get('data') or {}
-        return bool(data.get('currentOrg'))
+        # _resolve probes the regions with the same currentOrg query and
+        # caches the hit, so validation doubles as region detection.
+        return _resolve(token) is not None
 
     def list_media(
         self, token: str, *, workspace: str | None = None

--- a/src/anthias_server/lib/integrations/screencloud.py
+++ b/src/anthias_server/lib/integrations/screencloud.py
@@ -1,4 +1,4 @@
-"""ScreenCloud (Studio) import provider — GraphQL.
+"""ScreenCloud (Studio) import provider (GraphQL).
 
 ScreenCloud's Signage/Studio API is a PostGraphile GraphQL endpoint (not
 REST), which is exactly why the provider interface is transport-agnostic:
@@ -10,27 +10,21 @@ creation + idempotency that every provider shares.
 Media is split across two GraphQL types:
 
 * ``File``  → uploaded images and videos (distinguished by ``mimetype``).
-  The downloadable original comes from ``fileOutputsByFileId``.
+  The downloadable original is ``File.source``.
 * ``Link``  → web pages / URLs (imported as Anthias ``webpage`` assets).
 
 Remote ids are namespaced ``file:<uuid>`` / ``link:<uuid>`` so a single
 ``import_item`` call knows which GraphQL type to fetch.
 
-Endpoint / region: ScreenCloud endpoints are per-organization and region
-(``eu`` / ``us``). The operator can prefix the token with a region
-(``eu:<token>`` / ``us:<token>``); without a prefix the EU endpoint is
-used. See ``token_help``.
-
-TODO(confirm-with-live-token): the production regional hostnames, the
-``fileById`` / ``linkById`` field names, and which ``FileOutput`` is the
-durable original vs a thumbnail are documented behind a ScreenCloud login
-and should be verified against a real account before GA. The resolution
-points are isolated in ``_endpoint_for`` / ``_file_download_url`` /
-``_FILE_BY_ID`` so confirming them is a localized change.
+Endpoint / region: ScreenCloud is regional (``eu`` / ``us``), with the
+region encoded in the endpoint host. The region is auto-detected by
+probing both endpoints with the token; an explicit ``eu:``/``us:`` token
+prefix overrides that. See ``_resolve``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import Any, Iterator
 
@@ -58,10 +52,15 @@ _REGION_ENDPOINTS = {
     'us': 'https://graphql.us.screencloud.com/graphql',
 }
 
-# Cache the resolved endpoint per token so a wizard run (validate → N
-# item imports) probes only once. The token is already in memory for the
-# duration of the request; this just avoids re-probing every call.
+# Cache the auto-detected endpoint so a wizard run (validate → N item
+# imports) probes only once. Keyed by a one-way hash of the token, never
+# the token itself, so no credential is retained in memory.
 _endpoint_cache: dict[str, str] = {}
+
+
+def _cache_key(bearer: str) -> str:
+    return hashlib.sha256(bearer.encode()).hexdigest()
+
 
 _LIST_PAGE_SIZE = 100
 _VALIDATE_TIMEOUT_S = 15.0
@@ -146,19 +145,23 @@ def _accepts(endpoint: str, bearer: str) -> bool:
 def _resolve(token: str) -> tuple[str, str] | None:
     """Return (endpoint, bearer) for the region that accepts this token.
 
-    Honours an explicit region prefix; otherwise probes each region.
-    Returns None if no region accepts the token; transport errors
-    propagate so the caller can answer 502.
+    An explicit ``eu:``/``us:`` prefix is an override: it's used directly
+    and bypasses the auto-detection cache. Otherwise each region is probed
+    and the hit is cached (by token hash). Returns None if no region
+    accepts the token; transport errors propagate so the caller can
+    answer 502.
     """
     region, bearer = _split_region(token)
-    cached = _endpoint_cache.get(bearer)
+    if region is not None:
+        endpoint = _REGION_ENDPOINTS[region]
+        return (endpoint, bearer) if _accepts(endpoint, bearer) else None
+    key = _cache_key(bearer)
+    cached = _endpoint_cache.get(key)
     if cached is not None:
         return cached, bearer
-    regions = [region] if region else list(_REGION_ENDPOINTS)
-    for name in regions:
-        endpoint = _REGION_ENDPOINTS[name]
+    for endpoint in _REGION_ENDPOINTS.values():
         if _accepts(endpoint, bearer):
-            _endpoint_cache[bearer] = endpoint
+            _endpoint_cache[key] = endpoint
             return endpoint, bearer
     return None
 

--- a/src/anthias_server/lib/integrations/xibo.py
+++ b/src/anthias_server/lib/integrations/xibo.py
@@ -127,7 +127,7 @@ class XiboProvider(ImportProvider):
     token_help = (
         'In your Xibo CMS create an API application (Applications → Add), '
         'then enter "<cms-url> <client_id> <client_secret>" (space '
-        'separated) — the CMS URL is your Xibo address, e.g. '
+        'separated). The CMS URL is your Xibo address, e.g. '
         'https://name.xibosignage.com, or your self-hosted CMS URL. Used '
         'only for this import and never stored.'
     )

--- a/src/anthias_server/lib/integrations/xibo.py
+++ b/src/anthias_server/lib/integrations/xibo.py
@@ -1,4 +1,4 @@
-"""Xibo import provider — REST (Xibo CMS API).
+"""Xibo import provider (REST, Xibo CMS API).
 
 Works with both Xibo Cloud (``https://<name>.xibosignage.com``) and
 self-hosted CMS instances (any URL, including a custom host, port or

--- a/src/anthias_server/lib/integrations/yodeck.py
+++ b/src/anthias_server/lib/integrations/yodeck.py
@@ -54,17 +54,24 @@ _LIST_PAGE_SIZE = 100
 _VALIDATE_TIMEOUT_S = 10.0
 _LIST_TIMEOUT_S = 30.0
 
-# Candidate fields that may carry a downloadable ORIGINAL file URL for an
+# Candidate fields that may carry a downloadable file URL for an
 # image/video, in priority order — first at the top level, then inside
-# ``arguments``. ``arguments.download_from_url`` is Yodeck's download link
-# for the original and is present for uploaded (``source: local``) media
-# too — it points at Yodeck (app.yodeck.com) and 302-redirects to a signed
-# S3 URL, so the token is attached for the Yodeck host and dropped by
-# ``requests`` on the cross-host redirect. The extra keys cover forward-
-# compatible alternatives; if none resolves, the item is skipped with a
-# clear reason rather than guessed at.
+# ``arguments``:
+#   * ``download_from_url`` — the external source for media added from a
+#     URL (full resolution).
+#   * ``play_from_url`` — the transcoded video Yodeck serves (an MP4).
+# The remaining keys are forward-compatible alternatives. Images that were
+# uploaded (rather than added from a URL) don't expose the original here;
+# they fall back to the resized render (``thumbnail_url``) in
+# ``_resolve_file`` — see there.
 _FILE_URL_KEYS = ('file', 'media_file', 'source_url', 'original_url', 'url')
-_ARGUMENT_FILE_KEYS = ('download_from_url', 'source_url', 'file', 'url')
+_ARGUMENT_FILE_KEYS = (
+    'download_from_url',
+    'play_from_url',
+    'source_url',
+    'file',
+    'url',
+)
 
 # Candidate fields carrying a webpage's destination URL (top level, then
 # inside ``arguments``).
@@ -94,11 +101,32 @@ def _webpage_url(detail: dict[str, Any]) -> str | None:
     return ingest.first_http_url([*top, *inner, *arguments.values()])
 
 
-def _file_url(detail: dict[str, Any]) -> str | None:
+def _resolve_file(
+    detail: dict[str, Any], media_type: str
+) -> tuple[str, str] | None:
+    """Return ``(download_url, extension)`` for an image/video, or None.
+
+    Tries the source/transcoded URLs first (see ``_ARGUMENT_FILE_KEYS``).
+    For an image with no such URL — an uploaded image whose original isn't
+    exposed by the API — it falls back to the resized render
+    (``thumbnail_url``), which Yodeck serves for display; that render is a
+    JPEG, so its extension is taken from the URL rather than the media's
+    stored ``file_extension``.
+    """
     arguments = detail.get('arguments') or {}
-    top = (detail.get(k) for k in _FILE_URL_KEYS)
-    inner = (arguments.get(k) for k in _ARGUMENT_FILE_KEYS)
-    return ingest.first_http_url([*top, *inner])
+    primary = ingest.first_http_url(
+        [
+            *(detail.get(k) for k in _FILE_URL_KEYS),
+            *(arguments.get(k) for k in _ARGUMENT_FILE_KEYS),
+        ]
+    )
+    if primary:
+        return primary, _file_ext(detail, primary)
+    if media_type == 'image':
+        thumb = ingest.first_http_url([detail.get('thumbnail_url')])
+        if thumb:
+            return thumb, ingest.file_ext_from(None, thumb)
+    return None
 
 
 def _is_internal_yodeck_url(url: str) -> bool:
@@ -166,10 +194,9 @@ class YodeckProvider(ImportProvider):
     )
     token_help = (
         'Create an API token in Yodeck under Account Settings → Advanced '
-        'Settings → API Tokens. Enter it as "<label>:<token>" — the name '
-        'you gave the token, a colon, then the copied token value (e.g. '
-        '"mylabel:XXXXXXXX"). It is used only for this import and is never '
-        'stored.'
+        'Settings → API Tokens, then paste the token value here. (You can '
+        'also enter it as "<label>:<token>" if you prefer.) It is used only '
+        'for this import and is never stored.'
     )
 
     # -- token / listing ---------------------------------------------------
@@ -317,28 +344,29 @@ class YodeckProvider(ImportProvider):
                 enable=enable,
             )
         else:
-            file_url = _file_url(detail)
-            if not file_url:
+            resolved = _resolve_file(detail, media_type)
+            if resolved is None:
                 return ImportOutcome(
                     success=False,
                     skipped=True,
                     reason=(
-                        f"Yodeck didn't expose a downloadable original for "
-                        f'this {media_type}; re-upload it manually.'
+                        f"Yodeck didn't expose a downloadable file for this "
+                        f'{media_type}; re-upload it manually.'
                     ),
                 )
+            file_url, ext = resolved
             asset = ingest.create_file_asset(
                 session=_session,
                 headers=_auth_headers(token),
                 # Scope the Yodeck token to the Yodeck host — never forward
-                # it to a pre-signed CDN original.
+                # it to a file on a different (S3/CDN) host.
                 auth_host=_YODECK_HOST,
                 provider_key=PROVIDER_KEY,
                 remote_id=remote_id,
                 name=name,
                 mimetype=media_type,
                 file_url=file_url,
-                ext=_file_ext(detail, file_url),
+                ext=ext,
                 # Video duration is probed server-side (the serializer
                 # requires 0 on input); images carry Yodeck's duration.
                 duration=(

--- a/website/content/docs/importing-content-from-other-platforms.md
+++ b/website/content/docs/importing-content-from-other-platforms.md
@@ -19,8 +19,9 @@ Xibo (Xibo Cloud or self-hosted).
 
 Anthias imports the content types it can play natively:
 
-- **Images** and **videos**: the original file is downloaded onto your
-  player and added to the schedule.
+- **Images** and **videos**: the file is downloaded onto your player and
+  added to the schedule (the original where the platform exposes it, or the
+  best available rendition otherwise).
 - **Web pages**: added as a web asset pointing at the same URL.
 
 Anything Anthias cannot play, or that would not work outside the source
@@ -30,9 +31,9 @@ platform, is **skipped and reported** rather than imported half-way:
 - **Apps and internally-generated content**: weather, clock, RSS, and
   dashboard widgets render inside the source platform, so their internal
   URLs would only produce broken assets on Anthias.
-- **Files the platform does not expose for download**: if the source only
-  offers a preview or thumbnail, the original cannot be copied, so those
-  items are flagged for you to re-upload manually.
+- **Files with no downloadable URL**: when the platform exposes neither the
+  original nor a usable rendition, the item is flagged for you to re-upload
+  manually.
 
 ## Before you start
 

--- a/website/content/docs/importing-content-from-other-platforms.md
+++ b/website/content/docs/importing-content-from-other-platforms.md
@@ -8,46 +8,43 @@ aliases:
 
 Moving to Anthias from another digital signage platform? Anthias ships a
 built-in import wizard that copies your media across using the other
-platform's API — no SSH or scripts required. Your existing Anthias assets
-are left untouched, and re-running an import skips anything already brought
-over, so it is safe to run more than once.
+platform's API, so no SSH or scripts are required. Your existing Anthias
+assets are left untouched, and re-running an import skips anything already
+brought over, so it is safe to run more than once.
 
-**Supported platforms:** [Yodeck](https://www.yodeck.com/),
-[ScreenCloud](https://screencloud.com/),
-[OptiSigns](https://www.optisigns.com/),
-[piSignage](https://pisignage.com/), and
-[Xibo](https://xibosignage.com/) (Xibo Cloud or self-hosted).
+**Supported platforms:** Yodeck, ScreenCloud, OptiSigns, piSignage, and
+Xibo (Xibo Cloud or self-hosted).
 
 ## What gets imported
 
 Anthias imports the content types it can play natively:
 
-- **Images** and **videos** — the original file is downloaded onto your
+- **Images** and **videos**: the original file is downloaded onto your
   player and added to the schedule.
-- **Web pages** — added as a web asset pointing at the same URL.
+- **Web pages**: added as a web asset pointing at the same URL.
 
 Anything Anthias cannot play, or that would not work outside the source
 platform, is **skipped and reported** rather than imported half-way:
 
 - **Audio** and **documents** (PDF, PowerPoint, and similar).
-- **Apps and internally-generated content** — weather, clock, RSS, and
+- **Apps and internally-generated content**: weather, clock, RSS, and
   dashboard widgets render inside the source platform, so their internal
   URLs would only produce broken assets on Anthias.
-- **Files the platform does not expose for download** — if the source only
-  offers a preview or thumbnail, the original cannot be copied; those items
-  are flagged so you can re-upload them manually.
+- **Files the platform does not expose for download**: if the source only
+  offers a preview or thumbnail, the original cannot be copied, so those
+  items are flagged for you to re-upload manually.
 
 ## Before you start
 
 You will need API credentials for the platform you are importing from. What
-to enter differs slightly per platform — the wizard shows a reminder for
+to enter differs slightly per platform, and the wizard shows a reminder for
 each. Credentials are **not** stored on the device; they are only used to
 talk to the platform's API while the import runs.
 
 | Platform | What to enter in the wizard | Where to create it |
 | --- | --- | --- |
-| **Yodeck** | `label:token` | Account Settings → Advanced Settings → API Tokens |
-| **ScreenCloud** | Your API token (add a `us:` prefix if your account is in the US region) | Studio → Account Settings → Developer → New Token |
+| **Yodeck** | Your API token | Account Settings → Advanced Settings → API Tokens |
+| **ScreenCloud** | Your API token (the region is detected automatically) | Studio → Account Settings → Developer → New Token |
 | **OptiSigns** | Your API key | Account Settings → API Keys → New API Key |
 | **piSignage** | `subdomain:email:password` (the `<name>` in `<name>.pisignage.com`, plus your login) | Your piSignage account login |
 | **Xibo** | `cms-url client_id client_secret` (space separated; the CMS URL works for Xibo Cloud or self-hosted) | Applications → Add (an API application) |
@@ -69,7 +66,7 @@ talk to the platform's API while the import runs.
 7. When it finishes, any items that failed can be retried with the **Retry
    _N_ failed** button, without repeating the ones that already succeeded.
 
-That's it — your imported media now lives on your Anthias player, ready to
+That is it. Your imported media now lives on your Anthias player, ready to
 schedule like any other asset.
 
 ## Prefer the command line?


### PR DESCRIPTION
### Issues Fixed

Corrections to the import providers found while testing them, plus doc/copy fixes.

### Description

**ScreenCloud**
- Use the correct production GraphQL endpoints (`graphql.{eu,us}.screencloud.com`); the previously-assumed `*.next.sc` hosts do not resolve.
- Auto-detect the account region by probing both endpoints, so the operator does not have to know or specify EU vs US. An explicit `eu:`/`us:` prefix still works as an override.
- Download the original from `File.source` (the `fileOutputsByFileId` renditions can be empty).

**Yodeck**
- Import transcoded videos via `arguments.play_from_url`.
- Fall back to the resized render (`thumbnail_url`) for uploaded images whose original is not exposed by the API, instead of skipping them.
- Accept a bare token (the `label:` prefix is optional).

**Docs / UI**
- The import doc now lists every supported provider (no external links).
- Removed em-dashes from the import doc and the wizard help text.

Providers reuse the shared ingest/http/graphql layer; tests updated and pass (ruff, mypy, pytest all green).

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)