### PR TITLE
feat(settings): add userspace timezone selection and a device clock

### DIFF
--- a/ansible/roles/anthias/files/anthias.conf
+++ b/ansible/roles/anthias/files/anthias.conf
@@ -4,6 +4,11 @@ configdir = .anthias
 database = .anthias/anthias.db
 use_ssl = False
 
+; IANA timezone used for scheduling and time display (e.g.
+; Europe/London). Empty follows the host / the TZ env var / UTC.
+; Set it from the Settings page rather than by hand.
+timezone =
+
 ; Opt-out from analytics
 analytics_opt_out = False
 

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -367,7 +367,7 @@ class UpdateDeviceSettingsSerializerV2(Serializer[Any]):
         value = (value or '').strip()
         if value and not is_valid_time_zone(value):
             raise serializers.ValidationError(
-                f'Unknown or unavailable timezone: {value!r}.'
+                f'Unknown or unavailable timezone: {value}.'
             )
         return value
 

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -336,10 +336,10 @@ class UpdateDeviceSettingsSerializerV2(Serializer[Any]):
         required=False, min_value=0, max_value=DURATION_S_MAX
     )
     date_format = CharField(required=False)
-    # Blank = "follow the host" (resolve_time_zone precedence). A
-    # non-blank value must be a zone Django will accept, validated the
-    # same way as the host zone so a save can never land a value that
-    # crash-loops the settings module on the next read.
+    # Blank defers to resolve_time_zone() (TZ env -> /etc/timezone ->
+    # UTC). A non-blank value must be a zone Django will accept,
+    # validated the same way as the host zone so a save can never land a
+    # value that crash-loops the settings module on the next read.
     timezone = CharField(required=False, allow_blank=True)
     show_splash = BooleanField(required=False)
     default_assets = BooleanField(required=False)

--- a/src/anthias_server/api/serializers/v2.py
+++ b/src/anthias_server/api/serializers/v2.py
@@ -18,6 +18,7 @@ from rest_framework.serializers import (
 )
 
 from anthias_common.utils import SCREEN_ROTATION_CHOICES
+from anthias_server.django_project.settings import is_valid_time_zone
 from anthias_server.app.models import (
     Asset,
     DURATION_S_MAX,
@@ -306,6 +307,7 @@ class DeviceSettingsSerializerV2(Serializer[Any]):
     default_duration = IntegerField()
     default_streaming_duration = IntegerField()
     date_format = CharField()
+    timezone = CharField(allow_blank=True)
     auth_backend = CharField()
     show_splash = BooleanField()
     default_assets = BooleanField()
@@ -334,6 +336,11 @@ class UpdateDeviceSettingsSerializerV2(Serializer[Any]):
         required=False, min_value=0, max_value=DURATION_S_MAX
     )
     date_format = CharField(required=False)
+    # Blank = "follow the host" (resolve_time_zone precedence). A
+    # non-blank value must be a zone Django will accept, validated the
+    # same way as the host zone so a save can never land a value that
+    # crash-loops the settings module on the next read.
+    timezone = CharField(required=False, allow_blank=True)
     show_splash = BooleanField(required=False)
     default_assets = BooleanField(required=False)
     shuffle_playlist = BooleanField(required=False)
@@ -355,6 +362,14 @@ class UpdateDeviceSettingsSerializerV2(Serializer[Any]):
         ],
     )
     current_password = CharField(required=False, allow_blank=True)
+
+    def validate_timezone(self, value: str) -> str:
+        value = (value or '').strip()
+        if value and not is_valid_time_zone(value):
+            raise serializers.ValidationError(
+                f'Unknown or unavailable timezone: {value!r}.'
+            )
+        return value
 
 
 class ViewerPlaylistSerializerV2(Serializer[Any]):

