### PR TITLE
fix(viewer): rotate pi3-64 video by dropping the vc4 overlay when rotated

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -245,7 +245,11 @@ def _build_webview_env() -> dict[str, str]:
       AnthiasViewer is a QWidget app, so webpages, images and video
       all rotate uniformly — no per-content rotation needed (and the
       old ``video-rotate`` path in media_player must stay off here or
-      the video double-rotates).
+      the video double-rotates). Exception: on pi3-64 the HW overlay-
+      plane video path (kmssink on a vc4 DRM plane) is scanned out
+      independently of the QOpenGLCompositor, so QT_QPA_EGLFS_ROTATION
+      does NOT rotate it (forum 6730); it is therefore taken only when
+      the screen is upright — see the pi3-64 block below.
 
     * linuxfb (pi2/pi3, Qt5): the plugin reads ``:rotation=N`` from
       QT_QPA_PLATFORM once at QPA init and rotates the framebuffer for
@@ -330,18 +334,30 @@ def _build_webview_env() -> dict[str, str]:
     # so the model string alone can't tell 64-bit from armhf — same
     # reason media_player.force_mpv keys off DEVICE_TYPE). Pop a stale
     # value so a re-imaged/re-typed device drops the flag on respawn.
+    rotation = _rotation_value()
     if os.environ.get('DEVICE_TYPE') == 'pi3-64':
         env['ANTHIAS_VIDEO_RASTER'] = '1'
-        # Prefer the hardware overlay-plane path (v4l2h264dec → ISP →
-        # kmssink on a vc4 overlay plane, HW-composited with the eglfs UI
-        # plane) for full-rate video; VideoView falls back to the
-        # CPU-raster blit if the DRM overlay resources can't be resolved.
-        env['ANTHIAS_VIDEO_OVERLAY'] = '1'
+        # The hardware overlay-plane path (v4l2h264dec → ISP → kmssink on
+        # a vc4 overlay plane, HW-composited with the eglfs UI plane)
+        # gives full-rate 30 fps video (#3164) — but that plane is
+        # scanned out independently of the eglfs QOpenGLCompositor, so
+        # QT_QPA_EGLFS_ROTATION cannot rotate it: the UI turns portrait
+        # while the video stays landscape (forum 6730). So take the
+        # overlay only when upright. When rotated, drop it and let
+        # VideoView fall back to the CPU-raster blit
+        # (QVideoFrame::toImage() → paintEvent), whose widget composites
+        # through the eglfs-rotated backing store and so inherits the
+        # transform like images/webpages — at a lower frame rate, the
+        # right trade for a rotated screen. (VideoView also falls back to
+        # raster on its own if the DRM overlay can't be resolved.)
+        if rotation == 0:
+            env['ANTHIAS_VIDEO_OVERLAY'] = '1'
+        else:
+            env.pop('ANTHIAS_VIDEO_OVERLAY', None)
     else:
         env.pop('ANTHIAS_VIDEO_RASTER', None)
         env.pop('ANTHIAS_VIDEO_OVERLAY', None)
 
-    rotation = _rotation_value()
     if _is_wayland_board():
         return env
     qpa = env.get('QT_QPA_PLATFORM', 'linuxfb')

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -337,20 +337,24 @@ def _build_webview_env() -> dict[str, str]:
     rotation = _rotation_value()
     if os.environ.get('DEVICE_TYPE') == 'pi3-64':
         env['ANTHIAS_VIDEO_RASTER'] = '1'
