### PR TITLE
fix(ws): tolerate a client that disconnects mid-broadcast

### DIFF
--- a/src/anthias_server/app/consumers.py
+++ b/src/anthias_server/app/consumers.py
@@ -22,7 +22,20 @@ class AssetConsumer(AsyncWebsocketConsumer):
         # Plain text frame: the client only needs to know "something
         # changed" to fire htmx refresh-assets; carrying the full
         # changeset over WS would duplicate the partial render path.
-        await self.send(text_data=event.get('asset_id', ''))
+        try:
+            await self.send(text_data=event.get('asset_id', ''))
+        except RuntimeError:
+            # The browser can disconnect in the window between the
+            # group_send dispatch and this send, so the ASGI server has
+            # already emitted 'websocket.close' and channels raises
+            # "Unexpected ASGI message 'websocket.send', after sending
+            # 'websocket.close'" (Sentry ANTHIAS-1K). group_discard runs
+            # in disconnect(), so this stale channel is on its way out —
+            # drop the nudge; the client's 5s poll keeps it consistent.
+            logger.debug(
+                'asset_update: send on a closed websocket; client '
+                'disconnected mid-broadcast'
+            )
 
 
 def notify_asset_update(asset_id: str = '*') -> None:

--- a/src/anthias_server/app/consumers.py
+++ b/src/anthias_server/app/consumers.py
@@ -25,17 +25,20 @@ class AssetConsumer(AsyncWebsocketConsumer):
         asset_id = event.get('asset_id', '')
         try:
             await self.send(text_data=asset_id)
-        except RuntimeError:
+        except RuntimeError as exc:
             # The browser can disconnect in the window between the
             # group_send dispatch and this send, so the ASGI server has
             # already emitted 'websocket.close' and channels raises
             # "Unexpected ASGI message 'websocket.send', after sending
