### PR TITLE
fix(viewer): stop webpage transitions flashing a foreign page

### DIFF
--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -21,20 +21,15 @@ export SHM_SIZE_KB="$(echo "$TOTAL_MEMORY_KB" \* 0.3 | bc | cut -d'.' -f1)"
 # against a decompression-bomb fixture or runaway ffprobe, not
 # because routine workloads come anywhere near it.
 export CELERY_MEMORY_LIMIT_KB=$(echo "$TOTAL_MEMORY_KB * 0.6" | bc | cut -d'.' -f1)
-# Low-RAM gate. Boards with < 1.5 GiB MemTotal (Pi 2/Pi 3 1GB, Pi 4 1GB,
-# Rock Pi 4 1GB, generic-arm64 SBCs in that class) can't keep two
-# QtWebEngine renderer processes resident *and* play 1080p+ video
-# without OOM-thrashing through swap. The viewer reads this env to
-# drop into single-WebEngineView mode (no preloaded crossfade); the
-# asset processor reads it via Redis (host:total_mem_kb) and rejects
-# uploads above 1080p. Threshold is 1.5 GiB so 1 GB SKUs land below
-# and 2 GB SKUs sit above; both 1024 MB and 2048 MB boards exist in
-# the supported fleet.
-if [ "${TOTAL_MEMORY_KB:-0}" -lt 1572864 ]; then
-    export ANTHIAS_LOW_RAM=1
-else
-    export ANTHIAS_LOW_RAM=0
-fi
+# NB: the AnthiasViewer used to be gated into single-WebEngineView mode
+# on < 1.5 GiB boards via an ``ANTHIAS_LOW_RAM`` export here. That flag
+# is gone — the viewer now runs a single QWebEngineView on every board
+# (issue #2954: the preloaded second buffer flashed a stale foreign
+# page on every webpage transition, and the fix was to drop it), which
+# also reclaims the ~100 MB the second renderer cost. The independent
+# 1080p upload cap on low-RAM boards is unaffected: it lives in
+# anthias_server (``is_low_ram_device`` reads ``host:total_mem_kb`` from
+# Redis), not this export.
 GIT_BRANCH="${GIT_BRANCH:-master}"
 
 MODE="${MODE:-pull}"

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -74,14 +74,6 @@ services:
       - LANG=${LANG}
       - LANGUAGE=${LANGUAGE}
       - LC_ALL=${LC_ALL}
-      # ``1`` on boards with < 1.5 GiB MemTotal. AnthiasViewer reads
-      # this to fall into single-QWebEngineView mode (no preloaded
-      # crossfade — the inactive renderer cost ~100 MB physical RAM
-      # per box, untenable on 1 GB SBCs). Derived from /proc/meminfo
-      # in bin/upgrade_containers.sh so the server side
-      # (host_agent → ``host:total_mem_kb`` in Redis) and the viewer
-      # side both observe the same total.
-      - ANTHIAS_LOW_RAM=${ANTHIAS_LOW_RAM}
     privileged: true
     restart: always
     # cage (the wlroots kiosk compositor used on Pi 5 / x86 /

--- a/docs/board-enablement.md
+++ b/docs/board-enablement.md
@@ -204,23 +204,30 @@ no public knob today.
 Boards with less than 1.5 GiB MemTotal (Pi 2/Pi 3 1GB, Pi 4 1GB, Rock Pi 4
 1GB, generic-arm64 1GB SKUs) run in a degraded "low-RAM" mode:
 
-* `bin/upgrade_containers.sh` reads `/proc/meminfo` and exports
-  `ANTHIAS_LOW_RAM=1` to the viewer container.
-* `AnthiasViewer` instantiates one `QWebEngineView` instead of two — no
-  preloaded crossfade between URL assets; the page swaps in place with a
-  brief blank during load.
 * `anthias_host_agent` publishes `host:total_mem_kb` to Redis;
   `anthias_server.processing` rejects uploads above 1920×1080 with the
   existing recipe machinery (`-vf scale=1920:1080:force_original_aspect_ratio=decrease`).
 * The diagnostics page's Memory card surfaces a "Low-RAM mode" banner so
   operators can see *why* the device degraded.
 
