### PR TITLE
fix(viewer): rotate eglfs/wayland clockwise to match linuxfb + video

### DIFF
--- a/src/anthias_viewer/__init__.py
+++ b/src/anthias_viewer/__init__.py
@@ -369,14 +369,21 @@ def _build_webview_env() -> dict[str, str]:
     qpa = env.get('QT_QPA_PLATFORM', 'linuxfb')
     if qpa.partition(':')[0] == 'eglfs':
         if rotation:
-            # eglfs only understands 180, 90 and -90. A literal 270
-            # hits the "Invalid rotation" default branch in
-            # QEglFSScreen::geometry(), so the QOpenGLCompositor still
-            # rotates the content but the screen geometry never swaps
-            # to portrait — the window lays out landscape and renders
-            # stretched (issue #2970). Spell 270° as -90 instead.
+            # ``screen_rotation`` is defined CLOCKWISE — that's the
+            # direction the linuxfb (paintEvent / injected CSS) and the
+            # GStreamer ``videoflip`` paths turn. A raw
+            # ``QT_QPA_EGLFS_ROTATION=N`` turns the QOpenGLCompositor the
+            # OTHER way (anticlockwise), so screen_rotation=90 came out
+            # 90° anticlockwise on eglfs boards while a Pi 2 turned it
+            # clockwise — opposite orientation for the same setting.
+            # Negate so every display stack agrees. eglfs only understands
+            # 180, 90 and -90 — a literal 270 hits the "Invalid rotation"
+            # default branch in QEglFSScreen::geometry() (the compositor
+            # still rotates but the geometry never swaps to portrait, so
+            # the window lays out landscape and renders stretched, issue
+            # #2970) — so 90° CW is spelled -90 and 270° CW is spelled 90.
             env['QT_QPA_EGLFS_ROTATION'] = str(
-                -90 if rotation == 270 else rotation
+                {90: -90, 180: 180, 270: 90}[rotation]
             )
         else:
             # Drop a stale value so dialling back to 0 actually
@@ -388,7 +395,11 @@ def _build_webview_env() -> dict[str, str]:
 
 
 def _wlr_transform_value(rotation_deg: int) -> str:
