### PR TITLE
feat(webview): per-asset custom HTTP headers for web assets

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -51,6 +51,30 @@ from unittest.mock import MagicMock
 import pytest
 
 # ---------------------------------------------------------------------------
+# 0. App-availability probe
+# ---------------------------------------------------------------------------
+#
+# This conftest lives at the repo root so the Redis/D-Bus/env isolation
+# reaches BOTH ``tests/`` and ``src/anthias_server/api/tests/`` (their only
+# common ancestor). But the root is also an ancestor of
+# ``tools/raspberry_pi_imager/tests/``, which the ``run-python-linter`` CI
+# job runs with ``-p no:django`` in a *minimal* venv that has neither
+# Django nor pytz. Importing the app stack there (``anthias_common.utils``
+# pulls in ``pytz``) would crash conftest collection for those tests.
+#
+# So gate every app-dependent hook on whether the app is importable at
+# all. When it isn't (the rpi-imager lint env), this whole file degrades
+# to a no-op and those app-free tests run untouched. ``os`` import is
+# never a problem; only the app imports are.
+try:
+    import anthias_common.utils as _anthias_common_utils  # noqa: F401
+
+    _APP_AVAILABLE = True
+except Exception:
+    _APP_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
 # 1. ENVIRONMENT=test (settings.py reads this at import time)
 # ---------------------------------------------------------------------------
 
@@ -217,7 +241,8 @@ def _patch_connect_to_redis() -> None:
     _lib_utils.connect_to_redis = lambda: _SESSION_FAKE_REDIS
 
 
-_patch_connect_to_redis()
+if _APP_AVAILABLE:
+    _patch_connect_to_redis()
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -231,6 +256,8 @@ def _ensure_assetdir() -> None:
     Materialise the path once per session so those fixtures don't
     ``FileNotFoundError`` out before the test even runs.
     """
+    if not _APP_AVAILABLE:
+        return
     from anthias_server.settings import settings as _anthias_settings
 
     asset_dir = _anthias_settings.get('assetdir')
@@ -274,7 +301,14 @@ def _mock_redis(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
     Tests that need their own Redis mock (e.g. ``tests/test_telemetry.py``,
     ``tests/test_messaging.py``) override this by patching ``module.r``
     directly — that takes precedence inside the per-test setup chain.
+
+    No-op (yields a bare fake) when the app stack isn't importable — the
+    app-free ``tools/raspberry_pi_imager/tests`` collected under this root
+    conftest must not drag in Django / redis / pytz.
     """
+    if not _APP_AVAILABLE:
+        yield _make_fake_redis()
+        return
     fake = _make_fake_redis()
     monkeypatch.setattr('anthias_common.utils.connect_to_redis', lambda: fake)
 

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ Three concerns are handled here, in order:
    default; CI overrides via ``ANTHIAS_TEST_DB_PATH``).
 
 2. Stub ``gi`` / ``gi.repository`` / ``pydbus`` in ``sys.modules`` *before*
