### PR TITLE
fix(image-builder): consume WebView-v2026.07.1 Qt5 toolchain

### DIFF
--- a/tools/image_builder/utils.py
+++ b/tools/image_builder/utils.py
@@ -169,12 +169,18 @@ def get_viewer_context(board: str, target_platform: str) -> dict[str, Any]:
 
     # Qt version is only relevant for the Qt 5 path: pi2/pi3 pull the
     # cross-built Qt 5 toolchain tarball at build time. Qt 5 is frozen
-    # for these boards, so the toolchain stays pinned to the
-    # WebView-v2026.07.0 release indefinitely. Qt 6 boards install Qt
-    # straight from Debian apt (qt6-*-dev in viewer_extra_apt below).
+    # for these boards, so the toolchain stays pinned to a WebView-v*
+    # release. Bumped from WebView-v2026.07.0 to WebView-v2026.07.1,
+    # which carries the armv7 NEON-alignment fix (arm_use_neon=false +
+    # a -mno-unaligned-access cross-compiler wrap) that stops the Pi 2/3
+    # blank-screen crash-loop: gcc otherwise lowers struct init of
+    # 8-byte-aligned types into a NEON :64 block store that faults on
+    # the 4-byte-aligned pointers QtWebEngine hands it. Qt 6 boards
+    # install Qt straight from Debian apt (qt6-*-dev in viewer_extra_apt
+    # below).
     qt_version = '6.4.2' if is_qt6 else '5.15.19'
     qt_major_version = qt_version.split('.')[0]
-    qt5_toolchain_url = f'{releases_url}/WebView-v2026.07.0'
+    qt5_toolchain_url = f'{releases_url}/WebView-v2026.07.1'
 
     # Viewer-only apt deps. The shared runtime set (cec-utils, curl,
     # ffmpeg, git, libcec7, procps, psmisc, python-is-python3,


### PR DESCRIPTION
### Issues Fixed

Ships the armv7 NEON-alignment fix to `master` by consuming the already-published fixed Qt 5 toolchain. Related forum report: https://forums.screenly.io/t/screen-stays-blank/6732

### Description

Bumps `qt5_toolchain_url` from `WebView-v2026.07.0` to `WebView-v2026.07.1` so the pi2/pi3 viewer image build fetches the fixed Qt 5 toolchain tarball.

The `WebView-v2026.07.1` toolchain (already released: https://github.com/Screenly/Anthias/releases/tag/WebView-v2026.07.1) was rebuilt with `arm_use_neon=false` + a `-mno-unaligned-access` cross-compiler wrap, stripping the NEON `:64` block stores that fault on the Pi 2 (Cortex-A7) and 32-bit Pi 3 (Cortex-A53) — the cause of the blank-screen crash-loop.

The fix lives entirely in the pre-built toolchain tarball (the Qt runtime libs), so consuming it here is a one-line URL bump; no build-script changes are needed. The toolchain build-script / rebuildability changes (`build_qt5.sh` + the Python 3.13 shims) are handled in a separate PR.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes. (comment + one URL string; no test-affecting logic — the `.07.1` assets are verified downloadable at the exact build URL, sha256-matched)
- [x] I have done an end-to-end test for Raspberry Pi devices. (real Pi 2 + a native 32-bit Pi 3: the unfixed build crash-loops with a blank screen; this toolchain gives a stable viewer that renders webpage/image/video with 0 alignment traps across a multi-hour soak)
- [ ] I have tested my changes for x86 devices. (N/A — armhf pi2/pi3 toolchain only)
- [ ] I added a documentation for the changes I have made (when necessary).