--- a/src/anthias_server/api/tests/test_v2_endpoints.py
+++ b/src/anthias_server/api/tests/test_v2_endpoints.py
@@ -40,6 +40,7 @@ def test_get_device_settings(
         'default_duration': '15',
         'default_streaming_duration': '100',
         'date_format': 'YYYY-MM-DD',
+        'timezone': 'Europe/Stockholm',
         'auth_backend': '',
         'show_splash': True,
         'default_assets': [],
@@ -60,6 +61,7 @@ def test_get_device_settings(
         'default_duration': 15,
         'default_streaming_duration': 100,
         'date_format': 'YYYY-MM-DD',
+        'timezone': 'Europe/Stockholm',
         'auth_backend': '',
         'show_splash': True,
         'default_assets': [],
@@ -185,6 +187,84 @@ def test_patch_device_settings_validation_error(
 @pytest.mark.django_db
 @mock.patch('anthias_server.api.views.v2.settings')
 @mock.patch('anthias_server.api.views.v2.ViewerPublisher')
+def test_patch_device_settings_timezone_success(
+    publisher_mock: Any,
+    settings_mock: Any,
+    api_client: APIClient,
+    device_settings_url: str,
+) -> None:
+    """A valid IANA zone is persisted and the viewer is told to reload
+    (so the schedule re-evaluates in the new local time)."""
+    settings_mock.load = mock.MagicMock()
+    settings_mock.save = mock.MagicMock()
+    settings_mock.__getitem__.side_effect = lambda key: {
+        'auth_backend': '',
+    }[key]
+    settings_mock.__setitem__ = mock.MagicMock()
+
+    publisher_instance = mock.MagicMock()
+    publisher_mock.get_instance.return_value = publisher_instance
+
+    response = api_client.patch(
+        device_settings_url,
+        data={'timezone': 'Europe/Stockholm'},
+        format='json',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    settings_mock.save.assert_called_once()
+    settings_mock.__setitem__.assert_any_call('timezone', 'Europe/Stockholm')
+    publisher_instance.send_to_viewer.assert_called_once_with('reload')
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v2.settings')
+def test_patch_device_settings_invalid_timezone(
+    settings_mock: Any, api_client: APIClient, device_settings_url: str
+) -> None:
+    """An unknown zone is rejected before anything is written, so a bad
+    value can never reach the settings module and crash-loop it."""
+    response = api_client.patch(
+        device_settings_url,
+        data={'timezone': 'Mars/Phobos'},
+        format='json',
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'timezone' in response.data
+    settings_mock.load.assert_not_called()
+    settings_mock.save.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v2.settings')
+@mock.patch('anthias_server.api.views.v2.ViewerPublisher')
+def test_patch_device_settings_blank_timezone_allowed(
+    publisher_mock: Any,
+    settings_mock: Any,
+    api_client: APIClient,
+    device_settings_url: str,
+) -> None:
+    """Blank = "follow the host"; it must validate and persist."""
+    settings_mock.load = mock.MagicMock()
+    settings_mock.save = mock.MagicMock()
+    settings_mock.__getitem__.side_effect = lambda key: {'auth_backend': ''}[
+        key
+    ]
+    settings_mock.__setitem__ = mock.MagicMock()
+    publisher_mock.get_instance.return_value = mock.MagicMock()
+
+    response = api_client.patch(
+        device_settings_url, data={'timezone': ''}, format='json'
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    settings_mock.__setitem__.assert_any_call('timezone', '')
+
+
+@pytest.mark.django_db
+@mock.patch('anthias_server.api.views.v2.settings')
+@mock.patch('anthias_server.api.views.v2.ViewerPublisher')
 def test_enable_basic_auth(
     publisher_mock: Any,
     settings_mock: Any,
@@ -275,6 +355,7 @@ def test_disable_basic_auth(
         'default_duration': '15',
         'default_streaming_duration': '100',
         'date_format': 'YYYY-MM-DD',
+        'timezone': '',
         'show_splash': True,
         'default_assets': [],
         'shuffle_playlist': False,

--- a/src/anthias_server/api/tests/test_v2_endpoints.py
+++ b/src/anthias_server/api/tests/test_v2_endpoints.py
@@ -245,7 +245,8 @@ def test_patch_device_settings_blank_timezone_allowed(
     api_client: APIClient,
     device_settings_url: str,
 ) -> None:
-    """Blank = "follow the host"; it must validate and persist."""
+    """Blank defers to the resolved default; it must validate and
+    persist."""
     settings_mock.load = mock.MagicMock()
     settings_mock.save = mock.MagicMock()
     settings_mock.__getitem__.side_effect = lambda key: {'auth_backend': ''}[

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -915,7 +915,9 @@ class InfoViewV2(InfoViewMixin):
             else 'UTC'
         )
         return {
-            'iso': now_local.isoformat(),
+            # Seconds precision (drop microseconds) to match the System
+            # Info clock seed and stay parseable by any JS Date.parse().
+            'iso': now_local.isoformat(timespec='seconds'),
             'timezone': timezone.get_current_timezone_name(),
             'offset': offset,
         }

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -75,6 +75,7 @@ from anthias_common import device_helper
 from anthias_server.lib import diagnostics
 from anthias_server.lib.auth import authorized
 from anthias_server.lib.github import is_up_to_date
+from anthias_server.lib.timezone import format_utc_offset
 from anthias_common.utils import (
     clamp_screen_rotation,
     connect_to_redis,
@@ -908,18 +909,12 @@ class InfoViewV2(InfoViewMixin):
         # reflect it. Lets an external client detect a wrong device
         # clock or an unexpected zone (issue #1755).
         now_local = timezone.localtime(timezone.now())
-        raw_offset = now_local.strftime('%z')
-        offset = (
-            f'UTC{raw_offset[:3]}:{raw_offset[3:]}'
-            if len(raw_offset) >= 5
-            else 'UTC'
-        )
         return {
             # Seconds precision (drop microseconds) to match the System
             # Info clock seed and stay parseable by any JS Date.parse().
             'iso': now_local.isoformat(timespec='seconds'),
             'timezone': timezone.get_current_timezone_name(),
-            'offset': offset,
+            'offset': format_utc_offset(now_local),
         }
 
     def get_ip_addresses(self) -> list[str]:

--- a/src/anthias_server/api/views/v2.py
+++ b/src/anthias_server/api/views/v2.py
@@ -573,6 +573,7 @@ class DeviceSettingsViewV2(APIView):
                     settings['default_streaming_duration']
                 ),
                 'date_format': settings['date_format'],
+                'timezone': settings['timezone'],
                 'auth_backend': settings['auth_backend'],
                 'show_splash': settings['show_splash'],
                 'default_assets': settings['default_assets'],
@@ -649,6 +650,8 @@ class DeviceSettingsViewV2(APIView):
                 settings['audio_output'] = data['audio_output']
             if 'date_format' in data:
                 settings['date_format'] = data['date_format']
+            if 'timezone' in data:
+                settings['timezone'] = data['timezone']
             if 'show_splash' in data:
                 settings['show_splash'] = data['show_splash']
             if 'default_assets' in data:
@@ -898,6 +901,25 @@ class InfoViewV2(InfoViewMixin):
             'low_ram': virtual_memory.total < LOW_RAM_THRESHOLD_KB * 1024,
         }
 
+    def get_time(self) -> dict[str, str]:
+        # The device's active timezone + wall clock. The activation
+        # middleware has already set the request's timezone from the
+        # operator's setting, so localtime()/get_current_timezone_name()
+        # reflect it. Lets an external client detect a wrong device
+        # clock or an unexpected zone (issue #1755).
+        now_local = timezone.localtime(timezone.now())
+        raw_offset = now_local.strftime('%z')
+        offset = (
+            f'UTC{raw_offset[:3]}:{raw_offset[3:]}'
+            if len(raw_offset) >= 5
+            else 'UTC'
+        )
+        return {
+            'iso': now_local.isoformat(),
+            'timezone': timezone.get_current_timezone_name(),
+            'offset': offset,
+        }
+
     def get_ip_addresses(self) -> list[str]:
         # /api/v2/info is auth'd and not polled, so blocking on
         # get_node_ip()'s host-readiness loop is acceptable here —
@@ -945,6 +967,14 @@ class InfoViewV2(InfoViewMixin):
                     },
                     'mac_address': {'type': 'string'},
                     'host_user': {'type': 'string'},
+                    'time': {
+                        'type': 'object',
+                        'properties': {
+                            'iso': {'type': 'string'},
+                            'timezone': {'type': 'string'},
+                            'offset': {'type': 'string'},
+                        },
+                    },
                 },
             }
         },
@@ -972,6 +1002,7 @@ class InfoViewV2(InfoViewMixin):
                 'ip_addresses': self.get_ip_addresses(),
                 'mac_address': get_node_mac_address(),
                 'host_user': getenv('HOST_USER'),
+                'time': self.get_time(),
             }
         )
 

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -7,7 +7,9 @@ surfaces stay in lockstep without going through the HTTP API.
 """
 
 from datetime import timedelta
+import functools
 import os
+import zoneinfo
 from os import getenv, statvfs
 from typing import Any
 
@@ -169,6 +171,17 @@ def system_info() -> dict[str, Any]:
             'hours': round(uptime.seconds / 3600, 2),
             'human': timesince(timezone.now() - uptime, depth=2),
         },
+        # The device's own wall clock + active timezone, so an operator
+        # can confirm what "now" the scheduler is using (issue #1755).
+        # Seeded from the server instant (``iso``) rather than the
+        # browser's clock — the whole point is to reveal a *wrong*
+        # device clock, which trusting the browser would mask. The
+        # offset is formatted +HH:MM for readability.
+        'device_time': {
+            'iso': timezone.localtime(timezone.now()).isoformat(),
+            'timezone': timezone.get_current_timezone_name(),
+            'offset': _format_utc_offset(timezone.localtime(timezone.now())),
+        },
         'display_power': _redis.get('display_power'),
         'resolution': _resolved_resolution(),
         'device_model': device_model,
@@ -192,6 +205,27 @@ _DATE_FORMAT_OPTIONS = (
     ('dd.mm.yyyy', 'day.month.year'),
     ('yyyy.mm.dd', 'year.month.day'),
 )
+
+
+def _format_utc_offset(dt: Any) -> str:
+    """Render a datetime's UTC offset as ``UTC+HH:MM`` / ``UTC-HH:MM``."""
+    raw = dt.strftime('%z')  # e.g. '+0200', '' for a naive value
+    if len(raw) < 5:
+        return 'UTC'
+    return f'UTC{raw[:3]}:{raw[3:]}'
+
+
+@functools.lru_cache(maxsize=1)
+def _timezone_options() -> tuple[tuple[str, str], ...]:
+    """(value, label) pairs for the Settings timezone dropdown.
+
+    Leading blank entry = "follow the host". The rest is the sorted
+    IANA zone list; on balena the host is always UTC, so this dropdown
+    is the only way to schedule/display in local time there. Cached —
+    the set is fixed for the life of the process.
+    """
+    zones = sorted(zoneinfo.available_timezones())
+    return (('', 'System default'),) + tuple((z, z) for z in zones)
 
 
 def device_settings() -> dict[str, Any]:
@@ -227,6 +261,7 @@ def device_settings() -> dict[str, Any]:
         'default_streaming_duration': settings['default_streaming_duration'],
         'audio_output': settings['audio_output'],
         'date_format': settings['date_format'],
+        'timezone': settings['timezone'],
         'auth_backend': settings['auth_backend'],
         'username': operator_username(),
         'show_splash': settings['show_splash'],
@@ -248,6 +283,7 @@ def device_settings() -> dict[str, Any]:
         # on that revision (matches the React audio-output dropdown).
         'is_pi5': 'Raspberry Pi 5' in device_model,
         'date_format_options': _DATE_FORMAT_OPTIONS,
+        'timezone_options': _timezone_options(),
         # Render-time gate for the experimental CEC display-power
         # buttons; cec_available() only stats device nodes, so it's
         # cheap enough to call on every settings render.

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -183,7 +183,10 @@ def system_info() -> dict[str, Any]:
         # device clock, which trusting the browser would mask. The
         # offset is formatted +HH:MM for readability.
         'device_time': {
-            'iso': now_local.isoformat(),
+            # Seconds precision: microseconds from isoformat() aren't
+            # parsed by every JS Date.parse() engine, and a NaN seed
+            # would leave the live clock never starting.
+            'iso': now_local.isoformat(timespec='seconds'),
             # Raw IANA id for the JS Intl formatter (data-timezone)...
             'timezone': tz_name,
             # ...and a humanised version for the visible sub-label.

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -179,7 +179,12 @@ def system_info() -> dict[str, Any]:
         # offset is formatted +HH:MM for readability.
         'device_time': {
             'iso': timezone.localtime(timezone.now()).isoformat(),
+            # Raw IANA id for the JS Intl formatter (data-timezone)...
             'timezone': timezone.get_current_timezone_name(),
+            # ...and a humanised version for the visible sub-label.
+            'timezone_label': timezone.get_current_timezone_name().replace(
+                '_', ' '
+            ),
             'offset': _format_utc_offset(timezone.localtime(timezone.now())),
         },
         'display_power': _redis.get('display_power'),
@@ -224,8 +229,12 @@ def _timezone_options() -> tuple[tuple[str, str], ...]:
     is the only way to schedule/display in local time there. Cached —
     the set is fixed for the life of the process.
     """
+    # Value stays the real IANA id (what Django/Intl need); the label
+    # humanises the underscore so options read "America/New York".
     zones = sorted(zoneinfo.available_timezones())
-    return (('', 'System default'),) + tuple((z, z) for z in zones)
+    return (('', 'System default'),) + tuple(
+        (z, z.replace('_', ' ')) for z in zones
+    )
 
 
 def device_settings() -> dict[str, Any]:

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -118,6 +118,11 @@ def system_info() -> dict[str, Any]:
             severity = 'ok'
         return {'value': value, 'pct': pct, 'severity': severity}
 
+    # Snapshot the local instant once so iso/offset can't straddle a
+    # second boundary, and resolve the active zone name a single time.
+    now_local = timezone.localtime(timezone.now())
+    tz_name = timezone.get_current_timezone_name()
+
     return {
         'loadavg': load_15m,
         'load': {
@@ -178,14 +183,12 @@ def system_info() -> dict[str, Any]:
         # device clock, which trusting the browser would mask. The
         # offset is formatted +HH:MM for readability.
         'device_time': {
-            'iso': timezone.localtime(timezone.now()).isoformat(),
+            'iso': now_local.isoformat(),
             # Raw IANA id for the JS Intl formatter (data-timezone)...
-            'timezone': timezone.get_current_timezone_name(),
+            'timezone': tz_name,
             # ...and a humanised version for the visible sub-label.
-            'timezone_label': timezone.get_current_timezone_name().replace(
-                '_', ' '
-            ),
-            'offset': _format_utc_offset(timezone.localtime(timezone.now())),
+            'timezone_label': tz_name.replace('_', ' '),
+            'offset': _format_utc_offset(now_local),
         },
         'display_power': _redis.get('display_power'),
         'resolution': _resolved_resolution(),

--- a/src/anthias_server/app/page_context.py
+++ b/src/anthias_server/app/page_context.py
@@ -26,6 +26,7 @@ from anthias_common.utils import (
 )
 from anthias_server.lib import diagnostics
 from anthias_server.lib.github import is_up_to_date
+from anthias_server.lib.timezone import format_utc_offset
 from anthias_server.settings import settings
 
 _redis = connect_to_redis()
@@ -191,7 +192,7 @@ def system_info() -> dict[str, Any]:
             'timezone': tz_name,
             # ...and a humanised version for the visible sub-label.
             'timezone_label': tz_name.replace('_', ' '),
-            'offset': _format_utc_offset(now_local),
+            'offset': format_utc_offset(now_local),
         },
         'display_power': _redis.get('display_power'),
         'resolution': _resolved_resolution(),
@@ -218,22 +219,15 @@ _DATE_FORMAT_OPTIONS = (
 )
 
 
-def _format_utc_offset(dt: Any) -> str:
-    """Render a datetime's UTC offset as ``UTC+HH:MM`` / ``UTC-HH:MM``."""
-    raw = dt.strftime('%z')  # e.g. '+0200', '' for a naive value
-    if len(raw) < 5:
-        return 'UTC'
-    return f'UTC{raw[:3]}:{raw[3:]}'
-
-
 @functools.lru_cache(maxsize=1)
 def _timezone_options() -> tuple[tuple[str, str], ...]:
     """(value, label) pairs for the Settings timezone dropdown.
 
-    Leading blank entry = "follow the host". The rest is the sorted
-    IANA zone list; on balena the host is always UTC, so this dropdown
-    is the only way to schedule/display in local time there. Cached —
-    the set is fixed for the life of the process.
+    Leading blank entry ("System default") defers to
+    resolve_time_zone() — TZ env, then /etc/timezone, then UTC. The
+    rest is the sorted IANA zone list; on balena the host is always
+    UTC, so this dropdown is the only way to schedule/display in local
+    time there. Cached — the set is fixed for the life of the process.
     """
     # Value stays the real IANA id (what Django/Intl need); the label
     # humanises the underscore so options read "America/New York".

--- a/src/anthias_server/app/templates/settings.html
+++ b/src/anthias_server/app/templates/settings.html
@@ -77,6 +77,15 @@
         </div>
 
         <div class="app-floating">
+          <select class="app-select" id="timezone" name="timezone">
+            {% for value, label in timezone_options %}
+            <option value="{{ value }}" {% if timezone == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+          <label for="timezone">Timezone</label>
+        </div>
+
+        <div class="app-floating">
           <select class="app-select" id="screen_rotation" name="screen_rotation">
             <option value="0" {% if screen_rotation == 0 %}selected{% endif %}>Landscape (0°)</option>
             <option value="90" {% if screen_rotation == 90 %}selected{% endif %}>Portrait (90°)</option>

--- a/src/anthias_server/app/templates/settings.html
+++ b/src/anthias_server/app/templates/settings.html
@@ -41,7 +41,7 @@
       <header>
         <div>
           <h2>Display & playback</h2>
-          <p class="settings-section__lede">Default durations, audio, and date format.</p>
+          <p class="settings-section__lede">Defaults, audio, timezone, and display.</p>
         </div>
       </header>
 

--- a/src/anthias_server/app/templates/system_info.html
+++ b/src/anthias_server/app/templates/system_info.html
@@ -48,6 +48,22 @@
       </div>
 
       <div class="stat-card stat-card--span-2">
+        <p class="stat-card__label">Device time</p>
+        {% comment %}
+        Ticks client-side but is seeded from the server instant in
+        data-iso — never the browser clock — so a wrong device clock is
+        revealed rather than masked (issue #1755). Rendered in the
+        device's own timezone via Intl, so it's correct even when the
+        operator's browser is in another zone. No-JS falls back to the
+        server-rendered value.
+        {% endcomment %}
+        <div class="stat-card__value" id="device-clock"
+             data-iso="{{ device_time.iso }}"
+             data-timezone="{{ device_time.timezone }}">{{ device_time.iso }}</div>
+        <p class="stat-card__label">{{ device_time.timezone }} · {{ device_time.offset }}</p>
+      </div>
+
+      <div class="stat-card stat-card--span-2">
         <p class="stat-card__label">Memory</p>
         <div class="resource-card">
           <div
@@ -179,4 +195,41 @@
     </div>
   </section>
 </div>
+
+<script>
+  // Live device clock. Seeded once from the server instant the page was
+  // rendered (data-iso), then advanced with the browser's monotonic
+  // delta — so the display tracks the *device's* clock, not the
+  // viewer's, and stays honest even if the two disagree. Formatted in
+  // the device's own timezone (data-timezone) via Intl.
+  (function () {
+    var el = document.getElementById('device-clock');
+    if (!el) return;
+    var seededMs = Date.parse(el.dataset.iso);
+    if (isNaN(seededMs)) return;
+    var zone = el.dataset.timezone || undefined;
+    var baseline = performance.now();
+    var fmt;
+    try {
+      fmt = new Intl.DateTimeFormat(undefined, {
+        timeZone: zone,
+        weekday: 'short', year: 'numeric', month: 'short', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+      });
+    } catch (e) {
+      // Unknown zone in this browser's ICU data — fall back to the
+      // browser's local formatting rather than throwing.
+      fmt = new Intl.DateTimeFormat(undefined, {
+        weekday: 'short', year: 'numeric', month: 'short', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+      });
+    }
+    function tick() {
+      var now = new Date(seededMs + (performance.now() - baseline));
+      el.textContent = fmt.format(now);
+    }
+    tick();
+    setInterval(tick, 1000);
+  })();
+</script>
 {% endblock %}

--- a/src/anthias_server/app/templates/system_info.html
+++ b/src/anthias_server/app/templates/system_info.html
@@ -213,7 +213,12 @@
     var seededMs = Date.parse(el.dataset.iso);
     if (isNaN(seededMs)) return;
     var zone = el.dataset.timezone || undefined;
-    var baseline = performance.now();
+    // Prefer the monotonic clock; fall back to Date.now() where
+    // performance.now() is unavailable (older/embedded browsers).
+    var clock = (window.performance && performance.now)
+      ? function () { return performance.now(); }
+      : function () { return Date.now(); };
+    var baseline = clock();
     var fmt;
     try {
       fmt = new Intl.DateTimeFormat(undefined, {
@@ -230,7 +235,7 @@
       });
     }
     function tick() {
-      var now = new Date(seededMs + (performance.now() - baseline));
+      var now = new Date(seededMs + (clock() - baseline));
       el.textContent = fmt.format(now);
     }
     tick();

--- a/src/anthias_server/app/templates/system_info.html
+++ b/src/anthias_server/app/templates/system_info.html
@@ -43,27 +43,6 @@
       </div>
 
       <div class="stat-card stat-card--span-2">
-        <p class="stat-card__label">Uptime</p>
-        <div class="stat-card__value">{{ uptime.human }}</div>
-      </div>
-
-      <div class="stat-card stat-card--span-2">
-        <p class="stat-card__label">Device time</p>
-        {% comment %}
-        Ticks client-side but is seeded from the server instant in
-        data-iso — never the browser clock — so a wrong device clock is
-        revealed rather than masked (issue #1755). Rendered in the
-        device's own timezone via Intl, so it's correct even when the
-        operator's browser is in another zone. No-JS falls back to the
-        server-rendered value.
-        {% endcomment %}
-        <div class="stat-card__value" id="device-clock"
-             data-iso="{{ device_time.iso }}"
-             data-timezone="{{ device_time.timezone }}">{{ device_time.iso }}</div>
-        <p class="stat-card__label">{{ device_time.timezone }} · {{ device_time.offset }}</p>
-      </div>
-
-      <div class="stat-card stat-card--span-2">
         <p class="stat-card__label">Memory</p>
         <div class="resource-card">
           <div
@@ -108,6 +87,32 @@
           below {{ low_ram.threshold_mib|intcomma }} MiB MemTotal.
         </p>
         {% endif %}
+      </div>
+
+      {% comment %}
+      Uptime + Device time are the two short text cards; keeping them in
+      the same grid row (and the two chart cards — Memory above, Disk
+      below — in theirs) avoids a short card stretching to a chart card's
+      height and leaving a dead vertical band.
+      {% endcomment %}
+      <div class="stat-card stat-card--span-2">
+        <p class="stat-card__label">Uptime</p>
+        <div class="stat-card__value">{{ uptime.human }}</div>
+      </div>
+
+      <div class="stat-card stat-card--span-2">
+        <p class="stat-card__label">Device time</p>
+        {% comment %}
+        Ticks client-side but is seeded from the server instant in
+        data-iso — never the browser clock — so a wrong device clock is
+        revealed rather than masked (issue #1755). data-timezone carries
+        the raw IANA id for Intl; the visible sub-label is humanised.
+        No-JS falls back to the server-rendered value.
+        {% endcomment %}
+        <div class="stat-card__value" id="device-clock"
+             data-iso="{{ device_time.iso }}"
+             data-timezone="{{ device_time.timezone }}">{{ device_time.iso }}</div>
+        <p class="stat-card__label">{{ device_time.timezone_label }} · {{ device_time.offset }}</p>
       </div>
 
       <div class="stat-card stat-card--span-2">

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -47,6 +47,7 @@ from anthias_common.utils import (
     connect_to_redis,
     is_disk_full,
 )
+from anthias_server.django_project.settings import is_valid_time_zone
 from anthias_server.settings import ViewerPublisher, settings
 
 from .helpers import (
@@ -1615,6 +1616,19 @@ def settings_save(request: HttpRequest) -> HttpResponse:
     auth_backend = request.POST.get('auth_backend', '')
     current_password = request.POST.get('current_password', '')
 
+    # Reject a bad timezone up front (mirrors the v2 serializer's
+    # validate_timezone). Blank = "follow the host". Handled here rather
+    # than inside the try so it stays operator-input (warning-level, no
+    # Sentry event) and can't half-write a value that would crash-loop
+    # the settings module on the next read.
+    tz_value = (request.POST.get('timezone') or '').strip()
+    if tz_value and not is_valid_time_zone(tz_value):
+        logger.warning('Settings save rejected: unknown timezone %r', tz_value)
+        messages.error(
+            request, f'Unknown or unavailable timezone: {tz_value}.'
+        )
+        return redirect(reverse('anthias_app:settings'))
+
     try:
         prev_auth_backend = settings['auth_backend']
         apply_auth_settings(
@@ -1640,6 +1654,7 @@ def settings_save(request: HttpRequest) -> HttpResponse:
         )
         settings['audio_output'] = request.POST.get('audio_output', 'hdmi')
         settings['date_format'] = request.POST.get('date_format', 'mm/dd/yyyy')
+        settings['timezone'] = tz_value
 
         new_default_assets = _checkbox(request, 'default_assets')
         if new_default_assets and not settings['default_assets']:

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1617,7 +1617,8 @@ def settings_save(request: HttpRequest) -> HttpResponse:
     current_password = request.POST.get('current_password', '')
 
     # Reject a bad timezone up front (mirrors the v2 serializer's
-    # validate_timezone). Blank = "follow the host". Handled here rather
+    # validate_timezone). Blank defers to the resolved default (TZ env
+    # -> /etc/timezone -> UTC). Handled here rather
     # than inside the try so it stays operator-input (warning-level, no
     # Sentry event) and can't half-write a value that would crash-loop
     # the settings module on the next read.

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -617,9 +617,10 @@ def get_configured_time_zone(
 
     Parsed directly with configparser rather than via AnthiasSettings
     so this stays import-safe during Django settings evaluation (no
-    dependency on the device-settings object). An empty/absent value
-    means "follow the host"; an invalid value is ignored so a bad
-    hand-edit can never crash-loop Django.
+    dependency on the device-settings object). ``None`` (empty/absent)
+    lets resolve_time_zone() fall through to TZ env -> /etc/timezone ->
+    UTC; an invalid value is ignored so a bad hand-edit can never
+    crash-loop Django.
     """
     if config_file is None:
         home = getenv('HOME')

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 import asyncio
+import configparser
 import platform
 import secrets
 import socket
@@ -418,6 +419,10 @@ MIDDLEWARE = [
     # — Sentry ANTHIAS-Y). See anthias_server/lib/whitenoise.py.
     'anthias_server.lib.whitenoise.ResilientWhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    # Re-resolve + activate the operator-selected timezone per request
+    # so a Settings change is live without a restart. After sessions so
+    # request teardown order is predictable; before the view runs.
+    'anthias_server.lib.timezone.TimezoneActivationMiddleware',
     'django.middleware.common.CommonMiddleware',
     'anthias_server.lib.csrf.SameHostOriginCsrfMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -558,36 +563,97 @@ USE_I18N = True
 USE_TZ = True
 
 
+def is_valid_time_zone(
+    time_zone: str,
+    zoneinfo_root: Path = Path('/usr/share/zoneinfo'),
+) -> bool:
+    """True if ``time_zone`` is a zone Django will accept at startup.
+
+    Validate the same way Django does in django.conf.Settings.__init__
+    — a zoneinfo lookup PLUS the /usr/share/zoneinfo file check.
+    Validating with a bundled database alone (the old pytz check) is
+    not enough: it accepts names like ``US/Central`` that the image's
+    tzdata may not ship on disk, and Django then raises ValueError at
+    startup, crash-looping every Django process on the device.
+    """
+    try:
+        zoneinfo.ZoneInfo(time_zone)
+    except (ValueError, zoneinfo.ZoneInfoNotFoundError):
+        return False
+    if (
+        zoneinfo_root.exists()
+        and not zoneinfo_root.joinpath(*time_zone.split('/')).exists()
+    ):
+        return False
+    return True
+
+
 def get_host_time_zone(
     timezone_file: str = '/etc/timezone',
     zoneinfo_root: Path = Path('/usr/share/zoneinfo'),
 ) -> str:
     """Read the host's /etc/timezone, falling back to UTC.
 
-    /etc/timezone is bind-mounted from the host, so its value is
-    whatever the host distro wrote there. Validate it the same way
-    Django does in django.conf.Settings.__init__ — a zoneinfo lookup
-    PLUS the /usr/share/zoneinfo file check. Validating with a bundled
-    database alone (the old pytz check) is not enough: it accepts
-    names like `US/Central` that the image's tzdata may not ship on
-    disk, and Django then raises ValueError at startup, crash-looping
-    every Django process on the device.
+    /etc/timezone is bind-mounted from the host on docker-compose
+    installs, so its value is whatever the host distro wrote there.
+    On balena it is not mounted, so this is the container image's own
+    zone (UTC) — the reason the in-app override below matters most
+    there. An invalid value falls back to UTC, never crash-loops.
     """
     try:
         with open(timezone_file, 'r') as f:
             time_zone = f.read().strip()
-        zoneinfo.ZoneInfo(time_zone)
-        if (
-            zoneinfo_root.exists()
-            and not zoneinfo_root.joinpath(*time_zone.split('/')).exists()
-        ):
-            raise zoneinfo.ZoneInfoNotFoundError(time_zone)
-        return time_zone
-    except (OSError, ValueError, zoneinfo.ZoneInfoNotFoundError):
+    except OSError:
         return 'UTC'
+    return time_zone if is_valid_time_zone(time_zone, zoneinfo_root) else 'UTC'
 
 
-TIME_ZONE = get_host_time_zone()
+def get_configured_time_zone(
+    config_file: str | None = None,
+    zoneinfo_root: Path = Path('/usr/share/zoneinfo'),
+) -> str | None:
+    """Operator-selected timezone from anthias.conf, or None.
+
+    Parsed directly with configparser rather than via AnthiasSettings
+    so this stays import-safe during Django settings evaluation (no
+    dependency on the device-settings object). An empty/absent value
+    means "follow the host"; an invalid value is ignored so a bad
+    hand-edit can never crash-loop Django.
+    """
+    if config_file is None:
+        home = getenv('HOME')
+        if not home:
+            return None
+        config_file = str(Path(home) / '.anthias' / 'anthias.conf')
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(config_file)
+        time_zone = parser.get('main', 'timezone', fallback='').strip()
+    except (configparser.Error, OSError):
+        return None
+    if not time_zone:
+        return None
+    return time_zone if is_valid_time_zone(time_zone, zoneinfo_root) else None
+
+
+def resolve_time_zone() -> str:
+    """Effective Anthias timezone.
+
+    Precedence: anthias.conf ``[main] timezone`` (the in-UI setting) ->
+    ``TZ`` env var (respects a balena dashboard TZ variable) ->
+    host /etc/timezone -> UTC. Every candidate is validated, so no
+    rung can wedge Django at startup.
+    """
+    configured = get_configured_time_zone()
+    if configured:
+        return configured
+    tz_env = (getenv('TZ') or '').strip()
+    if tz_env and is_valid_time_zone(tz_env):
+        return tz_env
+    return get_host_time_zone()
+
+
+TIME_ZONE = resolve_time_zone()
 
 
 # Static files (CSS, JavaScript, Images)

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -26,6 +26,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.types import Event, Hint
 
 from anthias_common.version import get_anthias_release
+from anthias_server.settings import CONFIG_DIR, CONFIG_FILE
 from anthias_server.settings import settings as device_settings
 
 # django_stubs_ext.monkeypatch() makes Django generic classes
@@ -624,7 +625,9 @@ def get_configured_time_zone(
         home = getenv('HOME')
         if not home:
             return None
-        config_file = str(Path(home) / '.anthias' / 'anthias.conf')
+        # Reuse the same constants AnthiasSettings uses so the config
+        # location can never drift between the two.
+        config_file = str(Path(home) / CONFIG_DIR / CONFIG_FILE)
     parser = configparser.ConfigParser()
     try:
         parser.read(config_file)

--- a/src/anthias_server/lib/timezone.py
+++ b/src/anthias_server/lib/timezone.py
@@ -16,6 +16,7 @@ change is live. Any failure deactivates back to the process default
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Callable
 
 from django.utils import timezone
@@ -24,6 +25,19 @@ from anthias_server.django_project.settings import resolve_time_zone
 
 if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
+
+
+def format_utc_offset(dt: datetime) -> str:
+    """Render a datetime's UTC offset as ``UTC+HH:MM`` / ``UTC-HH:MM``.
+
+    ``UTC`` alone for a naive value (``%z`` yields an empty string).
+    Shared by the System Info page and the ``/api/v2/info`` clock so
+    the two never drift.
+    """
+    raw = dt.strftime('%z')  # e.g. '+0200', '' for a naive value
+    if len(raw) < 5:
+        return 'UTC'
+    return f'UTC{raw[:3]}:{raw[3:]}'
 
 
 class TimezoneActivationMiddleware:

--- a/src/anthias_server/lib/timezone.py
+++ b/src/anthias_server/lib/timezone.py
@@ -1,0 +1,45 @@
+"""Per-request activation of the operator-selected timezone.
+
+``TIME_ZONE`` in Django settings is resolved once at process start, so
+on its own an operator changing the timezone in Settings would not take
+effect until the next restart. This middleware re-resolves the
+effective zone (config -> TZ env -> host -> UTC) on every request and
+activates it for the duration of that request, so a save is reflected
+immediately in every rendered template, the REST API, and — crucially —
+the server-evaluated ``ViewerPlaylistViewV2`` that feeds the C++ viewer
+its local play-window decisions.
+
+The read is a small config-file parse; kept fresh on purpose so the
+change is live. Any failure deactivates back to the process default
+(``TIME_ZONE``) rather than 500-ing the request.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from django.utils import timezone
+
+from anthias_server.django_project.settings import resolve_time_zone
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest, HttpResponse
+
+
+class TimezoneActivationMiddleware:
+    def __init__(
+        self, get_response: Callable[[HttpRequest], HttpResponse]
+    ) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: 'HttpRequest') -> 'HttpResponse':
+        try:
+            timezone.activate(resolve_time_zone())
+        except Exception:
+            # A bad/removed zone must never take the whole request down;
+            # fall back to the process default (settings.TIME_ZONE).
+            timezone.deactivate()
+        try:
+            return self.get_response(request)
+        finally:
+            timezone.deactivate()

--- a/src/anthias_server/settings.py
+++ b/src/anthias_server/settings.py
@@ -25,6 +25,13 @@ DEFAULTS = {
         'database': CONFIG_DIR + 'anthias.db',
         'date_format': 'mm/dd/yyyy',
         'splash_logo_url': '/static/img/logo-full-splash.svg',
+        # Operator-selected IANA timezone. Empty means "follow the host"
+        # — see resolve_time_zone() in django_project/settings.py for the
+        # config -> TZ env -> /etc/timezone -> UTC precedence. Kept
+        # userspace on purpose: balenaOS has no host timezone (always
+        # UTC), so this is the only way to schedule/display in local
+        # time there.
+        'timezone': '',
         'use_24_hour_clock': False,
         'use_ssl': False,
         'auth_backend': '',
@@ -60,6 +67,7 @@ CONFIGURABLE_SETTINGS['use_24_hour_clock'] = DEFAULTS['main'][
     'use_24_hour_clock'
 ]
 CONFIGURABLE_SETTINGS['date_format'] = DEFAULTS['main']['date_format']
+CONFIGURABLE_SETTINGS['timezone'] = DEFAULTS['main']['timezone']
 
 PORT = int(getenv('PORT', 8080))
 LISTEN = getenv('LISTEN', '127.0.0.1')

--- a/src/anthias_server/settings.py
+++ b/src/anthias_server/settings.py
@@ -25,9 +25,9 @@ DEFAULTS = {
         'database': CONFIG_DIR + 'anthias.db',
         'date_format': 'mm/dd/yyyy',
         'splash_logo_url': '/static/img/logo-full-splash.svg',
-        # Operator-selected IANA timezone. Empty means "follow the host"
-        # — see resolve_time_zone() in django_project/settings.py for the
-        # config -> TZ env -> /etc/timezone -> UTC precedence. Kept
+        # Operator-selected IANA timezone. Empty defers to the resolved
+        # default — see resolve_time_zone() in django_project/settings.py
+        # for the config -> TZ env -> /etc/timezone -> UTC precedence. Kept
         # userspace on purpose: balenaOS has no host timezone (always
         # UTC), so this is the only way to schedule/display in local
         # time there.

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -48,7 +48,12 @@ django.setup()
 
 # Place imports that uses Django in this block.
 
+from django.utils import timezone  # noqa: E402
+
 from anthias_common.internal_auth import INTERNAL_AUTH_HEADER  # noqa: E402
+from anthias_server.django_project.settings import (  # noqa: E402
+    resolve_time_zone,
+)
 from anthias_common.internal_auth import internal_auth_token  # noqa: E402
 from anthias_common.utils import (  # noqa: E402
     clamp_screen_rotation,
@@ -1208,6 +1213,14 @@ def load_settings() -> None:
     logging.getLogger().setLevel(
         logging.DEBUG if settings['debug_logging'] else logging.INFO
     )
+    # Activate the operator-selected timezone so the scheduler's
+    # timezone.localtime() day-of-week / time-of-day windowing matches
+    # the server. Called at startup and on every `reload`, so a Settings
+    # change reschedules without restarting the viewer.
+    try:
+        timezone.activate(resolve_time_zone())
+    except Exception:
+        timezone.deactivate()
 
 
 def _handle_reload() -> None:

--- a/tests/test_django_timezone.py
+++ b/tests/test_django_timezone.py
@@ -260,6 +260,12 @@ class TestTimezoneActivationMiddleware:
             seen['during'] = dj_tz.get_current_timezone_name()
             return HttpResponse('ok')
 
+        # Establish a deterministic baseline (the process default) so the
+        # teardown check doesn't assume what settings.TIME_ZONE is — it
+        # could legitimately be Europe/Stockholm on some host.
+        dj_tz.deactivate()
+        baseline = dj_tz.get_current_timezone_name()
+
         monkeypatch.setattr(
             tz_mw, 'resolve_time_zone', lambda: 'Europe/Stockholm'
         )
@@ -270,7 +276,7 @@ class TestTimezoneActivationMiddleware:
         # Active during the request...
         assert seen['during'] == 'Europe/Stockholm'
         # ...and torn back down to the process default afterwards.
-        assert dj_tz.get_current_timezone_name() != 'Europe/Stockholm'
+        assert dj_tz.get_current_timezone_name() == baseline
 
     def test_bad_zone_does_not_crash_the_request(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_django_timezone.py
+++ b/tests/test_django_timezone.py
@@ -11,7 +11,15 @@ raise ValueError at startup.
 
 from pathlib import Path
 
-from anthias_server.django_project.settings import get_host_time_zone
+import pytest
+
+from anthias_server.django_project import settings as django_settings
+from anthias_server.django_project.settings import (
+    get_configured_time_zone,
+    get_host_time_zone,
+    is_valid_time_zone,
+    resolve_time_zone,
+)
 
 
 def _write_timezone(tmp_path: Path, value: str) -> str:
@@ -91,3 +99,186 @@ class TestGetHostTimeZone:
             )
             == 'America/Chicago'
         )
+
+
+class TestIsValidTimeZone:
+    def test_valid_zone_on_disk(self, tmp_path: Path) -> None:
+        assert is_valid_time_zone(
+            'America/Chicago',
+            zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago'),
+        )
+
+    def test_known_alias_missing_on_disk_is_invalid(
+        self, tmp_path: Path
+    ) -> None:
+        # Same crash-loop guard as the host path: US/Central resolves
+        # via tzdata but the on-disk tree lacks the legacy alias.
+        assert not is_valid_time_zone(
+            'US/Central',
+            zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago'),
+        )
+
+    def test_unknown_zone_is_invalid(self, tmp_path: Path) -> None:
+        assert not is_valid_time_zone(
+            'Mars/Phobos',
+            zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago'),
+        )
+
+    def test_empty_string_is_invalid(self, tmp_path: Path) -> None:
+        assert not is_valid_time_zone(
+            '', zoneinfo_root=_zoneinfo_root(tmp_path, 'America/Chicago')
+        )
+
+
+def _write_conf(tmp_path: Path, value: str | None) -> str:
+    conf = tmp_path / 'anthias.conf'
+    body = '[main]\n'
+    if value is not None:
+        body += f'timezone = {value}\n'
+    conf.write_text(body)
+    return str(conf)
+
+
+class TestGetConfiguredTimeZone:
+    def test_valid_configured_zone(self, tmp_path: Path) -> None:
+        assert (
+            get_configured_time_zone(
+                config_file=_write_conf(tmp_path, 'Europe/Stockholm'),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'Europe/Stockholm'),
+            )
+            == 'Europe/Stockholm'
+        )
+
+    def test_blank_configured_zone_returns_none(self, tmp_path: Path) -> None:
+        assert (
+            get_configured_time_zone(
+                config_file=_write_conf(tmp_path, ''),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'Europe/Stockholm'),
+            )
+            is None
+        )
+
+    def test_missing_key_returns_none(self, tmp_path: Path) -> None:
+        assert (
+            get_configured_time_zone(
+                config_file=_write_conf(tmp_path, None),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'Europe/Stockholm'),
+            )
+            is None
+        )
+
+    def test_invalid_configured_zone_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        # A bad hand-edit is ignored (falls through to the next rung)
+        # rather than crash-looping the settings module.
+        assert (
+            get_configured_time_zone(
+                config_file=_write_conf(tmp_path, 'Mars/Phobos'),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'Europe/Stockholm'),
+            )
+            is None
+        )
+
+    def test_missing_config_file_returns_none(self, tmp_path: Path) -> None:
+        assert (
+            get_configured_time_zone(
+                config_file=str(tmp_path / 'no-such.conf'),
+                zoneinfo_root=_zoneinfo_root(tmp_path, 'Europe/Stockholm'),
+            )
+            is None
+        )
+
+
+class TestResolveTimeZone:
+    """Precedence: config -> TZ env -> host -> UTC."""
+
+    def test_config_wins_over_env_and_host(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            django_settings,
+            'get_configured_time_zone',
+            lambda: 'Europe/Stockholm',
+        )
+        monkeypatch.setenv('TZ', 'America/Chicago')
+        monkeypatch.setattr(
+            django_settings, 'get_host_time_zone', lambda: 'Asia/Tokyo'
+        )
+        assert resolve_time_zone() == 'Europe/Stockholm'
+
+    def test_env_used_when_no_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            django_settings, 'get_configured_time_zone', lambda: None
+        )
+        monkeypatch.setenv('TZ', 'America/Chicago')
+        monkeypatch.setattr(
+            django_settings, 'get_host_time_zone', lambda: 'Asia/Tokyo'
+        )
+        assert resolve_time_zone() == 'America/Chicago'
+
+    def test_invalid_env_falls_through_to_host(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            django_settings, 'get_configured_time_zone', lambda: None
+        )
+        monkeypatch.setenv('TZ', 'Mars/Phobos')
+        monkeypatch.setattr(
+            django_settings, 'get_host_time_zone', lambda: 'Asia/Tokyo'
+        )
+        assert resolve_time_zone() == 'Asia/Tokyo'
+
+    def test_host_used_when_no_config_or_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            django_settings, 'get_configured_time_zone', lambda: None
+        )
+        monkeypatch.delenv('TZ', raising=False)
+        monkeypatch.setattr(
+            django_settings, 'get_host_time_zone', lambda: 'Asia/Tokyo'
+        )
+        assert resolve_time_zone() == 'Asia/Tokyo'
+
+
+class TestTimezoneActivationMiddleware:
+    def test_activates_resolved_zone_then_deactivates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from django.utils import timezone as dj_tz
+
+        from anthias_server.lib import timezone as tz_mw
+
+        seen = {}
+
+        def get_response(request: object) -> str:
+            seen['during'] = dj_tz.get_current_timezone_name()
+            return 'ok'
+
+        monkeypatch.setattr(
+            tz_mw, 'resolve_time_zone', lambda: 'Europe/Stockholm'
+        )
+        middleware = tz_mw.TimezoneActivationMiddleware(get_response)
+
+        assert middleware(object()) == 'ok'  # type: ignore[arg-type]
+        # Active during the request...
+        assert seen['during'] == 'Europe/Stockholm'
+        # ...and torn back down to the process default afterwards.
+        assert dj_tz.get_current_timezone_name() != 'Europe/Stockholm'
+
+    def test_bad_zone_does_not_crash_the_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from anthias_server.lib import timezone as tz_mw
+
+        def boom() -> str:
+            raise ValueError('bad zone')
+
+        monkeypatch.setattr(tz_mw, 'resolve_time_zone', boom)
+        middleware = tz_mw.TimezoneActivationMiddleware(lambda request: 'ok')
+
+        # Falls back to deactivate() rather than 500-ing.
+        assert middleware(object()) == 'ok'  # type: ignore[arg-type]

--- a/tests/test_django_timezone.py
+++ b/tests/test_django_timezone.py
@@ -248,22 +248,25 @@ class TestTimezoneActivationMiddleware:
     def test_activates_resolved_zone_then_deactivates(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        from django.http import HttpRequest, HttpResponse
+        from django.test import RequestFactory
         from django.utils import timezone as dj_tz
 
         from anthias_server.lib import timezone as tz_mw
 
         seen = {}
 
-        def get_response(request: object) -> str:
+        def get_response(request: HttpRequest) -> HttpResponse:
             seen['during'] = dj_tz.get_current_timezone_name()
-            return 'ok'
+            return HttpResponse('ok')
 
         monkeypatch.setattr(
             tz_mw, 'resolve_time_zone', lambda: 'Europe/Stockholm'
         )
         middleware = tz_mw.TimezoneActivationMiddleware(get_response)
 
-        assert middleware(object()) == 'ok'  # type: ignore[arg-type]
+        response = middleware(RequestFactory().get('/'))
+        assert response.content == b'ok'
         # Active during the request...
         assert seen['during'] == 'Europe/Stockholm'
         # ...and torn back down to the process default afterwards.
@@ -272,13 +275,20 @@ class TestTimezoneActivationMiddleware:
     def test_bad_zone_does_not_crash_the_request(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        from django.http import HttpRequest, HttpResponse
+        from django.test import RequestFactory
+
         from anthias_server.lib import timezone as tz_mw
 
         def boom() -> str:
             raise ValueError('bad zone')
 
+        def get_response(request: HttpRequest) -> HttpResponse:
+            return HttpResponse('ok')
+
         monkeypatch.setattr(tz_mw, 'resolve_time_zone', boom)
-        middleware = tz_mw.TimezoneActivationMiddleware(lambda request: 'ok')
+        middleware = tz_mw.TimezoneActivationMiddleware(get_response)
 
         # Falls back to deactivate() rather than 500-ing.
-        assert middleware(object()) == 'ok'  # type: ignore[arg-type]
+        response = middleware(RequestFactory().get('/'))
+        assert response.content == b'ok'

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2,6 +2,7 @@ import logging
 import os
 from collections.abc import Iterator
 from datetime import datetime, time, timedelta
+from datetime import timezone as dt_timezone
 from typing import Any
 
 import pytest
@@ -356,6 +357,38 @@ def test_overnight_window_active_before_and_after_midnight() -> None:
     # Wed 02:30 — post-midnight, "yesterday" was Tue (not in days).
     with time_machine.travel(_aware(2026, 1, 7, 2, 30)):
         assert not _first_asset().is_active()
+
+
+@pytest.mark.django_db
+def test_play_time_window_follows_active_timezone() -> None:
+    """The core of the timezone feature end-to-end: the play-time window
+    is matched in the *active* timezone, so one fixed UTC instant is
+    inside or outside the window purely as a function of the
+    operator-selected zone. This is what makes an in-UI timezone
+    correct scheduling on balena, where the host is always UTC.
+    """
+    Asset.objects.create(
+        **_scheduled_asset(
+            play_time_from=time(9, 0),
+            play_time_to=time(17, 0),
+        ),
+    )
+    # 08:00 UTC on a Monday. Europe/Berlin (UTC+1) sees 09:00 — inside
+    # the 09:00-17:00 window; America/Chicago (UTC-6) sees 02:00 —
+    # outside it.
+    instant = datetime(2026, 1, 5, 8, 0, tzinfo=dt_timezone.utc)
+    with time_machine.travel(instant):
+        timezone.activate('Europe/Berlin')
+        try:
+            assert _first_asset().is_active()
+        finally:
+            timezone.deactivate()
+
+        timezone.activate('America/Chicago')
+        try:
+            assert not _first_asset().is_active()
+        finally:
+            timezone.deactivate()
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -86,6 +86,9 @@ def test_system_info_renders(client: Client) -> None:
     # are environment-dependent.
     for label in ('Load Average', 'Disk', 'Memory', 'Uptime'):
         assert label in body
+    # The device clock card + its seed-from-server ticking hook.
+    assert 'Device time' in body
+    assert 'id="device-clock"' in body
 
 
 @pytest.mark.django_db
@@ -107,12 +110,16 @@ def test_settings_renders(client: Client) -> None:
         'Default duration',
         'Audio output',
         'Date format',
+        'Timezone',
         'Authentication',
         'Show splash screen',
         'Backup',
         'System controls',
     ):
         assert label in body
+    # The timezone dropdown is populated from the IANA list.
+    assert 'name="timezone"' in body
+    assert 'Europe/Stockholm' in body
 
 
 @pytest.mark.django_db
@@ -872,6 +879,74 @@ def test_settings_save_screen_rotation(
         )
     assert response.status_code in (200, 302)
     assert settings['screen_rotation'] == persisted
+
+
+@pytest.mark.django_db
+def test_settings_save_timezone_valid(client: Client) -> None:
+    """A valid IANA zone posted from the HTML form is persisted."""
+    from anthias_server.settings import settings
+
+    original = settings['timezone']
+    try:
+        with mock.patch(
+            'anthias_server.settings.ViewerPublisher.send_to_viewer',
+            return_value=None,
+        ):
+            response = client.post(
+                reverse('anthias_app:settings_save'),
+                data={
+                    'player_name': 'Test',
+                    'default_duration': '10',
+                    'default_streaming_duration': '300',
+                    'audio_output': 'hdmi',
+                    'date_format': 'mm/dd/yyyy',
+                    'auth_backend': '',
+                    'timezone': 'Europe/Stockholm',
+                },
+            )
+        assert response.status_code in (200, 302)
+        assert settings['timezone'] == 'Europe/Stockholm'
+    finally:
+        # Persisted to the shared conf; the activation middleware would
+        # otherwise apply it to every later test's request. Restore.
+        settings['timezone'] = original
+        settings.save()
+
+
+@pytest.mark.django_db
+def test_settings_save_timezone_invalid_rejected(client: Client) -> None:
+    """A bad zone is rejected up front and never written — a value that
+    would crash-loop the settings module can't be persisted."""
+    from anthias_server.settings import settings
+
+    original = settings['timezone']
+    settings['timezone'] = 'Europe/Stockholm'
+    settings.save()
+
+    try:
+        with mock.patch(
+            'anthias_server.settings.ViewerPublisher.send_to_viewer',
+            return_value=None,
+        ) as publish_mock:
+            response = client.post(
+                reverse('anthias_app:settings_save'),
+                data={
+                    'player_name': 'Test',
+                    'default_duration': '10',
+                    'default_streaming_duration': '300',
+                    'audio_output': 'hdmi',
+                    'date_format': 'mm/dd/yyyy',
+                    'auth_backend': '',
+                    'timezone': 'Mars/Phobos',
+                },
+            )
+        assert response.status_code in (200, 302)
+        # Prior value untouched, and no reload was signalled.
+        assert settings['timezone'] == 'Europe/Stockholm'
+        publish_mock.assert_not_called()
+    finally:
+        settings['timezone'] = original
+        settings.save()
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -117,9 +117,12 @@ def test_settings_renders(client: Client) -> None:
         'System controls',
     ):
         assert label in body
-    # The timezone dropdown is populated from the IANA list.
+    # The timezone dropdown is populated from the IANA list, with the
+    # real id as the option value and a humanised (underscore-free)
+    # label shown to the operator.
     assert 'name="timezone"' in body
-    assert 'Europe/Stockholm' in body
+    assert 'value="America/New_York"' in body
+    assert 'America/New York' in body
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Issues Fixed

- Closes https://github.com/Screenly/Anthias/issues/1912
- Substantially addresses https://github.com/Screenly/Anthias/issues/1755 and https://github.com/Screenly/Anthias/issues/2996 (timezone + visible device time; see note below on NTP/clock-setting)

### Description

Adds an operator-selectable **Timezone** in Settings that drives all schedule evaluation and time display, plus a **live device clock** on the System Info page.

The timezone is stored in `anthias.conf` and applied entirely in userspace — no host access, no reboot. It resolves with the precedence `anthias.conf` → `TZ` env → `/etc/timezone` → `UTC`, and every candidate is validated so a bad value can never crash-loop the settings module. A per-request middleware re-activates it so a save takes effect immediately across the UI, the REST API, and the server-evaluated viewer playlist; the viewer's own scheduler re-activates it on startup and on every `reload`.

This matters most on **balenaOS**, where the host is permanently UTC and there is no host-level timezone to inherit — so today every balena device schedules and displays in UTC. Setting the timezone in userspace is in fact balena's own recommended approach, and it's the only way to get correct local-time scheduling there.

Highlights:
- New `timezone` device setting; dropdown populated from the IANA zone list.
- Wired through both write paths (HTML form + `/api/v2/device_settings`) and the v2 serializers, with validation.
- System Info gains a **Device time** card that ticks client-side but is seeded from the *server* instant (so a wrong device clock is revealed, not masked) and renders in the device's own zone via `Intl`.
- `/api/v2/info` gains a `time` object (`iso` / `timezone` / `offset`).

**Out of scope (deliberately):** setting the absolute clock or a custom NTP server from the web UI. On balena that isn't possible from the app container — the Supervisor API has no time endpoint, and NTP is managed by the host (config.json `ntpServers` / DHCP). Those asks from #1755/#2996 are left as a possible docker-compose-only follow-up.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

