### PR TITLE
fix(upload): isolate resumable uploads with a per-request temp path

### DIFF
--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -174,7 +174,9 @@ def test_file_asset_chunked_out_of_order_reassembles(
     """A resumable (Content-Range) upload must reassemble correctly
     even when chunks arrive out of order. Append mode ignored the
     seek() and pinned every write to EOF, corrupting the .tmp; r+b
-    honours the offset."""
+    honours the offset. Chunks are tied to one file by the opaque
+    ``upload_id`` echoed via ``X-Upload-Id`` (issue #3135), not by the
+    filename."""
     from django.core.files.uploadedfile import SimpleUploadedFile
 
     url = reverse('api:file_asset_v1')
@@ -189,6 +191,7 @@ def test_file_asset_chunked_out_of_order_reassembles(
         },
         headers={'Content-Range': 'bytes 4-7/8'},
     )
+    upload_id = tail.data['upload_id']
     head = api_client.post(
         url,
         data={
@@ -196,7 +199,7 @@ def test_file_asset_chunked_out_of_order_reassembles(
                 'clip.png', b'AAAA', content_type='image/png'
             )
         },
-        headers={'Content-Range': 'bytes 0-3/8'},
+        headers={'Content-Range': 'bytes 0-3/8', 'X-Upload-Id': upload_id},
     )
 
     assert tail.status_code == status.HTTP_200_OK
@@ -270,16 +273,52 @@ def test_file_asset_content_range_chunk_length_mismatch_returns_400(
 
 
 @pytest.mark.django_db
-def test_file_asset_content_range_truncates_stale_tmp(
+def test_file_asset_same_name_uploads_are_isolated(
     api_client: APIClient, cleanup_asset_dir: None
 ) -> None:
-    """The .tmp path is deterministic per filename, so a shorter new
-    upload must not inherit trailing bytes from a longer previous
-    attempt. Writing the final chunk truncates to the declared total."""
+    """Two uploads of the same filename must stage at different temp
+    paths so they can't clobber or bleed into each other (issue #3135).
+    Each mints its own opaque ``upload_id`` and lands in its own file."""
     from django.core.files.uploadedfile import SimpleUploadedFile
 
     url = reverse('api:file_asset_v1')
-    # First upload: a 10-byte file in one chunk.
+    first = api_client.post(
+        url,
+        data={
+            'file_upload': SimpleUploadedFile(
+                'clip.png', b'AAAA', content_type='image/png'
+            )
+        },
+    )
+    second = api_client.post(
+        url,
+        data={
+            'file_upload': SimpleUploadedFile(
+                'clip.png', b'BBBBBBBB', content_type='image/png'
+            )
+        },
+    )
+    assert first.status_code == status.HTTP_200_OK
+    assert second.status_code == status.HTTP_200_OK
+    assert first.data['upload_id'] != second.data['upload_id']
+    assert first.data['uri'] != second.data['uri']
+    with open(first.data['uri'], 'rb') as f:
+        assert f.read() == b'AAAA'
+    with open(second.data['uri'], 'rb') as f:
+        assert f.read() == b'BBBBBBBB'
+
+
+@pytest.mark.django_db
+def test_file_asset_content_range_truncates_on_shrink(
+    api_client: APIClient, cleanup_asset_dir: None
+) -> None:
+    """Within one upload session (shared ``upload_id``), the final chunk
+    truncates to the declared total so a shrunk re-write can't inherit
+    trailing bytes from a longer earlier attempt to the same file."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    url = reverse('api:file_asset_v1')
+    # First write: a 10-byte file in one chunk.
     first = api_client.post(
         url,
         data={
@@ -289,7 +328,8 @@ def test_file_asset_content_range_truncates_stale_tmp(
         },
         headers={'Content-Range': 'bytes 0-9/10'},
     )
-    # Second upload, same filename (=> same .tmp path): shorter content.
+    upload_id = first.data['upload_id']
+    # Re-write the same session (same upload_id => same .tmp) shorter.
     second = api_client.post(
         url,
         data={
@@ -297,13 +337,37 @@ def test_file_asset_content_range_truncates_stale_tmp(
                 'clip.png', b'AAAA', content_type='image/png'
             )
         },
-        headers={'Content-Range': 'bytes 0-3/4'},
+        headers={'Content-Range': 'bytes 0-3/4', 'X-Upload-Id': upload_id},
     )
     assert first.status_code == status.HTTP_200_OK
     assert second.status_code == status.HTTP_200_OK
     assert second.data['uri'] == first.data['uri']
     with open(second.data['uri'], 'rb') as f:
         assert f.read() == b'AAAA'
+
+
+@pytest.mark.django_db
+def test_file_asset_malformed_upload_id_returns_400(
+    api_client: APIClient, cleanup_asset_dir: None
+) -> None:
+    """``X-Upload-Id`` becomes a filesystem path, so a value that isn't
+    the uuid4 hex shape we mint (here a traversal attempt) must 400
+    rather than escape the asset dir."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    response = api_client.post(
+        reverse('api:file_asset_v1'),
+        data={
+            'file_upload': SimpleUploadedFile(
+                'clip.png', b'AAAA', content_type='image/png'
+            )
+        },
+        headers={
+            'Content-Range': 'bytes 0-3/4',
+            'X-Upload-Id': '../../etc/passwd',
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.django_db

--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -191,6 +191,7 @@ def test_file_asset_chunked_out_of_order_reassembles(
         },
         headers={'Content-Range': 'bytes 4-7/8'},
     )
+    assert tail.status_code == status.HTTP_200_OK
     upload_id = tail.data['upload_id']
     head = api_client.post(
         url,
@@ -202,7 +203,6 @@ def test_file_asset_chunked_out_of_order_reassembles(
         headers={'Content-Range': 'bytes 0-3/8', 'X-Upload-Id': upload_id},
     )
 
-    assert tail.status_code == status.HTTP_200_OK
     assert head.status_code == status.HTTP_200_OK
     assert head.data['uri'] == tail.data['uri']
     with open(head.data['uri'], 'rb') as f:
@@ -328,6 +328,7 @@ def test_file_asset_content_range_truncates_on_shrink(
         },
         headers={'Content-Range': 'bytes 0-9/10'},
     )
+    assert first.status_code == status.HTTP_200_OK
     upload_id = first.data['upload_id']
     # Re-write the same session (same upload_id => same .tmp) shorter.
     second = api_client.post(
@@ -339,7 +340,6 @@ def test_file_asset_content_range_truncates_on_shrink(
         },
         headers={'Content-Range': 'bytes 0-3/4', 'X-Upload-Id': upload_id},
     )
-    assert first.status_code == status.HTTP_200_OK
     assert second.status_code == status.HTTP_200_OK
     assert second.data['uri'] == first.data['uri']
     with open(second.data['uri'], 'rb') as f:
@@ -368,6 +368,48 @@ def test_file_asset_malformed_upload_id_returns_400(
         },
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_file_asset_upload_id_ignored_without_content_range(
+    api_client: APIClient, cleanup_asset_dir: None
+) -> None:
+    """A single-shot (no Content-Range) upload takes the ``open('wb')``
+    truncating path, so ``X-Upload-Id`` must be ignored there — otherwise
+    one request could truncate another session's in-progress ``.tmp``.
+    The server mints a fresh id and leaves the named file untouched."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    url = reverse('api:file_asset_v1')
+    # A resumable session leaves a partial ``.tmp`` on disk.
+    session = api_client.post(
+        url,
+        data={
+            'file_upload': SimpleUploadedFile(
+                'clip.png', b'AAAA', content_type='image/png'
+            )
+        },
+        headers={'Content-Range': 'bytes 0-3/8'},
+    )
+    assert session.status_code == status.HTTP_200_OK
+    victim_id = session.data['upload_id']
+
+    # A single-shot upload that tries to reuse that id must not touch it.
+    other = api_client.post(
+        url,
+        data={
+            'file_upload': SimpleUploadedFile(
+                'other.png', b'ZZZZZZZZ', content_type='image/png'
+            )
+        },
+        headers={'X-Upload-Id': victim_id},
+    )
+    assert other.status_code == status.HTTP_200_OK
+    assert other.data['upload_id'] != victim_id
+    assert other.data['uri'] != session.data['uri']
+    # The resumable session's file kept its original bytes.
+    with open(session.data['uri'], 'rb') as f:
+        assert f.read() == b'AAAA'
 
 
 @pytest.mark.django_db

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -47,8 +47,10 @@ r = connect_to_redis()
 
 # A resumable upload's temp file is named ``<upload_id>.tmp``. The id is
 # echoed back by the client on every chunk, so it lands in a filesystem
-# path — pin it to the exact uuid4 hex shape we mint and reject anything
-# else so a crafted value can't traverse out of the asset dir.
+# path — require the 32-lowercase-hex-char shape of the ids we mint
+# (``uuid4().hex``) and reject anything else. This is a path-traversal
+# guard, not a UUID-version check: 32 hex chars simply can't contain a
+# ``/`` or ``..`` to escape the asset dir.
 UPLOAD_ID_RE = re.compile(r'[0-9a-f]{32}')
 
 
@@ -383,8 +385,16 @@ class FileAssetViewMixin(APIView):
                 # arriving together could both see "no file" and clobber
                 # each other. ``r+b`` (not append) so ``seek()`` decides
                 # the offset and an out-of-order chunk lands where the
-                # range says.
-                fd = os.open(file_path, os.O_RDWR | os.O_CREAT, 0o644)
+                # range says. ``0o666`` (masked by the process umask) and
+                # ``O_CLOEXEC`` match what the builtin ``open()`` on the
+                # non-range path below does, so permissions stay
+                # umask-controlled and the fd doesn't leak into forked
+                # subprocesses.
+                fd = os.open(
+                    file_path,
+                    os.O_RDWR | os.O_CREAT | os.O_CLOEXEC,
+                    0o666,
+                )
                 with os.fdopen(fd, 'r+b') as f:
                     f.seek(start_bytes)
                     f.write(data)

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import tarfile
 import uuid
@@ -43,6 +44,12 @@ from anthias_server.settings import ViewerPublisher, settings
 logger = logging.getLogger(__name__)
 
 r = connect_to_redis()
+
+# A resumable upload's temp file is named ``<upload_id>.tmp``. The id is
+# echoed back by the client on every chunk, so it lands in a filesystem
+# path — pin it to the exact uuid4 hex shape we mint and reject anything
+# else so a crafted value can't traverse out of the asset dir.
+UPLOAD_ID_RE = re.compile(r'[0-9a-f]{32}')
 
 
 class DeleteAssetViewMixin:
@@ -239,6 +246,20 @@ class DisplayPowerViewMixin(APIView):
 class FileAssetViewMixin(APIView):
     @extend_schema(
         summary='Upload file asset',
+        parameters=[
+            OpenApiParameter(
+                name='X-Upload-Id',
+                location=OpenApiParameter.HEADER,
+                type=OpenApiTypes.STR,
+                required=False,
+                description=(
+                    'Opaque upload session id returned as ``upload_id`` on '
+                    'the first chunk of a resumable (Content-Range) upload. '
+                    'Echo it on every subsequent chunk so they reassemble '
+                    'into the same file. Omit it to start a new upload.'
+                ),
+            ),
+        ],
         request={
             'multipart/form-data': {
                 'type': 'object',
@@ -253,6 +274,7 @@ class FileAssetViewMixin(APIView):
                 'properties': {
                     'uri': {'type': 'string'},
                     'ext': {'type': 'string'},
+                    'upload_id': {'type': 'string'},
                 },
             }
         },
@@ -281,13 +303,22 @@ class FileAssetViewMixin(APIView):
                 {'file_upload': 'Invalid file type. Expected image or video.'}
             )
 
-        file_path = (
-            path.join(
-                settings['assetdir'],
-                uuid.uuid5(uuid.NAMESPACE_URL, filename).hex,
-            )
-            + '.tmp'
-        )
+        # Stage the upload at a per-request temp path. The id is random
+        # (uuid4) and never derived from the filename: a filename-derived
+        # path is shared by every upload of that name, so two concurrent
+        # same-name uploads would interleave into one corrupt file and a
+        # stale ``.tmp`` from an earlier interrupted attempt would bleed
+        # into a later one (issue #3135). A resumable (Content-Range)
+        # upload gets one isolated file per session: the client echoes the
+        # ``upload_id`` we return on the first chunk back via ``X-Upload-Id``
+        # so every chunk lands in the same file.
+        upload_id = request.headers.get('X-Upload-Id')
+        if upload_id is None:
+            upload_id = uuid.uuid4().hex
+        elif not UPLOAD_ID_RE.fullmatch(upload_id):
+            raise ValidationError({'X-Upload-Id': 'Malformed upload id.'})
+
+        file_path = path.join(settings['assetdir'], upload_id) + '.tmp'
 
         has_range = 'Content-Range' in request.headers
         start_bytes = 0
@@ -334,23 +365,25 @@ class FileAssetViewMixin(APIView):
 
         try:
             if has_range:
-                # ``r+b`` (not ``ab``): append mode pins every write to
-                # EOF and silently ignores ``seek()``, so an out-of-
-                # order chunk would land at the wrong offset and corrupt
-                # the ``.tmp``. Open the existing file for in-place
-                # random-access writes; if it doesn't exist yet, ``wb``
-                # creates it.
-                mode = 'r+b' if path.isfile(file_path) else 'wb'
-                with open(file_path, mode) as f:
+                # ``os.open`` with ``O_CREAT`` and no ``O_TRUNC``: create
+                # the file on the first chunk, otherwise open the
+                # in-progress upload for random-access writes without
+                # discarding the bytes already written. This closes the
+                # ``isfile()``-then-``open('wb')`` race where two chunks
+                # arriving together could both see "no file" and clobber
+                # each other. ``r+b`` (not append) so ``seek()`` decides
+                # the offset and an out-of-order chunk lands where the
+                # range says.
+                fd = os.open(file_path, os.O_RDWR | os.O_CREAT, 0o644)
+                with os.fdopen(fd, 'r+b') as f:
                     f.seek(start_bytes)
                     f.write(data)
                     # On the final chunk, truncate to the declared total
-                    # so stale trailing bytes from a previous, longer
-                    # upload to this deterministic path can't survive
-                    # into the reassembled asset. Order-independent: the
-                    # file ends up exactly ``total_bytes`` long whenever
-                    # the last byte is written, regardless of chunk
-                    # arrival order.
+                    # so a resumed session that shrank can't keep trailing
+                    # bytes from a longer earlier attempt. Order-
+                    # independent: the file ends up exactly ``total_bytes``
+                    # long whenever the last byte is written, regardless
+                    # of chunk arrival order.
                     if end_bytes + 1 == total_bytes:
                         f.truncate(total_bytes)
             else:
@@ -368,7 +401,13 @@ class FileAssetViewMixin(APIView):
                 status=status.HTTP_507_INSUFFICIENT_STORAGE,
             )
 
-        return Response({'uri': file_path, 'ext': guess_extension(file_type)})
+        return Response(
+            {
+                'uri': file_path,
+                'ext': guess_extension(file_type),
+                'upload_id': upload_id,
+            }
+        )
 
 
 class AssetContentViewMixin(APIView):

--- a/src/anthias_server/api/views/mixins.py
+++ b/src/anthias_server/api/views/mixins.py
@@ -303,6 +303,8 @@ class FileAssetViewMixin(APIView):
                 {'file_upload': 'Invalid file type. Expected image or video.'}
             )
 
+        has_range = 'Content-Range' in request.headers
+
         # Stage the upload at a per-request temp path. The id is random
         # (uuid4) and never derived from the filename: a filename-derived
         # path is shared by every upload of that name, so two concurrent
@@ -312,15 +314,23 @@ class FileAssetViewMixin(APIView):
         # upload gets one isolated file per session: the client echoes the
         # ``upload_id`` we return on the first chunk back via ``X-Upload-Id``
         # so every chunk lands in the same file.
-        upload_id = request.headers.get('X-Upload-Id')
+        #
+        # ``X-Upload-Id`` is only honoured alongside ``Content-Range``: a
+        # single-shot upload takes the ``open('wb')`` path below, so an
+        # echoed id there would let one request truncate another session's
+        # in-progress ``.tmp``. Without a range we always mint a fresh id.
+        upload_id = request.headers.get('X-Upload-Id') if has_range else None
         if upload_id is None:
             upload_id = uuid.uuid4().hex
-        elif not UPLOAD_ID_RE.fullmatch(upload_id):
-            raise ValidationError({'X-Upload-Id': 'Malformed upload id.'})
+        else:
+            # Normalise case (the id we mint is lowercase hex) before the
+            # traversal guard so an upper-cased echo doesn't 400.
+            upload_id = upload_id.strip().lower()
+            if not UPLOAD_ID_RE.fullmatch(upload_id):
+                raise ValidationError({'X-Upload-Id': 'Malformed upload id.'})
 
         file_path = path.join(settings['assetdir'], upload_id) + '.tmp'
 
-        has_range = 'Content-Range' in request.headers
         start_bytes = 0
         end_bytes = 0
         total_bytes = 0


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/Screenly/Anthias/issues/3135

### Description

The `file_asset` upload endpoint staged every upload at a **deterministic** temp path derived from the filename (`uuid5(NAMESPACE_URL, filename).hex + '.tmp'`), so two uploads of the same name shared one `.tmp` with no per-upload isolation. That allowed a concurrency race (two chunk requests both opening `wb` and clobbering each other) and cross-attempt bleed (a stale `.tmp` from an interrupted upload reused by a later one).

This adds per-upload session isolation:

- Stage each upload at a random `<uuid4>.tmp` — never derived from the filename — so concurrent same-name uploads and stale attempts land in separate files.
- Return an opaque `upload_id`; a resumable (Content-Range) client echoes it via the `X-Upload-Id` header so every chunk reassembles into the same file. A malformed id is rejected with 400 (path-traversal guard).
- Open chunks with `os.open(..., O_CREAT)` (no `O_TRUNC`) to close the `isfile()`-then-`open('wb')` race.

Orphaned `.tmp` files are already reaped by the hourly `cleanup()` Celery task (the random names still match its `*.tmp` sweep), and the single-POST browser path already used a random `uuid4` name, so no client changes are needed for the common case.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).