### PR TITLE
fix(server): serve remote-hosted image previews from their source URL

### DIFF
--- a/bin/collect_debug.sh
+++ b/bin/collect_debug.sh
@@ -339,23 +339,40 @@ DB_FILE="${CONFIG_DIR}/anthias.db"
 [[ -f "$DB_FILE" ]] || DB_FILE="${CONFIG_DIR}/screenly.db"
 if [[ -f "$DB_FILE" ]]; then
     section "Database file" "$DB" ls -la "$DB_FILE"
+    # `is_reachable` is the single most useful column for triaging a
+    # "web content doesn't display" report: the server marks a remote
+    # asset unreachable when its reachability probe fails, and the
+    # viewer then skips it. Keep it in the inventory on both paths.
+    integrity_q='PRAGMA integrity_check;'
+    journal_q='PRAGMA journal_mode;'
+    tables_q='.tables'
+    count_q='SELECT count(*) AS total, sum(is_enabled) AS enabled, sum(NOT is_reachable) AS unreachable FROM assets;'
+    # Asset inventory without leaking full URLs of private content.
+    inventory_q="SELECT substr(asset_id,1,8), substr(name,1,40), mimetype, is_enabled, is_reachable, substr(uri,1,60) FROM assets;"
     if command -v sqlite3 >/dev/null 2>&1; then
-        section "Integrity check" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" 'PRAGMA integrity_check;'
-        section "Journal mode" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" 'PRAGMA journal_mode;'
-        section "Tables" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" '.tables'
-        section "Asset count" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" \
-            'SELECT count(*) AS total, sum(is_enabled) AS enabled FROM assets;'
-        # Asset inventory without leaking full URLs of private content.
-        section "Assets (truncated)" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" \
-            "SELECT substr(asset_id,1,8), substr(name,1,40), mimetype, is_enabled, substr(uri,1,60) FROM assets;"
+        section "Integrity check" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" "$integrity_q"
+        section "Journal mode" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" "$journal_q"
+        section "Tables" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" "$tables_q"
+        section "Asset count" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" "$count_q"
+        section "Assets (truncated)" "$DB" sqlite3 "file:${DB_FILE}?mode=ro" "$inventory_q"
     else
-        echo "sqlite3 not installed on host — DB inspected via container below" >>"$DB"
-        # Fall back to the sqlite3 inside the server container.
+        echo "sqlite3 not installed on host — DB inspected via the server container" >>"$DB"
+        # Fall back to the sqlite3 inside the server container. The host
+        # config dir is bind-mounted at /data/.anthias, so the same DB
+        # file is reachable there under its original basename.
         cid="$("${DOCKER[@]}" ps -q --filter "name=anthias-server" 2>/dev/null | head -1)"
         if [[ -n "$cid" ]]; then
+            c_db="file:/data/.anthias/$(basename "$DB_FILE")?mode=ro"
+            section "Integrity check (in container)" "$DB" \
+                "${DOCKER[@]}" exec "$cid" sqlite3 "$c_db" "$integrity_q"
+            section "Journal mode (in container)" "$DB" \
+                "${DOCKER[@]}" exec "$cid" sqlite3 "$c_db" "$journal_q"
             section "Asset count (in container)" "$DB" \
-                "${DOCKER[@]}" exec "$cid" python -m anthias_server.manage shell -c \
-                'from anthias_app.models import Asset; print("total", Asset.objects.count(), "enabled", Asset.objects.filter(is_enabled=1).count())'
+                "${DOCKER[@]}" exec "$cid" sqlite3 "$c_db" "$count_q"
+            section "Assets (truncated, in container)" "$DB" \
+                "${DOCKER[@]}" exec "$cid" sqlite3 "$c_db" "$inventory_q"
+        else
+            echo "server container not running — cannot inspect DB" >>"$DB"
         fi
     fi
 else

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1377,15 +1377,23 @@ def assets_download(request: HttpRequest, asset_id: str) -> HttpResponseBase:
     asset = Asset.objects.filter(asset_id=asset_id).first()
     if asset is None or not asset.uri:
         return redirect(reverse('anthias_app:home'))
-    if asset.mimetype in ('webpage', 'streaming'):
-        safe = _safe_redirect_uri(asset.uri)
+    # Any asset whose content lives at a remote http(s) URL — a webpage,
+    # a stream, or a remote-hosted image/video — has no local file to
+    # stream, so we redirect the browser to the source. Only locally
+    # uploaded assets (uri is a filesystem path) are served from disk.
+    # Keying off the URI scheme rather than the mimetype is what fixes
+    # the blank preview/download for remote image/video assets (forum
+    # "web content doesn't display"): those are stored mimetype
+    # image/video but their uri is an http(s) URL, so the old
+    # mimetype-only branch fell through to the local-path lookup, found
+    # nothing, and bounced to the home page.
+    safe = _safe_redirect_uri(asset.uri)
+    if safe is not None:
         # `safe` is whitelisted to http(s):// schemes by _safe_redirect_uri,
         # and the endpoint is gated by @authorized (only operators with a
         # session reach this). The redirect target is the operator's own
         # asset URI — that's the feature, not a sink.
-        return (  # lgtm [py/url-redirection]
-            redirect(safe) if safe else redirect(reverse('anthias_app:home'))
-        )
+        return redirect(safe)  # lgtm [py/url-redirection]
     safe_path = _safe_local_asset_path(asset.uri)
     if safe_path is None:
         return redirect(reverse('anthias_app:home'))