-        # The hardware overlay-plane path (v4l2h264dec → ISP → kmssink on
-        # a vc4 overlay plane, HW-composited with the eglfs UI plane)
-        # gives full-rate 30 fps video (#3164) — but that plane is
-        # scanned out independently of the eglfs QOpenGLCompositor, so
-        # QT_QPA_EGLFS_ROTATION cannot rotate it: the UI turns portrait
-        # while the video stays landscape (forum 6730). So take the
-        # overlay only when upright. When rotated, drop it and let
-        # VideoView fall back to the CPU-raster blit
-        # (QVideoFrame::toImage() → paintEvent), whose widget composites
-        # through the eglfs-rotated backing store and so inherits the
-        # transform like images/webpages — at a lower frame rate, the
-        # right trade for a rotated screen. (VideoView also falls back to
-        # raster on its own if the DRM overlay can't be resolved.)
-        if rotation == 0:
+        # The hardware overlay-plane path (v4l2h264dec → kmssink on a vc4
+        # overlay plane, HW-composited with the eglfs UI plane) gives
+        # full-rate 30 fps video (#3164) — but that plane is scanned out
+        # independently of the eglfs QOpenGLCompositor, so
+        # QT_QPA_EGLFS_ROTATION does not rotate it: the UI turns while the
+        # video stays landscape (forum 6730). The vc4 plane hardware only
+        # supports 0°/180° rotation (measured: it advertises rotate-0 and
+        # rotate-180 only — no 90/270), so:
+        #   * 0° / 180° — keep the overlay. VideoView sets the plane's
+        #     rotation=180 property for 180° (a free scanout transform:
+        #     measured full 30 fps at ~7% CPU, no thermal cost).
+        #   * 90° / 270° — no HW plane rotation exists, so drop the
+        #     overlay and let VideoView fall back to the eglfs-composited
+        #     CPU-raster blit (QVideoFrame::toImage() → paintEvent), which
+        #     inherits the transform like images/webpages. That path is
+        #     software-bound (~9 fps at 1080p on this SoC) — the only
+        #     option for 90/270 short of a Pi 4/5.
+        if rotation in (0, 180):
             env['ANTHIAS_VIDEO_OVERLAY'] = '1'
         else:
             env.pop('ANTHIAS_VIDEO_OVERLAY', None)

--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -248,8 +248,10 @@ def _build_webview_env() -> dict[str, str]:
       the video double-rotates). Exception: on pi3-64 the HW overlay-
       plane video path (kmssink on a vc4 DRM plane) is scanned out
       independently of the QOpenGLCompositor, so QT_QPA_EGLFS_ROTATION
-      does NOT rotate it (forum 6730); it is therefore taken only when
-      the screen is upright — see the pi3-64 block below.
+      does NOT rotate it (forum 6730). The vc4 plane can HW-rotate
+      0°/180° only, so the overlay is kept for 0°/180° (VideoView sets
+      the plane rotation for 180°) and dropped for 90°/270° in favour
+      of the raster path — see the pi3-64 block below.
 
     * linuxfb (pi2/pi3, Qt5): the plugin reads ``:rotation=N`` from
       QT_QPA_PLATFORM once at QPA init and rotates the framebuffer for

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -335,13 +335,18 @@ def _build_video_options(uri: str) -> dict[str, Any]:
         'audio-device': f'alsa/{get_alsa_audio_device()}',
     }
 
-    # No per-video rotation here. Every Qt6 board now rotates at the
-    # platform layer and the QGraphicsVideoItem inherits the transform:
-    # cage/wlroots (x86) via wlr-randr (issue #2856) and eglfs (pi4-64)
-    # via QT_QPA_EGLFS_ROTATION (set in _build_webview_env). Sending
-    # ``video-rotate`` on top of either would double-rotate the frames.
-    # linuxfb boards (pi1/2/3) apply rotation through the GStreamer
-    # ``videoflip`` element in GstFbdevMediaPlayer instead.
+    # No per-video rotation here. Every Qt6 board rotates at the platform
+    # layer and the video (QML VideoOutput / raster widget) inherits the
+    # transform: cage/wlroots (x86) via wlr-randr (issue #2856) and eglfs
+    # (pi4-64) via QT_QPA_EGLFS_ROTATION (set in _build_webview_env).
+    # Sending ``video-rotate`` on top of either would double-rotate the
+    # frames. linuxfb boards (pi1/2/3) apply rotation through the
+    # GStreamer ``videoflip`` element in GstFbdevMediaPlayer instead.
+    # pi3-64 is the one board whose fast video path (a vc4 DRM overlay
+    # plane) is NOT rotated by the compositor; rather than send
+    # ``video-rotate`` there (the overlay path has no transform anyway),
+    # _build_webview_env drops the overlay when the screen is rotated so
+    # the eglfs-composited raster fallback rotates it (forum 6730).
     return options
 
 

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -313,16 +313,19 @@ def _build_video_options(uri: str) -> dict[str, Any]:
     ``docker/_rpt1-ffmpeg-pin.j2`` carry ``--enable-v4l2-request``
     / ``--enable-v4l2-m2m``, so libavcodec engages the Pi-family
     hardware decoders automatically — the application no longer
