### PR TITLE
fix(celery): give reconcile_stuck_processing a soft time limit

### DIFF
--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -165,6 +165,23 @@ ASSET_REVALIDATION_SOFT_TIME_LIMIT_S = ASSET_REVALIDATION_TIME_LIMIT_S - 60
 PERIODIC_POKE_SOFT_TIME_LIMIT_S = 30
 PERIODIC_POKE_TIME_LIMIT_S = 60
 
+# Time budget for the stuck-row reconciler sweep. It was the last
+# periodic task still carrying a bare ``time_limit=300`` with no soft
+# companion: its inner loop makes unbounded per-row calls (a SQLite
+# SELECT/UPDATE, a kombu ``.delay()`` publish to the Redis broker, and
+# ``r.set``/``r.eval``), so on a memory-pressured board a wedged Redis
+# publish or SQLite lock can push the sweep past 300s. Tripping the
+# *hard* limit SIGKILLs the pool child, which Sentry groups by the kill
+# signature — the same ANTHIAS-A / ANTHIAS-9 / ANTHIAS-B trio the sibling
+# pokes (#3017/#3063) already closed, leaving this task as the last
+# contributor. The soft limit raises ``SoftTimeLimitExceeded`` *inside*
+# the sweep so it aborts cleanly (releasing its Redis lock via the
+# existing ``finally``) and the next tick retries; the hard limit stays
+# as the backstop for a call stuck in C code where the soft signal can't
+# be delivered.
+RECONCILE_STUCK_TIME_LIMIT_S = 300
+RECONCILE_STUCK_SOFT_TIME_LIMIT_S = RECONCILE_STUCK_TIME_LIMIT_S - 30
+
 # Redis key for the sweep singleton lock. Whoever sets it first runs
 # the sweep; later beat ticks observe the key and exit. The TTL matches
 # the time_limit so a worker that crashes mid-sweep doesn't lock the
@@ -1376,7 +1393,10 @@ def _parse_processing_started_at(value: Any) -> datetime | None:
     return parsed
 
 
-@celery.task(time_limit=300)
+@celery.task(
+    time_limit=RECONCILE_STUCK_TIME_LIMIT_S,
+    soft_time_limit=RECONCILE_STUCK_SOFT_TIME_LIMIT_S,
+)
 def reconcile_stuck_processing() -> None:
     """Recover ``Asset`` rows stuck at ``is_processing=True``.
 
@@ -1440,7 +1460,7 @@ def reconcile_stuck_processing() -> None:
         RECONCILE_STUCK_LOCK_KEY,
         token,
         nx=True,
-        ex=300,  # matches the task's time_limit
+        ex=RECONCILE_STUCK_TIME_LIMIT_S,  # matches the task's hard time_limit
     ):
         logging.info(
             'reconcile_stuck_processing: previous sweep still running, '
@@ -1514,6 +1534,17 @@ def reconcile_stuck_processing() -> None:
                     'Processing stalled past threshold; flag cleared '
                     'by reconciler. Re-upload the asset to retry.',
                 )
+    except SoftTimeLimitExceeded:
+        # A per-row Redis publish or SQLite lock wedged the sweep past
+        # the soft budget. Abort this tick rather than let the hard
+        # limit SIGKILL the worker (ANTHIAS-A / 9 / B); the finally
+        # below still releases the lock and the next beat tick resumes
+        # from wherever the rows now stand.
+        logging.warning(
+            'reconcile_stuck_processing: sweep exceeded %ss; '
+            'skipping the rest of this tick',
+            RECONCILE_STUCK_SOFT_TIME_LIMIT_S,
+        )
     finally:
         # Compare-and-delete via the shared Lua script: only release
         # if the lock still holds *our* token. If our TTL expired and

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -2118,6 +2118,47 @@ class TestPeriodicPokeTimeLimits:
         assert result.successful()
 
 
+class TestReconcileTimeLimits:
+    """The stuck-row reconciler was the last periodic task carrying a
+    bare ``time_limit=300`` with no soft companion, so its unbounded
+    per-row work (SQLite + a kombu ``.delay()`` publish) could still
+    trip the hard limit and SIGKILL the pool child — keeping the
+    ANTHIAS-A / ANTHIAS-9 / ANTHIAS-B group alive after #3017/#3063
+    closed the sibling tasks."""
+
+    def test_reconcile_task_has_soft_limit_headroom(self) -> None:
+        soft = reconcile_stuck_processing.soft_time_limit
+        hard = reconcile_stuck_processing.time_limit
+        assert soft == celery_tasks_module.RECONCILE_STUCK_SOFT_TIME_LIMIT_S
+        assert hard == celery_tasks_module.RECONCILE_STUCK_TIME_LIMIT_S
+        assert soft is not None
+        assert hard is not None
+        assert soft < hard
+
+    @pytest.mark.django_db
+    def test_reconcile_soft_limit_aborts_and_releases_lock(
+        self, eager_celery_reconcile: None
+    ) -> None:
+        old = (
+            timezone.now()
+            - timedelta(seconds=RECONCILE_STUCK_THRESHOLD_S + 60)
+        ).isoformat()
+        _make_stuck_asset(processing_started_at=old, mimetype='video')
+
+        # A per-row re-dispatch wedges past the soft budget.
+        with mock.patch(
+            'anthias_server.processing.dispatch_normalize_video',
+            side_effect=SoftTimeLimitExceeded,
+        ):
+            result = reconcile_stuck_processing.apply()
+        # Caught inside the sweep — no exception propagates, so the tick
+        # ends as a clean success instead of a hard-kill task failure.
+        assert result.successful()
+        # The finally block must have released the singleton lock so the
+        # next beat tick can run.
+        assert celery_tasks_module.r.get(RECONCILE_STUCK_LOCK_KEY) is None
+
+
 class TestWaitForMigrations:
     """Startup gate for Sentry ANTHIAS-1 — the worker must not consume
     tasks while the server's migrate/dbrestore pass is still rewriting


### PR DESCRIPTION
## What

`reconcile_stuck_processing` was the **last** periodic Celery task still carrying a bare `time_limit=300` with no `soft_time_limit`. Its inner loop makes unbounded per-row calls (a SQLite SELECT/UPDATE, a kombu `.delay()` publish to the Redis broker, and `r.set`/`r.eval`), so on a memory-pressured board a wedged Redis publish or SQLite lock can push the sweep past 300s. Tripping the **hard** limit SIGKILLs the pool child.

## Why

Sentry groups that SIGKILL by the kill signature, so this one task kept the **ANTHIAS-A / ANTHIAS-9 / ANTHIAS-B** trio alive (251 + 232 + 292 events, almost all on pi3-64) after the earlier soft-limit work closed its three siblings (asset probe, telemetry POST, display-power CEC query). A deep audit of the still-open Sentry backlog found this was the only remaining unguarded contributor.

## How

- Add `RECONCILE_STUCK_SOFT_TIME_LIMIT_S = RECONCILE_STUCK_TIME_LIMIT_S - 30` and apply both limits to the task decorator, mirroring the three sibling tasks.
- Catch `SoftTimeLimitExceeded` inside the sweep so it aborts cleanly; the existing `finally` still releases the Redis singleton lock and the next beat tick resumes. The hard limit stays as the backstop for a call stuck in C code where the soft signal can't be delivered.

## Tests

New `TestReconcileTimeLimits`: asserts the soft/hard headroom, and that a soft-limit mid-sweep ends as a clean success **and** releases the lock. Full non-integration suite green (1475 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)