### PR TITLE
chore(deps): use the uv Dependabot ecosystem so uv.lock stays in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,18 @@ updates:
       bun:
         patterns:
           - "*"
-  - package-ecosystem: "pip"
+  # "uv", not "pip": the pip ecosystem reads the PEP 621 pins in
+  # pyproject.toml but has no concept of uv.lock, so it opened PRs that
+  # bumped the pin and left the lockfile on the old version. The uv
+  # ecosystem understands both and keeps them in sync.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      python:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Fixes the root cause behind the lockfile drift that https://github.com/Screenly/Anthias/pull/3201 had to clean up by hand.

## The problem

The Python entry used `package-ecosystem: "pip"`. The pip ecosystem reads the PEP 621 pins in `pyproject.toml` but has **no concept of `uv.lock`** — so every Python bump it opened updated the pin and left the lockfile resolved to the old version. All five bumps bundled in 3201 carried that drift, and it would have recurred on every future Python bump.

Dependabot can't be told to "run `uv lock`" — it doesn't execute arbitrary commands. The fix is the native `uv` ecosystem, which understands `pyproject.toml` and `uv.lock` and updates them together.

## Notes on the change

- **Replaces `pip` rather than adding alongside it.** Running both would open duplicate PRs for the same dependencies.
- **No loss of coverage.** `pyproject.toml` + `uv.lock` are the only Python manifests in the repo — there is no `requirements.txt`, `setup.py`, `Pipfile`, or `poetry.lock`.
- **Groups Python updates into one PR**, matching the existing `bun`, `docker` and `github-actions` entries. `pip` was the only ecosystem without a group, which is exactly why five separate PRs landed instead of one.
- **No `cooldown` needed.** That's only recommended to mirror uv's `exclude-newer`, which this repo doesn't set.

## On the strict `==` pins

Worth flagging, since there was a known issue (dependabot/dependabot-core#12788) about the uv ecosystem updating `uv.lock` but not `pyproject.toml`. It was closed as a non-bug: that reporter used `>=` constraints, so their manifest genuinely needed no change. This repo pins with `==`, so a bump cannot satisfy the existing constraint and Dependabot must update both files.

## Validation

Nothing in CI validates this file — `actionlint` only covers `.github/workflows/`, so a malformed config would fail silently rather than break a check. Verified manually instead:

- Parses as valid YAML; all four ecosystems resolve as intended (`bun`, `uv`, `docker`, `github-actions`), each with its group.
- Validates against the official [schemastore dependabot-2.0 schema](https://json.schemastore.org/dependabot-2.0.json), and `uv` is confirmed present in that schema's `package-ecosystem` enum.

The real proof is the next Dependabot run opening a grouped Python PR that touches both `pyproject.toml` and `uv.lock` — worth a glance when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)