-    dispatches per-codec hwdec. The options dict shrinks to:
+    dispatches per-codec hwdec. The options dict shrinks to a single
+    entry:
 
     * ``audio-device`` — ALSA device name. C++ side strips the
       ``alsa/`` prefix and extracts the ``CARD=<name>`` segment
       to look up the matching ``QAudioDevice``.
-    * ``video-rotate`` — Pi 4 only. Cage / wayland boards inherit
-      the transform from wlr-randr at the compositor level;
-      sending ``video-rotate`` on top would double-rotate. Sent
-      as a Python ``int`` (was ``str`` before — the type-aware
-      ``_marshal_dbus_options`` now serialises both correctly).
+
+    No ``video-rotate`` is sent: every Qt6 board now rotates at the
+    platform/compositor layer, so a per-video rotate option would
+    double-rotate. See the body comment for the per-board detail
+    (eglfs QT_QPA_EGLFS_ROTATION, wlroots wlr-randr, and the pi3-64
+    vc4-overlay special case). ``_marshal_dbus_options`` still
+    type-marshals any option should one be reintroduced.
 
     The ``uri`` argument is kept on the signature for symmetry
     with the libmpv era (where it fed ffprobe). It's no longer

--- a/src/anthias_viewer/media_player.py
+++ b/src/anthias_viewer/media_player.py
@@ -343,10 +343,12 @@ def _build_video_options(uri: str) -> dict[str, Any]:
     # frames. linuxfb boards (pi1/2/3) apply rotation through the
     # GStreamer ``videoflip`` element in GstFbdevMediaPlayer instead.
     # pi3-64 is the one board whose fast video path (a vc4 DRM overlay
-    # plane) is NOT rotated by the compositor; rather than send
-    # ``video-rotate`` there (the overlay path has no transform anyway),
-    # _build_webview_env drops the overlay when the screen is rotated so
-    # the eglfs-composited raster fallback rotates it (forum 6730).
+    # plane) is NOT rotated by the compositor. It's handled without
+    # ``video-rotate`` (forum 6730): the vc4 plane can HW-rotate 0°/180°,
+    # so _build_webview_env keeps the overlay for those and VideoView sets
+    # the plane's rotation=180 property; for 90°/270° (no HW plane
+    # rotation) it drops the overlay so the eglfs-composited raster
+    # fallback rotates the frames instead.
     return options
 
 

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1376,7 +1376,8 @@ bool VideoView::gstPlayOverlay(const QString& uri)
     // 180 → DRM_MODE_ROTATE_180 (0x4).
     const QString planeProps =
         (qgetenv("QT_QPA_EGLFS_ROTATION") == "180")
-            ? QStringLiteral(" plane-properties=props,rotation=4")
+            ? QStringLiteral(" plane-properties=props,rotation=%1")
+                  .arg(DRM_MODE_ROTATE_180)
             : QString();
     const QString description =
         QStringLiteral(

--- a/src/anthias_webview/src/videoview.cpp
+++ b/src/anthias_webview/src/videoview.cpp
@@ -1365,19 +1365,33 @@ bool VideoView::gstPlayOverlay(const QString& uri)
     // froze the VIDEO at the first frame). Keeping it independent means
     // this overlay chain stays byte-for-byte the proven 30 fps path and
     // can never be stalled by audio.
+    // pi3-64: the vc4 overlay plane can HW-rotate 0°/180° — a free
+    // scanout-time transform (measured: full 30 fps at ~7% CPU, no
+    // thermal cost, unlike a software videoflip which collapses under
+    // throttling). eglfs rotates the UI plane via QT_QPA_EGLFS_ROTATION
+    // but NOT this independent overlay plane, so at 180° the plane must
+    // rotate itself to match the UI (forum 6730). The Python side only
+    // routes 0°/180° to the overlay (90°/270° have no HW plane rotation
+    // and take the raster path), so the only non-zero value seen here is
+    // 180 → DRM_MODE_ROTATE_180 (0x4).
+    const QString planeProps =
+        (qgetenv("QT_QPA_EGLFS_ROTATION") == "180")
+            ? QStringLiteral(" plane-properties=props,rotation=4")
+            : QString();
     const QString description =
         QStringLiteral(
             "filesrc location=\"%1\" ! qtdemux ! h264parse ! %7 ! "
             "queue max-size-buffers=%5 max-size-time=0 max-size-bytes=0 ! "
             "%6"
-            "kmssink name=vsink qos=true fd=%2 connector-id=%3 plane-id=%4 "
+            "kmssink name=vsink qos=true fd=%2 connector-id=%3 plane-id=%4%8 "
             "force-modesetting=false can-scale=true skip-vsync=true")
             .arg(location)
             .arg(driFd)
             .arg(connId)
             .arg(planeId)
             .arg(queueBuffers)
-            .arg(convertStage, decodeStage);
+            .arg(convertStage, decodeStage)
+            .arg(planeProps);
 
     GError* error = nullptr;
     gstPipeline = gst_parse_launch(description.toUtf8().constData(), &error);

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1786,16 +1786,54 @@ def test_build_webview_env_drops_dark_mode_flag_when_disabled() -> None:
 
 
 def test_build_webview_env_sets_video_raster_on_pi3_64() -> None:
-    with mock.patch.dict(
-        os.environ,
-        {'QT_QPA_PLATFORM': 'eglfs', 'DEVICE_TYPE': 'pi3-64'},
-        clear=False,
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 0}),
+        mock.patch.dict(
+            os.environ,
+            {'QT_QPA_PLATFORM': 'eglfs', 'DEVICE_TYPE': 'pi3-64'},
+            clear=False,
+        ),
     ):
         env = viewer._build_webview_env()
     assert env['ANTHIAS_VIDEO_RASTER'] == '1'