+The single-`QWebEngineView` renderer is **not** low-RAM-specific — every
+board runs it. The viewer used to instantiate a second, off-screen
+`QWebEngineView` to preload the next URL asset and swap it in, gated on
+`ANTHIAS_LOW_RAM` so 1 GB boards skipped the ~100 MB extra renderer. That
+preload path is gone (issue #2954): on the single fullscreen surface the Qt6
+boards use (Wayland/cage on Pi 5 / x86, eglfs on pi4-64) a hidden
+`QWebEngineView` is frame-throttled by Chromium and never composited the
+preloaded page, so revealing it flashed the *stale* page it had last shown
+two rotations earlier for ~1 frame on every webpage transition. Collapsing
+to one view fixed the flash and reclaimed the ~100 MB on all 2 GB+ boards
+too.
+
 The 1.5 GiB threshold cleanly separates 1 GB SKUs from 2 GB+ SKUs in the
-supported fleet. The cap was sized against on-device measurements: idle
-viewer + 2 QtWebEngine renderers + zygotes consume ~440 MB RSS on Rock Pi 4
-1GB, leaving roughly 500 MB for the kernel, host services, and decode
-pipeline. A 4K HEVC capture-buffer allocation pushes the container past the
-cgroup limit; the kernel logs `global_oom` and the container restart-loops.
+supported fleet. The upload cap was sized against on-device measurements:
+idle viewer + one QtWebEngine renderer + zygotes leave roughly 500 MB on
+Rock Pi 4 1GB for the kernel, host services, and decode pipeline. A 4K HEVC
+capture-buffer allocation pushes the container past the cgroup limit; the
+kernel logs `global_oom` and the container restart-loops.
 
 ### armv7 (Pi 2 / Pi 3) WebEngine-init crash + spawn retry
 
@@ -239,8 +246,8 @@ loaned 64-bit Pi 3B+ running the armv7 `anthias-viewer:*-pi3` image:
   corruption.
 * It is **heap-layout dependent**, firing on ~75–90 % of launches — so a
   *fresh* launch clears it ~10–25 % of the time. No userspace mitigation
-  fixes it: trimming the CJK fonts, `--single-process`, `--no-zygote`, a
-  single `QWebEngineView` (`ANTHIAS_LOW_RAM=1`), a jemalloc preload, and
+  fixes it: trimming the CJK fonts, `--single-process`, `--no-zygote`, the
+  single `QWebEngineView`, a jemalloc preload, and
   disabling glibc's tcache check (which just turns the abort into a raw
   `SIGSEGV`) all still crash.
 

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -135,8 +135,9 @@ View::View(QWidget* parent) : QWidget(parent)
     // ``webView1`` so the rest of the file's historical dual-buffer
     // logic still compiles and runs — every operation that would have
     // targeted the off-screen ``webView2`` now lands on the same
-    // widget, and the visibility swap in switchToNextWebView() is a
-    // no-op. A loadPage() call keeps the current page composited until
+    // widget, and switchToNextWebView() takes its single-view fast path
+    // (show the one view, no hide/show toggle or pointer swap). A
+    // loadPage() call keeps the current page composited until
     // the next one has painted (QtWebEngine holds the last frame across
     // an in-place navigation), so transitions are seamless with at most
     // a brief black frame on a slow load, never a foreign page.
@@ -745,6 +746,24 @@ void View::switchToNextWebView()
         return;
     }
 
+    nextWebViewReady = false;
+
+    if (currentWebView == nextWebView) {
+        // Single-view mode (the only mode today — see the constructor).
+        // There is no off-screen buffer to reveal: the freshly-loaded
+        // page is already in the one view. Just make sure it is shown —
+        // it may have been hidden by a preceding image/video asset
+        // (loadImage()/playVideo() hide the web views) — and skip the
+        // dual-buffer hide/show + pointer swap, which on a single
+        // aliased widget would only toggle its visibility for no reason
+        // (and risk an avoidable flicker).
+        currentWebView->setVisible(true);
+        currentWebView->clearFocus();
+        armReloadTimer();
+        qDebug() << "Showing loaded web page (single-view)";
+        return;
+    }
+
     qDebug() << "Switching to next web view";
 
     currentWebView->setVisible(false);
@@ -754,8 +773,6 @@ void View::switchToNextWebView()
     QWebEngineView* temp = currentWebView;
     currentWebView = nextWebView;
     nextWebView = temp;
