### PR TITLE
pi3-64 hardware video playback (30fps, zero drops) + audio

### DIFF
--- a/bin/lib/viewer/common.sh
+++ b/bin/lib/viewer/common.sh
@@ -87,11 +87,16 @@ chown -Rf viewer /data/.anthias
 mkdir -p /data/.local/share/AnthiasViewer/QtWebEngine \
     /data/.cache/AnthiasViewer \
     /data/.cache/fontconfig \
+    /data/.cache/gstreamer-1.0 \
     /data/.pki
 
 chown -Rf viewer /data/.local/share/AnthiasViewer
 chown -Rf viewer /data/.cache/AnthiasViewer/
 chown -Rf viewer /data/.cache/fontconfig
+# pi3-64's video path links GStreamer; without a writable registry cache
+# the viewer rescans every plugin on each launch (slow startup — enough to
+# blow the 30s D-Bus handshake budget on the memory-tight 1GB board).
+chown -Rf viewer /data/.cache/gstreamer-1.0
 chown -Rf viewer /data/.pki
 
 # Qt + dbus + various Linux apps look up XDG_RUNTIME_DIR; without it they

--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -84,16 +84,30 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # pi3-64 runtime for the in-process GStreamer HW video path (issue #3084):
 # gstreamer1.0-plugins-good carries the V4L2 elements (v4l2h264dec →
 # bcm2835 decoder, v4l2convert → bcm2835 ISP); -base/-bad round out
-# qtdemux / h264parse / appsink; -alsa is the audio sink. gstreamer1.0-libav
-# supplies the audio decoders (avdec_ac3 / avdec_aac / avdec_mp3 …) the
-# separate audio pipeline autoplugs — without it decodebin reports "missing
-# a plug-in" on anything but the few codecs -bad ships. Only this board
-# links GStreamer, so only this board ships the plugin set.
+# qtdemux / h264parse / appsink / kmssink; -alsa is the audio sink.
+# gstreamer1.0-libav supplies the audio decoders (avdec_ac3 / avdec_aac /
+# avdec_mp3 …) the separate audio pipeline autoplugs — without it decodebin
+# reports "missing a plug-in" on anything but the few codecs -bad ships.
+# Only this board links GStreamer, so only this board ships the plugin set.
+#
+# Pin base/bad/alsa to the RPi archive's ``+rpt3`` builds (the archive +
+# keyring are already configured by _rpt1-ffmpeg-pin.j2 above — pi3-64 is
+# in its board list). These are RPi-tuned for the Broadcom stack; -bad in
+# particular carries the vc4 ``kmssink`` the overlay-plane path scans out
+# through. -good (the V4L2 HW decode/convert elements) and -libav are NOT
+# in the RPi archive, so they stay on Debian (kernel-driven, works). The
+# +rpt3 plugins share upstream 1.26.2 with Debian's ``libgstreamer1.0-0``
+# core (not shipped in the RPi archive), so the ABI matches.
 {% if disable_cache_mounts %}
 RUN \
 {% else %}
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 {% endif %}
+    printf '%s\n' \
+        'Package: gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gstreamer1.0-alsa libgstreamer-plugins-base1.0-0 libgstreamer-plugins-bad1.0-0' \
+        'Pin: origin archive.raspberrypi.com' \
+        'Pin-Priority: 1001' \
+        > /etc/apt/preferences.d/raspberrypi-gstreamer && \
     apt-get update && \
     apt-get -y install --no-install-recommends \
         gstreamer1.0-plugins-base \

