### PR TITLE
feat(apps): render native date/time pickers for schema format fields

### DIFF
--- a/src/anthias_server/app/static/src/apps/manifest-form.ts
+++ b/src/anthias_server/app/static/src/apps/manifest-form.ts
@@ -8,15 +8,17 @@
 // Anthias's modal styling and wired to a callback instead of writing an
 // <input> directly).
 //
-// Supported `x-widget`s (falling back to the JSON Schema type): text,
-// url, number, select (enum), toggle (boolean), timezone, and
-// location-map (a {lat,lng} object). Unknown widgets degrade to a text
-// input; unsupported structural types (arrays, non-location objects)
-// are skipped rather than mis-rendered.
+// Supported `x-widget`s (falling back to the JSON Schema type, or a
+// string `format`): text, url, number, datetime/date/time (from a
+// `date-time`/`date`/`time` format), select (enum), toggle (boolean),
+// timezone, and location-map (a {lat,lng} object). Unknown widgets
+// degrade to a text input; unsupported structural types (arrays,
+// non-location objects) are skipped rather than mis-rendered.
 
 import { initLocationMap } from './location-map'
 import { selectOptionLabel } from './select-label'
 import type { SettingSchema, SettingValue } from './types'
+import { widgetFor } from './widget-for'
 
 type SetFn = (key: string, value: SettingValue) => void
 
@@ -37,23 +39,6 @@ export function teardownHost(host: HTMLElement): void {
   })
   h.__cfgCleanups = []
   host.replaceChildren()
-}
-
-// Which control to render for a settings property.
-function widgetFor(schema: SettingSchema): string {
-  if (schema['x-widget']) return schema['x-widget']
-  if (Array.isArray(schema.enum)) return 'select'
-  if (schema.type === 'boolean') return 'toggle'
-  if (schema.type === 'number' || schema.type === 'integer') return 'number'
-  // Only a {lat,lng} object is a location map; other objects/arrays
-  // have no generic control, so mark them unsupported (skipped) rather
-  // than mis-render.
-  if (schema.type === 'object') {
-    const props = schema.properties || {}
-    return props.lat && props.lng ? 'location-map' : 'unsupported'
-  }
-  if (schema.type === 'array') return 'unsupported'
-  return 'text'
 }
 
 // A labelled wrapper shared by every control. When the control is a
@@ -225,6 +210,15 @@ function renderField(
     if (schema.maximum !== undefined) input.max = String(schema.maximum)
   } else if (widget === 'url') {
     input.type = 'url'
+  } else if (widget === 'datetime') {
+    // A `date-time` string: native picker. Its value is the local
+    // wall-clock (`YYYY-MM-DDTHH:mm`), which apps like Timer resolve
+    // against the separate time-zone field — matching their docs.
+    input.type = 'datetime-local'
+  } else if (widget === 'date') {
+    input.type = 'date'
+  } else if (widget === 'time') {
+    input.type = 'time'
   } else {
     input.type = 'text'
   }

--- a/src/anthias_server/app/static/src/apps/types.ts
+++ b/src/anthias_server/app/static/src/apps/types.ts
@@ -21,7 +21,8 @@ export type SettingValues = Record<string, SettingValue>
 // One JSON Schema property inside `manifest.settings.properties`,
 // augmented with the store's `x-*` UI hints (which JSON Schema
 // validators ignore). The renderer keys off `x-widget` first, then