-            # 'websocket.close'" (Sentry ANTHIAS-1K). group_discard runs
-            # in disconnect(), so this stale channel is on its way out —
-            # drop the nudge; the client's 5s poll keeps it consistent.
-            # Log the exception and asset_id at debug so this expected
-            # race stays distinguishable from any other RuntimeError out
-            # of send() without upgrading it to a reportable event.
+            # 'websocket.close'" (Sentry ANTHIAS-1K). Match on that
+            # message so a genuine send() failure (a serialization error,
+            # a Channels bug) still propagates instead of being hidden.
+            # group_discard runs in disconnect(), so this stale channel
+            # is on its way out — drop the nudge; the client's 5s poll
+            # keeps it consistent. Log at debug (with the asset_id) so the
+            # race stays diagnosable without becoming a reportable event.
+            if "Unexpected ASGI message 'websocket.send'" not in str(exc):
+                raise
             logger.debug(
                 'asset_update: send on a closed websocket for %r; client '
                 'disconnected mid-broadcast',

--- a/src/anthias_server/app/consumers.py
+++ b/src/anthias_server/app/consumers.py
@@ -22,8 +22,9 @@ class AssetConsumer(AsyncWebsocketConsumer):
         # Plain text frame: the client only needs to know "something
         # changed" to fire htmx refresh-assets; carrying the full
         # changeset over WS would duplicate the partial render path.
+        asset_id = event.get('asset_id', '')
         try:
-            await self.send(text_data=event.get('asset_id', ''))
+            await self.send(text_data=asset_id)
         except RuntimeError:
             # The browser can disconnect in the window between the
             # group_send dispatch and this send, so the ASGI server has
@@ -32,9 +33,14 @@ class AssetConsumer(AsyncWebsocketConsumer):
             # 'websocket.close'" (Sentry ANTHIAS-1K). group_discard runs
             # in disconnect(), so this stale channel is on its way out —
             # drop the nudge; the client's 5s poll keeps it consistent.
+            # Log the exception and asset_id at debug so this expected
+            # race stays distinguishable from any other RuntimeError out
+            # of send() without upgrading it to a reportable event.
             logger.debug(
-                'asset_update: send on a closed websocket; client '
-                'disconnected mid-broadcast'
+                'asset_update: send on a closed websocket for %r; client '
+                'disconnected mid-broadcast',
+                asset_id,
+                exc_info=True,
             )
 
 

--- a/src/anthias_server/app/consumers.py
+++ b/src/anthias_server/app/consumers.py
@@ -30,14 +30,25 @@ class AssetConsumer(AsyncWebsocketConsumer):
             # group_send dispatch and this send, so the ASGI server has
             # already emitted 'websocket.close' and channels raises
             # "Unexpected ASGI message 'websocket.send', after sending
-            # 'websocket.close'" (Sentry ANTHIAS-1K). Match on that
-            # message so a genuine send() failure (a serialization error,
-            # a Channels bug) still propagates instead of being hidden.
-            # group_discard runs in disconnect(), so this stale channel
-            # is on its way out — drop the nudge; the client's 5s poll
-            # keeps it consistent. Log at debug (with the asset_id) so the
-            # race stays diagnosable without becoming a reportable event.
-            if "Unexpected ASGI message 'websocket.send'" not in str(exc):
+            # 'websocket.close' or response already completed." (Sentry
+            # ANTHIAS-1K). Require both the out-of-order 'websocket.send'
+            # and the close/completed clause so a genuine send() failure
+            # (a serialization error, a Channels bug) — even one that
+            # merely mentions websocket.send — still propagates instead
+            # of being hidden. group_discard runs in disconnect(), so
+            # this stale channel is on its way out — drop the nudge; the
+            # client's 5s poll keeps it consistent. Log at debug (with
+            # the asset_id) so the race stays diagnosable without
+            # becoming a reportable event.
+            message = str(exc)
+            is_send_after_close = (
+                "Unexpected ASGI message 'websocket.send'" in message
+                and (
+                    'websocket.close' in message
+                    or 'response already completed' in message
+                )
+            )
+            if not is_send_after_close:
                 raise
             logger.debug(
                 'asset_update: send on a closed websocket for %r; client '

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,6 +1,8 @@
 import asyncio
 from unittest import mock
 
+import pytest
+
 from anthias_server.app.consumers import AssetConsumer
 
 
@@ -33,3 +35,16 @@ def test_asset_update_swallows_send_after_close() -> None:
     asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
 
     consumer.send.assert_awaited_once()
+
+
+def test_asset_update_reraises_unrelated_runtime_error() -> None:
+    """The swallow is scoped to the send-after-close message — any other
+    RuntimeError out of send() (a serialization error, a Channels bug) is
+    a genuine failure and must still propagate."""
+    consumer = AssetConsumer()
+    consumer.send = mock.AsyncMock(
+        side_effect=RuntimeError('something actually broke')
+    )
+
+    with pytest.raises(RuntimeError, match='something actually broke'):
+        asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -10,11 +10,12 @@ def test_asset_update_sends_asset_id() -> None:
     """The happy path forwards the asset_id as the text frame so the
     browser's htmx handler knows which row changed."""
     consumer = AssetConsumer()
-    consumer.send = mock.AsyncMock()
+    send = mock.AsyncMock()
 
-    asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
+    with mock.patch.object(consumer, 'send', send):
+        asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
 
-    consumer.send.assert_awaited_once_with(text_data='abc123')
+    send.assert_awaited_once_with(text_data='abc123')
 
 
 def test_asset_update_swallows_send_after_close() -> None:
@@ -24,7 +25,7 @@ def test_asset_update_swallows_send_after_close() -> None:
     best-effort (the 5s poll backs it up), so the consumer must swallow
     it rather than let it reach Sentry (ANTHIAS-1K)."""
     consumer = AssetConsumer()
-    consumer.send = mock.AsyncMock(
+    send = mock.AsyncMock(
         side_effect=RuntimeError(
             "Unexpected ASGI message 'websocket.send', after sending "
             "'websocket.close' or response already completed."
@@ -32,9 +33,10 @@ def test_asset_update_swallows_send_after_close() -> None:
     )
 
     # Must not raise.
-    asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
+    with mock.patch.object(consumer, 'send', send):
+        asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
 
-    consumer.send.assert_awaited_once()
+    send.assert_awaited_once()
 
 
 def test_asset_update_reraises_unrelated_runtime_error() -> None:
@@ -42,11 +44,12 @@ def test_asset_update_reraises_unrelated_runtime_error() -> None:
     RuntimeError out of send() (a serialization error, a Channels bug) is
     a genuine failure and must still propagate."""
     consumer = AssetConsumer()
-    consumer.send = mock.AsyncMock(
-        side_effect=RuntimeError('something actually broke')
-    )
+    send = mock.AsyncMock(side_effect=RuntimeError('something actually broke'))
 
-    with pytest.raises(RuntimeError, match='something actually broke'):
+    with (
+        mock.patch.object(consumer, 'send', send),
+        pytest.raises(RuntimeError, match='something actually broke'),
+    ):
         asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
 
 
@@ -55,12 +58,15 @@ def test_asset_update_reraises_non_close_websocket_send_error() -> None:
     that merely mentions 'websocket.send' but is not the send-after-close
     race (some other ASGI state bug) must still propagate."""
     consumer = AssetConsumer()
-    consumer.send = mock.AsyncMock(
+    send = mock.AsyncMock(
         side_effect=RuntimeError(
             "Unexpected ASGI message 'websocket.send', after sending "
             "'websocket.accept' was expected"
         )
     )
 
-    with pytest.raises(RuntimeError, match='websocket.accept'):
+    with (
+        mock.patch.object(consumer, 'send', send),
+        pytest.raises(RuntimeError, match='websocket.accept'),
+    ):
         asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,0 +1,35 @@
+import asyncio
+from unittest import mock
+
+from anthias_server.app.consumers import AssetConsumer
+
+
+def test_asset_update_sends_asset_id() -> None:
+    """The happy path forwards the asset_id as the text frame so the
+    browser's htmx handler knows which row changed."""
+    consumer = AssetConsumer()
+    consumer.send = mock.AsyncMock()
+
+    asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
+
+    consumer.send.assert_awaited_once_with(text_data='abc123')
+
+
+def test_asset_update_swallows_send_after_close() -> None:
+    """A browser can disconnect between the group_send dispatch and this
+    send, so channels raises RuntimeError("Unexpected ASGI message
+    'websocket.send', after sending 'websocket.close'"). The nudge is
+    best-effort (the 5s poll backs it up), so the consumer must swallow
+    it rather than let it reach Sentry (ANTHIAS-1K)."""
+    consumer = AssetConsumer()
+    consumer.send = mock.AsyncMock(
+        side_effect=RuntimeError(
+            "Unexpected ASGI message 'websocket.send', after sending "
+            "'websocket.close' or response already completed."
+        )
+    )
+
+    # Must not raise.
+    asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
+
+    consumer.send.assert_awaited_once()

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -48,3 +48,19 @@ def test_asset_update_reraises_unrelated_runtime_error() -> None:
 
     with pytest.raises(RuntimeError, match='something actually broke'):
         asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))