-
-    nextWebViewReady = false;
 
     qDebug() << "Successfully switched to next web view";
 

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -296,7 +296,7 @@ void View::loadPage(const QString &uri)
 
     startPageLoad(uri, requestId);
 
-    qDebug() << "Loading web page in background web view:" << uri;
+    qDebug() << "Loading web page:" << uri;
 }
 
 void View::startPageLoad(const QString &uri, quint64 requestId)
@@ -335,7 +335,7 @@ void View::startPageLoad(const QString &uri, quint64 requestId)
             if (ok) {
                 pageLoadWatchdog->stop();
                 pendingPageUri.clear();
-                qDebug() << "Background web page loaded successfully";
+                qDebug() << "Web page loaded successfully";
                 nextWebViewReady = true;
                 switchToNextWebView();
             } else {
@@ -347,7 +347,7 @@ void View::startPageLoad(const QString &uri, quint64 requestId)
                 // playlist will ever see — view_webpage() skips the
                 // loadPage D-Bus call when the URL hasn't changed
                 // (issue #2999).
-                qDebug() << "Background web page failed to load";
+                qDebug() << "Web page failed to load";
                 nextWebViewReady = false;
             }
         }

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -97,22 +97,6 @@ QString detectAcceptLanguage()
 
 
 namespace {
-// ``ANTHIAS_LOW_RAM=1`` is exported by bin/upgrade_containers.sh when
-// the host has < 1.5 GiB MemTotal (Pi 2/Pi 3 1GB, Pi 4 1GB, Rock Pi
-// 4 1GB, generic-arm64 1GB SKUs). On those boards we collapse the
-// double-buffer ``webView1`` / ``webView2`` design to a single shared
-// QWebEngineView — the inactive Chromium renderer cost ~100 MB
-// physical RAM per device and was the leading edge of the OOM
-// cascade measured on a Rock Pi 4 1GB. UX trade-off: loadPage
-// switches to in-place (brief blank during navigation), no
-// preloaded-then-swap crossfade. Documented in
-// docs/board-enablement.md.
-bool isLowRamMode()
-{
-    const QByteArray value = qgetenv("ANTHIAS_LOW_RAM");
-    return value == "1";
-}
-
 // Issue #2999 — page-load watchdog interval. Chromium has no overall
 // navigation timeout, so a fetch whose packets stop arriving (WiFi
 // dropout mid-load; the TCP socket stays ESTABLISHED with no FIN/RST)
@@ -146,24 +130,36 @@ View::View(QWidget* parent) : QWidget(parent)
 {
     webView1 = new QWebEngineView(this);
     configureWebView(webView1);
-    if (isLowRamMode()) {
-        // Single-view mode: alias the second pointer onto the first
-        // so the rest of the file's dual-buffer logic still compiles
-        // and runs — every operation that would have targeted the
-        // off-screen ``webView2`` now lands on the same widget, and
-        // the visibility swap in switchToNextWebView() becomes a
-        // no-op. The net effect for the operator: a loadPage call
-        // shows the page's own ``page()->backgroundColor()`` (black)
-        // during the load, then the page itself; no smooth fade
-        // between assets. Acceptable degradation; the alternative
-        // is the box OOM-cycling on 1 GB.
-        webView2 = webView1;
-        qInfo() << "View: ANTHIAS_LOW_RAM=1 — single-QWebEngineView "
-                << "mode (no preloaded crossfade).";
-    } else {
-        webView2 = new QWebEngineView(this);
-        configureWebView(webView2);
-    }
+
+    // Single-QWebEngineView rendering. ``webView2`` is aliased onto
+    // ``webView1`` so the rest of the file's historical dual-buffer
+    // logic still compiles and runs — every operation that would have
+    // targeted the off-screen ``webView2`` now lands on the same
+    // widget, and the visibility swap in switchToNextWebView() is a
+    // no-op. A loadPage() call keeps the current page composited until
+    // the next one has painted (QtWebEngine holds the last frame across
+    // an in-place navigation), so transitions are seamless with at most
+    // a brief black frame on a slow load, never a foreign page.
+    //
+    // This was previously gated behind ``ANTHIAS_LOW_RAM=1`` (1 GB
+    // boards) purely to save the ~100 MB a second resident Chromium
+    // renderer costs. It is now unconditional because the preloaded
+    // second buffer was also *broken*: issue #2954 — on the single
+    // fullscreen surface used by the Qt6 boards (Wayland/cage on
+    // Pi 5 / x86, eglfs on pi4-64) a hidden or sibling-occluded
+    // QWebEngineView is frame-callback-throttled by Chromium and never
+    // composites, so ``loadFinished`` on the off-screen buffer did NOT
+    // mean it had painted the new page. Revealing it in
+    // switchToNextWebView() therefore showed its *stale* GPU surface —
+    // the page it last displayed two rotations earlier — for ~1 frame
+    // before the new page painted, flashing an unrelated asset on every
+    // webpage→webpage transition. Live-reproduced and the fix
+    // live-verified on a Pi 5 (grim burst capture, 2026-07-08): every
+    // transition flashed the (n-2) page before, none after. The Qt5
+    // 1 GB boards already ran this path, so only the 2 GB+ Qt6 boards
+    // change behaviour — exactly where #2954 was reported. See
+    // docs/board-enablement.md.
+    webView2 = webView1;
 
     // Both webViews share the default profile, so the HTTP-cache setup
     // is per-process, not per-view. Use in-memory only — the default


### PR DESCRIPTION
### Issues Fixed

Fixes #2954 — webpage asset transitions briefly flash another page in rotation.

### Description

On the Qt6 boards (Pi 5 / x86 on Wayland/cage, pi4-64 on eglfs) the viewer
rendered URL assets through a two-`QWebEngineView` ping-pong: the next page
was loaded into an off-screen buffer and swapped in on `loadFinished`. But a
hidden or sibling-occluded `QWebEngineView` is frame-callback-throttled by
Chromium on the single fullscreen surface these boards use — it never
composited the preloaded page. So the swap revealed a buffer whose GPU
surface still held the page it had last shown **two rotations earlier**,
which flashed for ~1 frame before the new page painted — an unrelated asset
on every webpage→webpage transition.

The fix collapses webpage rendering to a single `QWebEngineView` on every
board (the path the 1 GB low-RAM boards already ran). An in-place `load()`
on the visible view keeps the current page composited until the next one
paints, so transitions are seamless — at worst a brief black frame, never a
foreign page. The now-obsolete `ANTHIAS_LOW_RAM` viewer flag and its
compose/upgrade plumbing are removed; the independent 1080p upload cap
(`is_low_ram_device` via `host:total_mem_kb`) is untouched. Reclaims the
~100 MB the second renderer cost on 2 GB+ boards as a bonus.

**Validation** (live on a Pi 5, grim burst-capture of a 4-page 10 s
rotation): baseline flashed the exact (n-2) page at every transition; after
the fix, 0 foreign flashes across 7 transitions, all seamless.

### Memory & slow-load regression check

Removing `ANTHIAS_LOW_RAM` makes single-view universal, so the natural
question is whether the 2 GB+ boards lose the dual-buffer's seamless
crossfade and instead get the "brief blank during load" that #2915's commit
message noted for the 1 GB path. **Measured on a Pi 5** with a page whose
HTTP response is delayed 5 s, rotated against instant pages, dual-buffer vs
single-view side by side (grim burst-capture, 1205 frames each):

| | Dual-buffer (before) | Single-view (this PR) |
|---|---|---|
| Previous page held during the 5 s load | yes (~13 s total) | yes (~13 s total) |
| **Near-black frames** (of 1205) | **0** | **0** |
| Foreign flash (#2954) | every transition | **none** |
| QtWebEngine renderers | 2 (~100 MB extra) | 1 |

QtWebEngine holds the last composited frame across an in-place `load()`
until the new page first-paints, even for a multi-second load — so there is
**no blank-during-load regression**; single-view is seamless *and*
flash-free. The 1080p upload cap and the diagnostics "Low-RAM mode" banner
are unaffected (separate `is_low_ram_device()` / `host:total_mem_kb` path).

On the **RockPi 4 (1 GB)** the change is a no-op — it already ran single-view
(`ANTHIAS_LOW_RAM=1`); verified 1 QtWebEngine renderer, stable memory while
cycling webpage assets.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes (no test-surface change; C++/shell/docs only).
- [x] I have done an end-to-end test for Raspberry Pi devices (full stack on a Pi 5, real display).
- [ ] I have tested my changes for x86 devices (not tested; same Qt6/cage single-surface path, fix applies).
- [x] I added a documentation for the changes I have made (when necessary).
