### PR TITLE
pi3-64: reduced-seam in-slot video looping (SEGMENT seeks)

### DIFF
--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1637,37 +1637,53 @@ void VideoView::gstRestartLoop()
     gstLoopAudio();
 }
 
-void VideoView::gstSegmentSeek(GstElement* pipe, bool flush)
+bool VideoView::gstSegmentSeek(GstElement* pipe, bool flush)
 {
     if (!pipe) {
-        return;
+        return false;
     }
     // A SEGMENT seek makes the pipeline post SEGMENT_DONE (not EOS) at the
     // end; re-arming it there WITHOUT flushing loops the clip gaplessly —
     // the HW decoder is never torn down, so no re-prime gap. The first
     // seek must flush to switch the pipeline into segment mode; subsequent
-    // ones must not.
-    GstSeekFlags flags = GST_SEEK_FLAG_SEGMENT;
+    // ones must not. KEY_UNIT matches the flushing loop seeks; the target
+    // is 0, always a keyframe, so it only keeps the flag set consistent.
+    GstSeekFlags flags = static_cast<GstSeekFlags>(GST_SEEK_FLAG_SEGMENT
+                                                   | GST_SEEK_FLAG_KEY_UNIT);
     if (flush) {
         flags = static_cast<GstSeekFlags>(flags | GST_SEEK_FLAG_FLUSH);
     }
-    gst_element_seek(pipe, 1.0, GST_FORMAT_TIME, flags,
-                     GST_SEEK_TYPE_SET, 0,
-                     GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE);
+    return gst_element_seek(pipe, 1.0, GST_FORMAT_TIME, flags,
+                            GST_SEEK_TYPE_SET, 0,
+                            GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE);
 }
 
 void VideoView::gstVideoSegmentDone()
 {
-    gstSegmentSeek(gstPipeline, false);
-    // Keep audio aligned to the video's loop point.
-    gstSegmentSeek(gstAudioPipeline, false);
+    // Re-arm the video segment without flushing (gapless). If the re-arm
+    // fails, segment mode delivers no EOS, so the pipeline would freeze on
+    // its last frame forever — fall back to the flushing restart (small
+    // seam, but the clip keeps looping) and stop here.
+    if (!gstSegmentSeek(gstPipeline, false)) {
+        gstRestartLoop();
+        return;
+    }
+    // Keep audio aligned to the video's loop point; on failure loop it the
+    // flushing way rather than let it stall silently.
+    if (!gstSegmentSeek(gstAudioPipeline, false)) {
+        gstLoopAudio();
+    }
 }
 
 void VideoView::gstAudioSegmentDone()
 {
     // Video drives re-alignment; if audio finishes its segment first just
-    // re-arm audio so it keeps playing until the video loops it again.
-    gstSegmentSeek(gstAudioPipeline, false);
+    // re-arm audio so it keeps playing until the video loops it again. On
+    // a failed re-arm fall back to the flushing loop so audio doesn't
+    // stall silently at the segment boundary.
+    if (!gstSegmentSeek(gstAudioPipeline, false)) {
+        gstLoopAudio();
+    }
 }
 
 void VideoView::onOverlayBuffer(struct _GstPad* pad)

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1038,6 +1038,9 @@ gboolean anthias_gst_audio_bus(GstBus* /*bus*/, GstMessage* message,
 {
     auto* view = static_cast<VideoView*>(user_data);
     switch (GST_MESSAGE_TYPE(message)) {
+    case GST_MESSAGE_ASYNC_DONE:
+        view->gstArmAudioSegment();
+        break;
     case GST_MESSAGE_SEGMENT_DONE:
         view->gstAudioSegmentDone();
         break;
@@ -1068,10 +1071,19 @@ gboolean anthias_gst_bus_loop(GstBus* /*bus*/, GstMessage* message,
 {
     auto* view = static_cast<VideoView*>(user_data);
     switch (GST_MESSAGE_TYPE(message)) {
+    case GST_MESSAGE_ASYNC_DONE:
+        // Preroll complete: only now can a segment seek succeed. Enter
+        // segment mode here (once) rather than right after set_state, where
+        // the pipeline is still prerolling and the seek is rejected. Arming
+        // latches only on a successful seek, so an early ASYNC_DONE from a
+        // child bin just retries on the pipeline's own ASYNC_DONE.
+        view->gstArmVideoSegment();
+        break;
     case GST_MESSAGE_SEGMENT_DONE:
-        // Gapless loop: re-arm the segment without flushing so the HW
-        // decoder stays primed (a flushing seek re-primes it and drops
-        // ~0.35s of frames at every loop point).
+        // Reduced-seam loop: re-arm the segment without flushing so the HW
+        // decoder is not fully torn down. On the bcm2835 v4l2 decoder this
+        // roughly halves the loop-point drop vs the flushing restart
+        // (measured ~0.2s -> ~0.1s on real pi3-64; not fully gapless).
         view->gstVideoSegmentDone();
         break;
     case GST_MESSAGE_EOS:
@@ -1420,10 +1432,9 @@ bool VideoView::gstPlayOverlay(const QString& uri)
         rasterWidget->clear();
     }
     gstOverlayActive = true;
-    // Switch to segment playback so the clip loops gaplessly (see
-    // gstSegmentSeek) instead of the flushing-seek restart that dropped
-    // ~0.35s at each loop point.
-    gstSegmentSeek(gstPipeline, true);
+    // Segment mode (for reduced-seam looping) is entered from the
+    // ASYNC_DONE bus message once the pipeline has prerolled — a seek issued
+    // here, right after set_state(PLAYING), races preroll and is rejected.
     writeStats(
         QStringLiteral("INIT"),
         QStringLiteral(
@@ -1496,8 +1507,8 @@ void VideoView::gstStartAudio(const QString& location, const QString& alsaDev)
         gstStopAudio();
         return;
     }
-    // Match the video: segment playback so audio loops gaplessly too.
-    gstSegmentSeek(gstAudioPipeline, true);
+    // Match the video: segment mode is entered from the audio pipeline's
+    // ASYNC_DONE (see gstArmAudioSegment) so audio loops the same way.
     writeStats(QStringLiteral("AUDIO"),
                QStringLiteral("started sink=%1 device=%2")
                    .arg(audioSink,
@@ -1544,6 +1555,7 @@ void VideoView::gstStopAudio()
     gst_element_set_state(gstAudioPipeline, GST_STATE_NULL);
     gst_object_unref(gstAudioPipeline);
     gstAudioPipeline = nullptr;
+    gstAudioSegmentArmed = false;
 }
 
 void VideoView::gstStop()
@@ -1560,6 +1572,7 @@ void VideoView::gstStop()
         }
     }
     gstOverlayActive = false;
+    gstSegmentArmed = false;
     if (gstAppSink) {
         gst_object_unref(gstAppSink);
         gstAppSink = nullptr;
@@ -1643,11 +1656,14 @@ bool VideoView::gstSegmentSeek(GstElement* pipe, bool flush)
         return false;
     }
     // A SEGMENT seek makes the pipeline post SEGMENT_DONE (not EOS) at the
-    // end; re-arming it there WITHOUT flushing loops the clip gaplessly —
-    // the HW decoder is never torn down, so no re-prime gap. The first
-    // seek must flush to switch the pipeline into segment mode; subsequent
-    // ones must not. KEY_UNIT matches the flushing loop seeks; the target
-    // is 0, always a keyframe, so it only keeps the flag set consistent.
+    // end; re-arming it there WITHOUT flushing loops the clip without a full
+    // decoder teardown, which roughly halves the loop-point frame drop on
+    // the bcm2835 v4l2 decoder (~0.2s flushing restart -> ~0.1s; the
+    // decoder still partially re-primes, so it is reduced, not eliminated).
+    // The first seek must flush to switch the pipeline into segment mode;
+    // subsequent ones must not. KEY_UNIT matches the flushing loop seeks;
+    // the target is 0, always a keyframe, so it only keeps the flag set
+    // consistent.
     GstSeekFlags flags = static_cast<GstSeekFlags>(GST_SEEK_FLAG_SEGMENT
                                                    | GST_SEEK_FLAG_KEY_UNIT);
     if (flush) {
@@ -1658,12 +1674,35 @@ bool VideoView::gstSegmentSeek(GstElement* pipe, bool flush)
                             GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE);
 }
 
+void VideoView::gstArmVideoSegment()
+{
+    if (gstSegmentArmed || !gstPipeline) {
+        return;
+    }
+    // Latch only on success: an early ASYNC_DONE (e.g. from a child bin
+    // mid-preroll) whose seek is rejected leaves the flag clear so the
+    // pipeline's own ASYNC_DONE retries.
+    if (gstSegmentSeek(gstPipeline, true)) {
+        gstSegmentArmed = true;
+    }
+}
+
+void VideoView::gstArmAudioSegment()
+{
+    if (gstAudioSegmentArmed || !gstAudioPipeline) {
+        return;
+    }
+    if (gstSegmentSeek(gstAudioPipeline, true)) {
+        gstAudioSegmentArmed = true;
+    }
+}
+
 void VideoView::gstVideoSegmentDone()
 {
-    // Re-arm the video segment without flushing (gapless). If the re-arm
-    // fails, segment mode delivers no EOS, so the pipeline would freeze on
-    // its last frame forever — fall back to the flushing restart (small
-    // seam, but the clip keeps looping) and stop here.
+    // Re-arm the video segment without flushing. If the re-arm fails,
+    // segment mode delivers no EOS, so the pipeline would freeze on its
+    // last frame forever — fall back to the flushing restart (small seam,
+    // but the clip keeps looping) and stop here.
     if (!gstSegmentSeek(gstPipeline, false)) {
         gstRestartLoop();
         return;

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1038,6 +1038,9 @@ gboolean anthias_gst_audio_bus(GstBus* /*bus*/, GstMessage* message,
 {
     auto* view = static_cast<VideoView*>(user_data);
     switch (GST_MESSAGE_TYPE(message)) {
+    case GST_MESSAGE_SEGMENT_DONE:
+        view->gstAudioSegmentDone();
+        break;
     case GST_MESSAGE_EOS:
         view->gstLoopAudio();
         break;
@@ -1065,7 +1068,15 @@ gboolean anthias_gst_bus_loop(GstBus* /*bus*/, GstMessage* message,
 {
     auto* view = static_cast<VideoView*>(user_data);
     switch (GST_MESSAGE_TYPE(message)) {
+    case GST_MESSAGE_SEGMENT_DONE:
+        // Gapless loop: re-arm the segment without flushing so the HW
+        // decoder stays primed (a flushing seek re-primes it and drops
+        // ~0.35s of frames at every loop point).
+        view->gstVideoSegmentDone();
+        break;
     case GST_MESSAGE_EOS:
+        // Fallback if the pipeline delivered EOS instead of SEGMENT_DONE
+        // (segment seek unsupported); flushing restart, small seam.
         view->gstRestartLoop();
         break;
     case GST_MESSAGE_QOS: {
@@ -1409,6 +1420,10 @@ bool VideoView::gstPlayOverlay(const QString& uri)
         rasterWidget->clear();
     }
     gstOverlayActive = true;
+    // Switch to segment playback so the clip loops gaplessly (see
+    // gstSegmentSeek) instead of the flushing-seek restart that dropped
+    // ~0.35s at each loop point.
+    gstSegmentSeek(gstPipeline, true);
     writeStats(
         QStringLiteral("INIT"),
         QStringLiteral(
@@ -1481,6 +1496,8 @@ void VideoView::gstStartAudio(const QString& location, const QString& alsaDev)
         gstStopAudio();
         return;
     }
+    // Match the video: segment playback so audio loops gaplessly too.
+    gstSegmentSeek(gstAudioPipeline, true);
     writeStats(QStringLiteral("AUDIO"),
                QStringLiteral("started sink=%1 device=%2")
                    .arg(audioSink,
@@ -1618,6 +1635,39 @@ void VideoView::gstRestartLoop()
     // Re-seek audio to the top too so it re-aligns with the video every
     // loop (the two pipelines otherwise drift on their own clocks).
     gstLoopAudio();
+}
+
+void VideoView::gstSegmentSeek(GstElement* pipe, bool flush)
+{
+    if (!pipe) {
+        return;
+    }
+    // A SEGMENT seek makes the pipeline post SEGMENT_DONE (not EOS) at the
+    // end; re-arming it there WITHOUT flushing loops the clip gaplessly —
+    // the HW decoder is never torn down, so no re-prime gap. The first
+    // seek must flush to switch the pipeline into segment mode; subsequent
+    // ones must not.
+    GstSeekFlags flags = GST_SEEK_FLAG_SEGMENT;
+    if (flush) {
+        flags = static_cast<GstSeekFlags>(flags | GST_SEEK_FLAG_FLUSH);
+    }
+    gst_element_seek(pipe, 1.0, GST_FORMAT_TIME, flags,
+                     GST_SEEK_TYPE_SET, 0,
+                     GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE);
+}
+
+void VideoView::gstVideoSegmentDone()
+{
+    gstSegmentSeek(gstPipeline, false);
+    // Keep audio aligned to the video's loop point.
+    gstSegmentSeek(gstAudioPipeline, false);
+}
+
+void VideoView::gstAudioSegmentDone()
+{
+    // Video drives re-alignment; if audio finishes its segment first just
+    // re-arm audio so it keeps playing until the video loops it again.
+    gstSegmentSeek(gstAudioPipeline, false);
 }
 
 void VideoView::onOverlayBuffer(struct _GstPad* pad)

--- a/src/anthias_webview/src/videoview.h
+++ b/src/anthias_webview/src/videoview.h
@@ -192,7 +192,10 @@ public:
     // Gapless loop via SEGMENT seeks: gstSegmentSeek re-arms a pipeline's
     // segment (flush only on the first, to enter segment mode); the
     // *SegmentDone hooks are called from the bus watches on SEGMENT_DONE.
-    void gstSegmentSeek(struct _GstElement* pipe, bool flush);
+    // Returns the seek result: in segment mode no EOS is posted, so a
+    // failed re-arm would stall the pipeline forever — callers fall back
+    // to the flushing loop when it returns false.
+    bool gstSegmentSeek(struct _GstElement* pipe, bool flush);
     void gstVideoSegmentDone();
     void gstAudioSegmentDone();
     // Overlay-path instrumentation (streaming thread). onOverlayBuffer:

--- a/src/anthias_webview/src/videoview.h
+++ b/src/anthias_webview/src/videoview.h
@@ -189,7 +189,7 @@ public:
     // from the pipeline bus watch (anthias_gst_bus_loop), which GLib
     // services on the GUI thread, so the seek never races stop().
     Q_INVOKABLE void gstRestartLoop();
-    // Gapless loop via SEGMENT seeks: gstSegmentSeek re-arms a pipeline's
+    // Reduced-seam loop via SEGMENT seeks: gstSegmentSeek re-arms a pipeline's
     // segment (flush only on the first, to enter segment mode); the
     // *SegmentDone hooks are called from the bus watches on SEGMENT_DONE.
     // Returns the seek result: in segment mode no EOS is posted, so a
@@ -198,6 +198,11 @@ public:
     bool gstSegmentSeek(struct _GstElement* pipe, bool flush);
     void gstVideoSegmentDone();
     void gstAudioSegmentDone();
+    // Enter segment mode on the first ASYNC_DONE (preroll done). Idempotent
+    // via gstSegmentArmed / gstAudioSegmentArmed. Called from the bus
+    // watches on GST_MESSAGE_ASYNC_DONE.
+    void gstArmVideoSegment();
+    void gstArmAudioSegment();
     // Overlay-path instrumentation (streaming thread). onOverlayBuffer:
     // count each frame reaching kmssink + latch the source framerate from
     // the pad caps. logOverlayQos: record kmssink's authoritative
@@ -245,6 +250,16 @@ private:
     struct _GstElement* gstAudioPipeline = nullptr;
     struct _GstElement* gstAppSink = nullptr;
     bool gstMode = false;
+    // Enter segment mode ONCE, from ASYNC_DONE (preroll complete) rather
+    // than synchronously after set_state(PLAYING) — a segment seek issued
+    // while the pipeline is still prerolling returns FALSE, so the pipeline
+    // never enters segment mode and looping falls back to the flushing EOS
+    // restart (which fully re-primes the decoder, roughly double the
+    // loop-point drop this change reduces to). These guard against
+    // re-arming on the extra ASYNC_DONE the flushing seek itself posts.
+    // Reset in gstPlay/gstStop.
+    bool gstSegmentArmed = false;
+    bool gstAudioSegmentArmed = false;
     // Single-slot handoff: the appsink callback (streaming thread) writes
     // the newest frame under gstFrameMutex and, if no drain is already
     // queued (gstDrainPending), posts one onGstFrame() to the GUI thread.

--- a/src/anthias_webview/src/videoview.h
+++ b/src/anthias_webview/src/videoview.h
@@ -189,6 +189,12 @@ public:
     // from the pipeline bus watch (anthias_gst_bus_loop), which GLib
     // services on the GUI thread, so the seek never races stop().
     Q_INVOKABLE void gstRestartLoop();
+    // Gapless loop via SEGMENT seeks: gstSegmentSeek re-arms a pipeline's
+    // segment (flush only on the first, to enter segment mode); the
+    // *SegmentDone hooks are called from the bus watches on SEGMENT_DONE.
+    void gstSegmentSeek(struct _GstElement* pipe, bool flush);
+    void gstVideoSegmentDone();
+    void gstAudioSegmentDone();
     // Overlay-path instrumentation (streaming thread). onOverlayBuffer:
     // count each frame reaching kmssink + latch the source framerate from
     // the pad caps. logOverlayQos: record kmssink's authoritative


### PR DESCRIPTION
## What

Reduces the loop-point frame drop for in-slot video looping on pi3-64. When a clip is shorter than its playlist slot, the viewer loops it in-process; the previous flushing-seek restart fully re-primed the bcm2835 HW decoder at each internal loop, dropping ~0.2 s of frames. This switches the overlay video (and separate audio) pipeline to **SEGMENT playback** so the decoder is not fully torn down at the loop point.

Follow-up to #3164 (merged).

## How

- After preroll, an initial flushing **segment** seek enters segment mode; each `SEGMENT_DONE` re-arms the segment **without flushing**.
- The initial segment seek is issued from `GST_MESSAGE_ASYNC_DONE` (preroll complete), **not** synchronously after `set_state(PLAYING)` — a seek issued while the pipeline is still prerolling returns `FALSE`, so segment mode would never engage.
- `gstSegmentSeek` returns the seek result; the `SEGMENT_DONE` handlers fall back to the flushing restart if a re-arm fails (in segment mode no EOS is posted, so a failed re-arm would otherwise freeze the clip forever).
- EOS handling is retained as a fallback for pipelines that don't deliver `SEGMENT_DONE`.

## Validation on real pi3-64 (192.168.x hardware, 1080p30 H.264, 60 s clip looping in a 300 s slot)

Measured loop-point frame drop (SAMPLE `expected − rendered` in the loop-transition second), steady-state background drop ≈ 0.09 frames/s:

| Build | Segment mode engaged? | Loop-point drop |
|---|---|---|
| master (flushing restart) | n/a | ~6–10 frames (~0.2 s) |
| this PR, first two commits only | **No** — init seek raced preroll, silently fell back to EOS/flush | ~6–10 frames (no change) |
| + ASYNC_DONE fix (3rd commit) | **Yes** — `SEGMENT_DONE` every loop, video + audio | ~1–5 frames (~0.1 s) |

**Honest framing:** this **roughly halves** the loop hitch; it does **not** make looping perfectly gapless. The bcm2835 v4l2 decoder still partially re-primes even on a non-flushing segment seek. Comments/wording were changed from "gapless" to "reduced-seam" to match. True gaplessness on this decoder would likely need a non-seek approach.

## Scope

Only affects looping **within** a slot. A single-video playlist still rebuilds at each slot boundary — a separate scheduler change.

## Commits

1. Original SEGMENT-seek change (did not engage on hardware on its own).
2. Fall back to flushing loop if a segment re-arm seek fails (prevents a freeze-forever stall; from Copilot review).
3. Enter segment mode on `ASYNC_DONE` — the fix that actually makes segment mode engage on pi3-64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