@@ -1408,15 +1416,18 @@ def assets_preview(request: HttpRequest, asset_id: str) -> HttpResponseBase:
     asset = Asset.objects.filter(asset_id=asset_id).first()
     if asset is None or not asset.uri:
         return redirect(reverse('anthias_app:home'))
-    if asset.mimetype in ('webpage', 'streaming'):
-        safe = _safe_redirect_uri(asset.uri)
+    # Remote http(s) assets (webpage, streaming, or a remote-hosted
+    # image/video) redirect to the source; the modal renders those in an
+    # <img>/<video>/<iframe>. Keying off the URI scheme rather than the
+    # mimetype is what makes remote image/video previews work — see
+    # assets_download for the full rationale.
+    safe = _safe_redirect_uri(asset.uri)
+    if safe is not None:
         # `safe` is whitelisted to http(s):// schemes by _safe_redirect_uri,
         # and the endpoint is gated by @authorized (only operators with a
         # session reach this). The redirect target is the operator's own
         # asset URI — that's the feature, not a sink.
-        return (  # lgtm [py/url-redirection]
-            redirect(safe) if safe else redirect(reverse('anthias_app:home'))
-        )
+        return redirect(safe)  # lgtm [py/url-redirection]
     safe_path = _safe_local_asset_path(asset.uri)
     if safe_path is None:
         return redirect(reverse('anthias_app:home'))

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2261,6 +2261,65 @@ def test_assets_preview_404_for_unknown_id(client: Client) -> None:
     assert response['Location'].endswith('/')
 
 
+def _remote_media_asset(mimetype: str, uri: str) -> Asset:
+    now = timezone.now()
+    return Asset.objects.create(
+        name=f'Remote {mimetype}',
+        uri=uri,
+        mimetype=mimetype,
+        duration=10,
+        is_enabled=True,
+        is_processing=False,
+        play_order=0,
+        start_date=now,
+        end_date=now + timedelta(days=30),
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'mimetype,uri',
+    [
+        ('image', 'https://upload.wikimedia.org/wikipedia/x/cat.jpg'),
+        ('video', 'https://cdn.example.com/clip.mp4'),
+    ],
+)
+def test_assets_preview_redirects_for_remote_media(
+    client: Client, mimetype: str, uri: str
+) -> None:
+    """Regression for the forum "web content doesn't display" report:
+    a remote-hosted image is stored mimetype image with an http(s) uri
+    (unlike remote videos, which Celery downloads to a local file), so
+    the preview must redirect to the source rather than 302-ing to the
+    home page (the blank preview). The endpoint dispatches on the uri
+    scheme, so a remote-uri video row redirects the same way."""
+    asset = _remote_media_asset(mimetype, uri)
+    response = client.get(
+        reverse('anthias_app:assets_preview', args=[asset.asset_id])
+    )
+    assert response.status_code == 302
+    assert response['Location'] == uri
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'mimetype,uri',
+    [
+        ('image', 'https://upload.wikimedia.org/wikipedia/x/cat.jpg'),
+        ('video', 'https://cdn.example.com/clip.mp4'),
+    ],
+)
+def test_assets_download_redirects_for_remote_media(
+    client: Client, mimetype: str, uri: str
+) -> None:
+    asset = _remote_media_asset(mimetype, uri)
+    response = client.get(
+        reverse('anthias_app:assets_download', args=[asset.asset_id])
+    )
+    assert response.status_code == 302
+    assert response['Location'] == uri
+
+
 @pytest.mark.django_db
 def test_settings_save_invalid_default_streaming_duration(
     client: Client,


### PR DESCRIPTION
## Summary

Follow-up to the forum report ["Web content doesn't display"](https://forums.screenly.io/t/web-content-doesnt-display/6726). Two independent, reproduced bugs:

### 1. Blank preview/download for remote-hosted images

`assets_preview` / `assets_download` chose "redirect to source URL" vs. "stream a local file" by **mimetype** — only `webpage`/`streaming` redirected. A remote-hosted image is stored `mimetype=image` with an `http(s)://` URI, so it fell through to the local-file lookup, found nothing on disk, and 302'd to the home page (blank preview).

Fix: dispatch on the **URI scheme**. Any `http(s)://` asset redirects to its source; only filesystem-path assets are served from disk. `rtsp`/`rtmp` streams and unknown schemes still fall back to home, unchanged.

Remote *videos* are downloaded to a local file by Celery, so the materially-affected case is remote images (which keep their remote URI), but the scheme-based dispatch covers both.

### 2. `collect_debug.sh` DB section threw a traceback

The host-`sqlite3`-missing fallback imported the pre-rewrite module path (`anthias_app.models`), so the debug bundle carried a Python traceback instead of any asset data — on exactly the script we ask forum users to run. The server container already ships `sqlite3` and bind-mounts the DB, so the fallback now runs the same read-only queries in-container, and surfaces `is_reachable` (the field that tells a failed reachability probe from a working one when triaging this class of report).

## Testing

- **Live on the x86 testbed** (master): remote-image preview now `302 → source` and renders (`image/jpeg`); local-image preview still served from disk (`200`); `rtsp` streams still fall to home. `collect_debug.sh` bundle now shows integrity check, WAL mode, asset count with unreachable tally, and full per-asset `is_reachable`, with PII redaction intact.
- 4 new regression tests for remote-media preview/download; full non-integration suite green; `ruff` + `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)