### PR TITLE
fix(splash): stop the Pi 2 boot splash falling back to the text theme

### DIFF
--- a/ansible/roles/splashscreen/files/plymouthd.default
+++ b/ansible/roles/splashscreen/files/plymouthd.default
@@ -1,5 +1,15 @@
-# Distribution defaults. Changes to this file will get overwritten during
-# upgrades.
+# Anthias splash configuration, managed by ansible/roles/splashscreen.
+# Edits here are overwritten on the next Ansible run.
+#
+# Installed to two paths, and the distinction matters:
+#   /etc/plymouth/plymouthd.conf         — admin config, read first
+#   /usr/share/plymouth/plymouthd.defaults — distro defaults, fallback
+#     for keys absent from the conf above
+# The defaults copy does not survive: `apt-get install plymouth
+# --reinstall` in install.sh's cleanup() reverts it to the distro's own
+# (Theme=ceratopsian, DeviceTimeout=8). So the /etc copy is the one that
+# actually decides behaviour — every key we rely on must be set here
+# rather than left to fall through.
 [Daemon]
 Theme=anthias
 ShowDelay=2

--- a/ansible/roles/splashscreen/files/plymouthd.default
+++ b/ansible/roles/splashscreen/files/plymouthd.default
@@ -3,3 +3,13 @@
 [Daemon]
 Theme=anthias
 ShowDelay=2
+# Seconds plymouthd waits for a graphics device before giving up and
+# falling back to the text splash. Without this key plymouthd inherits
+# the distro's 8s, which is too short for the slower Pi boards: on a
+# Pi 2 vc4's /dev/dri/card0 only appears ~14s in, so plymouthd decides
+# there is "no suitable graphics hardware", commits to the text splash,
+# and then ignores card0 when it finally arrives ("ignoring since we're
+# already using text splash") — the Anthias splash never paints. This
+# costs nothing on a genuinely headless board: the wait runs alongside
+# boot and plymouth-quit still tears it down at boot completion.
+DeviceTimeout=30

--- a/ansible/roles/splashscreen/handlers/main.yml
+++ b/ansible/roles/splashscreen/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+# plymouthd starts from the initramfs, so it reads the theme files and
+# plymouthd.conf baked in there rather than the ones on the root fs.
+# Anything this role installs is therefore inert until the initramfs is
+# rebuilt. Running it as a handler means one rebuild at the end of the
+# play, after every file is in place, instead of a `-R` mid-role that
+# would snapshot a half-configured state.
+- name: Regenerate initramfs
+  ansible.builtin.command: update-initramfs -u -k all
+  changed_when: true

--- a/ansible/roles/splashscreen/tasks/main.yml
+++ b/ansible/roles/splashscreen/tasks/main.yml
@@ -43,15 +43,22 @@
     - anthias.plymouth
     - anthias.script
     - splashscreen.png
+  notify: Regenerate initramfs
 
 - name: Get current plymouth theme
   ansible.builtin.command: plymouth-set-default-theme
   register: splashscreen_plymouth_theme
   changed_when: false
 
+# Deliberately NOT `-R`: that rebuilds the initramfs here, before the
+# config below is written, so the initramfs would embed the *old*
+# plymouthd.conf. plymouthd runs from the initramfs and reads its theme
+# and DeviceTimeout from the copy baked in there, so the rebuild has to
+# happen after every file this role installs — see the handler.
 - name: Set Plymouth default theme to Anthias
-  ansible.builtin.command: plymouth-set-default-theme -R anthias
+  ansible.builtin.command: plymouth-set-default-theme anthias
   changed_when: splashscreen_plymouth_theme.stdout != "anthias"
+  notify: Regenerate initramfs
 
 - name: Install plymouthd defaults
   ansible.builtin.copy:
@@ -60,6 +67,7 @@
     mode: "0644"
     owner: root
     group: root
+  notify: Regenerate initramfs
 
 - name: Install plymouthd.conf
   ansible.builtin.copy:
@@ -68,3 +76,4 @@
     mode: "0644"
     owner: root
     group: root
+  notify: Regenerate initramfs


### PR DESCRIPTION
### Issues Fixed

The Plymouth boot splash never paints on the Pi 2 — the screen shows the text plugin's status output on black instead of the Anthias splash. Not reproducible on a Pi 3 A+ despite byte-identical `config.txt`, `cmdline.txt`, theme files and Plymouth version, which is what made it look board-specific and mysterious.

### Description

`plymouthd` waits `DeviceTimeout` seconds for a graphics device before concluding there is none. Our `plymouthd.conf` never set the key, so it inherited the distro default of **8s**. A `plymouth.debug` trace on the Pi 2 shows vc4's `/dev/dri/card0` only appearing at **~14.3s**, while the timeout expires at **~12.65s**:

```
04.646  Device timeout is set to nan        <- our plymouthd.conf
04.648  Device timeout is set to 8.000000   <- distro defaults
12.652  Timeout elapsed, looking for devices from udev
12.661  Creating non-graphical devices, since there's no suitable graphics hardware
12.662  adding text display for terminal /dev/tty1
14.325  got add event for device /dev/dri/card0
14.325  ignoring since we're already using text splash for local console
```

`plymouthd` commits to the text splash, then *explicitly ignores* `card0` when it finally arrives. A Pi 3 A+ (Cortex-A53 @1.4GHz) probes vc4 inside the 8s window; the Pi 2 (Cortex-A7 @900MHz) does not. Same config, different clock — so this is a timing race, and any board slow enough to probe vc4 past 8s is affected.

**Two changes:**

1. **`DeviceTimeout=30`** in `plymouthd.default`, giving slower boards room. This costs nothing on a genuinely headless board: the wait runs alongside boot and `plymouth-quit` still tears the splash down at boot completion.

2. **Rebuild the initramfs from a handler.** This is part of the fix, not incidental — `plymouthd` starts *from the initramfs* and reads its theme and `DeviceTimeout` from the copy baked in there, so a config-only change would be inert. The role wrote `plymouthd.conf` **after** `plymouth-set-default-theme -R`, so the initramfs only ever embedded the pre-copy config. It happened to work because `cleanup()` in `install.sh` runs `apt-get install plymouth --reinstall`, which triggers `update-initramfs` afterwards — load-bearing by accident. Dropping `-R` and rebuilding once from a handler makes the ordering explicit and correct.

### Validation

Real Pi 2 (armhf/Raspbian trixie, display attached):

1. Reverted the board to the exact pre-fix state (conf without `DeviceTimeout`, distro `plymouthd.defaults`, initramfs rebuilt).
2. Ran the `splashscreen` role against it — handler fired.
3. Confirmed `DeviceTimeout=30` is embedded **inside `initramfs7`**, not just on disk.
4. Rebooted. Trace now shows:

```
Device timeout is set to 30.000000
drm driver: vc4
Creating 1920x1080 renderer head
Loading boot splash theme '.../anthias/anthias.plymouth'
show_splash_screen : starting boot animation
executing script file
```

`no pixel displays`: **0**. Text fallback: **0**. Only theme loaded: `anthias`.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes. (`ansible-lint ansible/` passes, production profile, 0 failures.)
- [x] I have done an end-to-end test for Raspberry Pi devices. (Role run + reboot on a real Pi 2 with a display; see Validation.)
- [ ] I have tested my changes for x86 devices. **Not tested on x86** — the role runs there too, but x86 boots via GRUB/efifb and was not part of this repro. The change is a timeout increase plus an initramfs rebuild, both benign there, but worth a sanity check before merge.
- [ ] I added a documentation for the changes I have made (when necessary). Not needed — rationale is captured in-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)