-// falls back to `type`/`enum`.
+// falls back to `type`/`enum`, and to a string `format` (date-time /
+// date / time) for the native date & time pickers.
 export interface SettingSchema {
   type?: 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'
   title?: string

--- a/src/anthias_server/app/static/src/apps/types.ts
+++ b/src/anthias_server/app/static/src/apps/types.ts
@@ -28,6 +28,10 @@ export interface SettingSchema {
   description?: string
   default?: unknown
   enum?: unknown[]
+  // Standard JSON Schema string `format` (e.g. 'date-time', 'date',
+  // 'time'). Apps use it to request a typed input without pinning the
+  // widget; widgetFor() maps it to the matching HTML5 control.
+  format?: string
   minimum?: number
   maximum?: number
   properties?: Record<string, SettingSchema>

--- a/src/anthias_server/app/static/src/apps/widget-for.test.ts
+++ b/src/anthias_server/app/static/src/apps/widget-for.test.ts
@@ -1,0 +1,45 @@
+// Unit tests for widgetFor — the manifest-form control picker. Run with
+// `bun test src/anthias_server/app/static/src/apps/widget-for.test.ts`.
+// Pins the fix where a JSON Schema string `format` (e.g. the Timer app's
+// `date-time` target) fell through to a bare text input instead of a
+// native date/time picker.
+
+import { describe, expect, test } from 'bun:test'
+
+import type { SettingSchema } from './types'
+import { widgetFor } from './widget-for'
+
+describe('widgetFor', () => {
+  test('date-time string -> datetime picker', () => {
+    expect(widgetFor({ type: 'string', format: 'date-time' })).toBe('datetime')
+  })
+
+  test('date / time string formats -> matching pickers', () => {
+    expect(widgetFor({ type: 'string', format: 'date' })).toBe('date')
+    expect(widgetFor({ type: 'string', format: 'time' })).toBe('time')
+  })
+
+  test('unknown / absent format -> plain text', () => {
+    expect(widgetFor({ type: 'string' })).toBe('text')
+    expect(widgetFor({ type: 'string', format: 'email' })).toBe('text')
+  })
+
+  test('an explicit x-widget always wins over format', () => {
+    const schema: SettingSchema = {
+      type: 'string',
+      format: 'date-time',
+      'x-widget': 'timezone',
+    }
+    expect(widgetFor(schema)).toBe('timezone')
+  })
+
+  test('non-format widgets are unaffected', () => {
+    expect(widgetFor({ type: 'boolean' })).toBe('toggle')
+    expect(widgetFor({ type: 'integer' })).toBe('number')
+    expect(widgetFor({ type: 'string', enum: ['a', 'b'] })).toBe('select')
+    expect(
+      widgetFor({ type: 'object', properties: { lat: {}, lng: {} } }),
+    ).toBe('location-map')
+    expect(widgetFor({ type: 'array' })).toBe('unsupported')
+  })
+})

--- a/src/anthias_server/app/static/src/apps/widget-for.ts
+++ b/src/anthias_server/app/static/src/apps/widget-for.ts
@@ -1,0 +1,37 @@
+// Pure control-picker for the manifest-driven settings form: maps a
+// setting's JSON Schema to the widget key manifest-form.ts renders. Kept
+// in its own module (no leaflet / DOM imports) so the mapping is unit-
+// testable without dragging in the browser-only location-map chain.
+
+import type { SettingSchema } from './types'
+
+// Standard JSON Schema string `format`s we render as a native typed
+// input. A `date-time` becomes a real date/time picker instead of a
+// bare text box the operator has to hand-type an ISO string into.
+const FORMAT_WIDGET: Record<string, string> = {
+  'date-time': 'datetime',
+  date: 'date',
+  time: 'time',
+}
+
+// Which control to render for a settings property.
+export function widgetFor(schema: SettingSchema): string {
+  if (schema['x-widget']) return schema['x-widget']
+  if (Array.isArray(schema.enum)) return 'select'
+  if (schema.type === 'boolean') return 'toggle'
+  if (schema.type === 'number' || schema.type === 'integer') return 'number'
+  // Only a {lat,lng} object is a location map; other objects/arrays
+  // have no generic control, so mark them unsupported (skipped) rather
+  // than mis-render.
+  if (schema.type === 'object') {
+    const props = schema.properties || {}
+    return props.lat && props.lng ? 'location-map' : 'unsupported'
+  }
+  if (schema.type === 'array') return 'unsupported'
+  // A string with a date/time `format` gets the matching native picker.
+  if (schema.type === 'string' && schema.format) {
+    const w = FORMAT_WIDGET[schema.format]
+    if (w) return w
+  }
+  return 'text'
+}


### PR DESCRIPTION
### Issues Fixed

The Timer signage app's **"Target date & time"** field — a JSON Schema `string` with `format: date-time` — rendered as a **plain text input** in the *Add → Apps* config form, so operators had to hand-type or paste an ISO 8601 string. Same gap for any app field using a `date` / `time` / `date-time` format.

### Description

`widgetFor()` (the manifest-form control picker) only keyed off the schema `type` / `enum` / `x-widget`, so a `string` with `format: date-time` fell through to a bare `<input type="text">`. It now maps the standard JSON Schema string formats to native HTML5 pickers:

- `date-time` → `<input type="datetime-local">`
- `date` → `<input type="date">`
- `time` → `<input type="time">`

The datetime value stays a naive wall-clock time (`YYYY-MM-DDTHH:mm`), which apps like Timer resolve against their separate time-zone field — matching the app's own documented behaviour ("read in the time zone below"). An explicit `x-widget` still overrides `format`, and unknown formats degrade to text as before.

Also extracts `widgetFor` into its own module (`widget-for.ts`) so the mapping is unit-testable without importing the browser-only location-map / Leaflet chain that `manifest-form.ts` pulls in.

The plain-text `date-time` field was confirmed live in the *Add → Apps* modal on a device (it also looked out of place next to the Time zone field, which already renders as a dropdown). After this change it's a native date/time picker.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes. (New `widget-for` tests + the existing apps suite: 18/18 green.)
- [ ] I have done an end-to-end test for Raspberry Pi devices. (N/A — this is the browser-side management UI form renderer; the rendered picker is board-agnostic. The current text-input behaviour was verified in a device's live Add → Apps modal.)
- [ ] I have tested my changes for x86 devices. (N/A — same board-agnostic management UI.)
- [x] I added documentation for the changes I have made. (Updated the `manifest-form` module doc comment; new module is self-documented.)