-    return {0: 'normal', 90: '90', 180: '180', 270: '270'}.get(
+    # wlr-randr transforms turn the output ANTICLOCKWISE, the opposite of
+    # screen_rotation's clockwise convention (linuxfb + videoflip). Map a
+    # 90° clockwise turn to wlr transform '270' and 270° CW to '90' so
+    # wayland boards rotate the same way as every other display stack.
+    return {0: 'normal', 90: '270', 180: '180', 270: '90'}.get(
         rotation_deg, 'normal'
     )
 

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2120,6 +2120,20 @@ def test_build_webview_env_no_op_on_pi5_wayland() -> None:
     assert env['QT_QPA_PLATFORM'] == 'wayland'
 
 
+@pytest.mark.parametrize(
+    ('rotation', 'transform'),
+    [(0, 'normal'), (90, '270'), (180, '180'), (270, '90')],
+)
+def test_wlr_transform_value_is_clockwise(
+    rotation: int, transform: str
+) -> None:
+    """screen_rotation is clockwise but wlr-randr transforms turn the
+    output anticlockwise, so 90° CW maps to '270' and 270° CW to '90'
+    (0/180 are direction-agnostic). Keeps wayland aligned with linuxfb +
+    videoflip."""
+    assert viewer._wlr_transform_value(rotation) == transform
+
+
 def test_apply_wlr_transform_runs_on_pi5() -> None:
     """Issue #3044: the wlr-randr path must actually fire on Pi 5 —
     previously gated behind an x86-only _is_wayland_board(), so the

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1830,10 +1830,9 @@ def test_build_webview_env_pi3_64_drops_overlay_for_90_270(
         env = viewer._build_webview_env()
     assert env['ANTHIAS_VIDEO_RASTER'] == '1'
     assert 'ANTHIAS_VIDEO_OVERLAY' not in env
-    # Sanity: the screen itself still rotates via eglfs.
-    assert env['QT_QPA_EGLFS_ROTATION'] == (
-        '-90' if rotation == 270 else str(rotation)
-    )
+    # Sanity: the screen itself still rotates via eglfs (clockwise, so
+    # 90° CW is spelled -90 and 270° CW is spelled 90).
+    assert env['QT_QPA_EGLFS_ROTATION'] == ('-90' if rotation == 90 else '90')
 
 
 def test_build_webview_env_pi3_64_keeps_overlay_at_180() -> None:
@@ -2156,7 +2155,8 @@ def test_apply_wlr_transform_runs_on_pi5() -> None:
     ]
     assert len(transform_calls) == 1
     argv = transform_calls[0].args[0]
-    assert argv[argv.index('--transform') + 1] == '90'
+    # 90° clockwise == wlr transform '270' (wlr turns anticlockwise).
+    assert argv[argv.index('--transform') + 1] == '270'
 
 
 def test_build_webview_env_appends_rotation_on_linuxfb() -> None:
@@ -2270,7 +2270,7 @@ def test_build_webview_env_removes_stale_rotation_when_dialed_to_zero() -> (
 
 @pytest.mark.parametrize(
     ('rotation', 'expected'),
-    [(90, '90'), (180, '180'), (270, '-90')],
+    [(90, '-90'), (180, '180'), (270, '90')],
 )
 def test_build_webview_env_sets_eglfs_rotation(
     rotation: int, expected: str
@@ -2278,10 +2278,12 @@ def test_build_webview_env_sets_eglfs_rotation(
     """Pi 4 runs eglfs, which ignores the linuxfb ``:rotation=N`` plugin
     option (that silent no-op was the 2026.06.0 bug). eglfs reads
     QT_QPA_EGLFS_ROTATION at QPA init instead, so we set that and leave
-    QT_QPA_PLATFORM untouched. eglfs only accepts 180/90/-90 — a literal
-    270 rotates the content without swapping the screen geometry to
-    portrait, rendering everything stretched (issue #2970) — so 270°
-    must be emitted as -90."""
+    QT_QPA_PLATFORM untouched. The angle is NEGATED because eglfs turns
+    the compositor anticlockwise while screen_rotation is clockwise
+    (matching linuxfb + videoflip), and eglfs only accepts 180/90/-90 — a
+    literal 270 rotates the content without swapping the screen geometry
+    to portrait, rendering everything stretched (issue #2970). So 90° CW
+    is emitted as -90 and 270° CW as 90."""
     with (
         mock.patch.dict(settings, {'screen_rotation': rotation}),
         mock.patch.dict(


### PR DESCRIPTION
## Problem
`screen_rotation` is defined **clockwise** — the direction the linuxfb paths (image `paintEvent`, injected webpage CSS) and the GStreamer `videoflip` path turn. But the **eglfs** (`QT_QPA_EGLFS_ROTATION`) and **wayland** (`wlr-randr` transform) mappings both turned the output **anticlockwise**.

Result: the same `screen_rotation=90` produced **opposite physical orientation** across the fleet. Confirmed on real hardware with an orientation test page (red bar = top of page):

| Board | Stack | `screen_rotation=90` | Direction |
|---|---|---|---|
| Pi 2 | linuxfb | red bar → right | 90° CW |
| Pi 4 | eglfs | red bar → left | 90° CCW |
| x86 | wayland | red bar → left | 90° CCW |

## Fix
Negate the angle on the two anticlockwise stacks so every display rotates the same (clockwise) way:
- **eglfs**: `QT_QPA_EGLFS_ROTATION` 90→`-90`, 270→`90` (180 symmetric). Still avoids the literal-`270` "Invalid rotation" stretch path in `QEglFSScreen::geometry()`.
- **wayland**: `wlr-randr` transform 90→`270`, 270→`90` (180 unchanged).

linuxfb and the pi3-64 vc4 overlay plane (rotate-180 only, symmetric) are untouched.

## Scope
Pre-existing since the eglfs/wayland rotation paths were added — surfaced by the fleet-wide rotation QA for the 2026.07.3 release. Unit tests updated for the clockwise mapping (160 `test_viewer.py` pass). Will be hardware-verified on pi4 (eglfs), x86/pi5 (wayland), pi3-64 and rockpi4 before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)