### PR TITLE
chore(release): bump version metadata to 2026.07.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.07.1",
+  "version": "2026.07.2",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.07.1"
+version = "2026.07.2"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.7.1"
+version = "2026.7.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
### Issues Fixed

None. Housekeeping — the version-bump commit for the already-published `v2026.07.2` release never landed on `master`.

### Description

`v2026.07.2` was tagged and released on GitHub on 2026-07-13 (on the Pi 2/3 blank-screen fix), but the accompanying version bump was missed, so the in-repo version metadata still reported `2026.07.1`.

- `package.json` / `pyproject.toml`: `2026.07.1` → `2026.07.2`
- `uv.lock` anthias entry: `2026.7.1` → `2026.7.2` (no dependency changes; QA'd image set unaffected; `uv lock --check` passes)

`pyproject.toml`'s version is the source `anthias_common.version.get_anthias_release()` reads, so this restores the correct release string in the System Info page, the v2 info API, and the outbound User-Agent — all of which were self-reporting `2026.07.1` on devices actually running `2026.07.2`.

Reviewed the docs: install pages link to `releases/latest` dynamically and there is no in-repo changelog, so no prose docs needed updating.

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)