### PR TITLE
fix(sentry): drop client-disconnect static-file noise

### DIFF
--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -150,6 +150,16 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
         asset renders a "Failed" pill with the reason — the operator
         gets the feedback without a Sentry page (Sentry ANTHIAS-3T).
         Matched by name+module so we don't import yt_dlp here.
+      * ``RuntimeError: Response content shorter than Content-Length`` —
+        a client that hangs up mid-response while Django's ASGI handler
+        is still streaming a static file (WhiteNoise serving e.g. the
+        splash SVG as the viewer navigates away). Django declared a
+        Content-Length from the file size, then the transfer is cut
+        short by the disconnect — a broken pipe, not a truncated file.
+        Same client-disconnect class as ``CancelledError`` above, but it
+        surfaces as a bare ``RuntimeError``, so it's matched by message
+        text to avoid swallowing unrelated RuntimeErrors (Sentry
+        ANTHIAS-37).
     """
     # Imported lazily — this runs only when an event is about to send,
     # well after Django is configured, and avoids an import cycle at
@@ -172,6 +182,10 @@ def _sentry_before_send(event: Event, hint: Hint) -> Event | None:
         if isinstance(exc, AuthSettingsError):
             return None
         if isinstance(exc, socket.gaierror):
+            return None
+        if isinstance(exc, RuntimeError) and (
+            'Response content shorter than Content-Length' in str(exc)
+        ):
             return None
         exc_cls = type(exc)
         if exc_cls.__name__ == 'DownloadError' and (

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -240,6 +240,31 @@ class TestBeforeSendTransientNoise:
         hint = self._hint_for(lookalike_cls('not really yt-dlp'))
         assert _sentry_before_send(event, hint) == event
 
+    def test_drops_short_content_length_runtime_error(self) -> None:
+        # A client that hangs up while Django's ASGI handler is still
+        # streaming a static file raises a bare RuntimeError with this
+        # message — a broken pipe, not a truncated file (Sentry
+        # ANTHIAS-37).
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        hint = self._hint_for(
+            RuntimeError('Response content shorter than Content-Length')
+        )
+        assert _sentry_before_send({'event_id': 'x'}, hint) is None
+
+    def test_keeps_unrelated_runtime_error(self) -> None:
+        # The drop is scoped to the client-disconnect message — any
+        # other RuntimeError is a real bug and must NOT be swallowed.
+        from anthias_server.django_project.settings import (
+            _sentry_before_send,
+        )
+
+        event: Event = {'event_id': 'x'}
+        hint = self._hint_for(RuntimeError('something actually broke'))
+        assert _sentry_before_send(event, hint) == event
+
     def test_keeps_ordinary_exceptions(self) -> None:
         from anthias_server.django_project.settings import (
             _sentry_before_send,


### PR DESCRIPTION
## What

Adds `RuntimeError: Response content shorter than Content-Length` to the `_sentry_before_send` drop-list, matched by message text.

## Why

A client that hangs up mid-response while Django's ASGI handler is still streaming a static file (WhiteNoise serving e.g. `logo-full-splash.svg` as the viewer navigates away) makes Django declare a `Content-Length` from the file size and then have the transfer cut short by the disconnect — a broken pipe, not a truncated file. It is the same benign client-disconnect class as the `asyncio.CancelledError` already dropped here, but it surfaces as a bare `RuntimeError` (**ANTHIAS-37**, pi4-64).

## How

Match `isinstance(exc, RuntimeError) and 'Response content shorter than Content-Length' in str(exc)`. The message scope keeps it from swallowing unrelated RuntimeErrors.

## Tests

`TestBeforeSendTransientNoise` gains two cases: the short-Content-Length RuntimeError is dropped; an unrelated RuntimeError is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)