--- a/docker/Dockerfile.viewer.j2
+++ b/docker/Dockerfile.viewer.j2
@@ -20,7 +20,18 @@ RUN --mount=type=cache,target=/var/cache/apt,id=qt6-builder-apt-{{ artifact_boar
         qt6-base-dev \
         qt6-declarative-dev \
         qt6-multimedia-dev \
-        qt6-webengine-dev
+{% if board == 'pi3-64' %}        libgstreamer1.0-dev \
+        libgstreamer-plugins-base1.0-dev \
+        libdrm-dev \
+        qt6-base-private-dev \
+{% endif %}        qt6-webengine-dev
+# pi3-64 (VideoCore IV): links GStreamer so VideoView runs the in-process
+# hardware pipeline (v4l2h264dec → v4l2convert/ISP → appsink). That GPU
+# can't present QtMultimedia's VideoOutput (issue #3084) and the CPU is
+# too slow to convert HW frames (~600 ms/frame), so the ISP converts in
+# hardware; libgstreamer1.0-dev + plugins-base1.0-dev provide gstreamer-1.0
+# / gstreamer-app-1.0 / gstreamer-video-1.0 for the CONFIG+=anthias_gstreamer
+# build. Other boards keep the VideoOutput path (no GStreamer link).
 # qt6-multimedia-dev: AnthiasViewer's VideoView wraps QMediaPlayer
 # rendering into a QML ``VideoOutput`` (issue #2904, render path
 # reworked for #2967 — see ``src/anthias_webview/videoview.h``).
@@ -40,7 +51,7 @@ WORKDIR /src/anthias_webview
 # adding ccache would only save a couple of seconds on incremental
 # rebuilds and the cache mount + apt install + PATH wiring would
 # outweigh the saving.
-RUN qmake6 && \
+RUN qmake6 {% if board == 'pi3-64' %}CONFIG+=anthias_gstreamer {% endif %}&& \
     make -j"$(nproc)" && \
     make install
 RUN mkdir -p /out/bin /out/share/AnthiasViewer && \
@@ -68,6 +79,29 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         {{ dependency }}
         {% endif %}
     {% endfor %}
+
+{% if board == 'pi3-64' %}
+# pi3-64 runtime for the in-process GStreamer HW video path (issue #3084):
+# gstreamer1.0-plugins-good carries the V4L2 elements (v4l2h264dec →
+# bcm2835 decoder, v4l2convert → bcm2835 ISP); -base/-bad round out
+# qtdemux / h264parse / appsink; -alsa is the audio sink. gstreamer1.0-libav
+# supplies the audio decoders (avdec_ac3 / avdec_aac / avdec_mp3 …) the
+# separate audio pipeline autoplugs — without it decodebin reports "missing
+# a plug-in" on anything but the few codecs -bad ships. Only this board
+# links GStreamer, so only this board ships the plugin set.
+{% if disable_cache_mounts %}
+RUN \
+{% else %}
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+{% endif %}
+    apt-get update && \
+    apt-get -y install --no-install-recommends \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-alsa \
+        gstreamer1.0-libav
+{% endif %}
 
 COPY --from=uv-builder /venv /venv
 ENV PATH="/venv/bin:$PATH"

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -247,6 +247,30 @@ def _build_webview_env() -> dict[str, str]:
     else:
         env.pop('ANTHIAS_PREFER_DARK_MODE', None)
 
+    # pi3-64 (Raspberry Pi 3, VideoCore IV / vc4, GLES2-only) can't
+    # present the QML VideoOutput RHI video path: the scene renders but
+    # the QQuickWidget FBO never reaches the eglfs scanout, so every
+    # video black-screens (issue #3084) while images and webpages —
+    # which composite through the widget backing store — render fine.
+    # Route ONLY this board to the C++ CPU-raster presenter
+    # (QVideoFrame::toImage() → paintEvent), the same backing-store path
+    # images already use here. Pi 4 (V3D 4.2) and Pi 5 (V3D 7.x) keep
+    # the fast on-GPU VideoOutput path. Gated on the authoritative baked
+    # DEVICE_TYPE (get_device_type() returns 'pi3' on both Pi 3 streams,
+    # so the model string alone can't tell 64-bit from armhf — same
+    # reason media_player.force_mpv keys off DEVICE_TYPE). Pop a stale
+    # value so a re-imaged/re-typed device drops the flag on respawn.
+    if os.environ.get('DEVICE_TYPE') == 'pi3-64':
+        env['ANTHIAS_VIDEO_RASTER'] = '1'
+        # Prefer the hardware overlay-plane path (v4l2h264dec → ISP →
+        # kmssink on a vc4 overlay plane, HW-composited with the eglfs UI
+        # plane) for full-rate video; VideoView falls back to the
+        # CPU-raster blit if the DRM overlay resources can't be resolved.
+        env['ANTHIAS_VIDEO_OVERLAY'] = '1'
+    else:
+        env.pop('ANTHIAS_VIDEO_RASTER', None)
+        env.pop('ANTHIAS_VIDEO_OVERLAY', None)
+
     rotation = _rotation_value()
     if _is_wayland_board():
         return env

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -264,10 +264,11 @@ def _build_webview_env() -> dict[str, str]:
     # the QQuickWidget FBO never reaches the eglfs scanout, so every
     # video black-screens (issue #3084) while images and webpages —
     # which composite through the widget backing store — render fine.
-    # Route ONLY this board to the C++ CPU-raster presenter
-    # (QVideoFrame::toImage() → paintEvent), the same backing-store path
-    # images already use here. Pi 4 (V3D 4.2) and Pi 5 (V3D 7.x) keep
-    # the fast on-GPU VideoOutput path. Gated on the authoritative baked
+    # Route ONLY this board to the C++ non-VideoOutput presenter: the
+    # GStreamer vc4 overlay-plane path (preferred, ANTHIAS_VIDEO_OVERLAY),
+    # falling back to the CPU-raster blit (QVideoFrame::toImage() →
+    # paintEvent, the same backing-store path images use). Pi 4 (V3D 4.2)
+    # and Pi 5 (V3D 7.x) keep the fast on-GPU VideoOutput path. Gated on the authoritative baked
     # DEVICE_TYPE (get_device_type() returns 'pi3' on both Pi 3 streams,
     # so the model string alone can't tell 64-bit from armhf — same
     # reason media_player.force_mpv keys off DEVICE_TYPE). Pop a stale

--- a/src/anthias_webview/AnthiasViewer.pro
+++ b/src/anthias_webview/AnthiasViewer.pro
@@ -44,5 +44,28 @@ greaterThan(QT_MAJOR_VERSION, 5) {
     RESOURCES += src/videoview.qrc
 }
 
+# pi3-64 (VideoCore IV) only: link GStreamer so VideoView can run the
+# hardware pipeline (v4l2h264dec → v4l2convert/ISP → appsink) and blit
+# the ISP-converted RGB frames through RasterVideoWidget. That GPU can't
+# present QtMultimedia's VideoOutput (issue #3084) and its CPU is too slow
+# to convert HW frames itself (~600 ms/frame), so the ISP does the
+# SAND→RGB in hardware. Enabled by the pi3-64 Dockerfile with
+# ``qmake6 CONFIG+=anthias_gstreamer``; every other board builds without
+# it (the code is #ifdef ANTHIAS_GSTREAMER) and keeps the VideoOutput path.
+anthias_gstreamer {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0 libdrm
+    # gui-private: QPlatformNativeInterface, to read eglfs's DRM master
+    # fd / CRTC / connector (nativeResourceForIntegration("dri_fd") etc.)
+    # so kmssink can render onto a vc4 overlay plane using eglfs's own fd
+    # — HW scanout, bypassing the GL compositor that caps at ~9 fps.
+    QT += gui-private
+    DEFINES += ANTHIAS_GSTREAMER
+    # -rdynamic: export symbols so the fatal-signal backtrace in main.cpp
+    # resolves AnthiasViewer's own frames (not just addresses) while the
+    # overlay path is being stabilised.
+    QMAKE_LFLAGS += -rdynamic
+}
+
 # Default rules for deployment.
 include(src/deployment.pri)

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -3,20 +3,25 @@
 #include <QDebug>
 #include <QtDBus>
 
+#ifdef ANTHIAS_GSTREAMER
 #include <csignal>
 #include <cstdio>
 #include <execinfo.h>
 #include <unistd.h>
+#endif
 
 #include "mainwindow.h"
 
 namespace {
-// Fatal-signal backtrace. The pi3-64 overlay video path (VideoView +
-// kmssink on eglfs's DRM fd) segfaults silently — the kernel kills the
-// process and docker logs show only the respawn. Dumping a backtrace to
-// stderr (captured by the start_viewer wrapper) pins the crash frame.
-// Re-raises with the default handler so the exit status is unchanged and
-// the Python supervisor still respawns as before.
+#ifdef ANTHIAS_GSTREAMER
+// Fatal-signal backtrace. Scoped to the pi3-64 build (the only one that
+// links the GStreamer overlay path): VideoView + kmssink on eglfs's DRM
+// fd segfaulted silently while it was being brought up — the kernel
+// killed the process and docker logs showed only the respawn. Dumping a
+// backtrace to stderr (captured by the start_viewer wrapper) pins the
+// crash frame. Re-raises with the default handler so the core dump / exit
+// status are unchanged and the Python supervisor still respawns as
+// before. Other boards keep the default crash behaviour untouched.
 void anthiasCrashHandler(int sig)
 {
     void* frames[64];
@@ -36,6 +41,11 @@ void installCrashHandler()
     signal(SIGBUS, anthiasCrashHandler);
     signal(SIGFPE, anthiasCrashHandler);
 }
+#else
+// No-op on non-pi3-64 builds — leave the platform default crash handling
+// (core dumps) in place.
+void installCrashHandler() {}
+#endif
 
 // Realise the operator's "Prefer dark mode" setting. The Python viewer
 // plumbs the Django setting in via the ANTHIAS_PREFER_DARK_MODE env var

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -38,16 +38,25 @@ void anthiasCrashHandler(int sig)
         // Nothing safe to do if stderr is gone; fall through to re-raise.
     }
     backtrace_symbols_fd(frames, count, STDERR_FILENO);
-    signal(sig, SIG_DFL);
+    // SA_RESETHAND (below) already restored the default disposition, so
+    // re-raising re-runs the default handler (core dump / exit) without an
+    // async-signal-unsafe signal() call here.
     raise(sig);
 }
 
 void installCrashHandler()
 {
-    signal(SIGSEGV, anthiasCrashHandler);
-    signal(SIGABRT, anthiasCrashHandler);
-    signal(SIGBUS, anthiasCrashHandler);
-    signal(SIGFPE, anthiasCrashHandler);
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_handler = anthiasCrashHandler;
+    // SA_RESETHAND: reset to the default handler once ours fires, so the
+    // re-raise takes the default path and we never call the
+    // non-async-signal-safe signal() from within the handler.
+    sa.sa_flags = SA_RESETHAND;
+    sigaction(SIGSEGV, &sa, nullptr);
+    sigaction(SIGABRT, &sa, nullptr);
+    sigaction(SIGBUS, &sa, nullptr);
+    sigaction(SIGFPE, &sa, nullptr);
 }
 #else
 // No-op on non-pi3-64 builds — leave the platform default crash handling

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -5,7 +5,6 @@
 
 #ifdef ANTHIAS_GSTREAMER
 #include <csignal>
-#include <cstdio>
 #include <execinfo.h>
 #include <unistd.h>
 #endif
@@ -24,12 +23,18 @@ namespace {
 // before. Other boards keep the default crash behaviour untouched.
 void anthiasCrashHandler(int sig)
 {
+    // Async-signal-safe only: write() + backtrace_symbols_fd (which writes
+    // via the fd with no malloc, unlike backtrace_symbols/fprintf). The
+    // signal number is omitted from the header (formatting it isn't
+    // AS-safe) — the re-raise below preserves it in the exit status / core.
     void* frames[64];
     const int count = backtrace(frames, 64);
-    fprintf(stderr, "\n=== AnthiasViewer FATAL signal %d — backtrace ===\n",
-            sig);
+    static const char hdr[] =
+        "\n=== AnthiasViewer FATAL signal — backtrace ===\n";
+    if (write(STDERR_FILENO, hdr, sizeof(hdr) - 1) < 0) {
+        // Nothing safe to do if stderr is gone; fall through to re-raise.
+    }
     backtrace_symbols_fd(frames, count, STDERR_FILENO);
-    fflush(stderr);
     signal(sig, SIG_DFL);
     raise(sig);
 }

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -23,10 +23,13 @@ namespace {
 // before. Other boards keep the default crash behaviour untouched.
 void anthiasCrashHandler(int sig)
 {
-    // Async-signal-safe only: write() + backtrace_symbols_fd (which writes
-    // via the fd with no malloc, unlike backtrace_symbols/fprintf). The
-    // signal number is omitted from the header (formatting it isn't
-    // AS-safe) — the re-raise below preserves it in the exit status / core.
+    // Best-effort, kept as close to async-signal-safe as practical:
+    // write() is AS-safe; backtrace()/backtrace_symbols_fd() are glibc
+    // extensions that avoid malloc/stdio (unlike backtrace_symbols /
+    // fprintf) but are not formally guaranteed AS-safe — acceptable for a
+    // last-gasp diagnostic. The signal number is omitted from the header
+    // (formatting it isn't AS-safe); the re-raise below preserves it in
+    // the exit status / core dump.
     void* frames[64];
     const int count = backtrace(frames, 64);
     static const char hdr[] =

--- a/src/anthias_webview/src/main.cpp
+++ b/src/anthias_webview/src/main.cpp
@@ -3,9 +3,40 @@
 #include <QDebug>
 #include <QtDBus>
 
+#include <csignal>
+#include <cstdio>
+#include <execinfo.h>
+#include <unistd.h>
+
 #include "mainwindow.h"
 
 namespace {
+// Fatal-signal backtrace. The pi3-64 overlay video path (VideoView +
+// kmssink on eglfs's DRM fd) segfaults silently — the kernel kills the
+// process and docker logs show only the respawn. Dumping a backtrace to
+// stderr (captured by the start_viewer wrapper) pins the crash frame.
+// Re-raises with the default handler so the exit status is unchanged and
+// the Python supervisor still respawns as before.
+void anthiasCrashHandler(int sig)
+{
+    void* frames[64];
+    const int count = backtrace(frames, 64);
+    fprintf(stderr, "\n=== AnthiasViewer FATAL signal %d — backtrace ===\n",
+            sig);
+    backtrace_symbols_fd(frames, count, STDERR_FILENO);
+    fflush(stderr);
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+
+void installCrashHandler()
+{
+    signal(SIGSEGV, anthiasCrashHandler);
+    signal(SIGABRT, anthiasCrashHandler);
+    signal(SIGBUS, anthiasCrashHandler);
+    signal(SIGFPE, anthiasCrashHandler);
+}
+
 // Realise the operator's "Prefer dark mode" setting. The Python viewer
 // plumbs the Django setting in via the ANTHIAS_PREFER_DARK_MODE env var
 // (see _build_webview_env in src/anthias_viewer/__init__.py); here we
@@ -57,6 +88,7 @@ void applyDarkModePreference()
 
 int main(int argc, char *argv[])
 {
+    installCrashHandler();
     applyDarkModePreference();
 
     QApplication app(argc, argv);

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -367,12 +367,15 @@ void VideoView::play(const QString& uri, const QVariantMap& options)
         // still fails there is no QMediaPlayer fallback on this board (its
         // VideoOutput black-screens on VideoCore IV, issue #3084), so log
         // loudly — the supervisor's respawn is the recovery.
-        if (!gstPlay(uri, options)) {
+        if (gstPlay(uri, options)) {
+            if (statsTimer) {
+                statsTimer->start();
+            }
+        } else {
+            // Don't run the sampler with no pipeline — it would emit SAMPLE
+            // lines with position=-1/elapsed=-1 and bury the real failure.
             qWarning() << "VideoView::play: GStreamer playback failed for"
                        << uri << "(no QMediaPlayer fallback on this board)";
-        }
-        if (statsTimer) {
-            statsTimer->start();
         }
         return;
     }
@@ -1173,13 +1176,20 @@ bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
     }
 
     gstAppSink = gst_bin_get_by_name(GST_BIN(gstPipeline), "asink");
-    if (gstAppSink) {
-        GstAppSinkCallbacks callbacks = {};
-        callbacks.eos = anthias_gst_on_eos;
-        callbacks.new_sample = anthias_gst_on_new_sample;
-        gst_app_sink_set_callbacks(
-            GST_APP_SINK(gstAppSink), &callbacks, this, nullptr);
+    if (!gstAppSink) {
+        // Without the appsink no frames ever reach Qt — the pipeline would
+        // go PLAYING to a silent black screen. Fail hard so the caller
+        // logs it and the supervisor respawns, rather than limping.
+        qWarning() << "VideoView::gstPlay: appsink 'asink' missing —"
+                   << "tearing down";
+        gstStop();
+        return false;
     }
+    GstAppSinkCallbacks callbacks = {};
+    callbacks.eos = anthias_gst_on_eos;
+    callbacks.new_sample = anthias_gst_on_new_sample;
+    gst_app_sink_set_callbacks(
+        GST_APP_SINK(gstAppSink), &callbacks, this, nullptr);
 
     playStartedAt.start();
     if (gst_element_set_state(gstPipeline, GST_STATE_PLAYING)
@@ -1388,9 +1398,15 @@ void VideoView::gstStartAudio(const QString& location, const QString& alsaDev)
     const QString audioSink =
         qEnvironmentVariable("ANTHIAS_GST_AUDIO_SINK",
                              QStringLiteral("alsasink"));
+    // Escape the device string too (same as the filesrc path): it's
+    // interpolated into the gst_parse_launch description, so a quote or
+    // backslash would break the pipeline parse.
+    QString devEsc = alsaDev;
+    devEsc.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
+    devEsc.replace(QLatin1Char('"'), QLatin1String("\\\""));
     const QString audioDeviceProp =
         (audioSink == QLatin1String("alsasink") && !alsaDev.isEmpty())
-            ? QStringLiteral(" device=\"%1\"").arg(alsaDev)
+            ? QStringLiteral(" device=\"%1\"").arg(devEsc)
             : QString();
     // Escape the path for the filesrc string (caller passes a raw path).
     QString loc = location;
@@ -1499,6 +1515,15 @@ void VideoView::gstStop()
         gst_object_unref(gstPipeline);
         gstPipeline = nullptr;
     }
+    // A drain (onGstFrame) may already be queued on the GUI thread from a
+    // late pushGstFrame. Drop the stashed frame so that queued drain is a
+    // no-op (it early-returns on a null image) instead of repainting a
+    // stale frame after teardown; reset the coalescing flag too.
+    {
+        QMutexLocker locker(&gstFrameMutex);
+        gstLatestFrame = QImage();
+    }
+    gstDrainPending.storeRelaxed(0);
 }
 
 void VideoView::pushGstFrame(const QImage& frame)

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -946,14 +946,6 @@ GstFlowReturn anthias_gst_on_new_sample(GstAppSink* sink, gpointer user_data)
     return GST_FLOW_OK;
 }
 
-// Source drained: loop by flushing-seeking back to zero. Marshalled to
-// the GUI thread so it can't race a concurrent stop().
-void anthias_gst_on_eos(GstAppSink* /*sink*/, gpointer user_data)
-{
-    auto* view = static_cast<VideoView*>(user_data);
-    QMetaObject::invokeMethod(view, "gstRestartLoop", Qt::QueuedConnection);
-}
-
 // Find a free OVERLAY plane usable on ``crtcId``. The overlay-plane path
 // (kmssink) needs an explicit plane-id — otherwise kmssink grabs the
 // primary plane, which eglfs already scans out. Skips planes already
@@ -1080,13 +1072,19 @@ gboolean anthias_gst_bus_loop(GstBus* /*bus*/, GstMessage* message,
         GError* err = nullptr;
         gchar* dbg = nullptr;
         gst_message_parse_error(message, &err, &dbg);
-        qWarning() << "VideoView overlay pipeline error:"
+        qWarning() << "VideoView pipeline error:"
                    << (err ? err->message : "?") << (dbg ? dbg : "");
         if (err) {
             g_error_free(err);
         }
         g_free(dbg);
-        break;
+        // Don't sit on a stale frame with a dead pipeline: tear it down on
+        // the GUI thread (the next asset re-shows and rebuilds). Return
+        // FALSE to remove this bus watch — gstStop() also removes it, which
+        // is a harmless no-op.
+        QMetaObject::invokeMethod(
+            view, [view] { view->stop(); }, Qt::QueuedConnection);
+        return FALSE;
     }
     default:
         break;
@@ -1196,10 +1194,17 @@ bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
         return false;
     }
     GstAppSinkCallbacks callbacks = {};
-    callbacks.eos = anthias_gst_on_eos;
     callbacks.new_sample = anthias_gst_on_new_sample;
     gst_app_sink_set_callbacks(
         GST_APP_SINK(gstAppSink), &callbacks, this, nullptr);
+
+    // Bus watch for EOS (loop) and ERROR (tear down) — same handling as the
+    // overlay path, so an appsink pipeline error is surfaced/recovered
+    // instead of silently hanging. EOS looping moves here from the appsink
+    // callback so there's a single loop path.
+    GstBus* bus = gst_element_get_bus(gstPipeline);
+    gst_bus_add_watch(bus, anthias_gst_bus_loop, this);
+    gst_object_unref(bus);
 
     playStartedAt.start();
     if (gst_element_set_state(gstPipeline, GST_STATE_PLAYING)

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1598,10 +1598,11 @@ void VideoView::onGstFrame()
     // Clear the coalescing flag at the END: while this drain ran,
     // pushGstFrame kept gstDrainPending==1 (testAndSetOrdered) so no extra
     // onGstFrame was ever queued behind it — frames that arrived meanwhile
-    // just updated gstLatestFrame. Releasing it here lets the next push
-    // queue exactly one fresh drain, keeping the GUI event queue bounded to
+    // just updated gstLatestFrame. storeRelease pairs with the acquire in
+    // pushGstFrame's testAndSetOrdered so this drain's writes land before
+    // the next drain can be queued, keeping the GUI event queue bounded to
     // a single in-flight drain.
-    gstDrainPending.storeRelaxed(0);
+    gstDrainPending.storeRelease(0);
 }
 
 void VideoView::gstRestartLoop()

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -351,7 +351,7 @@ void VideoView::play(const QString& uri, const QVariantMap& options)
     framesDelivered = 0;
     framesForwarded = 0;
     framesRendered = 0;
-    containerFps = 0.0;
+    setContainerFps(0.0);
     sceneReadyForFrame = true;
     pendingFrame = QVideoFrame();
     writeStats(
@@ -471,7 +471,7 @@ void VideoView::onPlaybackStateChanged(QMediaPlayer::PlaybackState state)
 {
     if (state == QMediaPlayer::PlayingState) {
         const QMediaMetaData meta = player->metaData();
-        containerFps = meta.value(QMediaMetaData::VideoFrameRate).toReal();
+        setContainerFps(meta.value(QMediaMetaData::VideoFrameRate).toReal());
         writeStats(
             QStringLiteral("PLAYING"),
             QStringLiteral(
@@ -489,7 +489,7 @@ void VideoView::onPlaybackStateChanged(QMediaPlayer::PlaybackState state)
                                         .toSize()
                                         .height())
                          : QStringLiteral("?"),
-                     QString::number(containerFps),
+                     QString::number(containerFps()),
                      meta.value(QMediaMetaData::AudioCodec).toString(),
                      QString::number(currentRotation)));
     }
@@ -528,7 +528,7 @@ void VideoView::onMediaStatusChanged(QMediaPlayer::MediaStatus status)
         // rendered count far below delivered = paint-bound, the
         // #2967 failure mode the old log could not see.
         const qreal expected =
-            containerFps > 0.0 ? containerFps * (elapsedMs / 1000.0) : -1.0;
+            containerFps() > 0.0 ? containerFps() * (elapsedMs / 1000.0) : -1.0;
         const qint64 dropped =
             expected > 0.0
                 ? std::max<qint64>(0, qRound(expected) - framesDelivered)
@@ -588,7 +588,7 @@ void VideoView::sampleStats()
             playStartedAt.isValid() ? playStartedAt.elapsed() : -1;
         const qint64 rendered = gstRawSamples.loadRelaxed();
         const qreal expected =
-            containerFps > 0.0 ? containerFps * (elapsedMs / 1000.0) : -1.0;
+            containerFps() > 0.0 ? containerFps() * (elapsedMs / 1000.0) : -1.0;
         const qint64 dropped =
             expected > 0.0 ? std::max<qint64>(0, qRound(expected) - rendered)
                            : -1;
@@ -600,7 +600,7 @@ void VideoView::sampleStats()
                 .arg(rendered)
                 .arg(qRound(expected))
                 .arg(dropped)
-                .arg(QString::number(containerFps, 'f', 2)));
+                .arg(QString::number(containerFps(), 'f', 2)));
         return;
     }
 #endif
@@ -611,7 +611,7 @@ void VideoView::sampleStats()
     const qint64 elapsedMs =
         playStartedAt.isValid() ? playStartedAt.elapsed() : -1;
     const qreal expected =
-        containerFps > 0.0 ? containerFps * (elapsedMs / 1000.0) : -1.0;
+        containerFps() > 0.0 ? containerFps() * (elapsedMs / 1000.0) : -1.0;
     const qint64 dropped =
         expected > 0.0
             ? std::max<qint64>(0, qRound(expected) - framesDelivered)
@@ -989,8 +989,8 @@ uint32_t anthias_find_overlay_plane(int fd, uint32_t crtcId)
 // Buffer probe on kmssink's sink pad: counts frames that reach the sink
 // (the presentation rate for the overlay path, since there is no appsink)
 // and captures the source framerate once from the caps so sampleStats can
-// compute expected-vs-dropped. Runs on a streaming thread — the counter is
-// atomic and containerFps is a benign same-value race.
+// compute expected-vs-dropped. Runs on a streaming thread — both the
+// frame counter and containerFps (via setContainerFps) are atomic.
 GstPadProbeReturn anthias_gst_kms_probe(GstPad* pad, GstPadProbeInfo* /*info*/,
                                         gpointer user_data)
 {
@@ -1222,10 +1222,17 @@ bool VideoView::gstPlayOverlay(const QString& uri)
     QString location = uri;
     location.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
     location.replace(QLatin1Char('"'), QLatin1String("\\\""));
-    const int queueBuffers =
+    // Clamp to a sane positive count: a 0 / negative / non-numeric
+    // ANTHIAS_GST_QUEUE would make queueBuffers 0, i.e. queue
+    // max-size-buffers=0 with time/bytes also 0 = UNBOUNDED buffering →
+    // OOM on the 1 GB board. Fall back to the default 4 in that case.
+    int queueBuffers =
         qEnvironmentVariableIsSet("ANTHIAS_GST_QUEUE")
             ? qEnvironmentVariableIntValue("ANTHIAS_GST_QUEUE")
             : 4;
+    if (queueBuffers <= 0) {
+        queueBuffers = 4;
+    }
     // The bcm2835 decoder only emits I420 (renders blue on the vc4 plane;
     // its V4L2 capture won't negotiate NV12), so v4l2convert (bcm2835 ISP)
     // does I420→NV12. The critical bit is its OUTPUT io-mode: with the
@@ -1306,7 +1313,7 @@ bool VideoView::gstPlayOverlay(const QString& uri)
     // Count frames reaching kmssink (presentation rate) + latch the source
     // fps for sampleStats.
     gstRawSamples.storeRelaxed(0);
-    containerFps = 0.0;
+    setContainerFps(0.0);
     GstElement* sink = gst_bin_get_by_name(GST_BIN(gstPipeline), "vsink");
     if (sink) {
         GstPad* sinkPad = gst_element_get_static_pad(sink, "sink");
@@ -1394,7 +1401,18 @@ void VideoView::gstStartAudio(const QString& location, const QString& alsaDev)
     GstBus* bus = gst_element_get_bus(gstAudioPipeline);
     gst_bus_add_watch(bus, anthias_gst_audio_bus, this);
     gst_object_unref(bus);
-    gst_element_set_state(gstAudioPipeline, GST_STATE_PLAYING);
+    if (gst_element_set_state(gstAudioPipeline, GST_STATE_PLAYING)
+        == GST_STATE_CHANGE_FAILURE) {
+        // Best-effort audio: tear the failed pipeline down and leave the
+        // video playing silently rather than keeping a dead pipeline.
+        writeStats(QStringLiteral("AUDIO"),
+                   QStringLiteral("start-failed sink=%1 device=%2")
+                       .arg(audioSink,
+                            alsaDev.isEmpty() ? QStringLiteral("(default)")
+                                              : alsaDev));
+        gstStopAudio();
+        return;
+    }
     writeStats(QStringLiteral("AUDIO"),
                QStringLiteral("started sink=%1 device=%2")
                    .arg(audioSink,
@@ -1519,7 +1537,7 @@ void VideoView::gstRequeueUri(struct _GstElement* playbin)
 void VideoView::onOverlayBuffer(struct _GstPad* pad)
 {
     gstRawSamples.fetchAndAddRelaxed(1);
-    if (containerFps <= 0.0 && pad) {
+    if (containerFps() <= 0.0 && pad) {
         GstCaps* caps = gst_pad_get_current_caps(pad);
         if (caps) {
             GstStructure* s = gst_caps_get_structure(caps, 0);
@@ -1527,7 +1545,7 @@ void VideoView::onOverlayBuffer(struct _GstPad* pad)
             gint den = 0;
             if (s && gst_structure_get_fraction(s, "framerate", &num, &den)
                 && den > 0) {
-                containerFps = static_cast<qreal>(num) / den;
+                setContainerFps(static_cast<qreal>(num) / den);
             }
             gst_caps_unref(caps);
         }

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -363,7 +363,14 @@ void VideoView::play(const QString& uri, const QVariantMap& options)
     if (gstMode) {
         // pi3-64: hand off to the GStreamer HW pipeline instead of
         // QMediaPlayer. Frames arrive via onGstFrame → rasterWidget.
-        gstPlay(uri, options);
+        // gstPlay exhausts every GStreamer path (overlay → appsink); if it
+        // still fails there is no QMediaPlayer fallback on this board (its
+        // VideoOutput black-screens on VideoCore IV, issue #3084), so log
+        // loudly — the supervisor's respawn is the recovery.
+        if (!gstPlay(uri, options)) {
+            qWarning() << "VideoView::play: GStreamer playback failed for"
+                       << uri << "(no QMediaPlayer fallback on this board)";
+        }
         if (statsTimer) {
             statsTimer->start();
         }
@@ -1065,11 +1072,32 @@ bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
 {
     gstStop();
 
+    // filesrc needs a filesystem path. Anthias passes bare local paths
+    // (e.g. /data/anthias_assets/<id>) today; normalise a file:// URL
+    // defensively so a future caller can't yield a broken location=.
+    // Per-pipeline ``"``/``\`` escaping happens where each filesrc is
+    // built below.
+    QString localPath = uri;
+    if (localPath.startsWith(QLatin1String("file://"))) {
+        localPath = QUrl(uri).toLocalFile();
+    }
+    // Resolve the audio device once and start audio HERE (not inside
+    // gstPlayOverlay) so BOTH the overlay and the appsink-raster fallback
+    // get sound — previously the raster path played silent. Same
+    // audio-device option the QMediaPlayer path uses; strip the Qt
+    // ``alsa/`` scheme prefix for ALSA.
+    QString alsaDev =
+        options.value(QStringLiteral("audio-device")).toString();
+    if (alsaDev.startsWith(QLatin1String("alsa/"))) {
+        alsaDev = alsaDev.mid(5);
+    }
+
     // HW overlay-plane path first (if requested and resolvable): it scans
     // out the video directly on a vc4 overlay plane, bypassing the eglfs
     // GL compositor that caps at ~9 fps. Falls through to the appsink →
     // raster blit below on any failure.
-    if (gstOverlayMode && gstPlayOverlay(uri, options)) {
+    if (gstOverlayMode && gstPlayOverlay(localPath)) {
+        gstStartAudio(localPath, alsaDev);
         return true;
     }
 
@@ -1082,8 +1110,7 @@ bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
     // doing SAND→RGB16 in hardware (the conversion the CPU can't afford,
     // ~600 ms/frame). sync=true paces the appsink to each frame's PTS;
     // drop=true / max-buffers=2 bounds latency to the freshest frame.
-    // Audio is a follow-up; this first cut is video-only.
-    QString location = uri;
+    QString location = localPath;
     location.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
     location.replace(QLatin1Char('"'), QLatin1String("\\\""));
     // Optional ISP downscale (ANTHIAS_GST_SCALE="WxH", e.g. 1280x720):
@@ -1147,10 +1174,12 @@ bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
         gstStop();
         return false;
     }
+    // appsink-raster fallback is up; give it audio too.
+    gstStartAudio(localPath, alsaDev);
     return true;
 }
 
-bool VideoView::gstPlayOverlay(const QString& uri, const QVariantMap& options)
+bool VideoView::gstPlayOverlay(const QString& uri)
 {
     QPlatformNativeInterface* ni = QGuiApplication::platformNativeInterface();
     if (!ni) {
@@ -1237,24 +1266,13 @@ bool VideoView::gstPlayOverlay(const QString& uri, const QVariantMap& options)
             : QStringLiteral(
                   "v4l2convert capture-io-mode=%1 ! video/x-raw,format=NV12 ! ")
                   .arg(convIoMode);
-    // Audio plays in a SEPARATE GStreamer pipeline (see gstStartAudio),
-    // NOT a branch off the video's qtdemux. A shared pipeline coupled the
-    // two fatally: any audio condition — a slow/queuing decodebin preroll,
-    // an audio-provided clock that stalls, a missing track — froze the
-    // VIDEO at the first frame. An independent pipeline (own clock, own
-    // preroll, own bus) means the video path below stays byte-for-byte the
-    // proven 30 fps chain and can never be stalled by audio. Resolve the
-    // ALSA device here (same ``audio-device`` option the QMediaPlayer path
-    // uses, e.g. ``alsa/sysdefault:CARD=<hdmi>``; strip the Qt ``alsa/``
-    // scheme). We drive alsasink directly on the HDMI card rather than
-    // pulsesink: pi3-64 no longer routes video through QtMultimedia, and
-    // pulse's default sink is the 3.5mm jack while its vc4hdmi sink sits
-    // suspended (card free) — the legacy GstFbdev path did the same.
-    QString alsaDev =
-        options.value(QStringLiteral("audio-device")).toString();
-    if (alsaDev.startsWith(QLatin1String("alsa/"))) {
-        alsaDev = alsaDev.mid(5);
-    }
+    // Audio is a SEPARATE GStreamer pipeline started by the caller
+    // (gstPlay → gstStartAudio), NOT a branch off this video qtdemux: a
+    // shared pipeline coupled the two fatally (a slow/queuing decodebin
+    // preroll, an audio-provided clock that stalls, or a missing track
+    // froze the VIDEO at the first frame). Keeping it independent means
+    // this overlay chain stays byte-for-byte the proven 30 fps path and
+    // can never be stalled by audio.
     const QString description =
         QStringLiteral(
             "filesrc location=\"%1\" ! qtdemux ! h264parse ! %7 ! "
@@ -1328,9 +1346,8 @@ bool VideoView::gstPlayOverlay(const QString& uri, const QVariantMap& options)
             "backend=gstreamer/v4l2 sink=kms-overlay plane-id=%1 qt=%2")
             .arg(planeId)
             .arg(QStringLiteral(QT_VERSION_STR)));
-
-    // Video is up; bring up audio in its own pipeline (best-effort).
-    gstStartAudio(location, alsaDev);
+    // Audio is started by the caller (gstPlay) so it also covers the
+    // appsink-raster fallback, not just this overlay path.
     return true;
 }
 
@@ -1343,6 +1360,10 @@ void VideoView::gstStartAudio(const QString& location, const QString& alsaDev)
         (audioSink == QLatin1String("alsasink") && !alsaDev.isEmpty())
             ? QStringLiteral(" device=\"%1\"").arg(alsaDev)
             : QString();
+    // Escape the path for the filesrc string (caller passes a raw path).
+    QString loc = location;
+    loc.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
+    loc.replace(QLatin1Char('"'), QLatin1String("\\\""));
     // decodebin autoplugs the audio codec (AAC/MP3/…); the sink drives the
     // HDMI ALSA card directly. Own pipeline → own clock/preroll, fully
     // isolated from the video overlay pipeline.
@@ -1353,7 +1374,7 @@ void VideoView::gstStartAudio(const QString& location, const QString& alsaDev)
         QStringLiteral(
             "filesrc location=\"%1\" ! qtdemux name=ademux ademux.audio_0 ! "
             "queue ! decodebin ! audioconvert ! audioresample ! %2%3")
-            .arg(location, audioSink, audioDeviceProp);
+            .arg(loc, audioSink, audioDeviceProp);
 
     GError* error = nullptr;
     gstAudioPipeline =

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -408,6 +408,16 @@ void VideoView::stop()
         if (statsStream && !currentUri.isEmpty()) {
             const qint64 elapsedMs =
                 playStartedAt.isValid() ? playStartedAt.elapsed() : -1;
+            // Log the real pipeline position (the pipeline is still up here
+            // — gstStop() runs below), not a hard-coded 0 that reads like
+            // playback never advanced. -1 if the query fails.
+            gint64 posNs = 0;
+            const qint64 posMs =
+                (gstPipeline
+                 && gst_element_query_position(
+                        gstPipeline, GST_FORMAT_TIME, &posNs))
+                    ? posNs / GST_MSECOND
+                    : -1;
             writeStats(
                 QStringLiteral("STOP"),
                 QStringLiteral(
@@ -418,7 +428,7 @@ void VideoView::stop()
                     .arg(framesDelivered)
                     .arg(framesForwarded)
                     .arg(framesRendered)
-                    .arg(0));
+                    .arg(posMs));
         }
         gstStop();
         rasterReady = true;

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1106,6 +1106,10 @@ gboolean anthias_gst_bus_loop(GstBus* /*bus*/, GstMessage* message,
 bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
 {
     gstStop();
+    // Reset the raw frame counter here (covers BOTH the overlay and the
+    // appsink paths) so a new asset's stats don't carry over the previous
+    // one's cumulative count.
+    gstRawSamples.storeRelaxed(0);
 
     // filesrc needs a filesystem path. Anthias passes bare local paths
     // (e.g. /data/anthias_assets/<id>) today; normalise a file:// URL
@@ -1362,8 +1366,8 @@ bool VideoView::gstPlayOverlay(const QString& uri)
     }
 
     // Count frames reaching kmssink (presentation rate) + latch the source
-    // fps for sampleStats.
-    gstRawSamples.storeRelaxed(0);
+    // fps for sampleStats. (gstRawSamples is reset once in gstPlay for both
+    // paths.)
     setContainerFps(0.0);
     GstElement* sink = gst_bin_get_by_name(GST_BIN(gstPipeline), "vsink");
     if (sink) {

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1110,6 +1110,13 @@ bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
     // appsink paths) so a new asset's stats don't carry over the previous
     // one's cumulative count.
     gstRawSamples.storeRelaxed(0);
+    // Clear the on-screen raster surface so the previous asset's last frame
+    // can't linger (stale-frame flash) while the new pipeline prerolls or
+    // if it fails to start. The overlay path re-clears it too (the video is
+    // on the plane, not this widget).
+    if (rasterWidget) {
+        rasterWidget->clear();
+    }
 
     // filesrc needs a filesystem path. Anthias passes bare local paths
     // (e.g. /data/anthias_assets/<id>) today; normalise a file:// URL
@@ -1576,20 +1583,25 @@ void VideoView::onGstFrame()
     // that follows setImage() bumps framesRendered in onRasterPainted(),
     // so SAMPLE reports the true present rate; gstRawSamples (logged in
     // sampleStats) reports the pipeline's own delivery rate for contrast.
-    gstDrainPending.storeRelaxed(0);
     QImage frame;
     {
         QMutexLocker locker(&gstFrameMutex);
         frame = gstLatestFrame;
     }
-    if (frame.isNull()) {
-        return;
+    if (!frame.isNull()) {
+        ++framesDelivered;
+        ++framesForwarded;
+        if (rasterWidget) {
+            rasterWidget->setImage(frame);
+        }
     }
-    ++framesDelivered;
-    ++framesForwarded;
-    if (rasterWidget) {
-        rasterWidget->setImage(frame);
-    }
+    // Clear the coalescing flag at the END: while this drain ran,
+    // pushGstFrame kept gstDrainPending==1 (testAndSetOrdered) so no extra
+    // onGstFrame was ever queued behind it — frames that arrived meanwhile
+    // just updated gstLatestFrame. Releasing it here lets the next push
+    // queue exactly one fresh drain, keeping the GUI event queue bounded to
+    // a single in-flight drain.
+    gstDrainPending.storeRelaxed(0);
 }
 
 void VideoView::gstRestartLoop()

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1134,8 +1134,10 @@ bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
     // would risk the software avdec_h264, which can't sustain realtime and
     // thermally reboots the 1 GB board. v4l2convert is the bcm2835 ISP
     // doing SAND→RGB16 in hardware (the conversion the CPU can't afford,
-    // ~600 ms/frame). sync=true paces the appsink to each frame's PTS;
-    // drop=true / max-buffers=2 bounds latency to the freshest frame.
+    // ~600 ms/frame). sync=false delivers frames as soon as the ISP emits
+    // them (the GUI-side coalescing gate in pushGstFrame paces what
+    // actually paints); drop=true / max-buffers=2 bounds latency to the
+    // freshest frame.
     QString location = localPath;
     location.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
     location.replace(QLatin1Char('"'), QLatin1String("\\\""));
@@ -1260,15 +1262,10 @@ bool VideoView::gstPlayOverlay(const QString& uri)
     // Explicit HW pipeline (reliably reaches the overlay — the playbin
     // variant hung in set_state). pi3-64 only receives H.264/MP4 (the
     // codec gate rejects other codecs), so qtdemux ! h264parse !
-    // v4l2h264dec forces the bcm2835 HW decoder. The ``queue`` sits
-    // BEFORE v4l2convert so it decouples the decoder thread from the
-    // convert+present thread WITHOUT hoarding the convert's OUTPUT pool —
-    // queuing the convert's output was the buffer-starvation deadlock.
-    // Here the queue holds decoder buffers (the decoder's larger DPB pool
-    // covers them) while kmssink holds only 1-2 of the convert's output
-    // buffers (the convert pool covers those). v4l2convert (bcm2835 ISP)
-    // pins NV12 — the vc4 plane's native scanout format; the raw decoder
-    // renegotiates I420, which shows wrong colours (blue).
+    // v4l2h264dec forces the bcm2835 HW decoder. Default is decoder-direct
+    // (I420 straight to kmssink — see the decode/convert stage notes
+    // below); the ``queue`` decouples the decoder thread from the scanout
+    // thread.
     QString location = uri;
     location.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
     location.replace(QLatin1Char('"'), QLatin1String("\\\""));
@@ -1283,31 +1280,26 @@ bool VideoView::gstPlayOverlay(const QString& uri)
     if (queueBuffers <= 0) {
         queueBuffers = 4;
     }
-    // The bcm2835 decoder only emits I420 (renders blue on the vc4 plane;
-    // its V4L2 capture won't negotiate NV12), so v4l2convert (bcm2835 ISP)
-    // does I420→NV12. The critical bit is its OUTPUT io-mode: with the
-    // default exported-dmabuf, kmssink zero-copies and PINS the convert's
-    // output buffers on the plane, starving the convert pool → ~18 fps (or
-    // a hard deadlock decoder-direct). Forcing ``capture-io-mode=mmap``
-    // makes the convert output CPU-memory buffers that kmssink cannot
-    // scan out directly, so kmssink COPIES each frame into its own dumb
-    // buffer and releases the convert buffer immediately — exactly how the
-    // legacy fbdevsink avoided the hold. The copy (~NV12 1080p ≈ 3 MB) is
-    // cheap next to the ISP work and buys full-rate, deadlock-free
-    // presentation. Overridable for tuning.
+    // io-mode of the ISP convert used ONLY by the fallback path
+    // (ANTHIAS_GST_ISP_CONVERT=1). mmap makes that convert output
+    // CPU-memory buffers so kmssink copies + releases them instead of
+    // pinning its pool — the same copy-not-pin trick the decoder-direct
+    // default applies to the decoder itself (see decodeStage). Overridable.
     const QString convIoMode =
         qEnvironmentVariable("ANTHIAS_GST_CONVERT_IOMODE",
                              QStringLiteral("mmap"));
-    // ANTHIAS_GST_ISP_CONVERT=0 → decoder-direct (skip the ~15-18fps ISP
-    // convert): the decoder emits I420 at full rate. To stop kmssink
-    // pinning the decoder's DPB buffers (which deadlocks it), force the
-    // DECODER's output to mmap so kmssink copies + releases immediately.
-    // Default: decoder-direct (I420) with the decoder's output forced to
-    // mmap so kmssink COPIES rather than pinning the decoder's DPB pool —
-    // that combination is what delivers a stable 30 fps with zero ongoing
-    // drops (the ISP-convert path is ~18fps-bound; plain decoder-direct
-    // deadlocks). ANTHIAS_GST_ISP_CONVERT=1 reinstates the ISP-convert
-    // (NV12) path for boards/streams where I420 direct-scanout misbehaves.
+    // Default (ANTHIAS_GST_ISP_CONVERT unset/0): decoder-direct — the
+    // bcm2835 decoder emits I420, which the vc4 overlay plane scans out
+    // directly, at full rate. The load-bearing bit is the DECODER's output
+    // io-mode: with exported-dmabuf kmssink zero-copies and PINS the
+    // decoder's DPB buffers on the plane, starving the pool → hard
+    // deadlock; ``capture-io-mode=mmap`` makes the decoder output
+    // CPU-memory buffers kmssink can't scan out directly, so it COPIES each
+    // frame (~I420 1080p ≈ 3 MB, cheap) and releases the buffer
+    // immediately — as the legacy fbdevsink did — giving stable 30 fps
+    // with zero ongoing drops. ANTHIAS_GST_ISP_CONVERT=1 inserts the ISP
+    // to emit NV12 instead (a second M2M pass, ~18 fps) for streams where
+    // direct I420 scanout misbehaves.
     const bool useConvert =
         qEnvironmentVariableIsSet("ANTHIAS_GST_ISP_CONVERT")
             ? qEnvironmentVariableIntValue("ANTHIAS_GST_ISP_CONVERT") != 0
@@ -1512,8 +1504,9 @@ void VideoView::gstStop()
 {
     gstStopAudio();
     if (gstPipeline) {
-        // Remove the bus watch the overlay path installed (no-op if the
-        // appsink path was used — that has no bus watch).
+        // Remove the bus watch (both the overlay and the appsink paths
+        // install one; a no-op if it was already dropped, e.g. after an
+        // error watch returned FALSE).
         GstBus* bus = gst_element_get_bus(gstPipeline);
         if (bus) {
             gst_bus_remove_watch(bus);

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -7,6 +7,8 @@
 #include <QFileInfo>
 #include <QMediaDevices>
 #include <QMediaMetaData>
+#include <QPaintEvent>
+#include <QPainter>
 #include <QQmlError>
 #include <QQuickItem>
 #include <QQuickWidget>
@@ -17,6 +19,78 @@
 #include <QVideoSink>
 #include <QtGlobal>
 
+#ifdef ANTHIAS_GSTREAMER
+#include <gst/app/gstappsink.h>
+#include <gst/gst.h>
+#include <gst/video/video.h>
+
+#include <QGuiApplication>
+#include <QScreen>
+#include <qpa/qplatformnativeinterface.h>
+
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include <cstring>
+#endif
+
+
+// CPU-raster video surface for boards whose GPU can't present the QML
+// VideoOutput RHI path (pi3-64 / VideoCore IV — issue #3084). Holds the
+// latest decoded frame as a QImage and blits it, aspect-fit on black,
+// through the widget backing store — the same compositing path images
+// and webpages use, which those boards DO scan out. No Q_OBJECT: it
+// carries no signals/slots and calls back into VideoView (its
+// friend-owner) directly from paintEvent to re-arm the pacing gate.
+class RasterVideoWidget : public QWidget
+{
+public:
+    explicit RasterVideoWidget(VideoView* owner)
+        : QWidget(owner), owner_(owner)
+    {
+        // The whole surface is repainted (black fill + frame) every
+        // paint, so suppress the default background clear and the
+        // pre-first-frame palette flash.
+        setAttribute(Qt::WA_OpaquePaintEvent);
+    }
+
+    void setImage(const QImage& image)
+    {
+        image_ = image;
+        update();
+    }
+
+    void clear()
+    {
+        image_ = QImage();
+        update();
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter painter(this);
+        painter.fillRect(rect(), Qt::black);
+        if (!image_.isNull()) {
+            // Aspect-fit letterbox — matches VideoOutput's
+            // PreserveAspectFit. Nearest-neighbour scale (no
+            // SmoothPixmapTransform): a 1080p frame on a 1080p panel is
+            // ~1:1 and smooth scaling is too costly for the VideoCore IV
+            // GUI thread this path exists to serve.
+            const QSize target =
+                image_.size().scaled(size(), Qt::KeepAspectRatio);
+            QRect dst(QPoint(0, 0), target);
+            dst.moveCenter(rect().center());
+            painter.drawImage(dst, image_);
+        }
+        owner_->onRasterPainted();
+    }
+
+private:
+    VideoView* owner_;
+    QImage image_;
+};
+
 
 VideoView::VideoView(QWidget* parent) : QWidget(parent)
 {
@@ -24,56 +98,90 @@ VideoView::VideoView(QWidget* parent) : QWidget(parent)
     videoLayout->setContentsMargins(0, 0, 0, 0);
     videoLayout->setSpacing(0);
 
-    // QML VideoOutput in a QQuickWidget: frames render through the
-    // RHI scene graph (shader YUV→RGB at composite time) instead of
-    // the QGraphicsVideoItem toImage()-readback-blit chain that
-    // capped presentation at 8–12 fps (issue #2967, see videoview.h).
-    // Black backdrop is two layers with distinct jobs: ``clearColor``
-    // covers the pre-QML-load window, the QML Rectangle provides the
-    // steady-state letterbox fill around PreserveAspectFit. (No
-    // widget-palette layer on top — the QQuickWidget fills the whole
-    // layout, so a palette would be permanently occluded.)
-    quickWidget = new QQuickWidget(this);
-    quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    quickWidget->setClearColor(Qt::black);
-    quickWidget->setSource(QUrl(QStringLiteral("qrc:/videoview.qml")));
-    if (quickWidget->status() == QQuickWidget::Error) {
-        const auto errors = quickWidget->errors();
-        for (const QQmlError& error : errors) {
-            qWarning() << "VideoView: QML load error:" << error.toString();
-        }
-    }
-    videoLayout->addWidget(quickWidget);
+    // Board-selected presentation substrate. ANTHIAS_VIDEO_RASTER is
+    // set by the Python side for pi3-64 only (see _build_webview_env):
+    // that board's VideoCore IV / GLES2 GPU can't scan out the QML
+    // VideoOutput RHI path (issue #3084), so it uses the CPU-raster
+    // widget instead. Every other board keeps the fast on-GPU path.
+    rasterMode = qEnvironmentVariableIntValue("ANTHIAS_VIDEO_RASTER") != 0;
 
-    if (quickWidget->rootObject()) {
-        videoOutputItem = quickWidget->rootObject()
-                              ->findChild<QQuickItem*>(
-                                  QStringLiteral("videoOutput"));
+#ifdef ANTHIAS_GSTREAMER
+    // On pi3-64 the raster widget is fed by the in-process GStreamer HW
+    // pipeline (gstPlay), not QMediaPlayer+toImage — the ISP converts in
+    // hardware. gst_init is idempotent; safe to call unconditionally on
+    // this board.
+    gstMode = rasterMode;
+    if (gstMode) {
+        gst_init(nullptr, nullptr);
+        // Prefer the HW overlay-plane path when requested; gstPlay falls
+        // back to the appsink→raster blit if the DRM resources or a free
+        // overlay plane can't be resolved at play time.
+        gstOverlayMode =
+            qEnvironmentVariableIntValue("ANTHIAS_VIDEO_OVERLAY") != 0;
     }
-    if (videoOutputItem) {
-        // VideoOutput exposes its sink as a property; resolving it
-        // here (rather than player->setVideoOutput(item)) keeps an
-        // explicit QVideoSink* around for the frame-delivery counter.
-        videoSink = qvariant_cast<QVideoSink*>(
-            videoOutputItem->property("videoSink"));
-    }
-    if (!videoOutputItem || !videoSink) {
-        // Fail hard rather than limp into decode-but-render-nowhere:
-        // a kiosk that silently black-screens every video while its
-        // logs read "playing" is the exact failure mode the VLC/mmal
-        // era shipped (docs/board-enablement.md, "rendered to
-        // nowhere"). Aborting hands the device to the existing
-        // spawn-retry / container-restart supervision, which is loud
-        // in fleet telemetry. Most likely cause on a device image:
-        // qml6-module-qtquick / qml6-module-qtmultimedia missing —
-        // the QML import fails at runtime, not the C++ link (see
-        // tools/image_builder/utils.py).
-        qFatal("VideoView: QML video scene unavailable (videoOutput "
-               "item or its videoSink missing — check the QML load "
-               "errors above and the qml6-module-qtquick / "
-               "qml6-module-qtmultimedia packages). Aborting so the "
-               "supervisor restarts the viewer instead of decoding "
-               "video to nowhere.");
+#endif
+
+    if (rasterMode) {
+        // No QQuickWidget / VideoOutput / videoSink here: frames are
+        // converted with QVideoFrame::toImage() in
+        // onVideoFrameDelivered() and blitted by rasterWidget. See
+        // videoview.h and RasterVideoWidget above.
+        rasterWidget = new RasterVideoWidget(this);
+        videoLayout->addWidget(rasterWidget);
+    } else {
+        // QML VideoOutput in a QQuickWidget: frames render through the
+        // RHI scene graph (shader YUV→RGB at composite time) instead of
+        // the QGraphicsVideoItem toImage()-readback-blit chain that
+        // capped presentation at 8–12 fps (issue #2967, see
+        // videoview.h). Black backdrop is two layers with distinct
+        // jobs: ``clearColor`` covers the pre-QML-load window, the QML
+        // Rectangle provides the steady-state letterbox fill around
+        // PreserveAspectFit. (No widget-palette layer on top — the
+        // QQuickWidget fills the whole layout, so a palette would be
+        // permanently occluded.)
+        quickWidget = new QQuickWidget(this);
+        quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+        quickWidget->setClearColor(Qt::black);
+        quickWidget->setSource(QUrl(QStringLiteral("qrc:/videoview.qml")));
+        if (quickWidget->status() == QQuickWidget::Error) {
+            const auto errors = quickWidget->errors();
+            for (const QQmlError& error : errors) {
+                qWarning()
+                    << "VideoView: QML load error:" << error.toString();
+            }
+        }
+        videoLayout->addWidget(quickWidget);
+
+        if (quickWidget->rootObject()) {
+            videoOutputItem = quickWidget->rootObject()
+                                  ->findChild<QQuickItem*>(
+                                      QStringLiteral("videoOutput"));
+        }
+        if (videoOutputItem) {
+            // VideoOutput exposes its sink as a property; resolving it
+            // here (rather than player->setVideoOutput(item)) keeps an
+            // explicit QVideoSink* around for the frame-delivery counter.
+            videoSink = qvariant_cast<QVideoSink*>(
+                videoOutputItem->property("videoSink"));
+        }
+        if (!videoOutputItem || !videoSink) {
+            // Fail hard rather than limp into decode-but-render-nowhere:
+            // a kiosk that silently black-screens every video while its
+            // logs read "playing" is the exact failure mode the VLC/mmal
+            // era shipped (docs/board-enablement.md, "rendered to
+            // nowhere"). Aborting hands the device to the existing
+            // spawn-retry / container-restart supervision, which is loud
+            // in fleet telemetry. Most likely cause on a device image:
+            // qml6-module-qtquick / qml6-module-qtmultimedia missing —
+            // the QML import fails at runtime, not the C++ link (see
+            // tools/image_builder/utils.py).
+            qFatal("VideoView: QML video scene unavailable (videoOutput "
+                   "item or its videoSink missing — check the QML load "
+                   "errors above and the qml6-module-qtquick / "
+                   "qml6-module-qtmultimedia packages). Aborting so the "
+                   "supervisor restarts the viewer instead of decoding "
+                   "video to nowhere.");
+        }
     }
 
     player = new QMediaPlayer(this);
@@ -111,8 +219,12 @@ VideoView::VideoView(QWidget* parent) : QWidget(parent)
     // item→window attachment ever lands later than this constructor
     // (qrc setSource is synchronous on Qt 6.8, but a dead counter
     // would silently report frames-rendered=0 — the inverse of the
-    // #2967 blind spot — so don't bet the diagnostic on it).
-    connectRenderCounter();
+    // #2967 blind spot — so don't bet the diagnostic on it). The
+    // raster path has no QQuickWindow; it counts frames-rendered in
+    // RasterVideoWidget::paintEvent via onRasterPainted() instead.
+    if (!rasterMode) {
+        connectRenderCounter();
+    }
 
     openStatsLog();
 
@@ -126,6 +238,9 @@ VideoView::~VideoView()
     if (statsTimer) {
         statsTimer->stop();
     }
+#ifdef ANTHIAS_GSTREAMER
+    gstStop();
+#endif
     if (player) {
         player->stop();
     }
@@ -158,15 +273,23 @@ void VideoView::openStatsLog()
         mode = QIODevice::WriteOnly | QIODevice::Truncate
                | QIODevice::Text;
     }
+    QString backend = QStringLiteral("qtmultimedia/ffmpeg");
+    QString sinkName = rasterMode ? QStringLiteral("raster-cpu")
+                                  : QStringLiteral("quick-videooutput");
+#ifdef ANTHIAS_GSTREAMER
+    if (gstMode) {
+        backend = QStringLiteral("gstreamer/v4l2");
+        sinkName = QStringLiteral("gst-appsink");
+    }
+#endif
     statsFile = new QFile(path, this);
     if (statsFile->open(mode)) {
         statsStream = new QTextStream(statsFile);
         writeStats(
             QStringLiteral("INIT"),
             QStringLiteral(
-                "backend=qtmultimedia/ffmpeg sink=quick-videooutput "
-                "qt=%1 audio_default=%2")
-                .arg(QStringLiteral(QT_VERSION_STR),
+                "backend=%1 sink=%2 qt=%3 audio_default=%4")
+                .arg(backend, sinkName, QStringLiteral(QT_VERSION_STR),
                      QMediaDevices::defaultAudioOutput().description()));
     } else {
         qWarning() << "VideoView: could not open" << path
@@ -236,6 +359,18 @@ void VideoView::play(const QString& uri, const QVariantMap& options)
         QStringLiteral("uri=%1 options={%2}")
             .arg(uri, summary.join(QLatin1Char(' '))));
 
+#ifdef ANTHIAS_GSTREAMER
+    if (gstMode) {
+        // pi3-64: hand off to the GStreamer HW pipeline instead of
+        // QMediaPlayer. Frames arrive via onGstFrame → rasterWidget.
+        gstPlay(uri, options);
+        if (statsTimer) {
+            statsTimer->start();
+        }
+        return;
+    }
+#endif
+
     // Local-path URIs (e.g. ``/data/anthias_assets/abc.mp4``) come
     // through as scheme-less strings; ``QUrl(uri)`` parses them as
     // relative URLs with no host/scheme and QMediaPlayer refuses
@@ -255,6 +390,34 @@ void VideoView::play(const QString& uri, const QVariantMap& options)
 
 void VideoView::stop()
 {
+#ifdef ANTHIAS_GSTREAMER
+    if (gstMode) {
+        if (statsTimer) {
+            statsTimer->stop();
+        }
+        if (statsStream && !currentUri.isEmpty()) {
+            const qint64 elapsedMs =
+                playStartedAt.isValid() ? playStartedAt.elapsed() : -1;
+            writeStats(
+                QStringLiteral("STOP"),
+                QStringLiteral(
+                    "uri=%1 elapsed_ms=%2 frames-delivered=%3 "
+                    "frames-forwarded=%4 frames-rendered=%5 position-ms=%6")
+                    .arg(currentUri)
+                    .arg(elapsedMs)
+                    .arg(framesDelivered)
+                    .arg(framesForwarded)
+                    .arg(framesRendered)
+                    .arg(0));
+        }
+        gstStop();
+        rasterReady = true;
+        if (rasterWidget) {
+            rasterWidget->clear();
+        }
+        return;
+    }
+#endif
     if (!player) {
         return;
     }
@@ -283,10 +446,16 @@ void VideoView::stop()
     // next reveal), nor keep its decoder buffer alive between
     // assets. Pushing an empty frame to the VideoOutput releases the
     // last displayed buffer too — black beats a stale frame when the
-    // widget is next shown.
+    // widget is next shown. The raster path clears rasterWidget for the
+    // same reason.
     pendingFrame = QVideoFrame();
     sceneReadyForFrame = true;
-    if (videoSink) {
+    rasterReady = true;
+    if (rasterMode) {
+        if (rasterWidget) {
+            rasterWidget->clear();
+        }
+    } else if (videoSink) {
         videoSink->setVideoFrame(QVideoFrame());
     }
 }
@@ -394,6 +563,40 @@ void VideoView::onErrorOccurred(
 
 void VideoView::sampleStats()
 {
+#ifdef ANTHIAS_GSTREAMER
+    if (gstOverlayActive) {
+        if (!statsStream) {
+            return;
+        }
+        // Overlay path: frames never touch the CPU, so rendered = the
+        // sink-pad buffer probe count, expected = source_fps × elapsed,
+        // and dropped = the shortfall. kmssink's own late-frame drops are
+        // logged separately as QOS lines from the bus watch.
+        gint64 posNs = 0;
+        const qint64 posMs =
+            gst_element_query_position(gstPipeline, GST_FORMAT_TIME, &posNs)
+                ? posNs / GST_MSECOND
+                : -1;
+        const qint64 elapsedMs =
+            playStartedAt.isValid() ? playStartedAt.elapsed() : -1;
+        const qint64 rendered = gstRawSamples.loadRelaxed();
+        const qreal expected =
+            containerFps > 0.0 ? containerFps * (elapsedMs / 1000.0) : -1.0;
+        const qint64 dropped =
+            expected > 0.0 ? std::max<qint64>(0, qRound(expected) - rendered)
+                           : -1;
+        writeStats(
+            QStringLiteral("SAMPLE"),
+            QStringLiteral("position-ms=%1 frames-rendered=%2 expected=%3 "
+                           "dropped=%4 container-fps=%5")
+                .arg(posMs)
+                .arg(rendered)
+                .arg(qRound(expected))
+                .arg(dropped)
+                .arg(QString::number(containerFps, 'f', 2)));
+        return;
+    }
+#endif
     if (!player || !statsStream) {
         return;
     }
@@ -417,11 +620,64 @@ void VideoView::sampleStats()
             .arg(framesRendered)
             .arg(qRound(expected))
             .arg(dropped));
+
+    // Raster instrumentation: average QVideoFrame::toImage() cost over
+    // the frames converted in this 1 s window. Reset the accumulators
+    // so each RASTER line is a fresh per-second average.
+    if (rasterMode && rasterConvertCount > 0) {
+        const double avgMs =
+            (rasterConvertUsAccum / 1000.0) / rasterConvertCount;
+        writeStats(
+            QStringLiteral("RASTER"),
+            QStringLiteral("convert-avg-ms=%1 n=%2")
+                .arg(QString::number(avgMs, 'f', 1))
+                .arg(rasterConvertCount));
+        rasterConvertUsAccum = 0;
+        rasterConvertCount = 0;
+    }
+
+#ifdef ANTHIAS_GSTREAMER
+    if (gstMode) {
+        // Cumulative appsink deliveries (pipeline's own rate). Compared
+        // against SAMPLE frames-rendered (paint rate) this separates a
+        // pipeline capped at N fps from a pipeline producing more than
+        // the eglfs paint can present.
+        writeStats(
+            QStringLiteral("GSTRAW"),
+            QStringLiteral("appsink-total=%1")
+                .arg(gstRawSamples.loadRelaxed()));
+    }
+#endif
 }
 
 void VideoView::onVideoFrameDelivered(const QVideoFrame& frame)
 {
     ++framesDelivered;
+
+    if (rasterMode) {
+        if (!frame.isValid()) {
+            // Stream end / source change marker — drop any parked frame
+            // and clear the surface to black instead of freezing on the
+            // last one.
+            pendingFrame = QVideoFrame();
+            if (rasterWidget) {
+                rasterWidget->clear();
+            }
+            return;
+        }
+        if (!rasterReady) {
+            // Paint of the previous frame still in flight — park the
+            // freshest frame (replacing any older parked one) for
+            // onRasterPainted() to forward. Self-paces the
+            // toImage()+blit to the widget's paint rate, which is what
+            // bounds this path on VideoCore IV.
+            pendingFrame = frame;
+            return;
+        }
+        presentRasterFrame(frame);
+        return;
+    }
+
     if (!videoSink) {
         return;
     }
@@ -466,6 +722,41 @@ void VideoView::onSceneRendered()
         return;
     }
     sceneReadyForFrame = true;
+}
+
+void VideoView::presentRasterFrame(const QVideoFrame& frame)
+{
+    // Close the one-frame gate, convert the decoded frame to a CPU
+    // QImage (a GPU→CPU readback for HW-decoded frames — the cost this
+    // path trades for actually reaching the VideoCore IV scanout), and
+    // hand it to rasterWidget, whose paintEvent blits it and calls
+    // onRasterPainted() to re-open the gate. A null conversion (e.g. a
+    // frame that can't be mapped) paints black for that frame but still
+    // re-arms, so it degrades to a dropped frame rather than a freeze.
+    rasterReady = false;
+    ++framesForwarded;
+    QElapsedTimer convertTimer;
+    convertTimer.start();
+    const QImage image = frame.toImage();
+    rasterConvertUsAccum += convertTimer.nsecsElapsed() / 1000;
+    ++rasterConvertCount;
+    if (rasterWidget) {
+        rasterWidget->setImage(image);
+    }
+}
+
+void VideoView::onRasterPainted()
+{
+    ++framesRendered;
+    if (pendingFrame.isValid()) {
+        // A newer frame arrived mid-paint — show it right away and keep
+        // the gate closed so delivery stays paced to paint capacity.
+        const QVideoFrame frame = pendingFrame;
+        pendingFrame = QVideoFrame();
+        presentRasterFrame(frame);
+        return;
+    }
+    rasterReady = true;
 }
 
 void VideoView::connectRenderCounter()
@@ -580,3 +871,655 @@ void VideoView::writeStats(const QString& kind, const QString& detail)
                  << QLatin1Char('\n');
     statsStream->flush();
 }
+
+#ifdef ANTHIAS_GSTREAMER
+
+namespace {
+
+// appsink pulled a frame on a GStreamer streaming thread. Wrap the
+// ISP-converted RGB16 buffer as a QImage (deep copy — the GstBuffer is
+// released on return), stash it as the newest frame, and post a single
+// coalesced onGstFrame() to the GUI thread. If a drain is already queued
+// we only overwrite the stashed frame (keeping the freshest) — so a GUI
+// thread slower than the pipeline drops intermediate frames rather than
+// piling QImages in the event queue and OOM'ing the 1 GB board.
+GstFlowReturn anthias_gst_on_new_sample(GstAppSink* sink, gpointer user_data)
+{
+    GstSample* sample = gst_app_sink_pull_sample(sink);
+    if (!sample) {
+        return GST_FLOW_OK;
+    }
+    GstCaps* caps = gst_sample_get_caps(sample);
+    GstBuffer* buffer = gst_sample_get_buffer(sample);
+    GstVideoInfo info;
+    GstMapInfo map;
+    if (caps && buffer && gst_video_info_from_caps(&info, caps)
+        && gst_buffer_map(buffer, &map, GST_MAP_READ)) {
+        const int width = GST_VIDEO_INFO_WIDTH(&info);
+        const int height = GST_VIDEO_INFO_HEIGHT(&info);
+        const int stride = GST_VIDEO_INFO_PLANE_STRIDE(&info, 0);
+        // GStreamer RGB16 is RGB565 — a byte-for-byte match for
+        // QImage::Format_RGB16, so wrapping needs no channel swizzle.
+        // copy() detaches from the soon-to-be-unmapped GstBuffer.
+        const QImage wrapped(
+            map.data, width, height, stride, QImage::Format_RGB16);
+        const QImage frame = wrapped.copy();
+        gst_buffer_unmap(buffer, &map);
+        static_cast<VideoView*>(user_data)->pushGstFrame(frame);
+    }
+    gst_sample_unref(sample);
+    return GST_FLOW_OK;
+}
+
+// Source drained: loop by flushing-seeking back to zero. Marshalled to
+// the GUI thread so it can't race a concurrent stop().
+void anthias_gst_on_eos(GstAppSink* /*sink*/, gpointer user_data)
+{
+    auto* view = static_cast<VideoView*>(user_data);
+    QMetaObject::invokeMethod(view, "gstRestartLoop", Qt::QueuedConnection);
+}
+
+// Find a free OVERLAY plane usable on ``crtcId``. The overlay-plane path
+// (kmssink) needs an explicit plane-id — otherwise kmssink grabs the
+// primary plane, which eglfs already scans out. Skips planes already
+// bound to a CRTC (eglfs's primary) and any non-overlay (primary/cursor)
+// type. Returns 0 if none found (caller falls back to the raster path).
+uint32_t anthias_find_overlay_plane(int fd, uint32_t crtcId)
+{
+    drmModeRes* res = drmModeGetResources(fd);
+    int crtcIndex = -1;
+    if (res) {
+        for (int i = 0; i < res->count_crtcs; ++i) {
+            if (res->crtcs[i] == crtcId) {
+                crtcIndex = i;
+                break;
+            }
+        }
+        drmModeFreeResources(res);
+    }
+    if (crtcIndex < 0) {
+        return 0;
+    }
+
+    drmSetClientCap(fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+    drmModePlaneRes* planes = drmModeGetPlaneResources(fd);
+    if (!planes) {
+        return 0;
+    }
+    uint32_t chosen = 0;
+    for (uint32_t i = 0; i < planes->count_planes && chosen == 0; ++i) {
+        drmModePlane* plane = drmModeGetPlane(fd, planes->planes[i]);
+        if (!plane) {
+            continue;
+        }
+        const bool crtcCapable = (plane->possible_crtcs >> crtcIndex) & 1u;
+        const bool free = plane->crtc_id == 0;
+        if (crtcCapable && free) {
+            drmModeObjectProperties* props = drmModeObjectGetProperties(
+                fd, plane->plane_id, DRM_MODE_OBJECT_PLANE);
+            if (props) {
+                for (uint32_t p = 0; p < props->count_props; ++p) {
+                    drmModePropertyRes* prop =
+                        drmModeGetProperty(fd, props->props[p]);
+                    if (!prop) {
+                        continue;
+                    }
+                    if (std::strcmp(prop->name, "type") == 0
+                        && props->prop_values[p] == DRM_PLANE_TYPE_OVERLAY) {
+                        chosen = plane->plane_id;
+                    }
+                    drmModeFreeProperty(prop);
+                }
+                drmModeFreeObjectProperties(props);
+            }
+        }
+        drmModeFreePlane(plane);
+    }
+    drmModeFreePlaneResources(planes);
+    return chosen;
+}
+
+// Buffer probe on kmssink's sink pad: counts frames that reach the sink
+// (the presentation rate for the overlay path, since there is no appsink)
+// and captures the source framerate once from the caps so sampleStats can
+// compute expected-vs-dropped. Runs on a streaming thread — the counter is
+// atomic and containerFps is a benign same-value race.
+GstPadProbeReturn anthias_gst_kms_probe(GstPad* pad, GstPadProbeInfo* /*info*/,
+                                        gpointer user_data)
+{
+    static_cast<VideoView*>(user_data)->onOverlayBuffer(pad);
+    return GST_PAD_PROBE_OK;
+}
+
+// Pipeline bus watch for the overlay path (kmssink has no appsink EOS
+// callback). Serviced on the GUI thread via Qt's GLib event dispatcher.
+// Loops the clip on EOS; logs kmssink QoS drop stats and errors.
+// Bus watch for the separate audio pipeline. Audio is best-effort: on EOS
+// loop it to stay roughly aligned with the looping video; on error tear it
+// down (a bad audio device/codec must not take the video with it).
+gboolean anthias_gst_audio_bus(GstBus* /*bus*/, GstMessage* message,
+                               gpointer user_data)
+{
+    auto* view = static_cast<VideoView*>(user_data);
+    switch (GST_MESSAGE_TYPE(message)) {
+    case GST_MESSAGE_EOS:
+        view->gstLoopAudio();
+        break;
+    case GST_MESSAGE_ERROR: {
+        GError* err = nullptr;
+        gchar* dbg = nullptr;
+        gst_message_parse_error(message, &err, &dbg);
+        view->logAudio(QStringLiteral("error=%1")
+                           .arg(err ? err->message : QStringLiteral("?")));
+        if (err) {
+            g_error_free(err);
+        }
+        g_free(dbg);
+        view->gstStopAudio();
+        break;
+    }
+    default:
+        break;
+    }
+    return TRUE;
+}
+
+gboolean anthias_gst_bus_loop(GstBus* /*bus*/, GstMessage* message,
+                              gpointer user_data)
+{
+    auto* view = static_cast<VideoView*>(user_data);
+    switch (GST_MESSAGE_TYPE(message)) {
+    case GST_MESSAGE_EOS:
+        view->gstRestartLoop();
+        break;
+    case GST_MESSAGE_QOS: {
+        // kmssink's own accounting: authoritative rendered vs dropped.
+        guint64 rendered = 0;
+        guint64 dropped = 0;
+        GstFormat format = GST_FORMAT_UNDEFINED;
+        gst_message_parse_qos_stats(message, &format, &rendered, &dropped);
+        view->logOverlayQos(rendered, dropped);
+        break;
+    }
+    case GST_MESSAGE_ERROR: {
+        GError* err = nullptr;
+        gchar* dbg = nullptr;
+        gst_message_parse_error(message, &err, &dbg);
+        qWarning() << "VideoView overlay pipeline error:"
+                   << (err ? err->message : "?") << (dbg ? dbg : "");
+        if (err) {
+            g_error_free(err);
+        }
+        g_free(dbg);
+        break;
+    }
+    default:
+        break;
+    }
+    return TRUE;
+}
+
+}  // namespace
+
+bool VideoView::gstPlay(const QString& uri, const QVariantMap& options)
+{
+    gstStop();
+
+    // HW overlay-plane path first (if requested and resolvable): it scans
+    // out the video directly on a vc4 overlay plane, bypassing the eglfs
+    // GL compositor that caps at ~9 fps. Falls through to the appsink →
+    // raster blit below on any failure.
+    if (gstOverlayMode && gstPlayOverlay(uri, options)) {
+        return true;
+    }
+
+    // Explicit hardware pipeline. pi3-64 only ever receives H.264/MP4
+    // (the codec gate rejects every other codec for this board), so an
+    // explicit qtdemux ! h264parse ! v4l2h264dec chain is safe and
+    // *guarantees* the bcm2835 hardware decoder — letting decodebin pick
+    // would risk the software avdec_h264, which can't sustain realtime and
+    // thermally reboots the 1 GB board. v4l2convert is the bcm2835 ISP
+    // doing SAND→RGB16 in hardware (the conversion the CPU can't afford,
+    // ~600 ms/frame). sync=true paces the appsink to each frame's PTS;
+    // drop=true / max-buffers=2 bounds latency to the freshest frame.
+    // Audio is a follow-up; this first cut is video-only.
+    QString location = uri;
+    location.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
+    location.replace(QLatin1Char('"'), QLatin1String("\\\""));
+    // Optional ISP downscale (ANTHIAS_GST_SCALE="WxH", e.g. 1280x720):
+    // the bcm2835 ISP scales in hardware, so a smaller output cuts the
+    // ISP's per-frame work (and, if the display substrate uploads a
+    // smaller texture, the composite cost too). Empty = native source
+    // resolution. Experimental knob for the pi3-64 fps tuning.
+    QString scaleCaps;
+    const QString scale = qEnvironmentVariable("ANTHIAS_GST_SCALE");
+    static const QRegularExpression scaleRe(
+        QStringLiteral("^(\\d+)x(\\d+)$"));
+    const QRegularExpressionMatch scaleMatch = scaleRe.match(scale);
+    if (scaleMatch.hasMatch()) {
+        scaleCaps = QStringLiteral(",width=%1,height=%2")
+                        .arg(scaleMatch.captured(1), scaleMatch.captured(2));
+    }
+
+    // A queue after v4l2convert runs decode+ISP on their own thread,
+    // decoupled from appsink delivery (leaky=downstream drops the oldest
+    // buffered frame if the GUI falls behind, keeping the pipeline
+    // free-running). sync=false delivers frames as soon as the ISP emits
+    // them rather than clock-pacing in the sink — the GUI-side coalescing
+    // gate (pushGstFrame) bounds what actually reaches the paint.
+    const QString description =
+        QStringLiteral(
+            "filesrc location=\"%1\" ! qtdemux ! h264parse ! v4l2h264dec ! "
+            "v4l2convert ! video/x-raw,format=RGB16%2 ! "
+            "queue max-size-buffers=3 leaky=downstream ! "
+            "appsink name=asink max-buffers=2 drop=true sync=false")
+            .arg(location, scaleCaps);
+
+    GError* error = nullptr;
+    gstPipeline = gst_parse_launch(description.toUtf8().constData(), &error);
+    if (!gstPipeline) {
+        qWarning() << "VideoView::gstPlay: pipeline build failed:"
+                   << (error ? error->message : "unknown");
+        if (error) {
+            g_error_free(error);
+        }
+        return false;
+    }
+    if (error) {
+        // Non-fatal parse warnings still populate error.
+        g_error_free(error);
+    }
+
+    gstAppSink = gst_bin_get_by_name(GST_BIN(gstPipeline), "asink");
+    if (gstAppSink) {
+        GstAppSinkCallbacks callbacks = {};
+        callbacks.eos = anthias_gst_on_eos;
+        callbacks.new_sample = anthias_gst_on_new_sample;
+        gst_app_sink_set_callbacks(
+            GST_APP_SINK(gstAppSink), &callbacks, this, nullptr);
+    }
+
+    playStartedAt.start();
+    if (gst_element_set_state(gstPipeline, GST_STATE_PLAYING)
+        == GST_STATE_CHANGE_FAILURE) {
+        qWarning() << "VideoView::gstPlay: could not start pipeline for"
+                   << uri;
+        gstStop();
+        return false;
+    }
+    return true;
+}
+
+bool VideoView::gstPlayOverlay(const QString& uri, const QVariantMap& options)
+{
+    QPlatformNativeInterface* ni = QGuiApplication::platformNativeInterface();
+    if (!ni) {
+        return false;
+    }
+    QScreen* screen = QGuiApplication::primaryScreen();
+    const int driFd = static_cast<int>(reinterpret_cast<qintptr>(
+        ni->nativeResourceForIntegration(QByteArrayLiteral("dri_fd"))));
+    const quint32 crtcId = static_cast<quint32>(reinterpret_cast<qintptr>(
+        ni->nativeResourceForScreen(QByteArrayLiteral("dri_crtcid"), screen)));
+    const quint32 connId = static_cast<quint32>(reinterpret_cast<qintptr>(
+        ni->nativeResourceForScreen(
+            QByteArrayLiteral("dri_connectorid"), screen)));
+    if (driFd <= 0 || crtcId == 0 || connId == 0) {
+        qWarning() << "VideoView::gstPlayOverlay: eglfs DRM resources"
+                   << "unavailable (fd" << driFd << "crtc" << crtcId
+                   << "connector" << connId << ") — using raster path";
+        return false;
+    }
+
+    const uint32_t planeId = anthias_find_overlay_plane(driFd, crtcId);
+    if (planeId == 0) {
+        qWarning() << "VideoView::gstPlayOverlay: no free overlay plane on"
+                   << "crtc" << crtcId << "— using raster path";
+        return false;
+    }
+
+    // Explicit HW pipeline (reliably reaches the overlay — the playbin
+    // variant hung in set_state). pi3-64 only receives H.264/MP4 (the
+    // codec gate rejects other codecs), so qtdemux ! h264parse !
+    // v4l2h264dec forces the bcm2835 HW decoder. The ``queue`` sits
+    // BEFORE v4l2convert so it decouples the decoder thread from the
+    // convert+present thread WITHOUT hoarding the convert's OUTPUT pool —
+    // queuing the convert's output was the buffer-starvation deadlock.
+    // Here the queue holds decoder buffers (the decoder's larger DPB pool
+    // covers them) while kmssink holds only 1-2 of the convert's output
+    // buffers (the convert pool covers those). v4l2convert (bcm2835 ISP)
+    // pins NV12 — the vc4 plane's native scanout format; the raw decoder
+    // renegotiates I420, which shows wrong colours (blue).
+    QString location = uri;
+    location.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
+    location.replace(QLatin1Char('"'), QLatin1String("\\\""));
+    const int queueBuffers =
+        qEnvironmentVariableIsSet("ANTHIAS_GST_QUEUE")
+            ? qEnvironmentVariableIntValue("ANTHIAS_GST_QUEUE")
+            : 4;
+    // The bcm2835 decoder only emits I420 (renders blue on the vc4 plane;
+    // its V4L2 capture won't negotiate NV12), so v4l2convert (bcm2835 ISP)
+    // does I420→NV12. The critical bit is its OUTPUT io-mode: with the
+    // default exported-dmabuf, kmssink zero-copies and PINS the convert's
+    // output buffers on the plane, starving the convert pool → ~18 fps (or
+    // a hard deadlock decoder-direct). Forcing ``capture-io-mode=mmap``
+    // makes the convert output CPU-memory buffers that kmssink cannot
+    // scan out directly, so kmssink COPIES each frame into its own dumb
+    // buffer and releases the convert buffer immediately — exactly how the
+    // legacy fbdevsink avoided the hold. The copy (~NV12 1080p ≈ 3 MB) is
+    // cheap next to the ISP work and buys full-rate, deadlock-free
+    // presentation. Overridable for tuning.
+    const QString convIoMode =
+        qEnvironmentVariable("ANTHIAS_GST_CONVERT_IOMODE",
+                             QStringLiteral("mmap"));
+    // ANTHIAS_GST_ISP_CONVERT=0 → decoder-direct (skip the ~15-18fps ISP
+    // convert): the decoder emits I420 at full rate. To stop kmssink
+    // pinning the decoder's DPB buffers (which deadlocks it), force the
+    // DECODER's output to mmap so kmssink copies + releases immediately.
+    // Default: decoder-direct (I420) with the decoder's output forced to
+    // mmap so kmssink COPIES rather than pinning the decoder's DPB pool —
+    // that combination is what delivers a stable 30 fps with zero ongoing
+    // drops (the ISP-convert path is ~18fps-bound; plain decoder-direct
+    // deadlocks). ANTHIAS_GST_ISP_CONVERT=1 reinstates the ISP-convert
+    // (NV12) path for boards/streams where I420 direct-scanout misbehaves.
+    const bool useConvert =
+        qEnvironmentVariableIsSet("ANTHIAS_GST_ISP_CONVERT")
+            ? qEnvironmentVariableIntValue("ANTHIAS_GST_ISP_CONVERT") != 0
+            : false;
+    const QString decodeStage =
+        useConvert
+            ? QStringLiteral("v4l2h264dec")
+            : QStringLiteral("v4l2h264dec capture-io-mode=mmap");
+    const QString convertStage =
+        !useConvert ? QString()
+        : convIoMode.isEmpty()
+            ? QStringLiteral("v4l2convert ! video/x-raw,format=NV12 ! ")
+            : QStringLiteral(
+                  "v4l2convert capture-io-mode=%1 ! video/x-raw,format=NV12 ! ")
+                  .arg(convIoMode);
+    // Audio plays in a SEPARATE GStreamer pipeline (see gstStartAudio),
+    // NOT a branch off the video's qtdemux. A shared pipeline coupled the
+    // two fatally: any audio condition — a slow/queuing decodebin preroll,
+    // an audio-provided clock that stalls, a missing track — froze the
+    // VIDEO at the first frame. An independent pipeline (own clock, own
+    // preroll, own bus) means the video path below stays byte-for-byte the
+    // proven 30 fps chain and can never be stalled by audio. Resolve the
+    // ALSA device here (same ``audio-device`` option the QMediaPlayer path
+    // uses, e.g. ``alsa/sysdefault:CARD=<hdmi>``; strip the Qt ``alsa/``
+    // scheme). We drive alsasink directly on the HDMI card rather than
+    // pulsesink: pi3-64 no longer routes video through QtMultimedia, and
+    // pulse's default sink is the 3.5mm jack while its vc4hdmi sink sits
+    // suspended (card free) — the legacy GstFbdev path did the same.
+    QString alsaDev =
+        options.value(QStringLiteral("audio-device")).toString();
+    if (alsaDev.startsWith(QLatin1String("alsa/"))) {
+        alsaDev = alsaDev.mid(5);
+    }
+    const QString description =
+        QStringLiteral(
+            "filesrc location=\"%1\" ! qtdemux ! h264parse ! %7 ! "
+            "queue max-size-buffers=%5 max-size-time=0 max-size-bytes=0 ! "
+            "%6"
+            "kmssink name=vsink qos=true fd=%2 connector-id=%3 plane-id=%4 "
+            "force-modesetting=false can-scale=true skip-vsync=true")
+            .arg(location)
+            .arg(driFd)
+            .arg(connId)
+            .arg(planeId)
+            .arg(queueBuffers)
+            .arg(convertStage, decodeStage);
+
+    GError* error = nullptr;
+    gstPipeline = gst_parse_launch(description.toUtf8().constData(), &error);
+    if (!gstPipeline) {
+        qWarning() << "VideoView::gstPlayOverlay: pipeline build failed:"
+                   << (error ? error->message : "unknown")
+                   << "— using raster path";
+        if (error) {
+            g_error_free(error);
+        }
+        return false;
+    }
+    if (error) {
+        g_error_free(error);
+        error = nullptr;
+    }
+
+    // Count frames reaching kmssink (presentation rate) + latch the source
+    // fps for sampleStats.
+    gstRawSamples.storeRelaxed(0);
+    containerFps = 0.0;
+    GstElement* sink = gst_bin_get_by_name(GST_BIN(gstPipeline), "vsink");
+    if (sink) {
+        GstPad* sinkPad = gst_element_get_static_pad(sink, "sink");
+        if (sinkPad) {
+            gst_pad_add_probe(sinkPad, GST_PAD_PROBE_TYPE_BUFFER,
+                              anthias_gst_kms_probe, this, nullptr);
+            gst_object_unref(sinkPad);
+        }
+        gst_object_unref(sink);
+    }
+
+    // Loop the clip: kmssink has no appsink EOS callback, so watch the bus
+    // (serviced on the GUI thread by Qt's GLib dispatcher on Linux).
+    GstBus* bus = gst_element_get_bus(gstPipeline);
+    gst_bus_add_watch(bus, anthias_gst_bus_loop, this);
+    gst_object_unref(bus);
+
+    playStartedAt.start();
+    if (gst_element_set_state(gstPipeline, GST_STATE_PLAYING)
+        == GST_STATE_CHANGE_FAILURE) {
+        qWarning() << "VideoView::gstPlayOverlay: could not start pipeline"
+                   << "for" << uri << "— using raster path";
+        gstStop();
+        return false;
+    }
+
+    // The video lives on the overlay plane now; clear the raster widget so
+    // the eglfs primary plane behind any letterbox bars is black, not a
+    // stale frame.
+    if (rasterWidget) {
+        rasterWidget->clear();
+    }
+    gstOverlayActive = true;
+    writeStats(
+        QStringLiteral("INIT"),
+        QStringLiteral(
+            "backend=gstreamer/v4l2 sink=kms-overlay plane-id=%1 qt=%2")
+            .arg(planeId)
+            .arg(QStringLiteral(QT_VERSION_STR)));
+
+    // Video is up; bring up audio in its own pipeline (best-effort).
+    gstStartAudio(location, alsaDev);
+    return true;
+}
+
+void VideoView::gstStartAudio(const QString& location, const QString& alsaDev)
+{
+    const QString audioSink =
+        qEnvironmentVariable("ANTHIAS_GST_AUDIO_SINK",
+                             QStringLiteral("alsasink"));
+    const QString audioDeviceProp =
+        (audioSink == QLatin1String("alsasink") && !alsaDev.isEmpty())
+            ? QStringLiteral(" device=\"%1\"").arg(alsaDev)
+            : QString();
+    // decodebin autoplugs the audio codec (AAC/MP3/…); the sink drives the
+    // HDMI ALSA card directly. Own pipeline → own clock/preroll, fully
+    // isolated from the video overlay pipeline.
+    // Pin the AUDIO pad explicitly: qtdemux exposes both a video and an
+    // audio pad, and a bare ``qtdemux ! decodebin`` links whichever appears
+    // first (often video → audioconvert then can't negotiate and no sound).
+    const QString audioDesc =
+        QStringLiteral(
+            "filesrc location=\"%1\" ! qtdemux name=ademux ademux.audio_0 ! "
+            "queue ! decodebin ! audioconvert ! audioresample ! %2%3")
+            .arg(location, audioSink, audioDeviceProp);
+
+    GError* error = nullptr;
+    gstAudioPipeline =
+        gst_parse_launch(audioDesc.toUtf8().constData(), &error);
+    if (!gstAudioPipeline) {
+        writeStats(QStringLiteral("AUDIO"),
+                   QStringLiteral("build-failed err=%1")
+                       .arg(error ? error->message : QStringLiteral("?")));
+        if (error) {
+            g_error_free(error);
+        }
+        return;
+    }
+    if (error) {
+        g_error_free(error);
+    }
+    GstBus* bus = gst_element_get_bus(gstAudioPipeline);
+    gst_bus_add_watch(bus, anthias_gst_audio_bus, this);
+    gst_object_unref(bus);
+    gst_element_set_state(gstAudioPipeline, GST_STATE_PLAYING);
+    writeStats(QStringLiteral("AUDIO"),
+               QStringLiteral("started sink=%1 device=%2")
+                   .arg(audioSink,
+                        alsaDev.isEmpty() ? QStringLiteral("(default)")
+                                          : alsaDev));
+}
+
+void VideoView::gstLoopAudio()
+{
+    if (!gstAudioPipeline) {
+        return;
+    }
+    gst_element_seek_simple(
+        GST_ELEMENT(gstAudioPipeline), GST_FORMAT_TIME,
+        static_cast<GstSeekFlags>(
+            GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT),
+        0);
+}
+
+void VideoView::logAudio(const QString& msg)
+{
+    writeStats(QStringLiteral("AUDIO"), msg);
+}
+
+void VideoView::gstStopAudio()
+{
+    if (!gstAudioPipeline) {
+        return;
+    }
+    GstBus* bus = gst_element_get_bus(gstAudioPipeline);
+    if (bus) {
+        gst_bus_remove_watch(bus);
+        gst_object_unref(bus);
+    }
+    gst_element_set_state(gstAudioPipeline, GST_STATE_NULL);
+    gst_object_unref(gstAudioPipeline);
+    gstAudioPipeline = nullptr;
+}
+
+void VideoView::gstStop()
+{
+    gstStopAudio();
+    if (gstPipeline) {
+        // Remove the bus watch the overlay path installed (no-op if the
+        // appsink path was used — that has no bus watch).
+        GstBus* bus = gst_element_get_bus(gstPipeline);
+        if (bus) {
+            gst_bus_remove_watch(bus);
+            gst_object_unref(bus);
+        }
+    }
+    gstOverlayActive = false;
+    if (gstAppSink) {
+        gst_object_unref(gstAppSink);
+        gstAppSink = nullptr;
+    }
+    if (gstPipeline) {
+        gst_element_set_state(gstPipeline, GST_STATE_NULL);
+        gst_object_unref(gstPipeline);
+        gstPipeline = nullptr;
+    }
+}
+
+void VideoView::pushGstFrame(const QImage& frame)
+{
+    // Streaming thread: stash the newest frame and post at most one
+    // coalesced drain to the GUI thread.
+    gstRawSamples.fetchAndAddRelaxed(1);
+    {
+        QMutexLocker locker(&gstFrameMutex);
+        gstLatestFrame = frame;
+    }
+    if (gstDrainPending.testAndSetOrdered(0, 1)) {
+        QMetaObject::invokeMethod(this, "onGstFrame", Qt::QueuedConnection);
+    }
+}
+
+void VideoView::onGstFrame()
+{
+    // GUI thread: take the freshest stashed frame and blit it. The paint
+    // that follows setImage() bumps framesRendered in onRasterPainted(),
+    // so SAMPLE reports the true present rate; gstRawSamples (logged in
+    // sampleStats) reports the pipeline's own delivery rate for contrast.
+    gstDrainPending.storeRelaxed(0);
+    QImage frame;
+    {
+        QMutexLocker locker(&gstFrameMutex);
+        frame = gstLatestFrame;
+    }
+    if (frame.isNull()) {
+        return;
+    }
+    ++framesDelivered;
+    ++framesForwarded;
+    if (rasterWidget) {
+        rasterWidget->setImage(frame);
+    }
+}
+
+void VideoView::gstRestartLoop()
+{
+    if (!gstPipeline) {
+        return;
+    }
+    gst_element_seek_simple(
+        GST_ELEMENT(gstPipeline), GST_FORMAT_TIME,
+        static_cast<GstSeekFlags>(
+            GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT),
+        0);
+    // Re-seek audio to the top too so it re-aligns with the video every
+    // loop (the two pipelines otherwise drift on their own clocks).
+    gstLoopAudio();
+}
+
+void VideoView::gstRequeueUri(struct _GstElement* playbin)
+{
+    if (playbin && !gstUri.isEmpty()) {
+        g_object_set(playbin, "uri", gstUri.constData(), nullptr);
+    }
+}
+
+void VideoView::onOverlayBuffer(struct _GstPad* pad)
+{
+    gstRawSamples.fetchAndAddRelaxed(1);
+    if (containerFps <= 0.0 && pad) {
+        GstCaps* caps = gst_pad_get_current_caps(pad);
+        if (caps) {
+            GstStructure* s = gst_caps_get_structure(caps, 0);
+            gint num = 0;
+            gint den = 0;
+            if (s && gst_structure_get_fraction(s, "framerate", &num, &den)
+                && den > 0) {
+                containerFps = static_cast<qreal>(num) / den;
+            }
+            gst_caps_unref(caps);
+        }
+    }
+}
+
+void VideoView::logOverlayQos(quint64 rendered, quint64 dropped)
+{
+    writeStats(
+        QStringLiteral("QOS"),
+        QStringLiteral("sink-rendered=%1 sink-dropped=%2")
+            .arg(rendered)
+            .arg(dropped));
+}
+
+#endif  // ANTHIAS_GSTREAMER

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -607,7 +607,22 @@ void VideoView::sampleStats()
     if (!player || !statsStream) {
         return;
     }
-    const qint64 posMs = player->position();
+    // Position source: on the gstMode appsink-raster fallback QMediaPlayer
+    // isn't the one playing, so query the GStreamer pipeline; only the
+    // plain QtMultimedia path reads player->position().
+    qint64 posMs = -1;
+#ifdef ANTHIAS_GSTREAMER
+    if (gstMode && gstPipeline) {
+        gint64 posNs = 0;
+        posMs =
+            gst_element_query_position(gstPipeline, GST_FORMAT_TIME, &posNs)
+                ? posNs / GST_MSECOND
+                : -1;
+    } else
+#endif
+    {
+        posMs = player->position();
+    }
     const qint64 elapsedMs =
         playStartedAt.isValid() ? playStartedAt.elapsed() : -1;
     const qreal expected =
@@ -1186,6 +1201,11 @@ bool VideoView::gstPlayOverlay(const QString& uri)
         return false;
     }
     QScreen* screen = QGuiApplication::primaryScreen();
+    if (!screen) {
+        qWarning() << "VideoView::gstPlayOverlay: no primary screen —"
+                   << "using raster path";
+        return false;
+    }
     const int driFd = static_cast<int>(reinterpret_cast<qintptr>(
         ni->nativeResourceForIntegration(QByteArrayLiteral("dri_fd"))));
     const quint32 crtcId = static_cast<quint32>(reinterpret_cast<qintptr>(
@@ -1193,6 +1213,11 @@ bool VideoView::gstPlayOverlay(const QString& uri)
     const quint32 connId = static_cast<quint32>(reinterpret_cast<qintptr>(
         ni->nativeResourceForScreen(
             QByteArrayLiteral("dri_connectorid"), screen)));
+    // driFd is eglfs's DRM master fd read back through the void*
+    // nativeResource API: a real fd here is always >2 (0/1/2 are the
+    // process's std streams, open before eglfs), and "no fd" comes back as
+    // a null pointer → 0. So ``<= 0`` is the correct not-available test in
+    // this context, not a rejection of a legitimately-0 fd.
     if (driFd <= 0 || crtcId == 0 || connId == 0) {
         qWarning() << "VideoView::gstPlayOverlay: eglfs DRM resources"
                    << "unavailable (fd" << driFd << "crtc" << crtcId

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -418,6 +418,12 @@ void VideoView::stop()
                         gstPipeline, GST_FORMAT_TIME, &posNs))
                     ? posNs / GST_MSECOND
                     : -1;
+            // On the overlay path frames never touch the CPU counters
+            // (framesDelivered/forwarded/rendered stay 0); the buffer-probe
+            // tally gstRawSamples is the real rendered count, so report it.
+            const qint64 rendered = gstOverlayActive
+                                        ? gstRawSamples.loadRelaxed()
+                                        : framesRendered;
             writeStats(
                 QStringLiteral("STOP"),
                 QStringLiteral(
@@ -427,7 +433,7 @@ void VideoView::stop()
                     .arg(elapsedMs)
                     .arg(framesDelivered)
                     .arg(framesForwarded)
-                    .arg(framesRendered)
+                    .arg(rendered)
                     .arg(posMs));
         }
         gstStop();
@@ -940,7 +946,10 @@ GstFlowReturn anthias_gst_on_new_sample(GstAppSink* sink, gpointer user_data)
             map.data, width, height, stride, QImage::Format_RGB16);
         const QImage frame = wrapped.copy();
         gst_buffer_unmap(buffer, &map);
-        static_cast<VideoView*>(user_data)->pushGstFrame(frame);
+        auto* view = static_cast<VideoView*>(user_data);
+        view->latchSourceFps(
+            GST_VIDEO_INFO_FPS_N(&info), GST_VIDEO_INFO_FPS_D(&info));
+        view->pushGstFrame(frame);
     }
     gst_sample_unref(sample);
     return GST_FLOW_OK;
@@ -1485,6 +1494,15 @@ void VideoView::logAudio(const QString& msg)
     writeStats(QStringLiteral("AUDIO"), msg);
 }
 
+void VideoView::latchSourceFps(int fpsNum, int fpsDen)
+{
+    // Latch once (the overlay pad-probe latches the same way); ignore a
+    // degenerate 0/0 or variable-rate caps.
+    if (fpsDen > 0 && fpsNum > 0 && containerFps() <= 0.0) {
+        setContainerFps(static_cast<qreal>(fpsNum) / fpsDen);
+    }
+}
+
 void VideoView::gstStopAudio()
 {
     if (!gstAudioPipeline) {
@@ -1583,13 +1601,6 @@ void VideoView::gstRestartLoop()
     // Re-seek audio to the top too so it re-aligns with the video every
     // loop (the two pipelines otherwise drift on their own clocks).
     gstLoopAudio();
-}
-
-void VideoView::gstRequeueUri(struct _GstElement* playbin)
-{
-    if (playbin && !gstUri.isEmpty()) {
-        g_object_set(playbin, "uri", gstUri.constData(), nullptr);
-    }
 }
 
 void VideoView::onOverlayBuffer(struct _GstPad* pad)

--- a/src/anthias_webview/src/videoview.h
+++ b/src/anthias_webview/src/videoview.h
@@ -334,7 +334,19 @@ private:
     qint64 framesDelivered = 0;
     qint64 framesForwarded = 0;
     qint64 framesRendered = 0;
-    qreal containerFps = 0.0;
+    // Source frame rate as fps×1000. On the overlay path it's latched from
+    // a GStreamer pad probe (streaming thread) and read by sampleStats
+    // (GUI thread), so the handoff is atomic — a plain double would be a
+    // data race / UB. Access via containerFps() / setContainerFps().
+    QAtomicInteger<int> containerFpsMilli { 0 };
+    qreal containerFps() const
+    {
+        return containerFpsMilli.loadRelaxed() / 1000.0;
+    }
+    void setContainerFps(qreal fps)
+    {
+        containerFpsMilli.storeRelaxed(qRound(fps * 1000.0));
+    }
 
     // Intermediate sink between QMediaPlayer and the QML
     // VideoOutput's sink — the pacing gate's tap point (see

--- a/src/anthias_webview/src/videoview.h
+++ b/src/anthias_webview/src/videoview.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <QAtomicInteger>
 #include <QAudioDevice>
+#include <QByteArray>
 #include <QElapsedTimer>
 #include <QFile>
+#include <QImage>
+#include <QMutex>
 #include <QHBoxLayout>
 #include <QMediaPlayer>
 #include <QString>
@@ -17,6 +21,7 @@ class QAudioOutput;
 class QQuickItem;
 class QQuickWidget;
 class QVideoSink;
+class RasterVideoWidget;
 
 // VideoView owns the Qt 6 multimedia playback pipeline for the Qt6
 // boards (issue #2904). An earlier revision embedded libmpv via
@@ -145,6 +150,104 @@ private:
     // #2967 blind spot).
     void connectRenderCounter();
 
+    // --- Pi 3 (VideoCore IV) CPU-raster presenter ------------------
+    // pi3-64's GLES2-only GPU can't present the QML VideoOutput RHI
+    // path: the scene renders but the QQuickWidget FBO never reaches
+    // the eglfs scanout, so every video black-screens (issue #3084)
+    // while images/webpages — which composite through the widget
+    // backing store — render fine. When ANTHIAS_VIDEO_RASTER is set
+    // (by the Python side for pi3-64 only, see _build_webview_env),
+    // frames are presented instead by ``QVideoFrame::toImage()`` +
+    // a backing-store blit — the same path images use, and the
+    // pre-#2967 substrate that was visible (if slow, 8–12 fps) on
+    // this GPU. rasterWidget replaces quickWidget in the layout;
+    // videoOutputItem / videoSink stay null.
+    //
+    // presentRasterFrame converts + shows one frame and closes the
+    // one-frame pacing gate; onRasterPainted (called by
+    // RasterVideoWidget::paintEvent) re-opens it and forwards any
+    // frame parked in pendingFrame while the paint was in flight.
+    void presentRasterFrame(const QVideoFrame& frame);
+    void onRasterPainted();
+    friend class RasterVideoWidget;
+
+#ifdef ANTHIAS_GSTREAMER
+public:
+    // GUI-thread drain slot: blits the newest frame the appsink has
+    // stashed in gstLatestFrame. Coalesced — the appsink callback only
+    // posts one invocation until this runs, so a GUI thread slower than
+    // the pipeline drops intermediate frames (keeping the freshest)
+    // instead of growing an unbounded event queue and OOM'ing the 1 GB
+    // board. Q_INVOKABLE so the streaming-thread callback can
+    // QMetaObject::invokeMethod it across the thread boundary.
+    Q_INVOKABLE void onGstFrame();
+    // Streaming-thread entry point: the appsink callback hands each
+    // ISP-converted RGB frame here; it stashes the newest under
+    // gstFrameMutex and posts a single coalesced onGstFrame() drain.
+    void pushGstFrame(const QImage& frame);
+    // Flushing-seek the pipeline to zero to loop the clip. Invoked
+    // (queued, GUI thread) from the appsink EOS callback so the seek
+    // never races stop().
+    Q_INVOKABLE void gstRestartLoop();
+    // Overlay-path instrumentation (streaming thread). onOverlayBuffer:
+    // count each frame reaching kmssink + latch the source framerate from
+    // the pad caps. logOverlayQos: record kmssink's authoritative
+    // rendered/dropped tallies from a bus QoS message.
+    void onOverlayBuffer(struct _GstPad* pad);
+    void logOverlayQos(quint64 rendered, quint64 dropped);
+    // Best-effort audio in its OWN pipeline, decoupled from the video
+    // overlay pipeline so no audio fault can stall the video. gstStartAudio
+    // builds+plays it; gstLoopAudio/gstStopAudio are driven from the audio
+    // bus watch (loop on EOS, tear down on error) and gstStop/gstRestart.
+    void gstStartAudio(const QString& location, const QString& alsaDev);
+    void gstLoopAudio();
+    void gstStopAudio();
+    // Record an AUDIO status/error line to the readable stats log (public
+    // so the audio bus-watch free function can report errors there).
+    void logAudio(const QString& msg);
+    // playbin gapless-loop hook: re-queue gstUri on ``about-to-finish``
+    // (called on a streaming thread; a property set only, no state change).
+    void gstRequeueUri(struct _GstElement* playbin);
+
+private:
+    // In-process GStreamer HW video path for pi3-64 (issue #3084):
+    // filesrc ! qtdemux ! h264parse ! v4l2h264dec ! v4l2convert(ISP) !
+    // RGB16 ! appsink. The bcm2835 ISP does the SAND→RGB conversion in
+    // hardware — the CPU can't (~600 ms/frame, [[toImage]] wall) — so the
+    // decode+convert stays fully on the VideoCore IV hardware and only a
+    // ready-made RGB frame reaches Qt, which rasterWidget blits (~26 fps,
+    // 0 drops measured). Active when rasterMode is built with
+    // ANTHIAS_GSTREAMER; every other board keeps the VideoOutput path.
+    bool gstPlay(const QString& uri, const QVariantMap& options);
+    // HW overlay-plane path (ANTHIAS_VIDEO_OVERLAY): render decoded frames
+    // straight onto a vc4 DRM overlay plane via kmssink, using eglfs's own
+    // DRM master fd / CRTC / connector — the display controller composites
+    // it with the eglfs UI plane in hardware, bypassing the GL compositor
+    // (which caps at ~9 fps on VideoCore IV). Returns false (caller falls
+    // back to the appsink→raster path) if the eglfs DRM resources or a
+    // free overlay plane can't be resolved.
+    bool gstPlayOverlay(const QString& uri, const QVariantMap& options);
+    void gstStop();
+    bool gstOverlayMode = false;
+    bool gstOverlayActive = false;
+    // URI for playbin's gapless re-queue loop (set in gstPlayOverlay).
+    QByteArray gstUri;
+    struct _GstElement* gstPipeline = nullptr;
+    struct _GstElement* gstAudioPipeline = nullptr;
+    struct _GstElement* gstAppSink = nullptr;
+    bool gstMode = false;
+    // Single-slot handoff: the appsink callback (streaming thread) writes
+    // the newest frame under gstFrameMutex and, if no drain is already
+    // queued (gstDrainPending), posts one onGstFrame() to the GUI thread.
+    QImage gstLatestFrame;
+    QMutex gstFrameMutex;
+    QAtomicInt gstDrainPending{0};
+    // Raw appsink delivery count (streaming thread) — logged alongside the
+    // painted count so SAMPLE shows the pipeline's own rate vs what the
+    // GUI actually presented.
+    QAtomicInteger<qint64> gstRawSamples{0};
+#endif
+
 private:
     // Resolve an ALSA device name (``alsa/sysdefault:CARD=vc4hdmi0``,
     // produced by ``anthias_viewer.media_player.get_alsa_audio_device``)
@@ -193,6 +296,25 @@ private:
     QHBoxLayout* videoLayout = nullptr;
     QMetaObject::Connection renderCounterConnection;
     int currentRotation = 0;
+
+    // Raster path (ANTHIAS_VIDEO_RASTER). rasterWidget is non-null and
+    // owns the on-screen surface only when rasterMode is true; it is
+    // mutually exclusive with quickWidget/videoOutputItem/videoSink.
+    RasterVideoWidget* rasterWidget = nullptr;
+    bool rasterMode = false;
+    // One-frame pacing gate for the raster path (the analogue of
+    // sceneReadyForFrame for the VideoOutput path): true once the last
+    // shown frame has been painted, so the next delivery converts and
+    // shows immediately; otherwise the freshest frame parks in
+    // pendingFrame until onRasterPainted() forwards it. Starts true so
+    // the first frame always shows.
+    bool rasterReady = true;
+    // Raster-path instrumentation: total QVideoFrame::toImage() time
+    // (µs) and count since the last SAMPLE, so a per-second RASTER line
+    // exposes the per-frame conversion cost — the suspected VideoCore
+    // IV bottleneck. Reset each SAMPLE.
+    qint64 rasterConvertUsAccum = 0;
+    qint64 rasterConvertCount = 0;
 
     // Stats state. Extends the libmpv-era line shape with a
     // ``frames-rendered=`` field (the presentation-side counter

--- a/src/anthias_webview/src/videoview.h
+++ b/src/anthias_webview/src/videoview.h
@@ -226,7 +226,7 @@ private:
     // (which caps at ~9 fps on VideoCore IV). Returns false (caller falls
     // back to the appsink→raster path) if the eglfs DRM resources or a
     // free overlay plane can't be resolved.
-    bool gstPlayOverlay(const QString& uri, const QVariantMap& options);
+    bool gstPlayOverlay(const QString& uri);
     void gstStop();
     bool gstOverlayMode = false;
     bool gstOverlayActive = false;

--- a/src/anthias_webview/src/videoview.h
+++ b/src/anthias_webview/src/videoview.h
@@ -185,9 +185,9 @@ public:
     // ISP-converted RGB frame here; it stashes the newest under
     // gstFrameMutex and posts a single coalesced onGstFrame() drain.
     void pushGstFrame(const QImage& frame);
-    // Flushing-seek the pipeline to zero to loop the clip. Invoked
-    // (queued, GUI thread) from the appsink EOS callback so the seek
-    // never races stop().
+    // Flushing-seek the pipeline to zero to loop the clip, on EOS. Called
+    // from the pipeline bus watch (anthias_gst_bus_loop), which GLib
+    // services on the GUI thread, so the seek never races stop().
     Q_INVOKABLE void gstRestartLoop();
     // Overlay-path instrumentation (streaming thread). onOverlayBuffer:
     // count each frame reaching kmssink + latch the source framerate from
@@ -195,6 +195,11 @@ public:
     // rendered/dropped tallies from a bus QoS message.
     void onOverlayBuffer(struct _GstPad* pad);
     void logOverlayQos(quint64 rendered, quint64 dropped);
+    // Latch the source frame rate (once) from the appsink's negotiated
+    // caps, so the appsink-raster path's SAMPLE can compute
+    // expected/dropped instead of reporting -1. Called from the appsink
+    // new-sample callback (streaming thread); setContainerFps is atomic.
+    void latchSourceFps(int fpsNum, int fpsDen);
     // Best-effort audio in its OWN pipeline, decoupled from the video
     // overlay pipeline so no audio fault can stall the video. gstStartAudio
     // builds+plays it; gstLoopAudio/gstStopAudio are driven from the audio
@@ -205,9 +210,6 @@ public:
     // Record an AUDIO status/error line to the readable stats log (public
     // so the audio bus-watch free function can report errors there).
     void logAudio(const QString& msg);
-    // playbin gapless-loop hook: re-queue gstUri on ``about-to-finish``
-    // (called on a streaming thread; a property set only, no state change).
-    void gstRequeueUri(struct _GstElement* playbin);
 
 private:
     // In-process GStreamer HW video path for pi3-64 (issue #3084):
@@ -230,8 +232,6 @@ private:
     void gstStop();
     bool gstOverlayMode = false;
     bool gstOverlayActive = false;
-    // URI for playbin's gapless re-queue loop (set in gstPlayOverlay).
-    QByteArray gstUri;
     struct _GstElement* gstPipeline = nullptr;
     struct _GstElement* gstAudioPipeline = nullptr;
     struct _GstElement* gstAppSink = nullptr;

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1394,6 +1394,38 @@ def test_build_webview_env_drops_dark_mode_flag_when_disabled() -> None:
     assert 'ANTHIAS_PREFER_DARK_MODE' not in env
 
 
+# Video presentation substrate — pi3-64 (VideoCore IV / GLES2) can't
+# scan out the QML VideoOutput RHI path (issue #3084), so the Python
+# side flags it onto the C++ CPU-raster presenter via
+# ANTHIAS_VIDEO_RASTER. Every other board keeps the GPU VideoOutput path.
+
+
+def test_build_webview_env_sets_video_raster_on_pi3_64() -> None:
+    with mock.patch.dict(
+        os.environ,
+        {'QT_QPA_PLATFORM': 'eglfs', 'DEVICE_TYPE': 'pi3-64'},
+        clear=False,
+    ):
+        env = viewer._build_webview_env()
+    assert env['ANTHIAS_VIDEO_RASTER'] == '1'
+
+
+def test_build_webview_env_no_video_raster_on_pi4_64() -> None:
+    # Pi 4 (V3D 4.2) keeps the GPU VideoOutput path; a stale flag
+    # inherited from the process env must not leak onto it.
+    with mock.patch.dict(
+        os.environ,
+        {
+            'QT_QPA_PLATFORM': 'eglfs',
+            'DEVICE_TYPE': 'pi4-64',
+            'ANTHIAS_VIDEO_RASTER': '1',
+        },
+        clear=False,
+    ):
+        env = viewer._build_webview_env()
+    assert 'ANTHIAS_VIDEO_RASTER' not in env
+
+
 # User-Agent token — the C++ webview appends ANTHIAS_UA_TOKEN to
 # QtWebEngine's default User-Agent (the profile setup in
 # src/anthias_webview/src/view.cpp). The token is composed by the

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1574,9 +1574,11 @@ def test_build_webview_env_drops_dark_mode_flag_when_disabled() -> None:
 
 
 # Video presentation substrate — pi3-64 (VideoCore IV / GLES2) can't
-# scan out the QML VideoOutput RHI path (issue #3084), so the Python
-# side flags it onto the C++ CPU-raster presenter via
-# ANTHIAS_VIDEO_RASTER. Every other board keeps the GPU VideoOutput path.
+# scan out the QML VideoOutput RHI path (issue #3084), so the Python side
+# flags it onto the C++ non-VideoOutput presenter: ANTHIAS_VIDEO_OVERLAY
+# selects the GStreamer vc4 overlay-plane path (preferred), with the
+# ANTHIAS_VIDEO_RASTER CPU-raster blit as the fallback. Every other board
+# keeps the GPU VideoOutput path.
 
 
 def test_build_webview_env_sets_video_raster_on_pi3_64() -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1587,10 +1587,13 @@ def test_build_webview_env_sets_video_raster_on_pi3_64() -> None:
     ):
         env = viewer._build_webview_env()
     assert env['ANTHIAS_VIDEO_RASTER'] == '1'
+    # The overlay-plane path is the pi3-64 default too; assert it so the
+    # default can't regress to the (slow) raster blit silently.
+    assert env['ANTHIAS_VIDEO_OVERLAY'] == '1'
 
 
 def test_build_webview_env_no_video_raster_on_pi4_64() -> None:
-    # Pi 4 (V3D 4.2) keeps the GPU VideoOutput path; a stale flag
+    # Pi 4 (V3D 4.2) keeps the GPU VideoOutput path; stale flags
     # inherited from the process env must not leak onto it.
     with mock.patch.dict(
         os.environ,
@@ -1598,11 +1601,13 @@ def test_build_webview_env_no_video_raster_on_pi4_64() -> None:
             'QT_QPA_PLATFORM': 'eglfs',
             'DEVICE_TYPE': 'pi4-64',
             'ANTHIAS_VIDEO_RASTER': '1',
+            'ANTHIAS_VIDEO_OVERLAY': '1',
         },
         clear=False,
     ):
         env = viewer._build_webview_env()
     assert 'ANTHIAS_VIDEO_RASTER' not in env
+    assert 'ANTHIAS_VIDEO_OVERLAY' not in env
 
 
 # User-Agent token — the C++ webview appends ANTHIAS_UA_TOKEN to


### PR DESCRIPTION
## What

Enables real hardware video playback on the **Raspberry Pi 3 arm64** board (`pi3-64`, VideoCore IV, eglfs) — **30 fps with zero ongoing dropped frames, with audio**.

Closes https://github.com/Screenly/Anthias/issues/3084

## Why

On `pi3-64`, QtMultimedia's `VideoOutput` cannot present a video node on the vc4 GL driver, so video rendered **black**; and compositing a full-screen video widget through eglfs GL caps at ~9 fps regardless. Anthias has a lot of active Pi 3 users, so this needed a proper hardware path, not a workaround.

## How

**Video** (`VideoView::gstPlayOverlay`) — in-process GStreamer, scanning out on a vc4 DRM **overlay plane** HW-composited with the eglfs UI:

```
filesrc ! qtdemux ! h264parse ! v4l2h264dec capture-io-mode=mmap ! queue ! kmssink (overlay plane)
```

- Uses eglfs's own DRM master fd + connector via `QPlatformNativeInterface` and a libdrm free-overlay-plane finder.
- `capture-io-mode=mmap` is the key: kmssink then **copies** each frame into its own scanout buffer instead of pinning the decoder's DPB pool — that pin deadlocked every plain decoder-direct attempt. The bcm2835 decoder emits I420 at full rate; the ISP convert-to-NV12 alternative is a second M2M pass that caps at ~18 fps, so it's only a fallback (`ANTHIAS_GST_ISP_CONVERT=1`).
- Degrades gracefully: CPU-raster appsink path, then QMediaPlayer, if DRM/plane resources can't be resolved.

**Audio** (`VideoView::gstStartAudio`) — a **separate** GStreamer pipeline (`qtdemux ! decodebin ! audioconvert ! audioresample ! alsasink` on the HDMI card):

- Independent clock/preroll/bus, so no audio condition (missing track, slow device, decode gap) can stall the video. A shared pipeline froze the video at the first frame.
- Adds `gstreamer1.0-libav` for the audio decoders (`avdec_ac3`/`aac`/`mp3`/…); decodebin reported a missing plug-in on AC3 with only faad (AAC) present.

**Plumbing**: only `pi3-64` links GStreamer (`AnthiasViewer.pro`, Dockerfile build + runtime deps); `_build_webview_env` enables the path; `start_viewer` chowns the GStreamer registry cache to avoid a per-launch rescan; `main.cpp` installs a fatal-signal backtrace handler.

## Testing

Validated on a **real Pi 3** (192.168.200.99) with a 1080p30 H.264/AC3 clip over HDMI, deployed as the full production image (no docker-cp, no env overrides):

- **~30 fps**, `dropped` flat at the startup ramp only (zero ongoing drops)
- Clean across the 60 s loop boundary; `respawns=1` (no crash, no deadlock)
- `/dev/video10` held (HW decode) on the vc4 overlay plane
- **HDMI PCM RUNNING** (AC3 → 48 kHz stereo) with video unaffected

Python unit tests for the env wiring pass (`tests/test_viewer.py`); `ruff check`/`format` clean.

## Follow-ups (not blocking)

- Pin the GStreamer plugin set to the RPi `+rpt3` archive for production parity.
- Per-HDMI-port audio routing (currently the resolved `audio-device` card, default HDMI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)