-   any application module is imported. ``viewer/__init__.py`` does
+   any application module is imported. ``src/anthias_viewer/__init__.py`` does
    ``import pydbus`` at module load, and ``pydbus`` in turn imports
    ``gi.repository.Gio`` — which only resolves on hosts with the
    distribution's ``python3-gi`` package installed and wired into the

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,325 @@
+"""
+Repository-root pytest configuration.
+
+This file holds the isolation that lets the unit-test suite run on a
+developer's host without Docker, without a Redis server, and without the
+system PyGObject stack the viewer service normally requires. It lives at
+the **repo root** — not under ``tests/`` — on purpose: pytest only loads
+a ``conftest.py`` for tests at or below its directory, and the two test
+trees (``tests/`` and ``src/anthias_server/api/tests/``) have no common
+ancestor other than the root. Putting the Redis/D-Bus/env isolation here
+means ``pytest src/anthias_server/api/tests`` in isolation gets the same
+fake-Redis wiring as a full run; previously that isolation lived only in
+``tests/conftest.py`` and silently didn't apply to the API tree, so every
+viewer-notifying view (asset create / update / delete → issue #2430)
+``ConnectionError``'d against ``redis:6379`` whenever the API tests were
+run on their own. The Playwright/marketing fixtures stay in
+``tests/conftest.py`` since only the integration suite under ``tests/``
+uses them.
+
+Three concerns are handled here, in order:
+
+1. Force ``ENVIRONMENT=test`` so ``anthias_server.django_project/settings.py`` selects
+   the SQLite test-DB branch (a repo-local path under ``BASE_DIR`` by
+   default; CI overrides via ``ANTHIAS_TEST_DB_PATH``).
+
+2. Stub ``gi`` / ``gi.repository`` / ``pydbus`` in ``sys.modules`` *before*
+   any application module is imported. ``viewer/__init__.py`` does
+   ``import pydbus`` at module load, and ``pydbus`` in turn imports
+   ``gi.repository.Gio`` — which only resolves on hosts with the
+   distribution's ``python3-gi`` package installed and wired into the
+   active interpreter. The stubs let the import succeed; tests that
+   exercise dbus paths mock the relevant calls themselves.
+
+3. Replace ``anthias_common.utils.connect_to_redis`` with a dict-backed
+   ``MagicMock`` factory before any test module imports it, then expose
+   the same fake via an autouse fixture. Several modules call
+   ``r = connect_to_redis()`` at import time
+   (``anthias_server.celery_tasks``, ``anthias_server.lib.github``, ``anthias_server.lib.telemetry``, ...); patching
+   the factory once at conftest load time means the module-level ``r``
+   bindings hold a fake, not a client pointed at host ``redis``.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. ENVIRONMENT=test (settings.py reads this at import time)
+# ---------------------------------------------------------------------------
+
+os.environ.setdefault('ENVIRONMENT', 'test')
+
+
+# ---------------------------------------------------------------------------
+# 2. Stub gi / gi.repository / pydbus before viewer modules are loaded
+# ---------------------------------------------------------------------------
+
+
+def _install_dbus_stubs() -> None:
+    """
+    Insert stand-in modules so ``import pydbus`` (and its transitive
+    ``from gi.repository import Gio, GLib, GObject``) succeeds on
+    hosts that don't have the full PyGObject + pydbus stack.
+
+    Three host shapes show up in the wild:
+
+    1. Both ``gi`` and ``pydbus`` available (target image): no-op.
+    2. ``gi`` missing entirely (typical dev laptop without
+       ``python3-gi`` apt package): stub both, because the real
+       pydbus's module-load does ``from gi.repository import
+       GLib, GObject`` and our minimal gi stub can't satisfy that.
+    3. ``gi`` present but ``pydbus`` not pip-installed: stub only
+       pydbus.
+    """
+    gi_missing = importlib.util.find_spec('gi') is None
+    pydbus_missing = importlib.util.find_spec('pydbus') is None
+
+    if gi_missing:
+        gi_module = types.ModuleType('gi')
+        gi_repository = types.ModuleType('gi.repository')
+        # MagicMock for the GLib/Gio/GObject surface — pydbus only
+        # touches these when a bus is actually constructed (e.g.
+        # ``pydbus.SessionBus()`` inside a function body); tests that
+        # hit those paths mock them themselves.
+        setattr(gi_repository, 'Gio', MagicMock(name='gi.repository.Gio'))
+        setattr(gi_repository, 'GLib', MagicMock(name='gi.repository.GLib'))
+        setattr(
+            gi_repository, 'GObject', MagicMock(name='gi.repository.GObject')
+        )
+        setattr(gi_module, 'repository', gi_repository)
+        sys.modules['gi'] = gi_module
+        sys.modules['gi.repository'] = gi_repository
+
+    if pydbus_missing or gi_missing:
+        pydbus_module = types.ModuleType('pydbus')
+        setattr(
+            pydbus_module, 'SessionBus', MagicMock(name='pydbus.SessionBus')
+        )
+        setattr(pydbus_module, 'SystemBus', MagicMock(name='pydbus.SystemBus'))
+        sys.modules['pydbus'] = pydbus_module
+
+
+_install_dbus_stubs()
+
+
+# ---------------------------------------------------------------------------
+# 3. Defensive Redis mock — replace connect_to_redis() everywhere
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_redis() -> MagicMock:
+    """
+    A dict-backed Redis mock matching the surface our code uses.
+
+    String ops (get/set/delete/expire/exists/flushdb/publish) and list
+    ops (rpush/lpop/blpop) are modelled on the real Redis semantics so
+    test paths that exercise both — notably ``ReplyCollector.recv_json``
+    via BLPOP — see realistic behaviour rather than no-ops.
+    """
+    store: dict[str, Any] = {}
+
+    fake = MagicMock(name='FakeRedis')
+    fake.get.side_effect = store.get
+
+    def _set(
+        key: str,
+        value: Any,
+        *,
+        nx: bool = False,
+        ex: int | None = None,
+        **_: Any,
+    ) -> bool | None:
+        # Match real Redis ``SET ... NX``: succeeds only if the key is
+        # not already present, returns True on success / None on no-op.
+        # Tests for SETNX-based gates (per-asset recheck cooldown,
+        # sweep singleton lock, splash IP-refresh debounce) rely on
+        # this — without it, every "is the lock held?" check would
+        # spuriously believe the lock was free.
+        if nx and key in store:
+            return None
+        store[key] = value
+        return True
+
+    fake.set.side_effect = _set
+    fake.delete.side_effect = lambda *keys: sum(
+        1 for k in keys if store.pop(k, None) is not None
+    )
+    fake.expire.side_effect = lambda key, _ttl: bool(key in store)
+    fake.exists.side_effect = lambda *keys: sum(1 for k in keys if k in store)
+    fake.flushdb.side_effect = lambda: store.clear()
+    fake.publish.side_effect = lambda channel, msg: 0
+
+    def _eval(script: str, numkeys: int, *args: Any) -> Any:
+        # Compare-and-delete is the only ``EVAL`` script in the
+        # codebase (sweep lock release in anthias_server.celery_tasks.py). Implement
+        # that pattern directly; any other script becomes a no-op.
+        if "redis.call('get', KEYS[1])" in script and "'del'" in script:
+            keys = list(args[:numkeys])
+            argv = list(args[numkeys:])
+            if keys and argv and store.get(keys[0]) == argv[0]:
+                store.pop(keys[0], None)
+                return 1
+            return 0
+        return None
+
+    fake.eval.side_effect = _eval
+
+    def _rpush(key: str, *values: Any) -> int:
+        bucket = store.setdefault(key, [])
+        bucket.extend(values)
+        return len(bucket)
+
+    def _lpop(key: str) -> Any:
+        bucket = store.get(key)
+        if not bucket:
+            return None
+        value = bucket.pop(0)
+        if not bucket:
+            store.pop(key, None)
+        return value
+
+    def _blpop(keys: Any, timeout: float | None = None) -> Any:
+        # Real BLPOP blocks until a value is available or the timeout
+        # expires. Tests don't drive a writer thread, so block-then-
+        # poll behaviour collapses to "return immediately": yield the
+        # first available value, or None if every key is empty.
+        if isinstance(keys, (str, bytes)):
+            keys = [keys]
+        for key in keys:
+            value = _lpop(key)
+            if value is not None:
+                return (key, value)
+        return None
+
+    fake.rpush.side_effect = _rpush
+    fake.lpop.side_effect = _lpop
+    fake.blpop.side_effect = _blpop
+    return fake
+
+
+# Patch ``connect_to_redis`` at the source so the module-level
+# ``r = connect_to_redis()`` bindings in anthias_server.celery_tasks / anthias_server.lib.github /
+# anthias_server.lib.telemetry / api.views.mixins / viewer / etc. all resolve to the
+# fake the moment those modules are first imported.
+_SESSION_FAKE_REDIS = _make_fake_redis()
+
+
+def _patch_connect_to_redis() -> None:
+    import anthias_common.utils as _lib_utils
+
+    _lib_utils.connect_to_redis = lambda: _SESSION_FAKE_REDIS
+
+
+_patch_connect_to_redis()
+
+
+@pytest.fixture(scope='session', autouse=True)
+def _ensure_assetdir() -> None:
+    """
+    Some legacy fixtures (e.g. ``api/tests/test_v1_endpoints.py::
+    cleanup_asset_dir``) iterate ``settings['assetdir']`` during
+    teardown without creating it first. The Docker test image creates
+    ``/data/anthias_assets`` in its build (see
+    ``docker/Dockerfile.test.j2``); local hosts have no such guarantee.
+    Materialise the path once per session so those fixtures don't
+    ``FileNotFoundError`` out before the test even runs.
+    """
+    from anthias_server.settings import settings as _anthias_settings
+
+    asset_dir = _anthias_settings.get('assetdir')
+    if asset_dir:
+        os.makedirs(asset_dir, exist_ok=True)
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Set ``DJANGO_ALLOW_ASYNC_UNSAFE=1`` only when the run actually
+    contains integration tests.
+
+    Playwright's sync API spins up an internal asyncio loop to talk
+    to the browser over the CDP socket; Django's ORM detects that
+    loop and refuses sync calls (``SynchronousOnlyOperation``) unless
+    this flag is set. The single-threaded test process never invokes
+    ORM and Playwright concurrently, so the safety net Django enforces
+    isn't doing useful work for this suite.
+
+    Setting it process-wide unconditionally would also disable the
+    safety net for unit tests, where an accidental ORM call from
+    inside an event loop is a real bug we want Django to flag. Hooking
+    at collection time means a unit-only run (``pytest -m "not
+    integration"``) leaves the variable unset and the check active;
+    a run that includes integration tests sets it once before
+    pytest-django's DB setup (which would otherwise hit the same
+    check itself).
+    """
+    if any('integration' in item.keywords for item in items):
+        os.environ['DJANGO_ALLOW_ASYNC_UNSAFE'] = '1'
+
+
+@pytest.fixture(autouse=True)
+def _mock_redis(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
+    """
+    Replace ``anthias_common.utils.connect_to_redis`` with a dict-backed
+    ``MagicMock`` for every test, including any module-level
+    ``r = connect_to_redis()`` bindings that fixtures import indirectly.
+
+    Tests that need their own Redis mock (e.g. ``tests/test_telemetry.py``,
+    ``tests/test_messaging.py``) override this by patching ``module.r``
+    directly — that takes precedence inside the per-test setup chain.
+    """
+    fake = _make_fake_redis()
+    monkeypatch.setattr('anthias_common.utils.connect_to_redis', lambda: fake)
+
+    # Replace already-bound ``r`` attributes on modules that called
+    # connect_to_redis() at import time. Only modules already in
+    # sys.modules are touched — others get the fake on first import via
+    # the conftest-level patch above.
+    for module_path in (
+        'anthias_server.app.views',
+        'anthias_server.api.views.mixins',
+        'anthias_server.api.views.v2',
+        'anthias_server.celery_tasks',
+        'anthias_server.lib.github',
+        'anthias_server.lib.telemetry',
+        'anthias_viewer',
+    ):
+        mod = sys.modules.get(module_path)
+        if mod is not None and hasattr(mod, 'r'):
+            monkeypatch.setattr(f'{module_path}.r', fake)
+
+    # ``ViewerPublisher`` / ``ReplyCollector`` are process-wide singletons
+    # (``INSTANCE`` classvar) that bind ``self._redis = connect_to_redis()``
+    # exactly once, in ``__init__``. Patching ``connect_to_redis`` above
+    # doesn't reach an instance an earlier test already built, so a
+    # singleton first constructed while pointed at the real ``redis`` host
+    # would leak that live client into every later test — any view that
+    # calls ``send_to_viewer`` (asset create / update / delete → issue
+    # #2430 viewer wake) would then ``ConnectionError`` on a host without
+    # Redis. Seed both singletons with this test's fake so the view's
+    # ``get_instance()`` returns a fake-backed instance regardless of what
+    # any prior test left behind, and clear them afterwards so nothing
+    # leaks forward.
+    from anthias_server.settings import ReplyCollector, ViewerPublisher
+
+    def _seed_singleton(cls: Any) -> None:
+        # Bypass __init__ (which both raises if an instance exists and
+        # calls the real connect_to_redis) and inject the fake directly.
+        instance = cls.__new__(cls)
+        instance._redis = fake
+        cls.INSTANCE = instance
+
+    _seed_singleton(ViewerPublisher)
+    _seed_singleton(ReplyCollector)
+
+    yield fake
+
+    ViewerPublisher.INSTANCE = None
+    ReplyCollector.INSTANCE = None

--- a/conftest.py
+++ b/conftest.py
@@ -63,9 +63,12 @@ import pytest
 # pulls in ``pytz``) would crash conftest collection for those tests.
 #
 # So gate every app-dependent hook on whether the app is importable at
-# all. When it isn't (the rpi-imager lint env), this whole file degrades
-# to a no-op and those app-free tests run untouched. ``os`` import is
-# never a problem; only the app imports are.
+# all. When it isn't (the rpi-imager lint env), those hooks (the
+# connect_to_redis patch, the _mock_redis / _ensure_assetdir autouse
+# fixtures) degrade to no-ops and the app-free tests run untouched. The
+# cheap, dependency-free setup — ENVIRONMENT=test and the gi/pydbus
+# stubs — still runs unconditionally; it's harmless for those tests and
+# needed by everything else.
 try:
     import anthias_common.utils as _anthias_common_utils  # noqa: F401
 

--- a/conftest.py
+++ b/conftest.py
@@ -73,7 +73,12 @@ try:
     import anthias_common.utils as _anthias_common_utils  # noqa: F401
 
     _APP_AVAILABLE = True
-except Exception:
+except ImportError:
+    # Only a missing dependency (the rpi-imager lint env lacks Django /
+    # pytz) should flip us to no-op. Catch ImportError specifically, not
+    # bare Exception: a genuine error inside the app package (SyntaxError,
+    # a broken import-time side effect) must surface loudly rather than
+    # silently disabling Redis isolation for the whole app test suite.
     _APP_AVAILABLE = False
 
 

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -281,12 +281,13 @@ class CreateAssetSerializerV2(
     # ``metadata['headers']`` and is surfaced back via
     # ``AssetSerializerV2.get_custom_headers``. ``DictField`` gives a
     # clean 400 on a non-object; ``validate_custom_headers`` enforces the
-    # header-name/value rules.
-    custom_headers = DictField(
-        child=CharField(allow_blank=True, trim_whitespace=False),
-        required=False,
-        write_only=True,
-    )
+    # header-name/value rules. No ``child=CharField``: that would *coerce*
+    # a numeric/boolean JSON value (``{"X": 123}`` -> ``"123"``) instead
+    # of rejecting it. The unvalidated child passes values through
+    # verbatim so ``validate_asset_headers``' ``isinstance(str)`` gate
+    # can 400 non-string values (and no CharField trimming mangles a
+    # value we send on the wire byte-for-byte).
+    custom_headers = DictField(required=False, write_only=True)
 
     def validate_play_days(self, value: Any) -> list[int]:
         return _normalise_play_days(value)
@@ -345,10 +346,10 @@ class UpdateAssetSerializerV2(UpdateAssetSerializer):
         min_value=0,
         max_value=REFRESH_INTERVAL_S_MAX,
     )
-    custom_headers = DictField(
-        child=CharField(allow_blank=True, trim_whitespace=False),
-        required=False,
-    )
+    # No ``child=CharField`` — see CreateAssetSerializerV2.custom_headers:
+    # the unvalidated child preserves value types so a non-string value is
+    # rejected (not coerced) and header values aren't trimmed.
+    custom_headers = DictField(required=False)
 
     def validate_play_days(self, value: Any) -> list[int]:
         return _normalise_play_days(value)

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -22,6 +22,7 @@ from anthias_common.utils import SCREEN_ROTATION_CHOICES
 from anthias_server.app.models import (
     Asset,
     DURATION_S_MAX,
+    MAX_ASSET_HEADERS,
     REFRESH_INTERVAL_S_MAX,
     clamp_refresh_interval,
     normalize_asset_headers,
@@ -74,11 +75,22 @@ def _validate_custom_headers(value: Any) -> dict[str, str]:
     Delegates to ``validate_asset_headers`` (the single source of truth
     for the header-name / value rules and the count cap) so the API and
     the viewer read path can't drift apart.
+
+    On failure we raise a fixed, self-authored message rather than
+    surfacing the caught exception's text: the rules are few and the
+    operator supplied the offending value themselves, so a static
+    description is just as actionable and keeps any exception detail off
+    the HTTP response (CodeQL "information exposure through an
+    exception").
     """
     try:
         return validate_asset_headers(value)
-    except ValueError as exc:
-        raise serializers.ValidationError(str(exc))
+    except ValueError:
+        raise serializers.ValidationError(
+            'Invalid custom headers. Each entry needs a valid header-name '
+            "token (letters, digits, and !#$%&'*+-.^_`|~) and a value with "
+            f'no CR/LF, and at most {MAX_ASSET_HEADERS} headers are allowed.'
+        ) from None
 
 
 def _validate_time_window(

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -9,6 +9,7 @@ from rest_framework.serializers import (
     CharField,
     ChoiceField,
     DateTimeField,
+    DictField,
     IntegerField,
     ListField,
     ModelSerializer,
@@ -23,6 +24,8 @@ from anthias_server.app.models import (
     DURATION_S_MAX,
     REFRESH_INTERVAL_S_MAX,
     clamp_refresh_interval,
+    normalize_asset_headers,
+    validate_asset_headers,
 )
 from anthias_server.api.serializers import UpdateAssetSerializer
 from anthias_server.api.serializers.mixins import CreateAssetSerializerMixin
@@ -64,6 +67,20 @@ def _normalise_play_days(value: list[int]) -> list[int]:
 # value without drift.
 
 
+def _validate_custom_headers(value: Any) -> dict[str, str]:
+    """Strictly validate the write-side ``custom_headers`` payload,
+    translating the model's ``ValueError`` into a DRF 400.
+
+    Delegates to ``validate_asset_headers`` (the single source of truth
+    for the header-name / value rules and the count cap) so the API and
+    the viewer read path can't drift apart.
+    """
+    try:
+        return validate_asset_headers(value)
+    except ValueError as exc:
+        raise serializers.ValidationError(str(exc))
+
+
 def _validate_time_window(
     attrs: dict[str, Any],
     instance: Asset | None = None,
@@ -100,6 +117,7 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
     is_active = SerializerMethodField()
     play_days = SerializerMethodField()
     refresh_interval_s = SerializerMethodField()
+    custom_headers = SerializerMethodField()
     metadata = SerializerMethodField()
 
     @extend_schema_field(OpenApiTypes.BOOL)
@@ -129,6 +147,17 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
             (obj.metadata or {}).get('refresh_interval_s', 0)
         )
 
+    @extend_schema_field(
+        {'type': 'object', 'additionalProperties': {'type': 'string'}}
+    )
+    def get_custom_headers(self, obj: Asset) -> dict[str, str]:
+        # Per-asset custom request headers for webpage assets (#2215),
+        # surfaced as a first-class field like ``refresh_interval_s`` but
+        # written back into ``metadata['headers']``. Sanitised on read so
+        # a legacy / hand-edited row can never echo an unsafe (CR/LF)
+        # value or a non-string blob. Empty {} = no custom headers.
+        return normalize_asset_headers((obj.metadata or {}).get('headers'))
+
     @extend_schema_field({'type': 'object', 'additionalProperties': True})
     def get_metadata(self, obj: Asset) -> dict[str, Any]:
         # Sanitise ``refresh_interval_s`` in the embedded metadata too,
@@ -142,6 +171,11 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
             raw['refresh_interval_s'] = clamp_refresh_interval(
                 raw['refresh_interval_s']
             )
+        # Same posture for the custom headers bag: keep the embedded
+        # ``metadata.headers`` consistent with the top-level
+        # ``custom_headers`` field a client also reads off this response.
+        if 'headers' in raw:
+            raw['headers'] = normalize_asset_headers(raw['headers'])
         return raw
 
     class Meta:
@@ -167,6 +201,7 @@ class AssetSerializerV2(ModelSerializer[Asset], CreateAssetSerializerMixin):
             'last_reachability_check',
             'metadata',
             'refresh_interval_s',
+            'custom_headers',
         ]
         read_only_fields = [
             'is_reachable',
@@ -229,9 +264,23 @@ class CreateAssetSerializerV2(
         min_value=0,
         max_value=REFRESH_INTERVAL_S_MAX,
     )
+    # write_only for the same reason as ``refresh_interval_s`` above:
+    # ``Asset`` has no ``custom_headers`` column — the value lives inside
+    # ``metadata['headers']`` and is surfaced back via
+    # ``AssetSerializerV2.get_custom_headers``. ``DictField`` gives a
+    # clean 400 on a non-object; ``validate_custom_headers`` enforces the
+    # header-name/value rules.
+    custom_headers = DictField(
+        child=CharField(allow_blank=True, trim_whitespace=False),
+        required=False,
+        write_only=True,
+    )
 
     def validate_play_days(self, value: Any) -> list[int]:
         return _normalise_play_days(value)
+
+    def validate_custom_headers(self, value: Any) -> dict[str, str]:
+        return _validate_custom_headers(value)
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         _validate_time_window(data)
@@ -249,6 +298,20 @@ class CreateAssetSerializerV2(
         if 'refresh_interval_s' in data:
             metadata = dict(prepared.get('metadata') or {})
             metadata['refresh_interval_s'] = int(data['refresh_interval_s'])
+            prepared['metadata'] = metadata
+        # POST round-trip for the per-asset custom headers, mirroring the
+        # refresh-interval handling above: fold into ``metadata`` so a
+        # freshly-created webpage asset carries its headers without a
+        # follow-up PATCH. An explicit empty object clears the key rather
+        # than storing ``{}`` so ``metadata`` stays clean for assets that
+        # didn't ask for headers.
+        if 'custom_headers' in data:
+            metadata = dict(prepared.get('metadata') or {})
+            headers = data['custom_headers']
+            if headers:
+                metadata['headers'] = headers
+            else:
+                metadata.pop('headers', None)
             prepared['metadata'] = metadata
         return prepared
 
@@ -270,9 +333,16 @@ class UpdateAssetSerializerV2(UpdateAssetSerializer):
         min_value=0,
         max_value=REFRESH_INTERVAL_S_MAX,
     )
+    custom_headers = DictField(
+        child=CharField(allow_blank=True, trim_whitespace=False),
+        required=False,
+    )
 
     def validate_play_days(self, value: Any) -> list[int]:
         return _normalise_play_days(value)
+
+    def validate_custom_headers(self, value: Any) -> dict[str, str]:
+        return _validate_custom_headers(value)
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         return _validate_time_window(data, instance=self.instance)
@@ -296,6 +366,20 @@ class UpdateAssetSerializerV2(UpdateAssetSerializer):
             metadata['refresh_interval_s'] = int(
                 validated_data['refresh_interval_s']
             )
+            instance.metadata = metadata
+        if 'custom_headers' in validated_data:
+            # Merge into metadata for the same reason as
+            # refresh_interval_s: pipeline-owned keys (original_ext,
+            # transcoded, error_message) must survive. An empty object
+            # clears the headers rather than storing ``{}``. Like
+            # refresh_interval_s, we accept and persist this on any
+            # asset, but the viewer only injects it for webpage assets.
+            metadata = dict(instance.metadata or {})
+            headers = validated_data['custom_headers']
+            if headers:
+                metadata['headers'] = headers
+            else:
+                metadata.pop('headers', None)
             instance.metadata = metadata
         return super().update(instance, validated_data)
 

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -881,17 +881,29 @@ def test_v2_patch_custom_headers_preserves_pipeline_metadata(
         {'X-Inject': 'a\r\nEvil: 1'},  # CRLF injection in value
         {'': 'v'},  # empty name
         {'X-Colon:': 'v'},  # colon in name
+        {'X-Num': 123},  # non-string value must be rejected, not coerced
+        {'X-Bool': True},  # non-string value must be rejected, not coerced
+        {'X-Null': None},  # non-string value must be rejected
     ],
-    ids=['space-in-name', 'crlf-in-value', 'empty-name', 'colon-in-name'],
+    ids=[
+        'space-in-name',
+        'crlf-in-value',
+        'empty-name',
+        'colon-in-name',
+        'numeric-value',
+        'bool-value',
+        'null-value',
+    ],
 )
 def test_v2_custom_headers_malformed_rejected(
     api_client: APIClient,
     v2_asset_detail_url: str,
-    headers: dict[str, str],
+    headers: dict[str, Any],
 ) -> None:
     """The strict API write path 400s on any malformed header rather
     than silently dropping it. CRLF-in-value is the security-critical
-    case (header/response splitting)."""
+    case (header/response splitting); the non-string cases guard against
+    DRF CharField coercing e.g. 123 -> "123" instead of rejecting it."""
     response = api_client.patch(
         v2_asset_detail_url,
         data={'custom_headers': headers},

--- a/src/anthias_server/api/tests/test_assets.py
+++ b/src/anthias_server/api/tests/test_assets.py
@@ -765,6 +765,181 @@ def test_v2_patch_refresh_interval_zero_disables(
     assert response.data['refresh_interval_s'] == 0
 
 
+# --- Per-asset custom HTTP request headers (feature #2215) -----------------
+
+
+@pytest.mark.django_db
+def test_v2_post_with_custom_headers_round_trips(
+    api_client: APIClient,
+) -> None:
+    """POST round-trip for per-asset custom request headers. Like
+    ``refresh_interval_s`` the value lives inside ``Asset.metadata``
+    (under ``headers``) but is surfaced as a top-level ``custom_headers``
+    field and accepted as a write field on create. Verify it lands on
+    the persisted row, not just on the echoed response."""
+    headers = {'Authorization': 'Bearer abc123', 'X-Env': 'prod'}
+    response = api_client.post(
+        reverse('api:asset_list_v2'),
+        data={**ASSET_CREATION_DATA, 'custom_headers': headers},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data['custom_headers'] == headers
+    assert response.data['metadata'] == {'headers': headers}
+
+    asset_id = response.data['asset_id']
+    detail = api_client.get(reverse('api:asset_detail_v2', args=[asset_id]))
+    assert detail.status_code == status.HTTP_200_OK
+    assert detail.data['custom_headers'] == headers
+
+
+@pytest.mark.django_db
+def test_v2_post_without_custom_headers_defaults_to_empty(
+    api_client: APIClient,
+) -> None:
+    """A create without ``custom_headers`` reads back as ``{}`` and does
+    not stamp a ``headers`` key into ``metadata``."""
+    response = api_client.post(
+        reverse('api:asset_list_v2'),
+        data=ASSET_CREATION_DATA,
+        format='json',
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data['custom_headers'] == {}
+    assert 'headers' not in response.data['metadata']
+
+
+@pytest.mark.django_db
+def test_v2_patch_custom_headers_round_trips(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """PATCH a single ``custom_headers`` object and read it back."""
+    headers = {'Authorization': 'Bearer xyz'}
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'custom_headers': headers},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['custom_headers'] == headers
+    assert response.data['metadata']['headers'] == headers
+
+
+@pytest.mark.django_db
+def test_v2_patch_custom_headers_empty_clears(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """An empty object clears the headers: the ``headers`` key is popped
+    from ``metadata`` rather than stored as ``{}``."""
+    api_client.patch(
+        v2_asset_detail_url,
+        data={'custom_headers': {'Authorization': 'Bearer xyz'}},
+        format='json',
+    )
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'custom_headers': {}},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['custom_headers'] == {}
+    assert 'headers' not in response.data['metadata']
+
+
+@pytest.mark.django_db
+def test_v2_patch_custom_headers_preserves_pipeline_metadata(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """Setting headers must merge into ``metadata`` rather than clobber
+    the upload-pipeline-owned keys — same contract as
+    ``refresh_interval_s``."""
+    from anthias_server.app.models import Asset
+
+    asset_id = v2_asset_detail_url.rstrip('/').split('/')[-1]
+    asset = Asset.objects.get(asset_id=asset_id)
+    asset.metadata = {'original_ext': '.png', 'transcoded': True}
+    asset.save(update_fields=['metadata'])
+
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'custom_headers': {'X-Token': 'v'}},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['metadata'] == {
+        'original_ext': '.png',
+        'transcoded': True,
+        'headers': {'X-Token': 'v'},
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'headers',
+    [
+        {'Bad Name': 'v'},  # space in name (not a token)
+        {'X-Inject': 'a\r\nEvil: 1'},  # CRLF injection in value
+        {'': 'v'},  # empty name
+        {'X-Colon:': 'v'},  # colon in name
+    ],
+    ids=['space-in-name', 'crlf-in-value', 'empty-name', 'colon-in-name'],
+)
+def test_v2_custom_headers_malformed_rejected(
+    api_client: APIClient,
+    v2_asset_detail_url: str,
+    headers: dict[str, str],
+) -> None:
+    """The strict API write path 400s on any malformed header rather
+    than silently dropping it. CRLF-in-value is the security-critical
+    case (header/response splitting)."""
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'custom_headers': headers},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'custom_headers' in response.data
+
+
+@pytest.mark.django_db
+def test_v2_custom_headers_over_count_cap_rejected(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """More than MAX_ASSET_HEADERS entries is a 400 (typo / abuse
+    guard on the D-Bus payload and header block size)."""
+    from anthias_server.app.models import MAX_ASSET_HEADERS
+
+    too_many = {f'X-H{i}': 'v' for i in range(MAX_ASSET_HEADERS + 1)}
+    response = api_client.patch(
+        v2_asset_detail_url,
+        data={'custom_headers': too_many},
+        format='json',
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'custom_headers' in response.data
+
+
+@pytest.mark.django_db
+def test_v2_get_sanitises_legacy_headers(
+    api_client: APIClient, v2_asset_detail_url: str
+) -> None:
+    """A hand-edited / legacy row with an unsafe header value must not
+    echo it back — the read path drops it via normalize_asset_headers."""
+    from anthias_server.app.models import Asset
+
+    asset_id = v2_asset_detail_url.rstrip('/').split('/')[-1]
+    asset = Asset.objects.get(asset_id=asset_id)
+    asset.metadata = {
+        'headers': {'Good': 'ok', 'Bad': 'x\r\ny', 'sp ace': 'v'}
+    }
+    asset.save(update_fields=['metadata'])
+
+    detail = api_client.get(reverse('api:asset_detail_v2', args=[asset_id]))
+    assert detail.status_code == status.HTTP_200_OK
+    assert detail.data['custom_headers'] == {'Good': 'ok'}
+    assert detail.data['metadata']['headers'] == {'Good': 'ok'}
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize('version', ['v1', 'v1_1', 'v1_2', 'v2'])
 def test_create_youtube_asset_dispatches_celery_task(

--- a/src/anthias_server/app/models.py
+++ b/src/anthias_server/app/models.py
@@ -37,12 +37,14 @@ DURATION_S_MAX = 365 * 24 * 60 * 60
 # Per-asset custom HTTP request headers for webpage assets (feature
 # #2215). Stored in ``Asset.metadata['headers']`` as a ``{name: value}``
 # object and injected by the C++ webview's request interceptor on
-# same-host requests, so a private dashboard (e.g. a Grafana
-# service-account token) renders without having to be made public.
-# Bounds keep a hostile or typo'd row from bloating the D-Bus payload,
-# the DB blob, or a single request's header block. The C++ interceptor
-# trusts whatever it is handed, so the validation below is the single
-# gate that keeps CR/LF out of the wire (header/response-splitting).
+# same-origin requests (scheme+host+port), so a private dashboard (e.g. a
+# Grafana service-account token) renders without having to be made
+# public. Bounds keep a hostile or typo'd row from bloating the D-Bus
+# payload, the DB blob, or a single request's header block. This
+# server-side validation is the primary gate keeping CR/LF out of the
+# wire (header/response-splitting); the webview re-validates defensively
+# at its D-Bus boundary too. ``MAX_HEADER_VALUE_LEN`` is a byte cap
+# (values go on the wire as UTF-8), matching the webview's check.
 MAX_ASSET_HEADERS = 20
 MAX_HEADER_NAME_LEN = 256
 MAX_HEADER_VALUE_LEN = 4096
@@ -66,7 +68,11 @@ def _is_valid_header_value(value: str) -> bool:
     # through. Everything else reaches the origin byte-for-byte.
     if any(ch in value for ch in ('\r', '\n', '\x00')):
         return False
-    return len(value) <= MAX_HEADER_VALUE_LEN
+    # Cap the UTF-8 *byte* length, not the character count: the value is
+    # sent on the wire as UTF-8 (the webview's toUtf8()), so a string of
+    # multi-byte characters would otherwise exceed the intended byte
+    # budget. Keeps this in lockstep with the webview's byte-based cap.
+    return len(value.encode('utf-8')) <= MAX_HEADER_VALUE_LEN
 
 
 def normalize_asset_headers(value: Any) -> dict[str, str]:

--- a/src/anthias_server/app/models.py
+++ b/src/anthias_server/app/models.py
@@ -1,4 +1,5 @@
 import json
+import re
 import uuid
 from datetime import datetime
 from typing import Any
@@ -31,6 +32,121 @@ REFRESH_INTERVAL_S_MAX = 86400
 # v1/v1.1/v1.2 create paths, the page-form handlers (clamping), and
 # the viewer's read-side clamp.
 DURATION_S_MAX = 365 * 24 * 60 * 60
+
+
+# Per-asset custom HTTP request headers for webpage assets (feature
+# #2215). Stored in ``Asset.metadata['headers']`` as a ``{name: value}``
+# object and injected by the C++ webview's request interceptor on
+# same-host requests, so a private dashboard (e.g. a Grafana
+# service-account token) renders without having to be made public.
+# Bounds keep a hostile or typo'd row from bloating the D-Bus payload,
+# the DB blob, or a single request's header block. The C++ interceptor
+# trusts whatever it is handed, so the validation below is the single
+# gate that keeps CR/LF out of the wire (header/response-splitting).
+MAX_ASSET_HEADERS = 20
+MAX_HEADER_NAME_LEN = 256
+MAX_HEADER_VALUE_LEN = 4096
+
+# RFC 7230 ``field-name`` is ``1*tchar``. Anchored so a name carrying a
+# colon, whitespace, or a control char is rejected outright rather than
+# smuggled onto the wire.
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+
+
+def _is_valid_header_name(name: str) -> bool:
+    return len(name) <= MAX_HEADER_NAME_LEN and bool(
+        _HEADER_NAME_RE.match(name)
+    )
+
+
+def _is_valid_header_value(value: str) -> bool:
+    # CR / LF / NUL would let a stored value inject additional headers
+    # (or split the request) once the C++ side writes it verbatim, so
+    # they are rejected here — the one place every write path funnels
+    # through. Everything else reaches the origin byte-for-byte.
+    if any(ch in value for ch in ('\r', '\n', '\x00')):
+        return False
+    return len(value) <= MAX_HEADER_VALUE_LEN
+
+
+def normalize_asset_headers(value: Any) -> dict[str, str]:
+    """Coerce an arbitrary ``metadata['headers']`` value into a safe
+    ``{name: value}`` dict, dropping (not raising on) anything malformed.
+
+    Same defensive posture as ``clamp_refresh_interval``: the strict
+    reject-on-invalid path lives in the v2 serializer's write validation
+    (``validate_asset_headers`` below), but a hand-edited row, a legacy
+    import, or a non-string JSON value must never crash the viewer read
+    path or the API GET. ``Any`` because callers pass whatever JSON the
+    column happens to hold.
+    """
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, str] = {}
+    for raw_name, raw_value in value.items():
+        if len(out) >= MAX_ASSET_HEADERS:
+            break
+        if not isinstance(raw_name, str) or not isinstance(raw_value, str):
+            continue
+        name = raw_name.strip()
+        if not _is_valid_header_name(name):
+            continue
+        if not _is_valid_header_value(raw_value):
+            continue
+        out[name] = raw_value
+    return out
+
+
+def validate_asset_headers(value: Any) -> dict[str, str]:
+    """Strict counterpart to ``normalize_asset_headers``: raises
+    ``ValueError`` (with a human reason) on any malformed entry instead
+    of silently dropping it.
+
+    Used by the v2 API write path so an operator sending a bad header
+    gets a 400 that names the problem, rather than a 200 that quietly
+    discarded half of what they typed. The server-rendered form uses the
+    forgiving ``parse_header_lines`` path instead (mirroring how
+    ``refresh_interval_s`` is 400'd by the API but clamped by the form).
+    """
+    if not isinstance(value, dict):
+        raise ValueError('Headers must be an object of name/value pairs.')
+    if len(value) > MAX_ASSET_HEADERS:
+        raise ValueError(
+            f'At most {MAX_ASSET_HEADERS} custom headers are allowed.'
+        )
+    out: dict[str, str] = {}
+    for raw_name, raw_value in value.items():
+        name = raw_name.strip() if isinstance(raw_name, str) else ''
+        if not _is_valid_header_name(name):
+            raise ValueError(f'Invalid header name: {raw_name!r}')
+        if not isinstance(raw_value, str) or not _is_valid_header_value(
+            raw_value
+        ):
+            raise ValueError(f'Invalid value for header {name!r}')
+        out[name] = raw_value
+    return out
+
+
+def parse_header_lines(text: Any) -> dict[str, str]:
+    """Parse a textarea of ``Name: Value`` lines into a sanitised header
+    dict for the server-rendered edit form.
+
+    Blank lines and lines without a colon are ignored; the value keeps
+    everything after the first colon (so ``Bearer a:b`` survives). The
+    result is funnelled through ``normalize_asset_headers`` so the form
+    clamps (drops bad entries) rather than 400ing, matching the
+    ``refresh_interval_s`` form contract.
+    """
+    if not isinstance(text, str):
+        return {}
+    headers: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or ':' not in line:
+            continue
+        name, _, raw_value = line.partition(':')
+        headers[name.strip()] = raw_value.strip()
+    return normalize_asset_headers(headers)
 
 
 def clamp_duration(value: Any) -> int:

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -40,6 +40,10 @@ interface AssetEdit {
   play_days_list: number[]
   play_time_from: string | null
   play_time_to: string | null
+  metadata?: {
+    refresh_interval_s?: number
+    headers?: Record<string, string>
+  } | null
 }
 
 type UploadState = null | 'sending' | 'processing'

--- a/src/anthias_server/app/templates/_asset_modal.html
+++ b/src/anthias_server/app/templates/_asset_modal.html
@@ -557,6 +557,26 @@
                   <p class="modal-section__hint mt-2 mb-0">
                     Reload the page on this cadence so dashboards stay current. Empty or 0 disables.
                   </p>
+                  {% comment %}
+                    Per-asset custom HTTP request headers (#2215). One
+                    "Name: Value" per line; the viewer's browser injects
+                    them on same-site requests so a private dashboard
+                    (e.g. a Grafana service-account token) renders without
+                    being made public. Seeded from metadata.headers as
+                    joined lines; posted verbatim to assets_update, which
+                    parses + sanitises via parse_header_lines.
+                  {% endcomment %}
+                  <div class="modal-section__divider"></div>
+                  <div class="app-floating">
+                    <textarea class="app-input" id="edit-custom-headers"
+                      name="custom_headers" rows="3"
+                      placeholder="Authorization: Bearer <token>"
+                      :value="(editAsset.metadata && editAsset.metadata.headers) ? Object.entries(editAsset.metadata.headers).map(function (e) { return e[0] + ': ' + e[1] }).join('\n') : ''"></textarea>
+                    <label for="edit-custom-headers">Custom HTTP headers</label>
+                  </div>
+                  <p class="modal-section__hint mt-2 mb-0">
+                    One <code>Name: Value</code> per line, sent only with requests to the asset's own host. Leave empty for none.
+                  </p>
                 </div>
               </template>
             </div>

--- a/src/anthias_server/app/templates/_asset_modal.html
+++ b/src/anthias_server/app/templates/_asset_modal.html
@@ -560,7 +560,7 @@
                   {% comment %}
                     Per-asset custom HTTP request headers (#2215). One
                     "Name: Value" per line; the viewer's browser injects
-                    them on same-site requests so a private dashboard
+                    them on same-origin requests so a private dashboard
                     (e.g. a Grafana service-account token) renders without
                     being made public. Seeded from metadata.headers as
                     joined lines; posted verbatim to assets_update, which
@@ -575,7 +575,7 @@
                     <label for="edit-custom-headers">Custom HTTP headers</label>
                   </div>
                   <p class="modal-section__hint mt-2 mb-0">
-                    One <code>Name: Value</code> per line, sent only with requests to the asset's own host. Leave empty for none.
+                    One <code>Name: Value</code> per line, sent only with requests to the asset's own origin (same scheme, host, and port). Leave empty for none.
                   </p>
                 </div>
               </template>

--- a/src/anthias_server/app/templatetags/asset_filters.py
+++ b/src/anthias_server/app/templatetags/asset_filters.py
@@ -157,6 +157,16 @@ def _to_dict(obj: Any) -> Any:
                 meta['refresh_interval_s']
             )
             out['metadata'] = meta
+        # Sanitise metadata['headers'] the same way, so a legacy /
+        # hand-edited row can't seed the edit modal's textarea with an
+        # unsafe (CR/LF) value or a non-string blob (#2215).
+        meta = out.get('metadata')
+        if isinstance(meta, dict) and 'headers' in meta:
+            from anthias_server.app.models import normalize_asset_headers
+
+            meta = dict(meta)
+            meta['headers'] = normalize_asset_headers(meta['headers'])
+            out['metadata'] = meta
         return out
     return _coerce(obj)
 

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -33,6 +33,7 @@ from anthias_server.app import page_context
 from anthias_server.app.models import (
     clamp_duration,
     clamp_refresh_interval,
+    parse_header_lines,
 )
 from anthias_server.celery_tasks import reboot_anthias, shutdown_anthias
 from anthias_server.lib import backup_helper, diagnostics
@@ -874,6 +875,22 @@ def assets_update(request: HttpRequest, asset_id: str) -> HttpResponse:
         metadata['refresh_interval_s'] = clamp_refresh_interval(
             raw_interval.strip() or 0
         )
+        asset.metadata = metadata
+
+    # Per-asset custom request headers — feature #2215. Same
+    # ``metadata``-backed, webpage-only posture as refresh_interval_s: a
+    # missing field means "non-webpage edit, leave the bag alone"; an
+    # empty textarea means "operator cleared the headers" and pops the
+    # key. The form clamps (drops malformed lines via parse_header_lines)
+    # rather than 400ing — the strict reject lives in the v2 API.
+    raw_headers = request.POST.get('custom_headers')
+    if raw_headers is not None:
+        metadata = dict(asset.metadata or {})
+        headers = parse_header_lines(raw_headers)
+        if headers:
+            metadata['headers'] = headers
+        else:
+            metadata.pop('headers', None)
         asset.metadata = metadata
 
     # Store-app reconfiguration. When editing an app asset (one carrying

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -1201,7 +1201,12 @@ def view_webpage(
         # reload and the headers would never reach the page. No-op for
         # the common success path.
         if headers_applied:
-            current_browser_headers = headers
+            # Store a copy, not the caller's dict: aliasing it would let a
+            # later in-place mutation of that dict silently change the
+            # cached value, making the next ``!=`` compare equal and skip a
+            # needed reload. The asset_loop currently hands us a fresh dict
+            # each tick, but the copy keeps that a non-assumption.
+            current_browser_headers = dict(headers)
     # ``setReloadInterval`` is a new D-Bus method. A viewer running
     # against an older AnthiasViewer (version skew across a fleet
     # rollout, where the viewer container has rotated to a newer image

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -1096,7 +1096,7 @@ def _apply_request_headers(headers: dict[str, str]) -> bool:
     — passing JSON keeps the marshaling trivial across pydbus versions
     and matches how the C++ side (``setRequestHeaders``) parses it. Sent
     on every webpage tick (cheap, idempotent); the C++ interceptor only
-    attaches them to same-host requests.
+    attaches them to same-origin requests (scheme+host+port).
 
     Version-skew tolerant, mirroring ``setReloadInterval``: an older
     AnthiasViewer that predates the slot raises UnknownMethod, which
@@ -1189,7 +1189,7 @@ def view_webpage(
     # str object on consecutive ticks, which a JSON-reconstructed URL
     # would defeat. Reload when the headers change too — a header-only
     # edit must still refetch so the new headers reach the main document,
-    # not just later same-host XHR.
+    # not just later same-origin XHR.
     if current_browser_url != uri or current_browser_headers != headers:
         if headers_applied:
             _send_to_webview(lambda: browser_bus.loadPage(uri))

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -1105,12 +1105,12 @@ def _apply_request_headers(headers: dict[str, str]) -> bool:
 
     Returns ``True`` when the call succeeded *or* the slot is
     unsupported (nothing left to retry), and ``False`` on a transient
-    failure — the C++ interceptor only picks the staged headers up on the
-    next ``loadPage``, so a transient failure on the first load of a
-    single-asset playlist (its URL never changes, so the unchanged-URL
-    short-circuit would otherwise skip ``loadPage`` forever) must force a
-    reload. The caller keys that reload off this return value. Observed on
-    real hardware: the very first ``setRequestHeaders`` can lose the race
+    failure. The caller keys navigation off this: on ``False`` it must
+    NOT issue ``loadPage``, because the C++ side still holds the previous
+    asset's staged headers and would scope them to the new asset's origin
+    (a cross-asset credential leak). It instead defers and retries next
+    tick, leaving the URL/header mismatch in place. Observed on real
+    hardware: the very first ``setRequestHeaders`` can lose the race
     against a just-spawned webview's D-Bus registration.
     """
     global _webview_supports_set_request_headers
@@ -1191,22 +1191,29 @@ def view_webpage(
     # edit must still refetch so the new headers reach the main document,
     # not just later same-host XHR.
     if current_browser_url != uri or current_browser_headers != headers:
-        _send_to_webview(lambda: browser_bus.loadPage(uri))
-        current_browser_url = uri
-        # Only cache the headers as applied once setRequestHeaders
-        # actually succeeded. If it transiently failed, leave
-        # ``current_browser_headers`` stale so the mismatch persists and
-        # the next tick re-issues both setRequestHeaders and loadPage —
-        # otherwise a single-asset playlist (unchanged URL) would never
-        # reload and the headers would never reach the page. No-op for
-        # the common success path.
         if headers_applied:
+            _send_to_webview(lambda: browser_bus.loadPage(uri))
+            current_browser_url = uri
             # Store a copy, not the caller's dict: aliasing it would let a
             # later in-place mutation of that dict silently change the
-            # cached value, making the next ``!=`` compare equal and skip a
-            # needed reload. The asset_loop currently hands us a fresh dict
-            # each tick, but the copy keeps that a non-assumption.
+            # cached value, making the next ``!=`` compare equal and skip
+            # a needed reload. The asset_loop currently hands us a fresh
+            # dict each tick, but the copy keeps that a non-assumption.
             current_browser_headers = dict(headers)
+        else:
+            # setRequestHeaders failed transiently, so the webview still
+            # holds the PREVIOUS asset's staged headers. Issuing loadPage
+            # now would make the C++ interceptor scope those stale headers
+            # to THIS asset's origin — a cross-asset credential leak (e.g.
+            # the prior asset's Authorization reaching the next asset's
+            # host). Defer navigation and leave current_browser_url /
+            # current_browser_headers stale so the next tick retries once
+            # the D-Bus call succeeds. A single-asset playlist self-heals
+            # the same way (the mismatch persists until the send lands).
+            logging.debug(
+                'Deferring loadPage until request headers apply '
+                '(transient setRequestHeaders failure)'
+            )
     # ``setReloadInterval`` is a new D-Bus method. A viewer running
     # against an older AnthiasViewer (version skew across a fleet
     # rollout, where the viewer container has rotated to a newer image

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -1087,9 +1087,10 @@ def _cache_busted_url(uri: str) -> str:
     return urlunparse(parts._replace(query=new_query))
 
 
-def _apply_request_headers(headers: dict[str, str]) -> None:
+def _apply_request_headers(headers: dict[str, str]) -> bool:
     """Push the current webpage asset's custom request headers to the
-    webview over D-Bus (#2215).
+    webview over D-Bus (#2215). Returns whether the headers are now in
+    effect on the webview.
 
     The payload is a JSON object string rather than a D-Bus ``a{sv}`` map
     — passing JSON keeps the marshaling trivial across pydbus versions
@@ -1100,15 +1101,25 @@ def _apply_request_headers(headers: dict[str, str]) -> None:
     Version-skew tolerant, mirroring ``setReloadInterval``: an older
     AnthiasViewer that predates the slot raises UnknownMethod, which
     latches the capability off for this viewer process so we don't flood
-    journald or keep paying the round-trip. Transient failures are logged
-    at debug and retried next rotation.
+    journald or keep paying the round-trip.
+
+    Returns ``True`` when the call succeeded *or* the slot is
+    unsupported (nothing left to retry), and ``False`` on a transient
+    failure — the C++ interceptor only picks the staged headers up on the
+    next ``loadPage``, so a transient failure on the first load of a
+    single-asset playlist (its URL never changes, so the unchanged-URL
+    short-circuit would otherwise skip ``loadPage`` forever) must force a
+    reload. The caller keys that reload off this return value. Observed on
+    real hardware: the very first ``setRequestHeaders`` can lose the race
+    against a just-spawned webview's D-Bus registration.
     """
     global _webview_supports_set_request_headers
     if not _webview_supports_set_request_headers:
-        return
+        return True
     payload = json.dumps(headers or {})
     try:
         browser_bus.setRequestHeaders(payload)
+        return True
     except Exception as exc:
         message = str(exc)
         method_missing = (
@@ -1121,12 +1132,13 @@ def _apply_request_headers(headers: dict[str, str]) -> None:
                 'skew?); custom headers disabled until viewer restart: %s',
                 exc,
             )
-        else:
-            logging.debug(
-                'Transient setRequestHeaders failure (will retry next '
-                'rotation): %s',
-                exc,
-            )
+            return True
+        logging.debug(
+            'Transient setRequestHeaders failure (will retry next '
+            'rotation): %s',
+            exc,
+        )
+        return False
 
 
 def view_webpage(
@@ -1171,7 +1183,7 @@ def view_webpage(
     # C++ interceptor has them when the navigation fires. Always sent
     # (empty {} for header-less assets) so switching away from a
     # header-carrying asset clears the previous asset's headers.
-    _apply_request_headers(headers)
+    headers_applied = _apply_request_headers(headers)
     # ``!=`` (value comparison): an ``is not`` identity check would
     # only short-circuit when the asset_loop happens to pass the same
     # str object on consecutive ticks, which a JSON-reconstructed URL
@@ -1181,7 +1193,15 @@ def view_webpage(
     if current_browser_url != uri or current_browser_headers != headers:
         _send_to_webview(lambda: browser_bus.loadPage(uri))
         current_browser_url = uri
-        current_browser_headers = headers
+        # Only cache the headers as applied once setRequestHeaders
+        # actually succeeded. If it transiently failed, leave
+        # ``current_browser_headers`` stale so the mismatch persists and
+        # the next tick re-issues both setRequestHeaders and loadPage —
+        # otherwise a single-asset playlist (unchanged URL) would never
+        # reload and the headers would never reach the page. No-op for
+        # the common success path.
+        if headers_applied:
+            current_browser_headers = headers
     # ``setReloadInterval`` is a new D-Bus method. A viewer running
     # against an older AnthiasViewer (version skew across a fleet
     # rollout, where the viewer container has rotated to a newer image

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import json
 import logging
 import os
 import subprocess
@@ -59,6 +60,7 @@ from anthias_common.utils import (  # noqa: E402
 from anthias_server.app.models import Asset  # noqa: E402
 from anthias_server.app.models import clamp_duration  # noqa: E402
 from anthias_server.app.models import clamp_refresh_interval  # noqa: E402
+from anthias_server.app.models import normalize_asset_headers  # noqa: E402
 from anthias_viewer.messaging import ViewerSubscriber  # noqa: E402
 from anthias_viewer.scheduling import Scheduler  # noqa: E402
 
@@ -77,6 +79,16 @@ current_browser_url: str | None = None
 # An operator who upgrades the webview package should restart the
 # viewer anyway; that resets the cache.
 _webview_supports_set_reload_interval: bool = True
+# Custom request headers currently applied to the webview (#2215). Held
+# so view_webpage can force a fresh load when only the headers change on
+# an asset whose URL is unchanged. Reset to {} on every (re)spawn along
+# with ``current_browser_url``.
+current_browser_headers: dict[str, str] = {}
+# Same version-skew latch as ``_webview_supports_set_reload_interval`` but
+# for the ``setRequestHeaders`` slot: an AnthiasViewer binary that
+# predates it raises UnknownMethod once, after which we stop paying the
+# D-Bus round-trip until the viewer restarts.
+_webview_supports_set_request_headers: bool = True
 browser: Any = None
 # Bounded sink for the current AnthiasViewer's merged stdout+stderr. See
 # _BoundedWebviewOutput / _spawn_webview_once (issue #3138). Mirrors
@@ -844,7 +856,8 @@ def load_browser(
     persistent failure can't freeze the asset_loop thread for minutes.
     """
     global browser, _webview_supports_set_reload_interval
-    global _last_applied_rotation, current_browser_url
+    global _webview_supports_set_request_headers
+    global _last_applied_rotation, current_browser_url, current_browser_headers
     global _last_applied_dark_mode
     logging.info('Loading browser...')
 
@@ -879,6 +892,9 @@ def load_browser(
     # case. Resetting on every launch keeps the latch tied to the
     # actual running process, not the viewer's lifetime.
     _webview_supports_set_reload_interval = True
+    # Same re-probe for the custom-headers slot (#2215): a webview
+    # restart may bring up a binary that now supports setRequestHeaders.
+    _webview_supports_set_request_headers = True
 
     # Apply screen rotation *before* the webview starts so it picks up
     # the rotated geometry on first frame: the wlroots compositor
@@ -914,6 +930,9 @@ def load_browser(
     # unchanged URL, e.g. a single-asset playlist) never gets the
     # loadImage/loadPage re-sent.
     current_browser_url = None
+    # Likewise drop the applied-headers cache so the next view_webpage
+    # re-sends them to the fresh process (whose interceptor starts empty).
+    current_browser_headers = {}
 
     # Retry the spawn with capped exponential backoff so a board that
     # intermittently crashes during Qt/WebEngine init self-heals on a
@@ -1068,8 +1087,53 @@ def _cache_busted_url(uri: str) -> str:
     return urlunparse(parts._replace(query=new_query))
 
 
+def _apply_request_headers(headers: dict[str, str]) -> None:
+    """Push the current webpage asset's custom request headers to the
+    webview over D-Bus (#2215).
+
+    The payload is a JSON object string rather than a D-Bus ``a{sv}`` map
+    — passing JSON keeps the marshaling trivial across pydbus versions
+    and matches how the C++ side (``setRequestHeaders``) parses it. Sent
+    on every webpage tick (cheap, idempotent); the C++ interceptor only
+    attaches them to same-host requests.
+
+    Version-skew tolerant, mirroring ``setReloadInterval``: an older
+    AnthiasViewer that predates the slot raises UnknownMethod, which
+    latches the capability off for this viewer process so we don't flood
+    journald or keep paying the round-trip. Transient failures are logged
+    at debug and retried next rotation.
+    """
+    global _webview_supports_set_request_headers
+    if not _webview_supports_set_request_headers:
+        return
+    payload = json.dumps(headers or {})
+    try:
+        browser_bus.setRequestHeaders(payload)
+    except Exception as exc:
+        message = str(exc)
+        method_missing = (
+            'UnknownMethod' in message or 'no such method' in message.lower()
+        )
+        if method_missing:
+            _webview_supports_set_request_headers = False
+            logging.warning(
+                'setRequestHeaders not supported by webview (version '
+                'skew?); custom headers disabled until viewer restart: %s',
+                exc,
+            )
+        else:
+            logging.debug(
+                'Transient setRequestHeaders failure (will retry next '
+                'rotation): %s',
+                exc,
+            )
+
+
 def view_webpage(
-    uri: str, reload_interval_s: int = 0, nocache: bool = False
+    uri: str,
+    reload_interval_s: int = 0,
+    nocache: bool = False,
+    headers: dict[str, str] | None = None,
 ) -> None:
     """Display a webpage and arm its per-asset auto-refresh timer.
 
@@ -1087,7 +1151,9 @@ def view_webpage(
     each time the asset is shown rather than served from QtWebEngine's
     HTTP cache or skipped by the unchanged-URL short-circuit below.
     """
-    global current_browser_url
+    global current_browser_url, current_browser_headers
+
+    headers = headers or {}
 
     if nocache:
         uri = _cache_busted_url(uri)
@@ -1101,13 +1167,21 @@ def view_webpage(
             backoff_cap=BROWSER_SPAWN_INLINE_BACKOFF_CAP_SECONDS,
             startup_timeout=BROWSER_SPAWN_INLINE_TIMEOUT_SECONDS,
         )
+    # Hand the per-asset headers to the webview BEFORE loadPage so the
+    # C++ interceptor has them when the navigation fires. Always sent
+    # (empty {} for header-less assets) so switching away from a
+    # header-carrying asset clears the previous asset's headers.
+    _apply_request_headers(headers)
     # ``!=`` (value comparison): an ``is not`` identity check would
     # only short-circuit when the asset_loop happens to pass the same
     # str object on consecutive ticks, which a JSON-reconstructed URL
-    # would defeat.
-    if current_browser_url != uri:
+    # would defeat. Reload when the headers change too — a header-only
+    # edit must still refetch so the new headers reach the main document,
+    # not just later same-host XHR.
+    if current_browser_url != uri or current_browser_headers != headers:
         _send_to_webview(lambda: browser_bus.loadPage(uri))
         current_browser_url = uri
+        current_browser_headers = headers
     # ``setReloadInterval`` is a new D-Bus method. A viewer running
     # against an older AnthiasViewer (version skew across a fleet
     # rollout, where the viewer container has rotated to a newer image
@@ -1764,10 +1838,16 @@ def asset_loop(scheduler: Any) -> None:
             interval = clamp_refresh_interval(
                 metadata.get('refresh_interval_s')
             )
+            # Per-asset custom request headers (#2215). Sanitised on read
+            # for the same reason as the interval: a hand-crafted DB row
+            # could hold junk, and the C++ interceptor trusts what it's
+            # handed, so this is the last gate before the wire.
+            headers = normalize_asset_headers(metadata.get('headers'))
             view_webpage(
                 uri,
                 reload_interval_s=interval,
                 nocache=bool(asset.get('nocache')),
+                headers=headers,
             )
         elif 'video' in mime or 'streaming' in mime:
             # ``'video' or 'streaming' in mime`` parses as ``'video'

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -74,7 +74,8 @@ int main(int argc, char *argv[])
     QDBusConnection connection = QDBusConnection::sessionBus();
 
     // ExportAllSlots covers loadPage / loadImage / setReloadInterval /
-    // playVideo / stopVideo; ExportAllSignals exposes MainWindow's
+    // setRequestHeaders / playVideo / stopVideo; ExportAllSignals
+    // exposes MainWindow's
     // ``videoEnded`` signal so the Python viewer can subscribe to it
     // and learn when libmpv finishes a clip without polling (issue
     // #2904 follow-up; the current asset_loop still sleeps for

--- a/src/anthias_webview/src/mainwindow.cpp
+++ b/src/anthias_webview/src/mainwindow.cpp
@@ -36,6 +36,11 @@ void MainWindow::setReloadInterval(int seconds)
     view->setReloadInterval(seconds);
 }
 
+void MainWindow::setRequestHeaders(const QString &headersJson)
+{
+    view->setRequestHeaders(headersJson);
+}
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void MainWindow::playVideo(const QString &uri, const QVariantMap &options)
 {

--- a/src/anthias_webview/src/mainwindow.h
+++ b/src/anthias_webview/src/mainwindow.h
@@ -17,6 +17,11 @@ class MainWindow : public QMainWindow
         void loadPage(const QString &uri);
         void loadImage(const QString &uri);
         void setReloadInterval(int seconds);
+        // Per-asset custom HTTP request headers (#2215). ``headersJson``
+        // is a JSON object of ``{name: value}`` pairs. Called by the
+        // viewer right before loadPage; forwarded to View which scopes
+        // them to the loaded URL's host. Un-gated (Qt5 + Qt6).
+        void setRequestHeaders(const QString &headersJson);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         // libmpv-in-Qt video playback (issue #2904). Replaces the
         // external mpv subprocess MPVMediaPlayer used to launch from

--- a/src/anthias_webview/src/mainwindow.h
+++ b/src/anthias_webview/src/mainwindow.h
@@ -20,7 +20,8 @@ class MainWindow : public QMainWindow
         // Per-asset custom HTTP request headers (#2215). ``headersJson``
         // is a JSON object of ``{name: value}`` pairs. Called by the
         // viewer right before loadPage; forwarded to View which scopes
-        // them to the loaded URL's host. Un-gated (Qt5 + Qt6).
+        // them to the loaded URL's origin (scheme+host+port). Un-gated
+        // (Qt5 + Qt6).
         void setRequestHeaders(const QString &headersJson);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         // libmpv-in-Qt video playback (issue #2904). Replaces the

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -43,6 +43,30 @@
 // called from the UI thread — so the shared state is guarded by a mutex.
 // No Q_OBJECT: the class adds no signals/slots, so it needs no moc and
 // can live entirely in this translation unit.
+
+// Canonical origin key ``scheme://host:port`` (both lower-cased, with the
+// scheme's default port filled in when the URL omits it) so scoping is by
+// full origin, not just host. Matching on host alone would still attach an
+// Authorization token across a scheme downgrade (https→http on the same
+// host) or to a different service on another port; comparing the whole
+// origin closes those leaks while remaining an exact same-origin match for
+// the page's own XHR/subresources.
+static QString originKey(const QUrl& url)
+{
+    int port = url.port();
+    if (port == -1) {
+        const QString scheme = url.scheme().toLower();
+        if (scheme == QLatin1String("https")) {
+            port = 443;
+        } else if (scheme == QLatin1String("http")) {
+            port = 80;
+        }
+    }
+    return url.scheme().toLower() + QStringLiteral("://")
+        + url.host().toLower() + QStringLiteral(":")
+        + QString::number(port);
+}
+
 class RequestHeaderInterceptor : public QWebEngineUrlRequestInterceptor
 {
 public:
@@ -52,32 +76,32 @@ public:
     }
 
     void setHeaders(
-        const QString& host,
+        const QString& origin,
         const QList<QPair<QByteArray, QByteArray>>& headers)
     {
         QMutexLocker locker(&m_mutex);
-        m_host = host;
+        m_origin = origin;
         m_headers = headers;
     }
 
     void clear()
     {
         QMutexLocker locker(&m_mutex);
-        m_host.clear();
+        m_origin.clear();
         m_headers.clear();
     }
 
     void interceptRequest(QWebEngineUrlRequestInfo& info) override
     {
         QMutexLocker locker(&m_mutex);
-        if (m_headers.isEmpty() || m_host.isEmpty()) {
+        if (m_headers.isEmpty() || m_origin.isEmpty()) {
             return;
         }
-        // Exact host match (case-insensitive, per DNS). Anything on a
-        // different host — including a cross-origin redirect target — is
-        // deliberately excluded so the header can't leak off-site.
-        if (info.requestUrl().host().compare(
-                m_host, Qt::CaseInsensitive) != 0) {
+        // Same-origin (scheme + host + port) only. Anything else — a
+        // cross-origin redirect target, an https→http downgrade, or a
+        // different port on the same host — is deliberately excluded so
+        // the operator's headers can't leak off the asset's own origin.
+        if (originKey(info.requestUrl()) != m_origin) {
             return;
         }
         for (const auto& header : m_headers) {
@@ -87,7 +111,7 @@ public:
 
 private:
     QMutex m_mutex;
-    QString m_host;
+    QString m_origin;
     QList<QPair<QByteArray, QByteArray>> m_headers;
 };
 
@@ -276,10 +300,15 @@ View::View(QWidget* parent) : QWidget(parent)
 
     // Per-asset custom request headers (#2215). Installed on the shared
     // profile once; the headers themselves are staged per asset by
-    // setRequestHeaders and scoped to the target host in startPageLoad.
+    // setRequestHeaders and scoped to the target origin in startPageLoad.
     // ``setUrlRequestInterceptor`` on QWebEngineProfile is available
     // identically on Qt 5.13+ and Qt 6, so no version macro is needed.
-    headerInterceptor = new RequestHeaderInterceptor(this);
+    // Parent the interceptor to the *profile* (process-lifetime), not to
+    // ``this``: the default profile can outlive the View, and if the
+    // interceptor were destroyed first the profile would be left holding
+    // a dangling pointer (use-after-free at teardown). ~View also detaches
+    // it defensively.
+    headerInterceptor = new RequestHeaderInterceptor(profile);
     profile->setUrlRequestInterceptor(headerInterceptor);
 
     currentWebView = webView1;
@@ -329,6 +358,11 @@ View::~View()
     if (pageLoadConnection) {
         QObject::disconnect(pageLoadConnection);
     }
+    // Detach the request interceptor from the (process-lifetime) default
+    // profile before we go away, so no request can be intercepted against
+    // torn-down View state. The interceptor object itself is owned by the
+    // profile (see ctor), so we only clear the profile's pointer here.
+    QWebEngineProfile::defaultProfile()->setUrlRequestInterceptor(nullptr);
     stopReloadTimer();
     stopAnimation();
 }
@@ -427,7 +461,7 @@ void View::startPageLoad(const QString &uri, quint64 requestId)
 
     pendingPageUri = uri;
 
-    // Scope the staged headers (#2215) to this URL's host and hand them
+    // Scope the staged headers (#2215) to this URL's origin and hand them
     // to the interceptor before the load fires. An empty ``pendingHeaders``
     // clears any headers left from a previous asset, so a header-less
     // page never inherits the prior page's Authorization.
@@ -436,7 +470,7 @@ void View::startPageLoad(const QString &uri, quint64 requestId)
             headerInterceptor->clear();
         } else {
             headerInterceptor->setHeaders(
-                QUrl(uri).host(), pendingHeaders);
+                originKey(QUrl(uri)), pendingHeaders);
         }
     }
 

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -7,6 +7,8 @@
 #include <QWebEnginePage>
 #include <QWebEngineProfile>
 #include <QWebEngineSettings>
+#include <QWebEngineUrlRequestInfo>
+#include <QWebEngineUrlRequestInterceptor>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
@@ -16,9 +18,78 @@
 #include <QMovie>
 #include <QBuffer>
 #include <QByteArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QList>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QPair>
 #include <QtGlobal>
 
 #include "view.h"
+
+// Attaches the operator-configured per-asset request headers (#2215) to
+// requests whose host matches the asset's own host. Same-host scoping is
+// the security boundary: a bearer token meant for a private Grafana
+// dashboard must never ride along on the requests that page makes to a
+// third-party CDN, font host, or analytics domain. The main-frame
+// navigation and same-host XHR/subresources (which a dashboard needs to
+// carry the token to render panels) get the headers; everything else is
+// left untouched.
+//
+// interceptRequest may run on a Chromium worker thread (Qt 5 invokes the
+// profile interceptor off the UI thread), while setHeaders/clear are
+// called from the UI thread — so the shared state is guarded by a mutex.
+// No Q_OBJECT: the class adds no signals/slots, so it needs no moc and
+// can live entirely in this translation unit.
+class RequestHeaderInterceptor : public QWebEngineUrlRequestInterceptor
+{
+public:
+    explicit RequestHeaderInterceptor(QObject* parent = nullptr)
+        : QWebEngineUrlRequestInterceptor(parent)
+    {
+    }
+
+    void setHeaders(
+        const QString& host,
+        const QList<QPair<QByteArray, QByteArray>>& headers)
+    {
+        QMutexLocker locker(&m_mutex);
+        m_host = host;
+        m_headers = headers;
+    }
+
+    void clear()
+    {
+        QMutexLocker locker(&m_mutex);
+        m_host.clear();
+        m_headers.clear();
+    }
+
+    void interceptRequest(QWebEngineUrlRequestInfo& info) override
+    {
+        QMutexLocker locker(&m_mutex);
+        if (m_headers.isEmpty() || m_host.isEmpty()) {
+            return;
+        }
+        // Exact host match (case-insensitive, per DNS). Anything on a
+        // different host — including a cross-origin redirect target — is
+        // deliberately excluded so the header can't leak off-site.
+        if (info.requestUrl().host().compare(
+                m_host, Qt::CaseInsensitive) != 0) {
+            return;
+        }
+        for (const auto& header : m_headers) {
+            info.setHttpHeader(header.first, header.second);
+        }
+    }
+
+private:
+    QMutex m_mutex;
+    QString m_host;
+    QList<QPair<QByteArray, QByteArray>> m_headers;
+};
 
 namespace {
 QString getServerHost()
@@ -203,6 +274,14 @@ View::View(QWidget* parent) : QWidget(parent)
         qDebug() << "User-Agent:" << userAgent;
     }
 
+    // Per-asset custom request headers (#2215). Installed on the shared
+    // profile once; the headers themselves are staged per asset by
+    // setRequestHeaders and scoped to the target host in startPageLoad.
+    // ``setUrlRequestInterceptor`` on QWebEngineProfile is available
+    // identically on Qt 5.13+ and Qt 6, so no version macro is needed.
+    headerInterceptor = new RequestHeaderInterceptor(this);
+    profile->setUrlRequestInterceptor(headerInterceptor);
+
     currentWebView = webView1;
     nextWebView = webView2;
     nextWebViewReady = false;
@@ -302,6 +381,36 @@ void View::loadPage(const QString &uri)
     qDebug() << "Loading web page in background web view:" << uri;
 }
 
+void View::setRequestHeaders(const QString &headersJson)
+{
+    // Parse the JSON object the viewer sent into a name/value list. We
+    // don't apply it to the interceptor here — startPageLoad does that
+    // once it knows the target host — because the header set is only
+    // meaningful together with the URL it belongs to. Store it so the
+    // very next loadPage picks it up. An empty / malformed payload
+    // leaves ``pendingHeaders`` empty, which clears any prior headers on
+    // the next load.
+    QList<QPair<QByteArray, QByteArray>> parsed;
+    const QJsonDocument doc = QJsonDocument::fromJson(headersJson.toUtf8());
+    if (doc.isObject()) {
+        const QJsonObject obj = doc.object();
+        for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
+            if (!it.value().isString()) {
+                continue;
+            }
+            const QByteArray name = it.key().toUtf8();
+            if (name.isEmpty()) {
+                continue;
+            }
+            // Brace-init the QPair rather than qMakePair(), which Qt 6
+            // deprecates — keeps the same source building warning-free
+            // on both the Qt 5 and Qt 6 toolchains.
+            parsed.append({name, it.value().toString().toUtf8()});
+        }
+    }
+    pendingHeaders = parsed;
+}
+
 void View::startPageLoad(const QString &uri, quint64 requestId)
 {
     // Drop any prior loadFinished handler before stop() — a synchronous
@@ -317,6 +426,19 @@ void View::startPageLoad(const QString &uri, quint64 requestId)
     nextWebView->stop();
 
     pendingPageUri = uri;
+
+    // Scope the staged headers (#2215) to this URL's host and hand them
+    // to the interceptor before the load fires. An empty ``pendingHeaders``
+    // clears any headers left from a previous asset, so a header-less
+    // page never inherits the prior page's Authorization.
+    if (headerInterceptor) {
+        if (pendingHeaders.isEmpty()) {
+            headerInterceptor->clear();
+        } else {
+            headerInterceptor->setHeaders(
+                QUrl(uri).host(), pendingHeaders);
+        }
+    }
 
     pageLoadConnection = connect(
         nextWebView->page(),

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -30,13 +30,14 @@
 #include "view.h"
 
 // Attaches the operator-configured per-asset request headers (#2215) to
-// requests whose host matches the asset's own host. Same-host scoping is
-// the security boundary: a bearer token meant for a private Grafana
-// dashboard must never ride along on the requests that page makes to a
-// third-party CDN, font host, or analytics domain. The main-frame
-// navigation and same-host XHR/subresources (which a dashboard needs to
-// carry the token to render panels) get the headers; everything else is
-// left untouched.
+// requests whose origin matches the asset's own origin (scheme + host +
+// port; see originKey). Same-origin scoping is the security boundary: a
+// bearer token meant for a private Grafana dashboard must never ride
+// along on the requests that page makes to a third-party CDN, font host,
+// or analytics domain (nor across a scheme downgrade or a different port
+// on the same host). The main-frame navigation and same-origin
+// XHR/subresources (which a dashboard needs to carry the token to render
+// panels) get the headers; everything else is left untouched.
 //
 // interceptRequest may run on a Chromium worker thread (Qt 5 invokes the
 // profile interceptor off the UI thread), while setHeaders/clear are

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -416,31 +416,76 @@ void View::loadPage(const QString &uri)
     qDebug() << "Loading web page in background web view:" << uri;
 }
 
+namespace {
+// Defensive re-validation of the D-Bus header payload. The server side
+// (validate_asset_headers) is the primary gate and the viewer only
+// forwards sanitised headers, but the ``setRequestHeaders`` slot is a
+// trust-no-one boundary (anything on the session bus can call it), so we
+// re-check here rather than put unsafe bytes on the wire — same posture
+// as kMaxReloadIntervalS. Mirrors the server's limits.
+constexpr int kMaxRequestHeaders = 20;
+constexpr int kMaxHeaderNameLen = 256;
+constexpr int kMaxHeaderValueLen = 4096;
+
+// RFC 7230 field-name is 1*tchar.
+bool isValidHeaderName(const QByteArray& name)
+{
+    if (name.isEmpty() || name.size() > kMaxHeaderNameLen) {
+        return false;
+    }
+    for (const char c : name) {
+        const bool tchar =
+            (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9')
+            || QByteArray("!#$%&'*+-.^_`|~").contains(c);
+        if (!tchar) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Reject CR / LF / NUL (header/request splitting) and oversized values.
+bool isValidHeaderValue(const QByteArray& value)
+{
+    if (value.size() > kMaxHeaderValueLen) {
+        return false;
+    }
+    return !value.contains('\r') && !value.contains('\n')
+        && !value.contains('\0');
+}
+}  // namespace
+
 void View::setRequestHeaders(const QString &headersJson)
 {
     // Parse the JSON object the viewer sent into a name/value list. We
     // don't apply it to the interceptor here — startPageLoad does that
-    // once it knows the target host — because the header set is only
+    // once it knows the target origin — because the header set is only
     // meaningful together with the URL it belongs to. Store it so the
     // very next loadPage picks it up. An empty / malformed payload
     // leaves ``pendingHeaders`` empty, which clears any prior headers on
-    // the next load.
+    // the next load. Entries that fail validation are dropped, not
+    // applied.
     QList<QPair<QByteArray, QByteArray>> parsed;
     const QJsonDocument doc = QJsonDocument::fromJson(headersJson.toUtf8());
     if (doc.isObject()) {
         const QJsonObject obj = doc.object();
         for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
+            if (parsed.size() >= kMaxRequestHeaders) {
+                break;
+            }
             if (!it.value().isString()) {
                 continue;
             }
             const QByteArray name = it.key().toUtf8();
-            if (name.isEmpty()) {
+            const QByteArray value = it.value().toString().toUtf8();
+            if (!isValidHeaderName(name) || !isValidHeaderValue(value)) {
                 continue;
             }
             // Brace-init the QPair rather than qMakePair(), which Qt 6
             // deprecates — keeps the same source building warning-free
             // on both the Qt 5 and Qt 6 toolchains.
-            parsed.append({name, it.value().toString().toUtf8()});
+            parsed.append({name, value});
         }
     }
     pendingHeaders = parsed;

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -3,9 +3,12 @@
 #include <QWidget>
 #include <QWebEngineView>
 #include <QAuthenticator>
+#include <QByteArray>
+#include <QList>
 #include <QNetworkAccessManager>
 #include <QImage>
 #include <QMovie>
+#include <QPair>
 #include <QTimer>
 #include <QUrl>
 #include <QVariantMap>
@@ -13,6 +16,13 @@
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include "videoview.h"
 #endif
+
+// Defined in view.cpp. A QWebEngineUrlRequestInterceptor installed on
+// the shared profile that attaches the current webpage asset's custom
+// headers to same-host requests (#2215). Forward-declared so View can
+// hold a pointer without pulling the QtWebEngineCore interceptor headers
+// into every translation unit that includes view.h.
+class RequestHeaderInterceptor;
 
 class View : public QWidget
 {
@@ -25,6 +35,12 @@ public:
     void loadPage(const QString &uri);
     void loadImage(const QString &uri);
     void setReloadInterval(int seconds);
+    // Per-asset custom HTTP request headers (#2215). ``headersJson`` is
+    // a JSON object of ``{name: value}`` string pairs (an empty object
+    // clears them). The viewer calls this right before loadPage so the
+    // interceptor is armed when the navigation fires; the headers are
+    // scoped to the loaded URL's host at load time.
+    void setRequestHeaders(const QString &headersJson);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // Hands the URI + option dict to VideoView (QtMultimedia
     // QMediaPlayer rendering into a QML VideoOutput) and switches
@@ -93,6 +109,15 @@ private:
     // across plays (no pipeline rebuild per asset).
     VideoView* videoView;
 #endif
+
+    // Request interceptor + the headers staged for the next page load
+    // (#2215). ``pendingHeaders`` is set by setRequestHeaders and applied
+    // — together with the loaded URL's host — to ``headerInterceptor`` in
+    // startPageLoad. Only touched on the UI thread; the interceptor's own
+    // copy is mutex-guarded because Chromium may invoke interceptRequest
+    // on a different thread (Qt 5).
+    RequestHeaderInterceptor* headerInterceptor;
+    QList<QPair<QByteArray, QByteArray>> pendingHeaders;
 
     // Dual web view system
     QWebEngineView* webView1;

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -19,7 +19,7 @@
 
 // Defined in view.cpp. A QWebEngineUrlRequestInterceptor installed on
 // the shared profile that attaches the current webpage asset's custom
-// headers to same-host requests (#2215). Forward-declared so View can
+// headers to same-origin requests (#2215). Forward-declared so View can
 // hold a pointer without pulling the QtWebEngineCore interceptor headers
 // into every translation unit that includes view.h.
 class RequestHeaderInterceptor;
@@ -39,7 +39,7 @@ public:
     // a JSON object of ``{name: value}`` string pairs (an empty object
     // clears them). The viewer calls this right before loadPage so the
     // interceptor is armed when the navigation fires; the headers are
-    // scoped to the loaded URL's host at load time.
+    // scoped to the loaded URL's origin (scheme+host+port) at load time.
     void setRequestHeaders(const QString &headersJson);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // Hands the URI + option dict to VideoView (QtMultimedia
@@ -112,8 +112,9 @@ private:
 
     // Request interceptor + the headers staged for the next page load
     // (#2215). ``pendingHeaders`` is set by setRequestHeaders and applied
-    // — together with the loaded URL's host — to ``headerInterceptor`` in
-    // startPageLoad. Only touched on the UI thread; the interceptor's own
+    // — together with the loaded URL's origin (scheme+host+port) — to
+    // ``headerInterceptor`` in startPageLoad. Only touched on the UI
+    // thread; the interceptor's own
     // copy is mutex-guarded because Chromium may invoke interceptRequest
     // on a different thread (Qt 5).
     RequestHeaderInterceptor* headerInterceptor;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,326 +1,41 @@
 """
-Root-level pytest configuration.
+Playwright browser overrides + opt-in marketing capture for the
+integration suite under ``tests/``.
 
-This file enables the unit-test suite to run on a developer's host
-without Docker, without a Redis server, and without the system PyGObject
-stack the viewer service normally requires. Integration tests
-(``-m integration``) opt back into real services by replacing these
-fixtures themselves.
+The shared unit-test isolation (ENVIRONMENT=test, gi/pydbus stubs, the
+fake-Redis wiring) lives in the **repo-root** ``conftest.py`` so it
+applies to every test tree — including ``src/anthias_server/api/tests/``,
+which has no ancestor conftest under ``tests/``. Only the Playwright
+fixtures, which just the ``tests/`` integration suite consumes, remain
+here.
 
-Three concerns are handled here, in order:
+Browser-test failure artifacts are owned by pytest-playwright. The
+``--tracing retain-on-failure --screenshot only-on-failure --output
+test-artifacts`` flags in pyproject.toml's addopts make it write
+``<output>/<test-id>/{trace.zip,test-failed-1.png}`` for failed tests and
+nothing for passing ones. The GH Actions upload-artifact@v7 step in
+test-runner.yml uploads the directory on job failure, where the trace
+replays via ``playwright show-trace``.
 
-1. Force ``ENVIRONMENT=test`` so ``anthias_server.django_project/settings.py`` selects
-   the SQLite test-DB branch (a repo-local path under ``BASE_DIR`` by
-   default; CI overrides via ``ANTHIAS_TEST_DB_PATH``).
-
-2. Stub ``gi`` / ``gi.repository`` / ``pydbus`` in ``sys.modules`` *before*
-   any application module is imported. ``viewer/__init__.py`` does
-   ``import pydbus`` at module load, and ``pydbus`` in turn imports
-   ``gi.repository.Gio`` — which only resolves on hosts with the
-   distribution's ``python3-gi`` package installed and wired into the
-   active interpreter. The stubs let the import succeed; tests that
-   exercise dbus paths mock the relevant calls themselves.
-
-3. Replace ``anthias_common.utils.connect_to_redis`` with a dict-backed
-   ``MagicMock`` factory before any test module imports it, then expose
-   the same fake via an autouse fixture. Several modules call
-   ``r = connect_to_redis()`` at import time
-   (``anthias_server.celery_tasks``, ``anthias_server.lib.github``, ``anthias_server.lib.telemetry``, ...); patching
-   the factory once at conftest load time means the module-level ``r``
-   bindings hold a fake, not a client pointed at host ``redis``.
-
-Browser-test concerns specific to the Playwright integration suite —
-the shared ``browser_context_args`` / ``browser_type_launch_args``
-overrides and the opt-in ``marketing_screenshot`` capture fixture —
-live at the bottom of this file, after the unit-test setup.
+The ``browser_context_args`` viewport (1400×900) matches the existing
+``website/assets/images/overview*.png`` convention exactly, so captures
+slot into the Hugo image-set without rescaling. The
+``marketing_screenshot`` fixture below is opt-in via
+MARKETING_SCREENSHOTS=1: when enabled it bumps the context to 3× device
+scale and saves a ``<name>.png`` plus retina ``<name>@2x.png`` and
+``<name>@3x.png`` siblings under test-artifacts/marketing/ — matching the
+website's existing overview*.png naming. Default integration runs stay at
+1× and the fixture is a no-op so call sites in test bodies don't need to
+branch.
 """
 
-import importlib.util
 import os
-import sys
-import types
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
-
-# ---------------------------------------------------------------------------
-# 1. ENVIRONMENT=test (settings.py reads this at import time)
-# ---------------------------------------------------------------------------
-
-os.environ.setdefault('ENVIRONMENT', 'test')
-
-
-# ---------------------------------------------------------------------------
-# 2. Stub gi / gi.repository / pydbus before viewer modules are loaded
-# ---------------------------------------------------------------------------
-
-
-def _install_dbus_stubs() -> None:
-    """
-    Insert stand-in modules so ``import pydbus`` (and its transitive
-    ``from gi.repository import Gio, GLib, GObject``) succeeds on
-    hosts that don't have the full PyGObject + pydbus stack.
-
-    Three host shapes show up in the wild:
-
-    1. Both ``gi`` and ``pydbus`` available (target image): no-op.
-    2. ``gi`` missing entirely (typical dev laptop without
-       ``python3-gi`` apt package): stub both, because the real
-       pydbus's module-load does ``from gi.repository import
-       GLib, GObject`` and our minimal gi stub can't satisfy that.
-    3. ``gi`` present but ``pydbus`` not pip-installed: stub only
-       pydbus.
-    """
-    gi_missing = importlib.util.find_spec('gi') is None
-    pydbus_missing = importlib.util.find_spec('pydbus') is None
-
-    if gi_missing:
-        gi_module = types.ModuleType('gi')
-        gi_repository = types.ModuleType('gi.repository')
-        # MagicMock for the GLib/Gio/GObject surface — pydbus only
-        # touches these when a bus is actually constructed (e.g.
-        # ``pydbus.SessionBus()`` inside a function body); tests that
-        # hit those paths mock them themselves.
-        setattr(gi_repository, 'Gio', MagicMock(name='gi.repository.Gio'))
-        setattr(gi_repository, 'GLib', MagicMock(name='gi.repository.GLib'))
-        setattr(
-            gi_repository, 'GObject', MagicMock(name='gi.repository.GObject')
-        )
-        setattr(gi_module, 'repository', gi_repository)
-        sys.modules['gi'] = gi_module
-        sys.modules['gi.repository'] = gi_repository
-
-    if pydbus_missing or gi_missing:
-        pydbus_module = types.ModuleType('pydbus')
-        setattr(
-            pydbus_module, 'SessionBus', MagicMock(name='pydbus.SessionBus')
-        )
-        setattr(pydbus_module, 'SystemBus', MagicMock(name='pydbus.SystemBus'))
-        sys.modules['pydbus'] = pydbus_module
-
-
-_install_dbus_stubs()
-
-
-# ---------------------------------------------------------------------------
-# 3. Defensive Redis mock — replace connect_to_redis() everywhere
-# ---------------------------------------------------------------------------
-
-
-def _make_fake_redis() -> MagicMock:
-    """
-    A dict-backed Redis mock matching the surface our code uses.
-
-    String ops (get/set/delete/expire/exists/flushdb/publish) and list
-    ops (rpush/lpop/blpop) are modelled on the real Redis semantics so
-    test paths that exercise both — notably ``ReplyCollector.recv_json``
-    via BLPOP — see realistic behaviour rather than no-ops.
-    """
-    store: dict[str, Any] = {}
-
-    fake = MagicMock(name='FakeRedis')
-    fake.get.side_effect = store.get
-
-    def _set(
-        key: str,
-        value: Any,
-        *,
-        nx: bool = False,
-        ex: int | None = None,
-        **_: Any,
-    ) -> bool | None:
-        # Match real Redis ``SET ... NX``: succeeds only if the key is
-        # not already present, returns True on success / None on no-op.
-        # Tests for SETNX-based gates (per-asset recheck cooldown,
-        # sweep singleton lock, splash IP-refresh debounce) rely on
-        # this — without it, every "is the lock held?" check would
-        # spuriously believe the lock was free.
-        if nx and key in store:
-            return None
-        store[key] = value
-        return True
-
-    fake.set.side_effect = _set
-    fake.delete.side_effect = lambda *keys: sum(
-        1 for k in keys if store.pop(k, None) is not None
-    )
-    fake.expire.side_effect = lambda key, _ttl: bool(key in store)
-    fake.exists.side_effect = lambda *keys: sum(1 for k in keys if k in store)
-    fake.flushdb.side_effect = lambda: store.clear()
-    fake.publish.side_effect = lambda channel, msg: 0
-
-    def _eval(script: str, numkeys: int, *args: Any) -> Any:
-        # Compare-and-delete is the only ``EVAL`` script in the
-        # codebase (sweep lock release in anthias_server.celery_tasks.py). Implement
-        # that pattern directly; any other script becomes a no-op.
-        if "redis.call('get', KEYS[1])" in script and "'del'" in script:
-            keys = list(args[:numkeys])
-            argv = list(args[numkeys:])
-            if keys and argv and store.get(keys[0]) == argv[0]:
-                store.pop(keys[0], None)
-                return 1
-            return 0
-        return None
-
-    fake.eval.side_effect = _eval
-
-    def _rpush(key: str, *values: Any) -> int:
-        bucket = store.setdefault(key, [])
-        bucket.extend(values)
-        return len(bucket)
-
-    def _lpop(key: str) -> Any:
-        bucket = store.get(key)
-        if not bucket:
-            return None
-        value = bucket.pop(0)
-        if not bucket:
-            store.pop(key, None)
-        return value
-
-    def _blpop(keys: Any, timeout: float | None = None) -> Any:
-        # Real BLPOP blocks until a value is available or the timeout
-        # expires. Tests don't drive a writer thread, so block-then-
-        # poll behaviour collapses to "return immediately": yield the
-        # first available value, or None if every key is empty.
-        if isinstance(keys, (str, bytes)):
-            keys = [keys]
-        for key in keys:
-            value = _lpop(key)
-            if value is not None:
-                return (key, value)
-        return None
-
-    fake.rpush.side_effect = _rpush
-    fake.lpop.side_effect = _lpop
-    fake.blpop.side_effect = _blpop
-    return fake
-
-
-# Patch ``connect_to_redis`` at the source so the module-level
-# ``r = connect_to_redis()`` bindings in anthias_server.celery_tasks / anthias_server.lib.github /
-# anthias_server.lib.telemetry / api.views.mixins / viewer / etc. all resolve to the
-# fake the moment those modules are first imported.
-_SESSION_FAKE_REDIS = _make_fake_redis()
-
-
-def _patch_connect_to_redis() -> None:
-    import anthias_common.utils as _lib_utils
-
-    _lib_utils.connect_to_redis = lambda: _SESSION_FAKE_REDIS
-
-
-_patch_connect_to_redis()
-
-
-@pytest.fixture(scope='session', autouse=True)
-def _ensure_assetdir() -> None:
-    """
-    Some legacy fixtures (e.g. ``api/tests/test_v1_endpoints.py::
-    cleanup_asset_dir``) iterate ``settings['assetdir']`` during
-    teardown without creating it first. The Docker test image creates
-    ``/data/anthias_assets`` in its build (see
-    ``docker/Dockerfile.test.j2``); local hosts have no such guarantee.
-    Materialise the path once per session so those fixtures don't
-    ``FileNotFoundError`` out before the test even runs.
-    """
-    from anthias_server.settings import settings as _anthias_settings
-
-    asset_dir = _anthias_settings.get('assetdir')
-    if asset_dir:
-        os.makedirs(asset_dir, exist_ok=True)
-
-
-# Browser-test failure artifacts are owned by pytest-playwright. The
-# `--tracing retain-on-failure --screenshot only-on-failure
-# --output test-artifacts` flags in pyproject.toml's addopts make it
-# write `<output>/<test-id>/{trace.zip,test-failed-1.png}` for failed
-# tests and nothing for passing ones. The GH Actions
-# upload-artifact@v7 step in test-runner.yml uploads the directory on
-# job failure, where the trace replays via `playwright show-trace`.
-
-
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
-    """Set ``DJANGO_ALLOW_ASYNC_UNSAFE=1`` only when the run actually
-    contains integration tests.
-
-    Playwright's sync API spins up an internal asyncio loop to talk
-    to the browser over the CDP socket; Django's ORM detects that
-    loop and refuses sync calls (``SynchronousOnlyOperation``) unless
-    this flag is set. The single-threaded test process never invokes
-    ORM and Playwright concurrently, so the safety net Django enforces
-    isn't doing useful work for this suite.
-
-    Setting it process-wide unconditionally would also disable the
-    safety net for unit tests, where an accidental ORM call from
-    inside an event loop is a real bug we want Django to flag. Hooking
-    at collection time means a unit-only run (``pytest -m "not
-    integration"``) leaves the variable unset and the check active;
-    a run that includes integration tests sets it once before
-    pytest-django's DB setup (which would otherwise hit the same
-    check itself).
-    """
-    if any('integration' in item.keywords for item in items):
-        os.environ['DJANGO_ALLOW_ASYNC_UNSAFE'] = '1'
-
-
-@pytest.fixture(autouse=True)
-def _mock_redis(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
-    """
-    Replace ``anthias_common.utils.connect_to_redis`` with a dict-backed
-    ``MagicMock`` for every test, including any module-level
-    ``r = connect_to_redis()`` bindings that fixtures import indirectly.
-
-    Tests that need their own Redis mock (e.g. ``tests/test_telemetry.py``,
-    ``tests/test_messaging.py``) override this by patching ``module.r``
-    directly — that takes precedence inside the per-test setup chain.
-    """
-    fake = _make_fake_redis()
-    monkeypatch.setattr('anthias_common.utils.connect_to_redis', lambda: fake)
-
-    # Replace already-bound ``r`` attributes on modules that called
-    # connect_to_redis() at import time. Only modules already in
-    # sys.modules are touched — others get the fake on first import via
-    # the conftest-level patch above.
-    for module_path in (
-        'anthias_server.app.views',
-        'anthias_server.api.views.mixins',
-        'anthias_server.api.views.v2',
-        'anthias_server.celery_tasks',
-        'anthias_server.lib.github',
-        'anthias_server.lib.telemetry',
-        'anthias_viewer',
-    ):
-        mod = sys.modules.get(module_path)
-        if mod is not None and hasattr(mod, 'r'):
-            monkeypatch.setattr(f'{module_path}.r', fake)
-
-    yield fake
-
-
-# ---------------------------------------------------------------------------
-# 4. Playwright browser overrides + opt-in marketing capture
-# ---------------------------------------------------------------------------
-#
-# Consolidates the ``browser_context_args`` / ``browser_type_launch_args``
-# overrides that test_app.py and test_migrate_to_screenly.py previously
-# duplicated. The viewport (1400×900) matches the existing
-# website/assets/images/overview*.png convention exactly, so captures
-# slot into the Hugo image-set without rescaling.
-#
-# The ``marketing_screenshot`` fixture below is opt-in via
-# MARKETING_SCREENSHOTS=1: when enabled it bumps the context to 3×
-# device scale and saves a ``<name>.png`` plus retina ``<name>@2x.png``
-# and ``<name>@3x.png`` siblings under test-artifacts/marketing/ —
-# matching the website's existing overview*.png naming. Default
-# integration runs stay at 1× and the fixture is a no-op so call sites
-# in test bodies don't need to branch.
 
 _MARKETING_ENABLED = os.environ.get('MARKETING_SCREENSHOTS') == '1'
 _MARKETING_SCALE = 3

--- a/tests/test_asset_headers.py
+++ b/tests/test_asset_headers.py
@@ -1,0 +1,113 @@
+"""Unit tests for the per-asset custom-header helpers (feature #2215).
+
+These cover the pure ``metadata['headers']`` sanitisers in
+``anthias_server.app.models`` in isolation — no DB, no HTTP — so the
+name/value rules that keep CR/LF off the wire are pinned independently of
+the serializer and form layers that call them.
+"""
+
+import pytest
+
+from anthias_server.app.models import (
+    MAX_ASSET_HEADERS,
+    normalize_asset_headers,
+    parse_header_lines,
+    validate_asset_headers,
+)
+
+
+class TestNormalizeAssetHeaders:
+    def test_passes_valid_headers_through(self) -> None:
+        headers = {'Authorization': 'Bearer abc', 'X-Env': 'prod'}
+        assert normalize_asset_headers(headers) == headers
+
+    @pytest.mark.parametrize(
+        'value',
+        [None, 'not-a-dict', 42, [], ('a', 'b')],
+    )
+    def test_non_dict_becomes_empty(self, value: object) -> None:
+        assert normalize_asset_headers(value) == {}
+
+    def test_drops_crlf_values(self) -> None:
+        result = normalize_asset_headers(
+            {'Good': 'ok', 'Bad': 'a\r\nEvil: 1', 'Also': 'b\nc'}
+        )
+        assert result == {'Good': 'ok'}
+
+    def test_drops_null_byte_values(self) -> None:
+        assert normalize_asset_headers({'X': 'a\x00b'}) == {}
+
+    def test_drops_non_token_names(self) -> None:
+        result = normalize_asset_headers(
+            {'sp ace': 'v', 'co:lon': 'v', '': 'v', 'Ok': 'v'}
+        )
+        assert result == {'Ok': 'v'}
+
+    def test_drops_non_string_entries(self) -> None:
+        assert normalize_asset_headers({'X': 1, 2: 'v', 'Y': 'ok'}) == {
+            'Y': 'ok'
+        }
+
+    def test_strips_whitespace_around_name(self) -> None:
+        assert normalize_asset_headers({'  X-Env  ': 'prod'}) == {
+            'X-Env': 'prod'
+        }
+
+    def test_caps_at_max(self) -> None:
+        result = normalize_asset_headers(
+            {f'X-H{i}': 'v' for i in range(MAX_ASSET_HEADERS + 5)}
+        )
+        assert len(result) == MAX_ASSET_HEADERS
+
+
+class TestValidateAssetHeaders:
+    def test_returns_clean_dict(self) -> None:
+        headers = {'Authorization': 'Bearer x'}
+        assert validate_asset_headers(headers) == headers
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            {'Bad Name': 'v'},
+            {'X': 'a\r\nb'},
+            {'': 'v'},
+            {'X:': 'v'},
+            {'X': 1},
+            'not-a-dict',
+        ],
+    )
+    def test_raises_on_malformed(self, value: object) -> None:
+        with pytest.raises(ValueError):
+            validate_asset_headers(value)
+
+    def test_raises_over_count_cap(self) -> None:
+        with pytest.raises(ValueError):
+            validate_asset_headers(
+                {f'X-H{i}': 'v' for i in range(MAX_ASSET_HEADERS + 1)}
+            )
+
+
+class TestParseHeaderLines:
+    def test_parses_name_value_lines(self) -> None:
+        text = 'Authorization: Bearer abc\nX-Env: prod'
+        assert parse_header_lines(text) == {
+            'Authorization': 'Bearer abc',
+            'X-Env': 'prod',
+        }
+
+    def test_ignores_blank_and_colonless_lines(self) -> None:
+        text = '\n\nAuthorization: x\njust-a-comment\n\n'
+        assert parse_header_lines(text) == {'Authorization': 'x'}
+
+    def test_value_keeps_later_colons(self) -> None:
+        assert parse_header_lines('X-Range: bytes=0-1:2') == {
+            'X-Range': 'bytes=0-1:2'
+        }
+
+    def test_drops_malformed_lines(self) -> None:
+        # A CRLF can't survive splitlines(), but a bad name still drops.
+        assert parse_header_lines('bad name: v\nOk: v') == {'Ok': 'v'}
+
+    @pytest.mark.parametrize('value', [None, 42, []])
+    def test_non_string_becomes_empty(self, value: object) -> None:
+        assert parse_header_lines(value) == {}

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -678,44 +678,48 @@ def test_view_webpage_setrequestheaders_version_skew_latches_off(
         fake_bus.setRequestHeaders.assert_called_once()
 
 
-def test_view_webpage_transient_header_failure_forces_reload_next_tick(
+def test_view_webpage_transient_header_failure_defers_navigation(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:
     """A *transient* setRequestHeaders failure (not UnknownMethod) must
-    not be cached as applied: ``current_browser_headers`` stays stale so
-    the next asset_loop tick re-issues loadPage + setRequestHeaders.
-    Otherwise a single-asset playlist whose URL never changes would keep
-    hitting the unchanged-URL short-circuit and the headers would never
-    reach the page. Regression guard for the webview-cold-boot race seen
-    on real hardware (#2215)."""
+    DEFER loadPage entirely. The C++ side still holds the previous
+    asset's staged headers, so navigating now would scope those stale
+    headers to the new asset's origin — a cross-asset credential leak.
+    The URL/header cache is left stale so the next tick retries once the
+    D-Bus call succeeds. Regression guard (#2215, Copilot review)."""
     fake_bus = mock.Mock()
     fake_bus.setRequestHeaders.side_effect = Exception(
         'org.freedesktop.DBus.Error.NoReply: bus busy'
     )
     fake_browser = mock.Mock()
     fake_browser.is_alive.return_value = True
-    url = 'https://example.com'
+    # Transitioning from a prior asset (different origin) to this one.
+    prev_url = 'https://prev.example.com'
 
     with (
         mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
         mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
-        mock.patch.object(viewer_fixtures.u, 'current_browser_url', url),
-        mock.patch.object(viewer_fixtures.u, 'current_browser_headers', {}),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', prev_url),
+        mock.patch.object(
+            viewer_fixtures.u, 'current_browser_headers', {'Old': '1'}
+        ),
         mock.patch.object(
             viewer_fixtures.u,
             '_webview_supports_set_request_headers',
             True,
         ),
     ):
-        # URL unchanged from the previous tick, only the headers differ.
-        viewer_fixtures.u.view_webpage(url, headers={'X': '1'})
+        viewer_fixtures.u.view_webpage(
+            'https://new.example.com', headers={'X': '1'}
+        )
 
         # Transient failure did not latch the capability off (retryable).
         assert viewer_fixtures.u._webview_supports_set_request_headers is True
-        # loadPage was re-issued because headers differed from the stale
-        # cache, and the cache was NOT advanced to the new headers.
-        fake_bus.loadPage.assert_called_once_with(url)
-        assert viewer_fixtures.u.current_browser_headers == {}
+        # Navigation is deferred: no loadPage, and the cache stays on the
+        # previous asset so the next tick retries.
+        fake_bus.loadPage.assert_not_called()
+        assert viewer_fixtures.u.current_browser_url == prev_url
+        assert viewer_fixtures.u.current_browser_headers == {'Old': '1'}
 
 
 def test_view_webpage_nocache_busts_url(

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -543,6 +543,141 @@ def test_view_webpage_default_zero_interval(
     fake_bus.setReloadInterval.assert_called_once_with(0)
 
 
+def test_view_webpage_sends_custom_headers(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """``view_webpage`` pushes the asset's custom headers to the webview
+    as a JSON string via ``setRequestHeaders`` before ``loadPage``, so
+    the C++ interceptor is armed when the navigation fires (#2215)."""
+    import json
+
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+    headers = {'Authorization': 'Bearer abc'}
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_headers', {}),
+    ):
+        viewer_fixtures.u.view_webpage('https://example.com', headers=headers)
+
+    fake_bus.setRequestHeaders.assert_called_once_with(json.dumps(headers))
+    fake_bus.loadPage.assert_called_once_with('https://example.com')
+
+
+def test_view_webpage_no_headers_sends_empty_object(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """A header-less webpage still calls ``setRequestHeaders('{}')`` so
+    the webview clears any headers left by a previous asset."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_headers', {}),
+    ):
+        viewer_fixtures.u.view_webpage('https://example.com')
+
+    fake_bus.setRequestHeaders.assert_called_once_with('{}')
+
+
+def test_view_webpage_reloads_when_only_headers_change(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """An edit that changes the headers but not the URL must still
+    re-issue ``loadPage`` so the new headers reach the main document,
+    not just later same-host XHR."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+    url = 'https://example.com'
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', url),
+        mock.patch.object(
+            viewer_fixtures.u, 'current_browser_headers', {'X-Old': '1'}
+        ),
+    ):
+        viewer_fixtures.u.view_webpage(url, headers={'X-New': '2'})
+
+    fake_bus.loadPage.assert_called_once_with(url)
+
+
+def test_view_webpage_no_reload_when_url_and_headers_unchanged(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """The unchanged-URL short-circuit still holds when the headers are
+    also unchanged: no ``loadPage``, but ``setRequestHeaders`` is still
+    (idempotently) sent."""
+    fake_bus = mock.Mock()
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+    url = 'https://example.com'
+    headers = {'X-Same': '1'}
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', url),
+        mock.patch.object(
+            viewer_fixtures.u, 'current_browser_headers', dict(headers)
+        ),
+    ):
+        viewer_fixtures.u.view_webpage(url, headers=headers)
+
+    fake_bus.loadPage.assert_not_called()
+    fake_bus.setRequestHeaders.assert_called_once()
+
+
+def test_view_webpage_setrequestheaders_version_skew_latches_off(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """An older AnthiasViewer without the ``setRequestHeaders`` slot
+    raises UnknownMethod; the capability latches off so we stop calling
+    it, and the asset still loads (no screen-down)."""
+    fake_bus = mock.Mock()
+    fake_bus.setRequestHeaders.side_effect = Exception(
+        'org.freedesktop.DBus.Error.UnknownMethod: no such method'
+    )
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', None),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_headers', {}),
+        mock.patch.object(
+            viewer_fixtures.u,
+            '_webview_supports_set_request_headers',
+            True,
+        ),
+    ):
+        viewer_fixtures.u.view_webpage(
+            'https://example.com', headers={'X': '1'}
+        )
+        # First call attempted the slot, hit UnknownMethod, latched off.
+        assert viewer_fixtures.u._webview_supports_set_request_headers is False
+        fake_bus.setRequestHeaders.assert_called_once()
+        # Page still loaded despite the missing slot.
+        fake_bus.loadPage.assert_called_once_with('https://example.com')
+
+        # A second webpage tick no longer calls the slot at all.
+        viewer_fixtures.u.view_webpage(
+            'https://example.org', headers={'X': '2'}
+        )
+        fake_bus.setRequestHeaders.assert_called_once()
+
+
 def test_view_webpage_nocache_busts_url(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -678,6 +678,46 @@ def test_view_webpage_setrequestheaders_version_skew_latches_off(
         fake_bus.setRequestHeaders.assert_called_once()
 
 
+def test_view_webpage_transient_header_failure_forces_reload_next_tick(
+    viewer_fixtures: _ViewerFixtures,
+) -> None:
+    """A *transient* setRequestHeaders failure (not UnknownMethod) must
+    not be cached as applied: ``current_browser_headers`` stays stale so
+    the next asset_loop tick re-issues loadPage + setRequestHeaders.
+    Otherwise a single-asset playlist whose URL never changes would keep
+    hitting the unchanged-URL short-circuit and the headers would never
+    reach the page. Regression guard for the webview-cold-boot race seen
+    on real hardware (#2215)."""
+    fake_bus = mock.Mock()
+    fake_bus.setRequestHeaders.side_effect = Exception(
+        'org.freedesktop.DBus.Error.NoReply: bus busy'
+    )
+    fake_browser = mock.Mock()
+    fake_browser.is_alive.return_value = True
+    url = 'https://example.com'
+
+    with (
+        mock.patch.object(viewer_fixtures.u, 'browser_bus', fake_bus),
+        mock.patch.object(viewer_fixtures.u, 'browser', fake_browser),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_url', url),
+        mock.patch.object(viewer_fixtures.u, 'current_browser_headers', {}),
+        mock.patch.object(
+            viewer_fixtures.u,
+            '_webview_supports_set_request_headers',
+            True,
+        ),
+    ):
+        # URL unchanged from the previous tick, only the headers differ.
+        viewer_fixtures.u.view_webpage(url, headers={'X': '1'})
+
+        # Transient failure did not latch the capability off (retryable).
+        assert viewer_fixtures.u._webview_supports_set_request_headers is True
+        # loadPage was re-issued because headers differed from the stale
+        # cache, and the cache was NOT advanced to the new headers.
+        fake_bus.loadPage.assert_called_once_with(url)
+        assert viewer_fixtures.u.current_browser_headers == {}
+
+
 def test_view_webpage_nocache_busts_url(
     viewer_fixtures: _ViewerFixtures,
 ) -> None:


### PR DESCRIPTION
## What & why

Resolves the feature request for saving and sending custom HTTP headers on web (webpage) assets — for example an `Authorization` header carrying a Grafana service-account token, so a private dashboard renders on screen without having to be made public.

Adds a **per-asset setting** whose headers are injected into QtWebEngine when the asset is displayed. It works on **both Qt5 (Pi 1–3) and Qt6 (Pi 5 / x86)** through a single, non-version-gated code path.

## How it works

Headers are stored in `Asset.metadata['headers']` as a `{name: value}` object (no schema migration — mirrors the existing `refresh_interval_s` feature end to end). A `QWebEngineUrlRequestInterceptor` installed on the shared profile attaches them at request time, **scoped to the asset's own host** so a bearer token is never sent to a third-party CDN/analytics/font domain the page also talks to — while same-host XHR (which a dashboard needs to render its panels) still carries it.

The chain:

- **Model** (`app/models.py`) — `normalize_asset_headers` / `validate_asset_headers` / `parse_header_lines`. Header names must be RFC 7230 tokens; CR/LF/NUL are rejected in values to prevent header/response splitting; count and length are capped.
- **v2 API** (`api/serializers/v2.py`) — `custom_headers` as a read field (SerializerMethodField) and a strict write field on create/update, folded into `metadata['headers']` (400 on malformed input).
- **Edit modal** (`_asset_modal.html`, `views.py`, `asset_filters.py`, `home.ts`) — a webpage-only "Custom HTTP headers" textarea, one `Name: Value` per line, parsed and clamped server-side (the form forgives; the API 400s).
- **Viewer** (`anthias_viewer/__init__.py`) — `view_webpage(headers=...)` sends the headers as JSON over a new `setRequestHeaders` D-Bus slot, version-skew-latched exactly like `setReloadInterval`; a header-only edit still forces a reload.
- **C++ webview** (`anthias_webview/src/*`) — `RequestHeaderInterceptor` (mutex-guarded, since Chromium may call it off the UI thread on Qt5), wired through `View` / `MainWindow`.

## Testing

- Full non-integration suite: **1421 passed**, 0 failed. `ruff check` + `ruff format --check` clean.
- New tests: header-helper unit tests, v2 API round-trip / rejection / CRLF / count-cap tests, and viewer D-Bus tests (send, empty-clears, reload-on-header-change, version-skew latch).
- The C++ isn't compiled on the dev host (no Qt WebEngine dev headers there); it builds in the webview Docker image.

### Incidental fix: host-only test isolation

Running `pytest src/anthias_server/api/tests/` **in isolation** produced 12 spurious 500s. The shared redis/dbus/env test isolation lived only in `tests/conftest.py`, which pytest never loads for the API test tree (no common ancestor), and `ViewerPublisher` / `ReplyCollector` are unreset singletons that leak a real redis client across tests. CI masked this because the `redis` service resolves there. Fixed by moving the shared isolation into a **root `conftest.py`** (both trees inherit it) and seeding those singletons with the per-test fake. Isolated API run: 12-failed/56s → **96-passed/5.8s**; full suite unchanged.

## Follow-up

- [x] Real-device E2E on Qt5 and Qt6 testbeds — **Qt6: full end-to-end pass on x86** (header injected through the integrated stack). **Qt5: compiled under Qt 5.15 and the interceptor is installed/driven at runtime on the armhf binary**; the render-level hop can't run on the current 64-bit-KMS test fleet (armhf Qt5 needs the legacy 32-bit dispmanx GL stack), so a render pass on a 32-bit-Raspbian Pi is still recommended pre-release. See validation comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