+
+
+def test_asset_update_reraises_non_close_websocket_send_error() -> None:
+    """The swallow requires the close/completed clause: a RuntimeError
+    that merely mentions 'websocket.send' but is not the send-after-close
+    race (some other ASGI state bug) must still propagate."""
+    consumer = AssetConsumer()
+    consumer.send = mock.AsyncMock(
+        side_effect=RuntimeError(
+            "Unexpected ASGI message 'websocket.send', after sending "
+            "'websocket.accept' was expected"
+        )
+    )
+
+    with pytest.raises(RuntimeError, match='websocket.accept'):
+        asyncio.run(consumer.asset_update({'asset_id': 'abc123'}))


### PR DESCRIPTION
## What

`AssetConsumer.asset_update` did an unguarded `await self.send()`. A browser can disconnect in the window between the `group_send` dispatch and this send, so the ASGI server has already emitted `websocket.close` and channels raises `RuntimeError("Unexpected ASGI message 'websocket.send', after sending 'websocket.close'")`.

## Why

A benign disconnect-vs-broadcast race that surfaces as an unhandled error in Sentry (**ANTHIAS-1K**, seen on pi5). The WS frame is only a best-effort "something changed" nudge — the client's 5s poll keeps the table consistent — and `group_discard` runs in `disconnect()`, so the stale channel is already on its way out.

## How

Wrap the send in `try/except RuntimeError`, log at `debug`, and drop the nudge. Scoped to `RuntimeError` so a genuine failure elsewhere still propagates.

## Tests

New `tests/test_consumers.py`: the happy path forwards the `asset_id` frame; a send-after-close `RuntimeError` is swallowed without propagating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)