### PR TITLE
chore(release): bump version metadata to 2026.07.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthias",
-  "version": "2026.07.2",
+  "version": "2026.07.3",
   "scripts": {
     "_build_note": "Alpine evaluates @click expressions against a `with(scope)`-style closure at runtime. Bun's --minify-identifiers renames internal Alpine vars (and our handler names in home.ts) in ways that break that lookup — silently. Stick to whitespace+syntax minification, which trims the bundle by half without touching identifiers.",
     "build:vendor": "bun build ./src/anthias_server/app/static/src/vendor.ts --outfile=./src/anthias_server/app/static/dist/js/vendor.js --target=browser --minify-whitespace --minify-syntax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthias"
-version = "2026.07.2"
+version = "2026.07.3"
 description = "The world's most popular open source digital signage project."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "anthias"
-version = "2026.7.2"
+version = "2026.7.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Bumps the version metadata to **2026.07.3** in preparation for the next release, following the same pattern as the 2026.07.2 bump.

- `package.json` / `pyproject.toml`: 2026.07.2 → 2026.07.3
- `uv.lock` anthias entry: 2026.7.2 → 2026.7.3 (no dependency changes; `uv lock --check` passes)
- `bun.lock` has no version field for the workspace root, so it is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)