### PR TITLE
fix(webview): rotate images and web pages on linuxfb (Pi 1/2/3)

### DIFF
--- a/src/anthias_webview/AnthiasViewer.pro
+++ b/src/anthias_webview/AnthiasViewer.pro
@@ -31,11 +31,13 @@ CONFIG += c++17
 
 SOURCES += src/main.cpp \
     src/mainwindow.cpp \
-    src/view.cpp
+    src/view.cpp \
+    src/rotation.cpp
 
 HEADERS += \
     src/mainwindow.h \
-    src/view.h
+    src/view.h \
+    src/rotation.h
 
 greaterThan(QT_MAJOR_VERSION, 5) {
     QT += multimedia quickwidgets

--- a/src/anthias_webview/src/rotation.cpp
+++ b/src/anthias_webview/src/rotation.cpp
@@ -1,0 +1,81 @@
+#include "rotation.h"
+
+#include <QByteArray>
+#include <QList>
+
+namespace rotation
+{
+
+int linuxfbRotationOverride()
+{
+    // eglfs / wayland rotate the whole compositor output, so the image is
+    // already turned by the platform and must NOT be rotated again here.
+    // Only linuxfb needs a manual rotation: its QPA plugin parses but
+    // does not act on the ``rotation=N`` option, so the Python side bakes
+    // the angle into QT_QPA_PLATFORM=linuxfb:...,rotation=N and we honour
+    // it in paintEvent.
+    const QByteArray qpa = qgetenv("QT_QPA_PLATFORM");
+    if (!qpa.startsWith("linuxfb")) {
+        return 0;
+    }
+    const int colon = qpa.indexOf(':');
+    if (colon < 0) {
+        return 0;
+    }
+    const QList<QByteArray> options = qpa.mid(colon + 1).split(',');
+    for (const QByteArray& option : options) {
+        if (!option.startsWith("rotation=")) {
+            continue;
+        }
+        bool ok = false;
+        const int raw = option.mid(9).toInt(&ok);
+        if (!ok) {
+            return 0;
+        }
+        const int normalised = ((raw % 360) + 360) % 360;
+        if (normalised == 90 || normalised == 180 || normalised == 270) {
+            return normalised;
+        }
+        return 0;
+    }
+    return 0;
+}
+
+QString webpageRotationScript(int angle)
+{
+    // 90/270 swap the viewport box so a landscape page fills the
+    // portrait-turned panel (pillar-boxed, like the image/video paths);
+    // 180 keeps the box. Applied as an !important stylesheet so it wins
+    // over the page's own rules, and re-asserted from a subtree
+    // MutationObserver so a page that removes/replaces the injected
+    // <style> node anywhere in the tree (SPAs rewriting <head>) can't
+    // drop the rotation. Injected in an isolated world (ApplicationWorld)
+    // so it never collides with the page's own scripts, but still mutates
+    // the shared DOM.
+    const QString box =
+        (angle % 180 != 0)
+            ? QStringLiteral(
+                  "position:fixed;top:calc((100vh - 100vw)/2);"
+                  "left:calc((100vw - 100vh)/2);width:100vh;height:100vw;")
+            : QStringLiteral("width:100vw;height:100vh;");
+    return QStringLiteral(
+               "(function(){"
+               "var css='html{transform:rotate(%1deg) !important;"
+               "transform-origin:50% 50% !important;"
+               "overflow:hidden !important;%2}';"
+               "function apply(){"
+               "var s=document.getElementById('anthias-rotation');"
+               "if(!s){s=document.createElement('style');"
+               "s.id='anthias-rotation';"
+               "(document.head||document.documentElement).appendChild(s);}"
+               "if(s.textContent!==css){s.textContent=css;}}"
+               "apply();"
+               "try{new MutationObserver(apply).observe("
+               "document.documentElement,{childList:true,subtree:true});}"
+               "catch(e){}"
+               "})();")
+        .arg(angle)
+        .arg(box);
+}
+
+}  // namespace rotation

--- a/src/anthias_webview/src/rotation.h
+++ b/src/anthias_webview/src/rotation.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QString>
+
+// Manual content-rotation helpers for the Qt5 linuxfb boards (Pi 1/2/3).
+// The linuxfb QPA plugin parses but silently ignores the ``rotation=N``
+// option in ``QT_QPA_PLATFORM=linuxfb:...,rotation=N`` — the surface
+// stays landscape — so images (View::paintEvent) and web pages (a
+// stylesheet injected into QtWebEngine) have to be turned by hand to
+// match the physically-rotated screen, the way the GStreamer video path
+// already rotates via ``videoflip``. eglfs / wayland rotate the whole
+// compositor output, so these return 0 / are unused there (no
+// double-rotation).
+//
+// Kept free of View / QtWebEngine so the parsing and CSS-generation
+// logic is unit-testable against QtCore alone (see tests/tests.pro).
+namespace rotation
+{
+// Parse the manual rotation angle from QT_QPA_PLATFORM. Returns one of
+// 0 / 90 / 180 / 270: 0 unless the platform is ``linuxfb`` and carries a
+// ``rotation=N`` option that normalises (mod 360) to 90, 180 or 270.
+int linuxfbRotationOverride();
+
+// JavaScript that rotates a web page's document root to ``angle`` degrees
+// clockwise with an !important stylesheet, re-asserted from a subtree
+// MutationObserver so a page that removes the injected node can't drop
+// it. 90/270 swap the viewport box so a landscape page fills the
+// portrait-turned panel (pillar-boxed); 180 keeps the box.
+QString webpageRotationScript(int angle);
+}  // namespace rotation

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -31,6 +31,7 @@
 #include <QtGlobal>
 
 #include "view.h"
+#include "rotation.h"
 
 // Attaches the operator-configured per-asset request headers (#2215) to
 // requests whose origin matches the asset's own origin (scheme + host +
@@ -273,7 +274,7 @@ int pageLoadTimeoutMs()
 
 View::View(QWidget* parent) : QWidget(parent)
 {
-    imageRotation = linuxfbRotationOverride();
+    imageRotation = rotation::linuxfbRotationOverride();
     if (imageRotation != 0) {
         qDebug() << "View: linuxfb screen rotation" << imageRotation
                  << "— rotating still images in paintEvent (the linuxfb "
@@ -472,7 +473,7 @@ void View::configureWebView(QWebEngineView* view)
     // MutationObserver (see webpageRotationScript) keeps it asserted across
     // SPA DOM rewrites within a single document.
     if (imageRotation != 0) {
-        const QString script = webpageRotationScript(imageRotation);
+        const QString script = rotation::webpageRotationScript(imageRotation);
         connect(page, &QWebEnginePage::loadFinished, this,
             [page, script](bool ok) {
                 if (ok) {
@@ -876,78 +877,6 @@ void View::loadAsStaticImage(const QByteArray& data)
     } else {
         qDebug() << "Failed to load image from data";
     }
-}
-
-int View::linuxfbRotationOverride()
-{
-    // eglfs / wayland rotate the whole compositor output, so the image is
-    // already turned by the platform and must NOT be rotated again here.
-    // Only linuxfb needs a manual rotation: its QPA plugin parses but
-    // does not act on the ``rotation=N`` option, so the Python side bakes
-    // the angle into QT_QPA_PLATFORM=linuxfb:...,rotation=N and we honour
-    // it in paintEvent.
-    const QByteArray qpa = qgetenv("QT_QPA_PLATFORM");
-    if (!qpa.startsWith("linuxfb")) {
-        return 0;
-    }
-    const int colon = qpa.indexOf(':');
-    if (colon < 0) {
-        return 0;
-    }
-    const QList<QByteArray> options = qpa.mid(colon + 1).split(',');
-    for (const QByteArray& option : options) {
-        if (!option.startsWith("rotation=")) {
-            continue;
-        }
-        bool ok = false;
-        const int raw = option.mid(9).toInt(&ok);
-        if (!ok) {
-            return 0;
-        }
-        const int normalised = ((raw % 360) + 360) % 360;
-        if (normalised == 90 || normalised == 180 || normalised == 270) {
-            return normalised;
-        }
-        return 0;
-    }
-    return 0;
-}
-
-QString View::webpageRotationScript(int angle)
-{
-    // 90/270 swap the viewport box so a landscape page fills the
-    // portrait-turned panel (pillar-boxed, like the image/video paths);
-    // 180 keeps the box. Applied as an !important stylesheet so it wins
-    // over the page's own rules, and re-asserted from a subtree
-    // MutationObserver so a page that removes/replaces the injected
-    // <style> node anywhere in the tree (SPAs rewriting <head>) can't
-    // drop the rotation. Injected in an isolated world (ApplicationWorld)
-    // so it never collides with the page's own scripts, but still mutates
-    // the shared DOM.
-    const QString box =
-        (angle % 180 != 0)
-            ? QStringLiteral(
-                  "position:fixed;top:calc((100vh - 100vw)/2);"
-                  "left:calc((100vw - 100vh)/2);width:100vh;height:100vw;")
-            : QStringLiteral("width:100vw;height:100vh;");
-    return QStringLiteral(
-               "(function(){"
-               "var css='html{transform:rotate(%1deg) !important;"
-               "transform-origin:50% 50% !important;"
-               "overflow:hidden !important;%2}';"
-               "function apply(){"
-               "var s=document.getElementById('anthias-rotation');"
-               "if(!s){s=document.createElement('style');"
-               "s.id='anthias-rotation';"
-               "(document.head||document.documentElement).appendChild(s);}"
-               "if(s.textContent!==css){s.textContent=css;}}"
-               "apply();"
-               "try{new MutationObserver(apply).observe("
-               "document.documentElement,{childList:true,subtree:true});}"
-               "catch(e){}"
-               "})();")
-        .arg(angle)
-        .arg(box);
 }
 
 void View::paintEvent(QPaintEvent*)

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -14,6 +14,7 @@
 #include <QNetworkRequest>
 #include <QSslError>
 #include <QWebEngineCertificateError>
+#include <QWebEngineScript>
 #include <QImage>
 #include <QImageReader>
 #include <QPainter>
@@ -451,6 +452,36 @@ void View::configureWebView(QWebEngineView* view)
     // Match the widget's black backdrop so dark-themed URL assets don't
     // flash white between the page-load start and the first paint.
     page->setBackgroundColor(Qt::black);
+
+    // linuxfb webpage rotation: the QPA plugin doesn't rotate the
+    // QtWebEngine surface (see linuxfbRotationOverride), so images/video
+    // rotate elsewhere (paintEvent / GStreamer videoflip) but web pages
+    // would stay upright. Inject a stylesheet that turns the page root to
+    // match the physically-rotated screen so every asset type rotates on
+    // linuxfb. No-op on eglfs / wayland (imageRotation is 0 there — those
+    // rotate the whole compositor output already).
+    //
+    // Injected imperatively from loadFinished rather than as a declarative
+    // QWebEngineScript: on this Qt 5.15 (qt5pi) build a page-collection
+    // QWebEngineScript in ApplicationWorld silently never fires, whereas
+    // runJavaScript() executes reliably. ApplicationWorld (an isolated
+    // world) is used so the injection bypasses any page Content-Security-
+    // Policy that would otherwise block a stylesheet. The handler is
+    // persistent (not the one-shot swap handler in startPageLoad) so the
+    // rotation re-applies after every auto-refresh reload; the in-page
+    // MutationObserver (see webpageRotationScript) keeps it asserted across
+    // SPA DOM rewrites within a single document.
+    if (imageRotation != 0) {
+        const QString script = webpageRotationScript(imageRotation);
+        connect(page, &QWebEnginePage::loadFinished, this,
+            [page, script](bool ok) {
+                if (ok) {
+                    page->runJavaScript(
+                        script, QWebEngineScript::ApplicationWorld);
+                }
+            });
+    }
+
     view->setVisible(false);
 }
 
@@ -880,6 +911,43 @@ int View::linuxfbRotationOverride()
         return 0;
     }
     return 0;
+}
+
+QString View::webpageRotationScript(int angle)
+{
+    // 90/270 swap the viewport box so a landscape page fills the
+    // portrait-turned panel (pillar-boxed, like the image/video paths);
+    // 180 keeps the box. Applied as an !important stylesheet so it wins
+    // over the page's own rules, and re-asserted from a subtree
+    // MutationObserver so a page that removes/replaces the injected
+    // <style> node anywhere in the tree (SPAs rewriting <head>) can't
+    // drop the rotation. Injected in an isolated world (ApplicationWorld)
+    // so it never collides with the page's own scripts, but still mutates
+    // the shared DOM.
+    const QString box =
+        (angle % 180 != 0)
+            ? QStringLiteral(
+                  "position:fixed;top:calc((100vh - 100vw)/2);"
+                  "left:calc((100vw - 100vh)/2);width:100vh;height:100vw;")
+            : QStringLiteral("width:100vw;height:100vh;");
+    return QStringLiteral(
+               "(function(){"
+               "var css='html{transform:rotate(%1deg) !important;"
+               "transform-origin:50% 50% !important;"
+               "overflow:hidden !important;%2}';"
+               "function apply(){"
+               "var s=document.getElementById('anthias-rotation');"
+               "if(!s){s=document.createElement('style');"
+               "s.id='anthias-rotation';"
+               "(document.head||document.documentElement).appendChild(s);}"
+               "if(s.textContent!==css){s.textContent=css;}}"
+               "apply();"
+               "try{new MutationObserver(apply).observe("
+               "document.documentElement,{childList:true,subtree:true});}"
+               "catch(e){}"
+               "})();")
+        .arg(angle)
+        .arg(box);
 }
 
 void View::paintEvent(QPaintEvent*)

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -472,14 +472,18 @@ void View::configureWebView(QWebEngineView* view)
     // rotation re-applies after every auto-refresh reload; the in-page
     // MutationObserver (see webpageRotationScript) keeps it asserted across
     // SPA DOM rewrites within a single document.
+    //
+    // Injected regardless of loadFinished's ``ok`` flag: a failed load
+    // (DNS failure, refused connection, captive portal) still leaves a
+    // QtWebEngine error-page document on screen, which must rotate too so
+    // a physically-turned panel never shows sideways text. runJavaScript
+    // on a cancelled/empty document is a harmless no-op.
     if (imageRotation != 0) {
         const QString script = rotation::webpageRotationScript(imageRotation);
         connect(page, &QWebEnginePage::loadFinished, this,
-            [page, script](bool ok) {
-                if (ok) {
-                    page->runJavaScript(
-                        script, QWebEngineScript::ApplicationWorld);
-                }
+            [page, script](bool) {
+                page->runJavaScript(
+                    script, QWebEngineScript::ApplicationWorld);
             });
     }
 

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -272,6 +272,13 @@ int pageLoadTimeoutMs()
 
 View::View(QWidget* parent) : QWidget(parent)
 {
+    imageRotation = linuxfbRotationOverride();
+    if (imageRotation != 0) {
+        qDebug() << "View: linuxfb screen rotation" << imageRotation
+                 << "— rotating still images in paintEvent (the linuxfb "
+                    "QPA ignores rotation=N)";
+    }
+
     webView1 = new QWebEngineView(this);
     configureWebView(webView1);
 
@@ -840,23 +847,82 @@ void View::loadAsStaticImage(const QByteArray& data)
     }
 }
 
+int View::linuxfbRotationOverride()
+{
+    // eglfs / wayland rotate the whole compositor output, so the image is
+    // already turned by the platform and must NOT be rotated again here.
+    // Only linuxfb needs a manual rotation: its QPA plugin parses but
+    // does not act on the ``rotation=N`` option, so the Python side bakes
+    // the angle into QT_QPA_PLATFORM=linuxfb:...,rotation=N and we honour
+    // it in paintEvent.
+    const QByteArray qpa = qgetenv("QT_QPA_PLATFORM");
+    if (!qpa.startsWith("linuxfb")) {
+        return 0;
+    }
+    const int colon = qpa.indexOf(':');
+    if (colon < 0) {
+        return 0;
+    }
+    const QList<QByteArray> options = qpa.mid(colon + 1).split(',');
+    for (const QByteArray& option : options) {
+        if (!option.startsWith("rotation=")) {
+            continue;
+        }
+        bool ok = false;
+        const int raw = option.mid(9).toInt(&ok);
+        if (!ok) {
+            return 0;
+        }
+        const int normalised = ((raw % 360) + 360) % 360;
+        if (normalised == 90 || normalised == 180 || normalised == 270) {
+            return normalised;
+        }
+        return 0;
+    }
+    return 0;
+}
+
 void View::paintEvent(QPaintEvent*)
 {
     QPainter painter(this);
     painter.setRenderHint(QPainter::SmoothPixmapTransform);
     painter.fillRect(rect(), Qt::black);
 
-    if (!currentImage.isNull()) {
+    if (currentImage.isNull()) {
+        return;
+    }
+
+    if (imageRotation == 0) {
         QSize scaledSize = currentImage.size();
         scaledSize.scale(size(), Qt::KeepAspectRatio);
-        QRect targetRect(
-            (width() - scaledSize.width()) / 2,
-            (height() - scaledSize.height()) / 2,
-            scaledSize.width(),
-            scaledSize.height()
-        );
-        painter.drawImage(targetRect, currentImage);
+        painter.drawImage(
+            QRect(
+                (width() - scaledSize.width()) / 2,
+                (height() - scaledSize.height()) / 2,
+                scaledSize.width(),
+                scaledSize.height()),
+            currentImage);
+        return;
     }
+
+    // linuxfb-only manual rotation (see linuxfbRotationOverride): rotate
+    // about the widget centre. A 90/270 turn swaps the drawable box, so
+    // the image is fit into the widget's transposed dimensions and
+    // centred — a landscape image on a portrait-turned screen is
+    // pillar-boxed, matching the GStreamer videoflip path.
+    const QSize box =
+        (imageRotation % 180 == 0) ? size() : QSize(height(), width());
+    QSize scaledSize = currentImage.size();
+    scaledSize.scale(box, Qt::KeepAspectRatio);
+    painter.translate(width() / 2.0, height() / 2.0);
+    painter.rotate(imageRotation);
+    painter.drawImage(
+        QRect(
+            -scaledSize.width() / 2,
+            -scaledSize.height() / 2,
+            scaledSize.width(),
+            scaledSize.height()),
+        currentImage);
 }
 
 void View::resizeEvent(QResizeEvent* event)

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -72,13 +72,19 @@ private:
     void configureWebView(QWebEngineView* view);
     // Parse the manual image-rotation angle (0/90/180/270) from
     // QT_QPA_PLATFORM. Non-zero ONLY on linuxfb (Pi 1/2/3, Qt5): that
-    // QPA plugin silently ignores the ``rotation=N`` option, so still
-    // images have to be turned by hand in paintEvent to match the
-    // physically-rotated screen — the way the GStreamer video path
-    // already rotates via ``videoflip``. Returns 0 on eglfs / wayland,
-    // which rotate the whole compositor output, so painting a second
-    // rotation here would double-rotate.
+    // QPA plugin silently ignores the ``rotation=N`` option, so raster
+    // image assets — still images and animated GIFs, which share the
+    // ``currentImage`` paint path — have to be turned by hand in
+    // paintEvent to match the physically-rotated screen, the way the
+    // GStreamer video path already rotates via ``videoflip``. Returns 0
+    // on eglfs / wayland, which rotate the whole compositor output, so
+    // painting a second rotation here would double-rotate.
     static int linuxfbRotationOverride();
+    // JavaScript injected into every web page (linuxfb only) that rotates
+    // the document root to ``angle`` degrees so web-page assets turn with
+    // the physically-rotated screen — the QtWebEngine surface is not
+    // covered by the paintEvent image rotation. See configureWebView.
+    static QString webpageRotationScript(int angle);
     void stopAnimation();
     bool tryLoadAsAnimatedGif(const QByteArray& data);
     void loadAsStaticImage(const QByteArray& data);
@@ -111,10 +117,11 @@ private:
     bool isAnimatedImage;
     quint64 loadGenerationId;
 
-    // Manual rotation applied to still images in paintEvent, in degrees
-    // clockwise (0/90/180/270). Set once at construction from
-    // linuxfbRotationOverride(); non-zero only on linuxfb boards whose
-    // QPA plugin ignores ``rotation=N``.
+    // Manual rotation applied in paintEvent to raster image assets —
+    // still images and animated GIFs, which share the ``currentImage``
+    // draw path — in degrees clockwise (0/90/180/270). Set once at
+    // construction from linuxfbRotationOverride(); non-zero only on
+    // linuxfb boards whose QPA plugin ignores ``rotation=N``.
     int imageRotation;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -70,6 +70,15 @@ private slots:
 
 private:
     void configureWebView(QWebEngineView* view);
+    // Parse the manual image-rotation angle (0/90/180/270) from
+    // QT_QPA_PLATFORM. Non-zero ONLY on linuxfb (Pi 1/2/3, Qt5): that
+    // QPA plugin silently ignores the ``rotation=N`` option, so still
+    // images have to be turned by hand in paintEvent to match the
+    // physically-rotated screen — the way the GStreamer video path
+    // already rotates via ``videoflip``. Returns 0 on eglfs / wayland,
+    // which rotate the whole compositor output, so painting a second
+    // rotation here would double-rotate.
+    static int linuxfbRotationOverride();
     void stopAnimation();
     bool tryLoadAsAnimatedGif(const QByteArray& data);
     void loadAsStaticImage(const QByteArray& data);
@@ -101,6 +110,12 @@ private:
     QMovie* movie;
     bool isAnimatedImage;
     quint64 loadGenerationId;
+
+    // Manual rotation applied to still images in paintEvent, in degrees
+    // clockwise (0/90/180/270). Set once at construction from
+    // linuxfbRotationOverride(); non-zero only on linuxfb boards whose
+    // QPA plugin ignores ``rotation=N``.
+    int imageRotation;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // QtMultimedia-backed video widget (issue #2904). Sibling of

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -70,21 +70,6 @@ private slots:
 
 private:
     void configureWebView(QWebEngineView* view);
-    // Parse the manual image-rotation angle (0/90/180/270) from
-    // QT_QPA_PLATFORM. Non-zero ONLY on linuxfb (Pi 1/2/3, Qt5): that
-    // QPA plugin silently ignores the ``rotation=N`` option, so raster
-    // image assets — still images and animated GIFs, which share the
-    // ``currentImage`` paint path — have to be turned by hand in
-    // paintEvent to match the physically-rotated screen, the way the
-    // GStreamer video path already rotates via ``videoflip``. Returns 0
-    // on eglfs / wayland, which rotate the whole compositor output, so
-    // painting a second rotation here would double-rotate.
-    static int linuxfbRotationOverride();
-    // JavaScript injected into every web page (linuxfb only) that rotates
-    // the document root to ``angle`` degrees so web-page assets turn with
-    // the physically-rotated screen — the QtWebEngine surface is not
-    // covered by the paintEvent image rotation. See configureWebView.
-    static QString webpageRotationScript(int angle);
     void stopAnimation();
     bool tryLoadAsAnimatedGif(const QByteArray& data);
     void loadAsStaticImage(const QByteArray& data);

--- a/src/anthias_webview/tests/test_rotation.cpp
+++ b/src/anthias_webview/tests/test_rotation.cpp
@@ -1,0 +1,172 @@
+// QtTest unit tests for the linuxfb manual-rotation helpers
+// (src/rotation.cpp), the Pi 1/2/3 path where the Qt5 linuxfb QPA
+// plugin ignores ``rotation=N`` so images and web pages have to be
+// turned by hand. The helpers are pure (QT_QPA_PLATFORM parsing and
+// CSS string generation), so these run against QtCore alone — no
+// display, no QtWebEngine. Hosted by the runRotationTests factory that
+// test_videoview.cpp's main() execs (QTEST_MAIN can only host one
+// class per binary).
+
+#include <QByteArray>
+#include <QObject>
+#include <QString>
+#include <QTest>
+
+#include "rotation.h"
+
+namespace
+{
+// RAII guard: set QT_QPA_PLATFORM for one test and restore it after, so
+// the cases don't leak platform strings into each other (or the runner).
+class QpaGuard
+{
+public:
+    explicit QpaGuard(const QByteArray& value)
+        : had_(qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
+        , previous_(qgetenv("QT_QPA_PLATFORM"))
+    {
+        qputenv("QT_QPA_PLATFORM", value);
+    }
+    ~QpaGuard()
+    {
+        if (had_) {
+            qputenv("QT_QPA_PLATFORM", previous_);
+        } else {
+            qunsetenv("QT_QPA_PLATFORM");
+        }
+    }
+
+private:
+    bool had_;
+    QByteArray previous_;
+};
+}  // namespace
+
+class TestRotation : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // linuxfbRotationOverride() only fires on linuxfb; every other
+    // platform (and an unset one) rotates at the compositor and must
+    // return 0 so paintEvent doesn't double-rotate.
+    void overrideNonLinuxfbIsZero_data()
+    {
+        QTest::addColumn<QByteArray>("qpa");
+        QTest::newRow("unset") << QByteArray();
+        QTest::newRow("eglfs") << QByteArray("eglfs");
+        QTest::newRow("wayland") << QByteArray("wayland");
+        QTest::newRow("offscreen") << QByteArray("offscreen");
+        // A rotation option on a non-linuxfb platform is still ignored.
+        QTest::newRow("eglfs-with-rotation")
+            << QByteArray("eglfs:rotation=90");
+    }
+    void overrideNonLinuxfbIsZero()
+    {
+        QFETCH(QByteArray, qpa);
+        QpaGuard guard(qpa);
+        QCOMPARE(rotation::linuxfbRotationOverride(), 0);
+    }
+
+    // linuxfb without a valid rotation=N option is unrotated (0).
+    void overrideLinuxfbNoAngleIsZero_data()
+    {
+        QTest::addColumn<QByteArray>("qpa");
+        QTest::newRow("bare") << QByteArray("linuxfb");
+        QTest::newRow("no-option") << QByteArray("linuxfb:");
+        QTest::newRow("other-option")
+            << QByteArray("linuxfb:fb=/dev/fb0");
+        QTest::newRow("non-numeric")
+            << QByteArray("linuxfb:rotation=left");
+        QTest::newRow("unsupported-45")
+            << QByteArray("linuxfb:rotation=45");
+        QTest::newRow("360-normalises-to-0")
+            << QByteArray("linuxfb:rotation=360");
+    }
+    void overrideLinuxfbNoAngleIsZero()
+    {
+        QFETCH(QByteArray, qpa);
+        QpaGuard guard(qpa);
+        QCOMPARE(rotation::linuxfbRotationOverride(), 0);
+    }
+
+    // Valid angles are parsed and normalised (mod 360, negatives wrap).
+    void overrideLinuxfbAngle_data()
+    {
+        QTest::addColumn<QByteArray>("qpa");
+        QTest::addColumn<int>("expected");
+        QTest::newRow("90") << QByteArray("linuxfb:rotation=90") << 90;
+        QTest::newRow("180") << QByteArray("linuxfb:rotation=180") << 180;
+        QTest::newRow("270") << QByteArray("linuxfb:rotation=270") << 270;
+        QTest::newRow("450-wraps-to-90")
+            << QByteArray("linuxfb:rotation=450") << 90;
+        QTest::newRow("-90-wraps-to-270")
+            << QByteArray("linuxfb:rotation=-90") << 270;
+        QTest::newRow("angle-among-options")
+            << QByteArray("linuxfb:fb=/dev/fb0,rotation=180") << 180;
+    }
+    void overrideLinuxfbAngle()
+    {
+        QFETCH(QByteArray, qpa);
+        QFETCH(int, expected);
+        QpaGuard guard(qpa);
+        QCOMPARE(rotation::linuxfbRotationOverride(), expected);
+    }
+
+    // The injected script carries the requested angle and always
+    // re-asserts itself from a subtree MutationObserver.
+    void webpageScriptCommonShape_data()
+    {
+        QTest::addColumn<int>("angle");
+        QTest::newRow("90") << 90;
+        QTest::newRow("180") << 180;
+        QTest::newRow("270") << 270;
+    }
+    void webpageScriptCommonShape()
+    {
+        QFETCH(int, angle);
+        const QString js = rotation::webpageRotationScript(angle);
+        QVERIFY(js.contains(
+            QStringLiteral("rotate(%1deg)").arg(angle)));
+        QVERIFY(js.contains(QStringLiteral("anthias-rotation")));
+        QVERIFY(js.contains(QStringLiteral("!important")));
+        // Robustness against SPAs removing the node deep in the tree.
+        QVERIFY(js.contains(QStringLiteral("subtree:true")));
+        QVERIFY(js.contains(QStringLiteral("MutationObserver")));
+    }
+
+    // 90/270 swap the viewport box (portrait fill, pillar-boxed); 180
+    // keeps the landscape box. The box governs whether a landscape page
+    // fits the portrait-turned panel.
+    void webpageScript90SwapsBox()
+    {
+        const QString js = rotation::webpageRotationScript(90);
+        QVERIFY(js.contains(QStringLiteral("width:100vh")));
+        QVERIFY(js.contains(QStringLiteral("height:100vw")));
+        QVERIFY(js.contains(QStringLiteral("position:fixed")));
+    }
+
+    void webpageScript270SwapsBox()
+    {
+        const QString js = rotation::webpageRotationScript(270);
+        QVERIFY(js.contains(QStringLiteral("width:100vh")));
+        QVERIFY(js.contains(QStringLiteral("height:100vw")));
+    }
+
+    void webpageScript180KeepsBox()
+    {
+        const QString js = rotation::webpageRotationScript(180);
+        QVERIFY(js.contains(QStringLiteral("width:100vw")));
+        QVERIFY(js.contains(QStringLiteral("height:100vh")));
+        // No portrait-fill repositioning at 180.
+        QVERIFY(!js.contains(QStringLiteral("position:fixed")));
+    }
+};
+
+int runRotationTests(int argc, char** argv)
+{
+    TestRotation tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include "test_rotation.moc"

--- a/src/anthias_webview/tests/test_rotation.cpp
+++ b/src/anthias_webview/tests/test_rotation.cpp
@@ -18,6 +18,9 @@ namespace
 {
 // RAII guard: set QT_QPA_PLATFORM for one test and restore it after, so
 // the cases don't leak platform strings into each other (or the runner).
+// A null QByteArray means "unset entirely" (qunsetenv) rather than "set
+// to empty string" — so the unset case genuinely exercises the
+// no-variable path, not an empty-string one.
 class QpaGuard
 {
 public:
@@ -25,7 +28,11 @@ public:
         : had_(qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
         , previous_(qgetenv("QT_QPA_PLATFORM"))
     {
-        qputenv("QT_QPA_PLATFORM", value);
+        if (value.isNull()) {
+            qunsetenv("QT_QPA_PLATFORM");
+        } else {
+            qputenv("QT_QPA_PLATFORM", value);
+        }
     }
     ~QpaGuard()
     {

--- a/src/anthias_webview/tests/test_videoview.cpp
+++ b/src/anthias_webview/tests/test_videoview.cpp
@@ -24,6 +24,7 @@
 // composite into, so we don't try to play media — just exercise the
 // API surface plus the option plumbing.
 
+#include <QApplication>
 #include <QCoreApplication>
 #include <QMediaPlayer>
 #include <QQuickItem>
@@ -227,5 +228,23 @@ private:
     }
 };
 
-QTEST_MAIN(TestVideoView)
+// Combined entry point: this binary hosts two independent QtTest
+// classes — TestVideoView (here) and TestRotation (test_rotation.cpp,
+// run via the runRotationTests factory so its class stays private to
+// its own translation unit). QTEST_MAIN can only host one, so we exec
+// each in turn and OR their exit codes. QApplication (not
+// QCoreApplication) because the VideoView tests need the widgets stack.
+extern int runRotationTests(int argc, char** argv);
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    int status = 0;
+    {
+        TestVideoView tc;
+        status |= QTest::qExec(&tc, argc, argv);
+    }
+    status |= runRotationTests(argc, argv);
+    return status;
+}
 #include "test_videoview.moc"

--- a/src/anthias_webview/tests/tests.pro
+++ b/src/anthias_webview/tests/tests.pro
@@ -12,14 +12,20 @@ QT += core gui testlib widgets multimedia quick quickwidgets dbus
 CONFIG += c++17 console testcase
 
 # Re-use the production sources verbatim — tests instantiate
-# VideoView directly. ``main.cpp`` is excluded because QTEST_MAIN
-# provides its own entry point. The qrc carries the QML scene
-# (videoview.qml) the production widget loads.
+# VideoView directly and call the rotation helpers. ``main.cpp`` is
+# excluded because QTEST_MAIN provides its own entry point. The qrc
+# carries the QML scene (videoview.qml) the production widget loads.
+# rotation.cpp is deliberately QtCore-only (no View / QtWebEngine) so
+# these tests link without the webengine modules.
 SOURCES += \
     ../src/videoview.cpp \
-    test_videoview.cpp
+    ../src/rotation.cpp \
+    test_videoview.cpp \
+    test_rotation.cpp
 
-HEADERS += ../src/videoview.h
+HEADERS += \
+    ../src/videoview.h \
+    ../src/rotation.h
 
 RESOURCES += ../src/videoview.qrc
 

--- a/src/anthias_webview/tests/tests.pro
+++ b/src/anthias_webview/tests/tests.pro
@@ -13,10 +13,12 @@ CONFIG += c++17 console testcase
 
 # Re-use the production sources verbatim — tests instantiate
 # VideoView directly and call the rotation helpers. ``main.cpp`` is
-# excluded because QTEST_MAIN provides its own entry point. The qrc
-# carries the QML scene (videoview.qml) the production widget loads.
-# rotation.cpp is deliberately QtCore-only (no View / QtWebEngine) so
-# these tests link without the webengine modules.
+# excluded because the test binary provides its own combined entry
+# point (test_videoview.cpp's main() runs both TestVideoView and
+# TestRotation — QTEST_MAIN only hosts one class). The qrc carries the
+# QML scene (videoview.qml) the production widget loads. rotation.cpp is
+# deliberately QtCore-only (no View / QtWebEngine) so these tests link
+# without the webengine modules.
 SOURCES += \
     ../src/videoview.cpp \
     ../src/rotation.cpp \


### PR DESCRIPTION
## Problem
On the linuxfb boards (Pi 1/2/3, Qt5), `screen_rotation` only turned **video** — **images and web pages stayed upright** at 90/180/270. Confirmed on a real Pi 2: at `screen_rotation=90` the `/dev/fb0` dump of an image asset was byte-identical to upright, and a web page's document root had `transform: none`.

## Root cause
The **Qt5 linuxfb QPA plugin ignores the `rotation=N` option** baked into `QT_QPA_PLATFORM=linuxfb:...,rotation=N` — the surface stays 1920×1080 landscape and every non-video asset fills it upright. Video works only because `GstFbdevMediaPlayer` rotates it *separately* via a GStreamer `videoflip` element. Long-standing since #2882, which assumed the plugin would "rotate the framebuffer for free" and only tested that the string was appended, never that content turned.

## Fix
Two surfaces, each rotated to match the (already-correct) video path — all clockwise for 90, matching `videoflip method=clockwise`:

1. **Still images / animated GIFs** — rotated by hand in `View::paintEvent` when `QT_QPA_PLATFORM=linuxfb` carries `rotation=N` (`linuxfbRotationOverride()`). 90/270 fit the image into the transposed box and pillar-box it; 180 fills the frame.
2. **Web pages** (QtWebEngine, a separate surface the QPA rotation also misses) — on every page load, inject JS that turns the document root with an `!important` transform (90/270 swap the viewport box so a landscape page fills the portrait-turned panel; 180 keeps the box), re-asserted from a `MutationObserver` for SPAs. Injected imperatively via `runJavaScript` from a persistent `loadFinished` handler (a declarative `ApplicationWorld` `QWebEngineScript` silently never fires on this qt5pi Qt 5.15 build); `ApplicationWorld` is used so it bypasses page CSP.

**Gated to linuxfb only** (`imageRotation != 0`) — eglfs (`QT_QPA_EGLFS_ROTATION`) and wayland (wlr-randr) rotate the whole compositor output, so this is a no-op there and those paths are byte-for-byte unchanged (no double-rotation).

## Validation — real Pi 2 (linuxfb, `/dev/fb0` captures + CDP DOM probe)
All four asset types validated on device; direction and pillar-boxing match across all of them.

**Images** (`paintEvent`):
| rotation | result |
|---|---|
| 0 | upright (unchanged — no regression) |
| 90 | 90° CW, red(top)→right, green(bottom)→left, pillar-boxed |
| 180 | upside-down, green→top, red→bottom, full-frame |
| 270 | 90° CCW (opposite of 90), red→left, green→right, pillar-boxed |

**Web pages** (injected transform; DOM probe confirms `styleExists:true` + a real rotation matrix at each angle):
| rotation | result |
|---|---|
| 0 | upright (no-op) |
| 90 | 90° CW, red bar→right, green→left, page fills portrait box |
| 180 | flipped, green→top, red→bottom, full-frame |
| 270 | 90° CCW, red→left, green→right |

**Video & streaming** (pre-existing `videoflip`, re-confirmed): `videoflip method=clockwise` at 90; portrait content correctly pillar-boxed into the landscape framebuffer for both a local file and an RTSP stream.

Compiled cleanly for pi2 (Qt5 toolchain) and deployed for the on-device validation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)