### PR TITLE
chore(deps): ignore Django major updates in the python group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,13 @@ updates:
       python:
         patterns:
           - "*"
+    # A Django major is a deliberate migration, not something to ride in
+    # on a routine grouped bump. Minor and patch updates still come
+    # through. Matching is case-insensitive and exact, so django-stubs,
+    # django-dbbackup and djangorestframework are unaffected.
+    ignore:
+      - dependency-name: "Django"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Keeps Django major version bumps out of the grouped Python Dependabot PR. A Django major is a deliberate migration, not something that should ride in on a routine grouped bump alongside patch-level tooling updates.

Minor and patch updates still flow through, so the 5.2.x line keeps getting security and bug fixes.

## Scope

The rule is an exact, case-insensitive name match on `Django` — **not** a `django*` wildcard, which would have swept up five unrelated packages. Verified by simulating dependabot-core's own `wildcard_match?` logic (it lowercases both sides, so `Django` and `django` both match):

| Candidate | Ignored |
| --- | --- |
| django / Django | yes |
| django-stubs | no |
| django-stubs-ext | no |
| django-dbbackup | no |
| djangorestframework | no |
| djangorestframework-stubs | no |

`ignore` sits at the ecosystem level rather than inside `groups:` — there is no per-group ignore. A group's `exclude-patterns` would only split Django into its own PR, not suppress the major.

## Why this is worth having

Django 6.0.7 is out while the repo pins 5.2.14. I confirmed 6.0.7 resolves cleanly against every current pin (`uv lock --dry-run` with the pin swapped: `Resolved 125 packages`, `django v5.2.14 -> v6.0.7`), and nothing in the tree caps Django below 6 — `djangorestframework` needs `>=4.2`, `drf-spectacular` needs `>=2.2`. So nothing would stop Dependabot proposing the major on a future run.

Worth noting for context: the first grouped Python run (https://github.com/Screenly/Anthias/pull/3205) did **not** include Django, so this is a forward-looking guard rather than a fix for something already broken.

## Validation

Nothing in CI validates this file — `actionlint` only covers `.github/workflows/`, so a malformed config fails silently rather than turning a check red. Verified manually:

- Validates against the official [schemastore dependabot-2.0 schema](https://json.schemastore.org/dependabot-2.0.json).
- `update-types: ["version-update:semver-major"]` matches the documented enum.
- Ignore matching simulated against dependabot-core's `wildcard_match?` (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)