### PR TITLE
docs(website): recommend Raspberry Pi Imager, demote curl|bash to advanced

### DIFF
--- a/website/content/docs/installation-options.md
+++ b/website/content/docs/installation-options.md
@@ -6,6 +6,12 @@ aliases:
   - "/docs/installation-options/"
 ---
 
+# Recommended: Raspberry Pi Imager
+
+> **Recommended for most users**
+>
+> No command line, no scripts &mdash; just flash an SD card and boot. If you're not sure which method to use, use this one. The command-line methods further down are for advanced users who want more control.
+
 The quickest way to get started on a Raspberry Pi is to use [Raspberry Pi Imager](https://www.raspberrypi.com/software/), where you can find Anthias under **Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias**. Pick the entry that matches your Pi (Pi 2, Pi 3, Pi 4, or Pi 5), select your SD card, and flash &mdash; the device boots straight into Anthias.
 
 ![Raspberry Pi Imager showing Other specific-purpose OS category](/docs/images/imager-01.png)
@@ -66,11 +72,15 @@ The image file looks something like `<yyyy>-<mm>-<dd>-anthias-<board>.img.xz`. T
 
 Devices installed from a disk image join the balena fleet and track the latest stable release. The image ships preloaded with the release it was built from, so the device boots and runs fully offline out of the box, then receives later releases automatically over the air once it has connectivity.
 
-# Installing on Raspberry Pi OS Lite or Debian
+# Advanced: scripted install on Raspberry Pi OS Lite or Debian
+
+> **Advanced method**
+>
+> This method uses the command line and is aimed at users who want more control &mdash; a specific OS, an existing Raspberry Pi OS Lite / Debian install, or a PC (x86). **If you just want to get going on a Raspberry Pi, use the [Raspberry Pi Imager method](#recommended-raspberry-pi-imager) above instead.**
 
 #### Overview
 
-If you'd like more control over your digital signage instance, try installing it on Raspberry Pi OS Lite or Debian.
+If you'd like more control over your digital signage instance, you can install it on Raspberry Pi OS Lite or Debian with a single command.
 
 > **Important**
 >
@@ -91,6 +101,18 @@ The TL;DR for on [Raspberry Pi OS](https://www.raspberrypi.com/software/) or Deb
 ```
 $ bash <(curl -sL https://install-anthias.srly.io)
 ```
+
+> **Prefer to read the script before running it?**
+>
+> Piping a remote script straight into your shell is convenient, but it's perfectly reasonable to want to see what it does first. Download it, review it, then run it:
+>
+> ```
+> curl -sL https://install-anthias.srly.io -o install-anthias.sh
+> less install-anthias.sh   # read through it
+> bash install-anthias.sh
+> ```
+>
+> The installer is open source &mdash; you can also read it in the [Anthias repository](https://github.com/Screenly/Anthias/blob/master/bin/install.sh).
 
 You'll be prompted with the following questions:
 

--- a/website/content/docs/installation-options.md
+++ b/website/content/docs/installation-options.md
@@ -6,11 +6,11 @@ aliases:
   - "/docs/installation-options/"
 ---
 
-# Recommended: Raspberry Pi Imager
+## Recommended: Raspberry Pi Imager
 
 > **Recommended for most users**
 >
-> No command line, no scripts &mdash; just flash an SD card and boot. If you're not sure which method to use, use this one. The command-line methods further down are for advanced users who want more control.
+> No command line, no scripts &mdash; just flash an SD card and boot. If you're not sure which method to use, use this one. The [scripted install](#advanced-scripted-install-on-raspberry-pi-os-lite-or-debian) further down is for advanced users who want to install onto an existing Raspberry Pi OS Lite / Debian system or a PC.
 
 The quickest way to get started on a Raspberry Pi is to use [Raspberry Pi Imager](https://www.raspberrypi.com/software/), where you can find Anthias under **Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias**. Pick the entry that matches your Pi (Pi 2, Pi 3, Pi 4, or Pi 5), select your SD card, and flash &mdash; the device boots straight into Anthias.
 
@@ -20,7 +20,7 @@ The quickest way to get started on a Raspberry Pi is to use [Raspberry Pi Imager
 
 ![Raspberry Pi Imager confirming the SD card target before writing Anthias](/docs/images/imager-03.png)
 
-# Using the images from balenaHub
+## Using the images from balenaHub
 
 > **Important**
 >
@@ -45,7 +45,7 @@ Flash the SD card and boot up your Raspberry Pi. It will take a few minutes to b
 
 Alternatively, you can [download our pre-built Balena disk images from the releases](#using-the-images-from-the-releases).
 
-# Using the images from the releases
+## Using the images from the releases
 
 You can find the latest release [here](https://github.com/Screenly/Anthias/releases/latest). From there, you can download the disk image that you need and flash it to your SD card.
 The image file looks something like `<yyyy>-<mm>-<dd>-anthias-<board>.img.xz`. Take note that the `.img` file is compressed in this `.img.xz` file.
@@ -72,7 +72,7 @@ The image file looks something like `<yyyy>-<mm>-<dd>-anthias-<board>.img.xz`. T
 
 Devices installed from a disk image join the balena fleet and track the latest stable release. The image ships preloaded with the release it was built from, so the device boots and runs fully offline out of the box, then receives later releases automatically over the air once it has connectivity.
 
-# Advanced: scripted install on Raspberry Pi OS Lite or Debian
+## Advanced: scripted install on Raspberry Pi OS Lite or Debian
 
 > **Advanced method**
 >
@@ -107,7 +107,7 @@ $ bash <(curl -sL https://install-anthias.srly.io)
 > Piping a remote script straight into your shell is convenient, but it's perfectly reasonable to want to see what it does first. Download it, review it, then run it:
 >
 > ```
-> curl -sL https://install-anthias.srly.io -o install-anthias.sh
+> curl -fsSL https://install-anthias.srly.io -o install-anthias.sh
 > less install-anthias.sh   # read through it
 > bash install-anthias.sh
 > ```
@@ -174,12 +174,12 @@ You have the option to reboot now or later. On the next boot, make sure to run
 
 Otherwise, if you've selected **No** for the system upgrade, then you don't need to do a reboot for the containers to be started. However, it's still recommended to do a reboot.
 
-# Installing with Balena
+## Installing with Balena
 
 Go through the steps in [this documentation](/docs/balena/)
 to deploy Anthias on your own Balena fleet.
 
-# Installing on a Raspberry Pi 5 with an SSD
+## Installing on a Raspberry Pi 5 with an SSD
 
 Go through the steps in [this documentation](/docs/pi5-ssd/)
 to deploy Anthias on a Pi5 with an SSD

--- a/website/content/docs/x86-installation.md
+++ b/website/content/docs/x86-installation.md
@@ -89,7 +89,7 @@ Once you can SSH (or log in locally) to the new install:
 
 ## Step 5 — Run the Anthias installer
 
-You're now ready to run the standard installer. Follow the [scripted install steps](/docs/install/#installing-on-raspberry-pi-os-lite-or-debian) — they're the same on PC as on a Raspberry Pi.
+You're now ready to run the standard installer. Follow the [scripted install steps](/docs/install/#advanced-scripted-install-on-raspberry-pi-os-lite-or-debian) — they're the same on PC as on a Raspberry Pi.
 
 ## References
 

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -195,7 +195,7 @@
 
     - question: How do I enable HTTPS?
       answer: |
-        From `~/anthias/`, run `./bin/enable_ssl.sh`. The default mode uses Caddy's built-in local CA, which is fine for IP-based LAN access. For Let's Encrypt or bring-your-own certificate, see the [TLS / SSL section in the docs](/docs/#tls-ssl).
+        From `~/anthias/`, run `./bin/enable_ssl.sh`. The default mode uses Caddy's built-in local CA, which is fine for IP-based LAN access. For Let's Encrypt or bring-your-own certificate, see the [TLS / SSL section in the docs](/docs/#tls--ssl).
 
     - question: How do I run Anthias behind my own reverse proxy?
       answer: |

--- a/website/layouts/_default/get-started.html
+++ b/website/layouts/_default/get-started.html
@@ -14,7 +14,7 @@
                 <div>
                     <h2 class="text-xl font-bold">Flash an SD card with Raspberry Pi Imager</h2>
                     <p class="text-zinc-500 mt-2 leading-relaxed">The recommended way to get started &mdash; no command line, no SSH. Open <a class="text-brand-purple no-underline hover:underline" href="https://www.raspberrypi.com/software/" target="_blank" rel="noopener">Raspberry Pi Imager</a>, choose <strong>Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias</strong>, pick the entry for your Pi model (Pi 2 through Pi 5), select your SD card, and flash.</p>
-                    <p class="text-zinc-400 text-sm mt-3">Insert the card into your Pi and power it on &mdash; it boots straight into Anthias. Prefer the command line? See the <a class="text-brand-purple no-underline hover:underline" href="/docs/install/">advanced methods below</a>.</p>
+                    <p class="text-zinc-400 text-sm mt-3">Insert the card into your Pi and power it on &mdash; it boots straight into Anthias. Prefer the command line? See the <a class="text-brand-purple no-underline hover:underline" href="#advanced-methods">advanced methods below</a>.</p>
                 </div>
             </div>
         </div>
@@ -43,7 +43,7 @@
 
 <section class="bg-bg-light py-16 lg:py-24 px-6 md:px-12 lg:px-20">
     <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl font-bold">Advanced &amp; alternative installation methods</h2>
+        <h2 id="advanced-methods" class="text-2xl font-bold">Advanced &amp; alternative installation methods</h2>
 
         <div class="mt-8 space-y-6">
             <div class="bg-white border border-black/10 rounded-lg p-6">

--- a/website/layouts/_default/get-started.html
+++ b/website/layouts/_default/get-started.html
@@ -12,12 +12,9 @@
             <div class="flex items-start gap-4">
                 <div class="step-number bg-brand-yellow text-brand-dark">1</div>
                 <div>
-                    <h2 class="text-xl font-bold">Install with one command</h2>
-                    <p class="text-zinc-500 mt-2 leading-relaxed">On a fresh Raspberry Pi OS Lite or Debian installation, run:</p>
-                    <div class="mt-4 bg-brand-dark rounded-lg p-5">
-                        <code class="text-brand-yellow font-mono text-sm md:text-base break-all">bash &lt;(curl -sL https://install-anthias.srly.io)</code>
-                    </div>
-                    <p class="text-zinc-400 text-sm mt-3">The installer will set up Docker, pull the container images, and start Anthias. This takes around 10&ndash;15 minutes depending on your hardware and network speed.</p>
+                    <h2 class="text-xl font-bold">Flash an SD card with Raspberry Pi Imager</h2>
+                    <p class="text-zinc-500 mt-2 leading-relaxed">The recommended way to get started &mdash; no command line, no SSH. Open <a class="text-brand-purple no-underline hover:underline" href="https://www.raspberrypi.com/software/" target="_blank" rel="noopener">Raspberry Pi Imager</a>, choose <strong>Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias</strong>, pick the entry for your Pi model (Pi 2 through Pi 5), select your SD card, and flash.</p>
+                    <p class="text-zinc-400 text-sm mt-3">Insert the card into your Pi and power it on &mdash; it boots straight into Anthias. Prefer the command line? See the <a class="text-brand-purple no-underline hover:underline" href="/docs/install/">advanced methods below</a>.</p>
                 </div>
             </div>
         </div>
@@ -46,13 +43,16 @@
 
 <section class="bg-bg-light py-16 lg:py-24 px-6 md:px-12 lg:px-20">
     <div class="max-w-3xl mx-auto">
-        <h2 class="text-2xl font-bold">Alternative installation methods</h2>
+        <h2 class="text-2xl font-bold">Advanced &amp; alternative installation methods</h2>
 
         <div class="mt-8 space-y-6">
             <div class="bg-white border border-black/10 rounded-lg p-6">
-                <h3 class="text-lg font-bold">Raspberry Pi Imager</h3>
-                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">The quickest path for Raspberry Pi. Open <a class="text-brand-purple no-underline hover:underline" href="https://www.raspberrypi.com/software/" target="_blank" rel="noopener">Raspberry Pi Imager</a>, pick <strong>Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias</strong>, choose your Pi model, and flash the SD card. Boots straight into Anthias.</p>
-                <p class="text-zinc-400 text-xs mt-2">Raspberry Pi 2 through Pi 5.</p>
+                <h3 class="text-lg font-bold">Install with one command <span class="text-zinc-400 font-normal text-sm">(advanced)</span></h3>
+                <p class="text-zinc-500 mt-2 text-sm leading-relaxed">For users comfortable with the command line who want to install over an existing Raspberry Pi OS Lite or Debian system (including a PC). On a fresh install, run:</p>
+                <div class="mt-3 bg-brand-dark rounded-lg p-4">
+                    <code class="text-brand-yellow font-mono text-xs md:text-sm break-all">bash &lt;(curl -sL https://install-anthias.srly.io)</code>
+                </div>
+                <p class="text-zinc-400 text-xs mt-2">Sets up Docker, pulls the images, and starts Anthias (~10&ndash;15 min). Prefer to read the script before running it? See the <a class="text-brand-purple no-underline hover:underline" href="/docs/install/">installation guide</a>.</p>
             </div>
 
             <div class="bg-white border border-black/10 rounded-lg p-6">

--- a/website/layouts/_default/get-started.html
+++ b/website/layouts/_default/get-started.html
@@ -114,6 +114,11 @@
                         <td class="py-3"><span class="text-zinc-400">Maintenance</span></td>
                     </tr>
                     <tr class="border-b border-black/5">
+                        <td class="py-3 pr-4">Raspberry Pi 3 Model A+ (512&nbsp;MB)</td>
+                        <td class="py-3 pr-4">32-bit</td>
+                        <td class="py-3"><span class="text-red-700 font-medium">Not recommended</span></td>
+                    </tr>
+                    <tr class="border-b border-black/5">
                         <td class="py-3 pr-4">x86 PC (NUC or similar)</td>
                         <td class="py-3 pr-4">64-bit</td>
                         <td class="py-3"><span class="text-green-700 font-medium">Recommended</span></td>
@@ -125,6 +130,7 @@
                     </tr>
                 </tbody>
             </table>
+            <p class="text-zinc-500 text-sm mt-4 leading-relaxed">The <strong>Raspberry Pi 3 Model A+</strong> ships with only 512&nbsp;MB of RAM &mdash; too little to run the Anthias stack comfortably, so it&rsquo;s <strong>not recommended</strong>. For a low-cost board, choose a Pi with at least 1&nbsp;GB (Pi 3 Model B/B+ or newer).</p>
             <p class="text-zinc-500 text-sm mt-4 leading-relaxed">Generic 64-bit ARM SBCs run the same Anthias stack on <strong>Debian-based Armbian</strong> (Bookworm / Trixie) with software video decode. Ubuntu-based Armbian builds aren&rsquo;t supported &mdash; the installer wires up the Debian Docker apt repository, so Ubuntu releases fail at &ldquo;apt update&rdquo;. Hardware video decode varies per SoC and isn&rsquo;t wired up out of the box &mdash; expect software decode (smooth at 720p, stutter-prone at 1080p, CPU-heavy at 4K). Per-SoC hardware decode is a follow-up; see <a class="text-brand-purple no-underline hover:underline" href="https://github.com/Screenly/Anthias/issues/2849" target="_blank" rel="noopener">issue #2849</a>.</p>
         </div>
     </div>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -217,17 +217,17 @@
 <section class="bg-bg-light py-20 lg:py-28 px-6 md:px-12 lg:px-20">
     <div class="max-w-7xl mx-auto">
         <h2 class="text-3xl lg:text-4xl font-extrabold tracking-tight">Get running in minutes</h2>
-        <p class="text-zinc-500 mt-3 text-lg max-w-xl">Two ready-to-go paths: flash an SD card with Raspberry Pi Imager, or install over an existing Raspberry Pi OS / Debian system.</p>
+        <p class="text-zinc-500 mt-3 text-lg max-w-xl">The recommended way is to flash an SD card with Raspberry Pi Imager &mdash; no command line needed. Advanced users can install over an existing Raspberry Pi OS / Debian system.</p>
 
         <div class="mt-8 grid md:grid-cols-2 gap-6 max-w-4xl">
             <div class="bg-white border border-black/10 rounded-lg p-6 flex flex-col">
-                <h3 class="text-lg font-bold">Raspberry Pi Imager</h3>
+                <div class="flex items-center gap-2"><h3 class="text-lg font-bold">Raspberry Pi Imager</h3><span class="text-xs font-semibold text-green-700 bg-green-100 rounded px-2 py-0.5">Recommended</span></div>
                 <p class="text-zinc-500 mt-2 text-sm leading-relaxed flex-grow">Open <a class="text-brand-purple no-underline hover:underline" href="https://www.raspberrypi.com/software/" target="_blank" rel="noopener">Raspberry Pi Imager</a>, pick <em>Other specific-purpose OS &rarr; Digital signage and kiosks &rarr; Anthias</em>, choose your Pi model, and flash. The SD card boots straight into Anthias &mdash; no SSH, no installer prompts.</p>
                 <p class="text-zinc-400 text-xs mt-3">Raspberry Pi 2 through Pi 5.</p>
             </div>
 
             <div class="bg-brand-dark rounded-lg p-6 flex flex-col">
-                <h3 class="text-white text-lg font-bold">One-line install</h3>
+                <h3 class="text-white text-lg font-bold">One-line install <span class="text-white/50 font-normal text-sm">(advanced)</span></h3>
                 <p class="text-white/60 text-sm mt-2 leading-relaxed">On a running Raspberry Pi OS Lite or Debian system, run:</p>
                 <div class="mt-3 bg-black/30 rounded-md p-4 flex-grow flex items-center">
                     <code class="text-brand-yellow font-mono text-xs md:text-sm break-all">bash &lt;(curl -sL https://install-anthias.srly.io)</code>


### PR DESCRIPTION
New users were greeted by a `bash <(curl ...)` pipe-to-shell as the first, most prominent install step — intimidating and easy to distrust. This reframes the install story around the **no-command-line Raspberry Pi Imager** method as recommended, with the scripted install clearly marked as an advanced alternative.

### Changes
- **get-started page**: Step 1 is now *"Flash an SD card with Raspberry Pi Imager"*; the one-command install moves down into *"Advanced & alternative installation methods"*.
- **homepage**: Imager card tagged **Recommended**; one-liner tagged **(advanced)**; intro reworded to lead with Imager.
- **installation-options doc**: adds a *"Recommended for most users"* callout to the Imager section, retitles the scripted section *"Advanced: scripted install"*, and adds **"read the script before running it"** guidance (download → review → run, plus a link to `install.sh`).

Hugo build passes (18 pages, no errors); all three edited pages render the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)