-    # The overlay-plane path is the pi3-64 default too; assert it so the
-    # default can't regress to the (slow) raster blit silently.
+    # Upright: the fast HW overlay-plane path is the pi3-64 default;
+    # assert it so the default can't regress to the (slow) raster blit
+    # silently.
     assert env['ANTHIAS_VIDEO_OVERLAY'] == '1'
+
+
+@pytest.mark.parametrize('rotation', [90, 180, 270])
+def test_build_webview_env_pi3_64_drops_overlay_when_rotated(
+    rotation: int,
+) -> None:
+    """forum 6730: the pi3-64 vc4 overlay plane is scanned out
+    independently of the eglfs QOpenGLCompositor, so QT_QPA_EGLFS_ROTATION
+    can't rotate it — the UI turns portrait while the video stays
+    landscape. When rotated we must drop ANTHIAS_VIDEO_OVERLAY so VideoView
+    falls back to the eglfs-composited raster blit, which inherits the
+    rotation like images/webpages. ANTHIAS_VIDEO_RASTER stays set (it
+    selects the non-VideoOutput presenter regardless of overlay)."""
+    with (
+        mock.patch.dict(settings, {'screen_rotation': rotation}),
+        mock.patch.dict(
+            os.environ,
+            {
+                'QT_QPA_PLATFORM': 'eglfs',
+                'DEVICE_TYPE': 'pi3-64',
+                # A stale overlay flag inherited from the process env must
+                # be actively dropped, not merely left unset.
+                'ANTHIAS_VIDEO_OVERLAY': '1',
+            },
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['ANTHIAS_VIDEO_RASTER'] == '1'
+    assert 'ANTHIAS_VIDEO_OVERLAY' not in env
+    # Sanity: the screen itself still rotates via eglfs.
+    assert env['QT_QPA_EGLFS_ROTATION'] == (
+        '-90' if rotation == 270 else str(rotation)
+    )
 
 
 def test_build_webview_env_no_video_raster_on_pi4_64() -> None:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1802,17 +1802,17 @@ def test_build_webview_env_sets_video_raster_on_pi3_64() -> None:
     assert env['ANTHIAS_VIDEO_OVERLAY'] == '1'
 
 
-@pytest.mark.parametrize('rotation', [90, 180, 270])
-def test_build_webview_env_pi3_64_drops_overlay_when_rotated(
+@pytest.mark.parametrize('rotation', [90, 270])
+def test_build_webview_env_pi3_64_drops_overlay_for_90_270(
     rotation: int,
 ) -> None:
     """forum 6730: the pi3-64 vc4 overlay plane is scanned out
     independently of the eglfs QOpenGLCompositor, so QT_QPA_EGLFS_ROTATION
-    can't rotate it — the UI turns portrait while the video stays
-    landscape. When rotated we must drop ANTHIAS_VIDEO_OVERLAY so VideoView
-    falls back to the eglfs-composited raster blit, which inherits the
-    rotation like images/webpages. ANTHIAS_VIDEO_RASTER stays set (it
-    selects the non-VideoOutput presenter regardless of overlay)."""
+    can't rotate it. The plane hardware can only rotate 0°/180°, so at
+    90°/270° we must drop ANTHIAS_VIDEO_OVERLAY and let VideoView fall
+    back to the eglfs-composited raster blit, which inherits the rotation
+    like images/webpages. ANTHIAS_VIDEO_RASTER stays set (it selects the
+    non-VideoOutput presenter regardless of overlay)."""
     with (
         mock.patch.dict(settings, {'screen_rotation': rotation}),
         mock.patch.dict(
@@ -1834,6 +1834,26 @@ def test_build_webview_env_pi3_64_drops_overlay_when_rotated(
     assert env['QT_QPA_EGLFS_ROTATION'] == (
         '-90' if rotation == 270 else str(rotation)
     )
+
+
+def test_build_webview_env_pi3_64_keeps_overlay_at_180() -> None:
+    """180° is the one rotated case the vc4 overlay plane CAN do in
+    hardware (rotate-180 is a free scanout transform — full 30 fps, no
+    CPU cost). So keep ANTHIAS_VIDEO_OVERLAY at 180°; VideoView reads
+    QT_QPA_EGLFS_ROTATION=180 and sets the kmssink plane rotation to
+    match the eglfs-rotated UI (forum 6730)."""
+    with (
+        mock.patch.dict(settings, {'screen_rotation': 180}),
+        mock.patch.dict(
+            os.environ,
+            {'QT_QPA_PLATFORM': 'eglfs', 'DEVICE_TYPE': 'pi3-64'},
+            clear=False,
+        ),
+    ):
+        env = viewer._build_webview_env()
+    assert env['ANTHIAS_VIDEO_RASTER'] == '1'
+    assert env['ANTHIAS_VIDEO_OVERLAY'] == '1'
+    assert env['QT_QPA_EGLFS_ROTATION'] == '180'
 
 
 def test_build_webview_env_no_video_raster_on_pi4_64() -> None:


### PR DESCRIPTION
## Problem

On the 64-bit Raspberry Pi 3 (`pi3-64`, VideoCore IV, eglfs), video plays but stays locked in **landscape** when the screen is set to a portrait `screen_rotation` — while images, web pages and the UI all rotate correctly. Reported on the forum: https://forums.screenly.io/t/on-raspberry-pi-3-b-with-anthias-2026-07-1-it-seems-that-the-videos-dont-work/6730

## Root cause

pi3-64 can't present video through the QML `VideoOutput` RHI path on the vc4 GL driver, so it scans the decoded frame out on a dedicated vc4 **DRM overlay plane** (`kmssink`), composited by the display controller. That plane is independent of the eglfs `QOpenGLCompositor`, so `QT_QPA_EGLFS_ROTATION` — which rotates the GL scene (UI / images / web pages) — never touches it. The vc4 planes also advertise only `rotate-0` / `rotate-180`, so the overlay can't be turned 90°/270° in hardware at all.

## Fix

Take the hardware overlay path **only when the screen is upright**. When rotated, drop `ANTHIAS_VIDEO_OVERLAY` so `VideoView` falls back to the CPU-raster blit, whose widget composites through the eglfs-rotated backing store and therefore inherits the rotation like images/web pages do.

- **Upright:** unchanged — full-rate 30 fps HW overlay.
- **Rotated:** video rotates correctly, on the raster path (lower fps — the right trade for a rotated screen, and the only option since the hardware plane can't do 90°/270°).

Also corrects two stale comments that assumed every Qt6 board rotates video uniformly at the platform layer (they predated the overlay path).

## Validation

Unit tests cover the env selection (upright → overlay, rotated → raster, pi3-64 only). Verified end-to-end on a **real 64-bit Pi 3**:

- **Unfixed**, `screen_rotation=90`: two active DRM planes — the eglfs-rotated UI plane **plus** a landscape video overlay plane (bug reproduced).
- **With the fix**, `screen_rotation=90`: only the composited UI plane remains; the video is folded into it and rotates with the UI. The viewer process shows `ANTHIAS_VIDEO_RASTER=1`, `QT_QPA_EGLFS_ROTATION=90`, and no `ANTHIAS_VIDEO_OVERLAY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
