### PR TITLE
fix(upgrade): stop swapoff OOM from aborting run_upgrade

### DIFF
--- a/ansible/roles/system/tasks/misc.yml
+++ b/ansible/roles/system/tasks/misc.yml
@@ -18,12 +18,45 @@
     owner: root
     group: root
 
+- name: Read memory and swap state for the swapoff guard (KiB)
+  ansible.builtin.command:
+    cmd: >-
+      awk '/^MemAvailable:/{a=$2} /^SwapTotal:/{t=$2} /^SwapFree:/{f=$2}
+      END{print a, t-f}' /proc/meminfo
+  register: system_mem_state
+  changed_when: false
+
 - name: Disable swap
   ansible.builtin.command:
     cmd: /sbin/swapoff --all
-    removes: /var/swap
+  # `swapoff --all` faults every swapped-out page back into RAM at once.
+  # On a memory-tight board that overshoots available memory and the
+  # kernel OOM-killer reaps swapoff (rc -9), aborting the whole upgrade
+  # (issue #3165). Only attempt it when RAM can absorb the used swap
+  # (MemAvailable minus a 64 MiB margin for allocations racing the
+  # swap-in). bin/install.sh stops the container stack before this play
+  # to widen that headroom; disabling swap is best-effort host hygiene,
+  # so skipping here when memory is tight is safe.
+  when: >-
+    system_mem_state.stdout.split()[1] | int
+    < (system_mem_state.stdout.split()[0] | int - 65536)
+  register: system_swapoff_result
+  # Memory pressure from the preceding dist-upgrade eases as its apt/dpkg
+  # processes exit, so retry before giving up. failed_when: false keeps a
+  # persistent OOM from aborting the upgrade — swap simply stays on.
+  retries: 3
+  delay: 5
+  until: system_swapoff_result.rc == 0
+  failed_when: false
+  changed_when: system_swapoff_result.rc == 0
 
 - name: Remove swapfile from disk
   ansible.builtin.file:
     path: /var/swap
     state: absent
+  # Never unlink an active swapfile: only remove it once swapoff actually
+  # succeeded. An undefined rc means the guard above skipped swapoff
+  # (swap still on), so the file stays too.
+  when:
+    - system_swapoff_result.rc is defined
+    - system_swapoff_result.rc == 0

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -511,6 +511,40 @@ function run_ansible_playbook() {
         site.yml "${ANSIBLE_PLAYBOOK_ARGS[@]}"
 }
 
+function stop_docker_stack() {
+    # Free the RAM held by the previous-version stack (server, viewer,
+    # webview, celery, redis) before the memory-intensive host work in
+    # the Ansible play: the apt dist-upgrade and, right after it,
+    # `swapoff --all`. With the stack resident, swapoff faults all swap
+    # back into RAM at once and the OOM-killer aborts the upgrade on
+    # memory-tight boards (issue #3165). Taking the stack down here also
+    # de-risks the dist-upgrade itself. upgrade_docker_containers brings
+    # everything back up (`up -d`) once the host work is done, and the
+    # install ends in a reboot regardless.
+    #
+    # No-op on a fresh install: there is no rendered compose file and
+    # nothing is running yet.
+    local compose_file="${ANTHIAS_REPO_DIR}/docker-compose.yml"
+    if [ ! -f "${compose_file}" ]; then
+        return 0
+    fi
+
+    display_section "Stop Docker Containers (free memory for the upgrade)"
+
+    local compose_files=(-f "${compose_file}")
+    local ssl_override="${ANTHIAS_REPO_DIR}/docker-compose.ssl.override.yml"
+    if [ -f "${ssl_override}" ]; then
+        compose_files+=(-f "${ssl_override}")
+    fi
+
+    # Best-effort: a leftover/mismatched compose file from an older
+    # release must not abort the upgrade, so tolerate a non-zero exit.
+    # --remove-orphans also sweeps containers from services since renamed
+    # or removed from the compose file.
+    sudo docker compose "${compose_files[@]}" down --remove-orphans \
+        || true
+}
+
 function upgrade_docker_containers() {
     display_section "Initialize/Upgrade Docker Containers"
 
@@ -729,6 +763,7 @@ function main() {
     post_clone_migrate_legacy_paths
     install_ansible
     provision_host_agent_venv
+    stop_docker_stack
     run_ansible_playbook
 
     upgrade_docker_containers


### PR DESCRIPTION
Fixes https://github.com/Screenly/Anthias/issues/3165

## Problem

`run_upgrade.sh` aborts at the Ansible task `system : Disable swap`
(`ansible/roles/system/tasks/misc.yml`) with:

```
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["/sbin/swapoff", "--all"],
  "rc": -9, "stderr": "", "stdout": ""}
```

`rc: -9` is a **SIGKILL from the OOM-killer**, not an error return.
`swapoff --all` faults every used swap page back into RAM at once. It
runs at the peak-memory moment of the whole upgrade: right after the apt
dist-upgrade **and** while the previous-version Docker stack is still
resident (the stack isn't torn down/rebuilt until `upgrade_docker_containers`,
which runs *after* the entire Ansible play). On a memory-tight board
(here a 1 GB Pi 4 on Trixie, whose dynamically-sized swap is larger than
the old fixed 100 MB) there isn't enough headroom, so the kernel kills
`swapoff` and the upgrade aborts. The task itself is long-standing; the
Trixie upgrade path is what now reliably tips these boards over.

## Fix

**`bin/install.sh`** — new `stop_docker_stack()`, called before
`run_ansible_playbook`, brings the running stack down first so `swapoff`
(and the dist-upgrade) have the RAM headroom they need. No-op on a fresh
install; best-effort so a stale compose file can't abort the upgrade.
`upgrade_docker_containers` brings everything back up afterwards, and the
install ends in a reboot regardless.

**`ansible/roles/system/tasks/misc.yml`** — hardened `Disable swap`:
- memory guard: only run `swapoff` when `SwapUsed < MemAvailable - 64 MiB`
- `retries: 3` + `until rc == 0` + `failed_when: false`: transient
  pressure retries; a persistent OOM leaves swap on rather than aborting
- swapfile removal gated on `rc == 0` — never unlink an active swapfile

Disabling swap is best-effort host hygiene, so skipping/leaving it on
under memory pressure is safe; it must never gate the whole upgrade.

## Validation (real 1 GB Pi 4, `arm64`, zram swap)

| Check | Result |
| --- | --- |
| Reported condition (stack up, ~340 MB free, 342 MB swap used) | guard skips swapoff → play green (old code would OOM-abort) |
| Exact `rc -9` SIGKILL reproduced | retried, tolerated, removal gated off, **ansible exits 0** |
| `docker compose stop` | reclaims ~140 MB RAM, drops zram usage 342 M → 65 M |
| Run branch (headroom present) | `swapoff` runs and succeeds (rc 0), removal gated on success |

`shellcheck`, `ansible-lint` (production profile) and
`ansible-playbook --syntax-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)