### PR TITLE
fix(webview): reduce black screen during image-fetch after video

### DIFF
--- a/src/anthias_webview/AnthiasViewer.pro
+++ b/src/anthias_webview/AnthiasViewer.pro
@@ -32,12 +32,14 @@ CONFIG += c++17
 SOURCES += src/main.cpp \
     src/mainwindow.cpp \
     src/view.cpp \
-    src/rotation.cpp
+    src/rotation.cpp \
+    src/image_fallback.cpp
 
 HEADERS += \
     src/mainwindow.h \
     src/view.h \
-    src/rotation.h
+    src/rotation.h \
+    src/image_fallback.h
 
 greaterThan(QT_MAJOR_VERSION, 5) {
     QT += multimedia quickwidgets

--- a/src/anthias_webview/src/image_fallback.cpp
+++ b/src/anthias_webview/src/image_fallback.cpp
@@ -1,0 +1,11 @@
+#include "image_fallback.h"
+
+namespace image_fallback
+{
+
+bool shouldUseLastRasterImage(bool currentImageIsNull, bool fallbackAllowed)
+{
+    return currentImageIsNull && fallbackAllowed;
+}
+
+}  // namespace image_fallback

--- a/src/anthias_webview/src/image_fallback.h
+++ b/src/anthias_webview/src/image_fallback.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Pure predicate behind View::paintEvent()'s black-flash fallback (a
+// real loadImage() fetch that starts from a blanked currentImage —
+// typically right after a video asset: shows the last decoded raster
+// frame instead of solid black while the fetch is in flight). The
+// three intentional blanks (playVideo(), the ``"null"`` sentinel in
+// loadImage(), loadPage()) must stay pure black, which is why this is
+// gated by a flag rather than firing on every null currentImage.
+//
+// Kept free of View / QtWebEngine, the same way rotation.cpp is, so
+// this one piece of the fallback logic is unit-testable against
+// QtCore alone (see tests/tests.pro). View owns the QImage state
+// (currentImage, lastRasterImage) and the flag itself; this only
+// answers the yes/no question.
+namespace image_fallback
+{
+// currentImageIsNull: View::currentImage.isNull() at paint time.
+// fallbackAllowed: View::fallbackToLastImageOnBlank, true only while
+// a real (non-"null") loadImage() request is outstanding; cleared on
+// every terminal outcome of that request (success, network error, or
+// decode failure) so a failed fetch goes black rather than leaving a
+// stale asset on screen indistinguishable from a successful rotation.
+//
+// Returns true when paintEvent() should paint lastRasterImage in
+// place of currentImage.
+bool shouldUseLastRasterImage(bool currentImageIsNull, bool fallbackAllowed);
+}  // namespace image_fallback

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -31,6 +31,7 @@
 #include <QtGlobal>
 
 #include "view.h"
+#include "image_fallback.h"
 #include "rotation.h"
 
 // Attaches the operator-configured per-asset request headers (#2215) to
@@ -521,6 +522,7 @@ void View::loadPage(const QString &uri, bool skipSslVerify)
     hideVideoSurface();
 #endif
     currentImage = QImage();
+    fallbackToLastImageOnBlank = false;
     stopAnimation();
     // Drop any per-asset reload timer left over from the previous
     // webpage AND the prior asset's pending interval — the viewer
@@ -713,7 +715,15 @@ void View::loadImage(const QString &preUri, bool skipSslVerify)
     qDebug() << "Type: Image";
     const quint64 requestId = ++loadGenerationId;
 
-    // ``view_image('null')`` in src/anthias_viewer/__init__.py:495
+    // Set before hideVideoSurface() below, not after, so this doesn't
+    // rely on hideVideoSurface()'s setVisible(false) deferring the
+    // repaint to the event loop. A real image fetch is starting
+    // whenever preUri isn't the video-onset sentinel, full stop; the
+    // "null" branch further down still sets this explicitly too, for
+    // anyone reading top-to-bottom without this comment.
+    fallbackToLastImageOnBlank = (preUri != QLatin1String("null"));
+
+    // ``view_image('null')`` in src/anthias_viewer/__init__.py:1504
     // is called AFTER ``media_player.play()`` to sweep any
     // lingering web/image background out of the way of the new
     // video — it is NOT a request to take down the freshly-
@@ -730,6 +740,23 @@ void View::loadImage(const QString &preUri, bool skipSslVerify)
         hideVideoSurface();
     }
 #endif
+
+    // fallbackToLastImageOnBlank note for Qt5 armhf (Pi 1/2/3):
+    // playVideo(), and its own ``fallbackToLastImageOnBlank = false``,
+    // only exists in the Qt6 build (see the #if above; those boards
+    // never route video through this class at all, GstFbdevMediaPlayer
+    // in media_player.py spawns an external gst_fbdev_player process
+    // that paints straight to /dev/fb0). On Qt5 the ``"null"`` branch
+    // below is therefore the *only* place that clears the flag ahead
+    // of a video asset. The guarantee that actually holds isn't about
+    // the order of play() vs. this sentinel call (play() runs first);
+    // it's that the flag can only flip back to true inside a later,
+    // real loadImage() call, and GstFbdevMediaPlayer.stop()
+    // (media_player.py) blocks - SIGTERM then wait(), escalating to
+    // SIGKILL — until that external process has exited before
+    // view_video() returns, and asset_loop only calls the next
+    // view_image()/view_video() after that. So the flag can't reach
+    // true while the fbdev process might still be writing frames.
 
     // Cancel any pending page load so we don't keep streaming a web
     // page in the background after the user has switched to image
@@ -778,6 +805,11 @@ void View::loadImage(const QString &preUri, bool skipSslVerify)
     else if (preUri == "null")
     {
         qDebug() << "Black page";
+        // Already false from the top-of-function assignment; kept
+        // explicit here too since this is the branch it actually
+        // matters for (see the lastRasterImage comment in view.h and
+        // the matching comment in playVideo()).
+        fallbackToLastImageOnBlank = false;
         currentImage = QImage();
         update();
         return;
@@ -815,6 +847,16 @@ void View::loadImage(const QString &preUri, bool skipSslVerify)
             qDebug() << "Ignoring stale image response";
             return;
         }
+
+        // This request is over, whatever the outcome. Drop the fallback
+        // here, in the one place ``finished`` always fires (Qt emits it
+        // after errorOccurred() too), so a failed/corrupt fetch goes
+        // black rather than leaving the previous asset on screen:
+        // which would be indistinguishable from a successful rotation.
+        // The success branch below clears it again (harmlessly) via
+        // loadAsStaticImage()/tryLoadAsAnimatedGif(), so this is a no-op
+        // on the happy path.
+        fallbackToLastImageOnBlank = false;
 
         if (reply->error() == QNetworkReply::NoError) {
             QByteArray data = reply->readAll();
@@ -889,6 +931,8 @@ void View::loadAsStaticImage(const QByteArray& data)
         webView1->setVisible(false);
         webView2->setVisible(false);
         currentImage = nextImage;
+        lastRasterImage = nextImage;
+        fallbackToLastImageOnBlank = false;
         update();
     } else {
         qDebug() << "Failed to load image from data:" << reader.errorString();
@@ -901,12 +945,26 @@ void View::paintEvent(QPaintEvent*)
     painter.setRenderHint(QPainter::SmoothPixmapTransform);
     painter.fillRect(rect(), Qt::black);
 
-    if (currentImage.isNull()) {
+    // Issue #3262, a real image fetch that starts from a blanked
+    // state (typically right after a video asset) would otherwise
+    // paint solid black for the whole QNetworkReply round-trip.
+    // Fall back to the last real frame in that case only; the
+    // video-onset / loadPage() blanks leave the flag off and stay
+    // pure black, unchanged from before. The yes/no decision itself
+    // is a pure predicate (image_fallback.cpp) so it's covered by
+    // test_image_fallback.cpp without pulling in QtWebEngine.
+    const QImage &imageToPaint =
+        image_fallback::shouldUseLastRasterImage(
+            currentImage.isNull(), fallbackToLastImageOnBlank)
+            ? lastRasterImage
+            : currentImage;
+
+    if (imageToPaint.isNull()) {
         return;
     }
 
     if (imageRotation == 0) {
-        QSize scaledSize = currentImage.size();
+        QSize scaledSize = imageToPaint.size();
         scaledSize.scale(size(), Qt::KeepAspectRatio);
         painter.drawImage(
             QRect(
@@ -914,7 +972,7 @@ void View::paintEvent(QPaintEvent*)
                 (height() - scaledSize.height()) / 2,
                 scaledSize.width(),
                 scaledSize.height()),
-            currentImage);
+            imageToPaint);
         return;
     }
 
@@ -925,7 +983,7 @@ void View::paintEvent(QPaintEvent*)
     // pillar-boxed, matching the GStreamer videoflip path.
     const QSize box =
         (imageRotation % 180 == 0) ? size() : QSize(height(), width());
-    QSize scaledSize = currentImage.size();
+    QSize scaledSize = imageToPaint.size();
     scaledSize.scale(box, Qt::KeepAspectRatio);
     painter.translate(width() / 2.0, height() / 2.0);
     painter.rotate(imageRotation);
@@ -935,7 +993,7 @@ void View::paintEvent(QPaintEvent*)
             -scaledSize.height() / 2,
             scaledSize.width(),
             scaledSize.height()),
-        currentImage);
+        imageToPaint);
 }
 
 void View::resizeEvent(QResizeEvent* event)
@@ -950,6 +1008,21 @@ void View::resizeEvent(QResizeEvent* event)
 #endif
 }
 
+// Qt6-only: mpv/QtMultimedia video lives here. On the Qt5 linuxfb
+// boards (Pi 1/2/3), video is a separate gst_fbdev_player subprocess
+// painting straight to /dev/fb0 (see media_player.py), and this
+// function never compiles — so fallbackToLastImageOnBlank is cleared
+// on those boards only via the "null" sentinel branch in loadImage(),
+// which view_video() (anthias_viewer/__init__.py) calls before every
+// video asset. That ordering is relied on, not enforced here; if a
+// future change ever skips that call before a Qt5 video, the fallback
+// would stay armed into the video. Confirmed safe today: GstFbdev-
+// MediaPlayer.stop() blocks on Popen.wait() (SIGTERM, falling back to
+// SIGKILL) before view_video() returns, so the next view_image() for
+// the following asset can't run, and therefore can't repaint this
+// widget's currentImage onto /dev/fb0, until gst_fbdev_player has
+// actually exited and stopped writing frames. No cross-process lock
+// enforces that; it's an ordering guarantee from the caller.
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void View::playVideo(const QString &uri, const QVariantMap &options)
 {
@@ -972,9 +1045,12 @@ void View::playVideo(const QString &uri, const QVariantMap &options)
     webView1->setVisible(false);
     webView2->setVisible(false);
     // Blank the image canvas so an old still doesn't flash through
-    // before the first mpv frame paints.
+    // before the first mpv frame paints. Deliberate blank: leave the
+    // lastRasterImage fallback off (see the comment on
+    // fallbackToLastImageOnBlank in view.h).
     stopAnimation();
     currentImage = QImage();
+    fallbackToLastImageOnBlank = false;
     update();
 
     if (!videoView) {
@@ -1040,6 +1116,8 @@ void View::setupAnimation()
     movie->start();
     movie->jumpToFrame(0);
     currentImage = movie->currentImage();
+    lastRasterImage = currentImage;
+    fallbackToLastImageOnBlank = false;
     update();
 }
 

--- a/src/anthias_webview/src/view.cpp
+++ b/src/anthias_webview/src/view.cpp
@@ -867,6 +867,17 @@ void View::loadImage(const QString &preUri, bool skipSslVerify)
             }
         } else {
             qDebug() << "Network error:" << reply->errorString();
+            // fallbackToLastImageOnBlank is already false (set above,
+            // unconditionally, before this branch runs). But nothing
+            // repaints on its own here. Without this, the stale frame
+            // painted while the fetch was in flight just stays on
+            // screen for the rest of the asset's slot, which reads as
+            // "rotating normally" instead of "this asset is broken."
+            // Confirmed on hardware (Pi 4 + Pi 3 A+):before this call
+            // the failed slot showed the previous asset for its full
+            // duration; after, it goes black immediately, matching
+            // pre-PR(master) behaviour for this failure case.
+            update();
         }
     });
 
@@ -936,6 +947,14 @@ void View::loadAsStaticImage(const QByteArray& data)
         update();
     } else {
         qDebug() << "Failed to load image from data:" << reader.errorString();
+        // Same reasoning as the network-error branch in loadImage():
+        // fallbackToLastImageOnBlank was already cleared before this
+        // function ran, but that alone doesn't repaint. Without this
+        // call, a corrupt/undecodable image would leave the previous
+        // asset frozen on screen for the rest of the slot instead of
+        // going black.Confirmed on hardware alongside the network-
+        // error fix.
+        update();
     }
 }
 

--- a/src/anthias_webview/src/view.h
+++ b/src/anthias_webview/src/view.h
@@ -98,6 +98,45 @@ private:
     QNetworkAccessManager* networkManager;
     QImage currentImage;
     QImage nextImage;
+    // Last successfully decoded raster image (static or first GIF
+    // frame), kept independently of ``currentImage``. When a real
+    // ``loadImage()`` request starts from a blanked state (most
+    // commonly right after a video asset, since playVideo() /
+    // the ``"null"`` sentinel blank ``currentImage``), paintEvent()
+    // shows this instead of a black frame while the new image's
+    // QNetworkReply is in flight. Never used as a fallback for the
+    // video-onset blank itself or for loadPage(): those blanks are
+    // intentional (see playVideo()) and must stay pure black.
+    //
+    // Memory cost: none on the static-image path. ``nextImage``
+    // (above) is assigned once per successful load and never cleared
+    // anywhere in the class, so it already pinned the last decoded
+    // static image for the process's lifetime before this member
+    // existed; ``currentImage`` and ``lastRasterImage`` are
+    // copy-on-write aliases of that same buffer, reassigned together
+    // on the next successful load. The one place this genuinely
+    // retains a frame ``nextImage`` wouldn't have is setupAnimation():
+    // one animated-GIF frame, bounded, freed on the next load.
+    //
+    // Scope: deliberately not limited to the video handover. Any real
+    // loadImage() arms the fallback (see the top of loadImage()), so
+    // it also covers webpage-to-image transitions. lastRasterImage can
+    // therefore be an asset from further back than the one immediately
+    // preceding it (skipped over a webpage, or, rarely, one since
+    // deleted from the playlist) and briefly reappear before the new
+    // fetch lands. Accepted: a short-lived stale frame beats a black
+    // one, and the window is bounded by one network round-trip.
+    QImage lastRasterImage;
+    // True only while a real (non-"null") loadImage() fetch is
+    // outstanding. Set in loadImage() when such a fetch starts, and
+    // cleared on every terminal outcome of that fetch (success,
+    // network error, or decode failure, see the ``finished`` handler
+    // in loadImage()) so a failed fetch goes black rather than leaving
+    // a stale asset on screen, which would be indistinguishable from
+    // a successful rotation. Gates the lastRasterImage fallback in
+    // paintEvent() so it never fires for the video-onset or
+    // loadPage() blanks.
+    bool fallbackToLastImageOnBlank = false;
     QMovie* movie;
     bool isAnimatedImage;
     quint64 loadGenerationId;

--- a/src/anthias_webview/tests/test_image_fallback.cpp
+++ b/src/anthias_webview/tests/test_image_fallback.cpp
@@ -1,0 +1,65 @@
+// QtTest unit tests for the black-flash fallback predicate
+// (src/image_fallback.cpp). Pure boolean logic, so this runs against
+// QtCore alone: no display, no QtWebEngine. Hosted by the
+// runImageFallbackTests factory that test_videoview.cpp's main()
+// execs (QTEST_MAIN can only host one class per binary).
+//
+// Scope: this pins only the extracted predicate, given
+// (currentImageIsNull, fallbackAllowed), which image paintEvent()
+// should use. It does NOT pin which code paths set or clear
+// fallbackAllowed (the "null" sentinel, playVideo(), loadPage(), and
+// the QNetworkReply finished handler in View::loadImage()), that
+// lifecycle still lives in view.cpp, which this test binary doesn't
+// link (tests.pro excludes it to stay QtWebEngine-free). A regression
+// in which paths set/clear the flag would not be caught here.
+
+#include <QObject>
+#include <QTest>
+
+#include "image_fallback.h"
+
+class TestImageFallback : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // Nothing to fall back to when there's already a real image on
+    // screen: currentImage isn't null, so the flag doesn't matter.
+    void currentImageNotNullNeverFallsBack_data()
+    {
+        QTest::addColumn<bool>("fallbackAllowed");
+        QTest::newRow("allowed") << true;
+        QTest::newRow("not-allowed") << false;
+    }
+    void currentImageNotNullNeverFallsBack()
+    {
+        QFETCH(bool, fallbackAllowed);
+        QVERIFY(!image_fallback::shouldUseLastRasterImage(
+            /*currentImageIsNull=*/false, fallbackAllowed));
+    }
+
+    // The three intentional blanks (playVideo(), the "null" sentinel,
+    // loadPage()) all leave the flag false: must paint pure black,
+    // never the stale frame.
+    void intentionalBlankStaysBlack()
+    {
+        QVERIFY(!image_fallback::shouldUseLastRasterImage(
+            /*currentImageIsNull=*/true, /*fallbackAllowed=*/false));
+    }
+
+    // A real fetch in flight from a blanked state (post-video) shows
+    // the last real frame instead of black - the fix this PR adds.
+    void inFlightFetchFromBlankUsesFallback()
+    {
+        QVERIFY(image_fallback::shouldUseLastRasterImage(
+            /*currentImageIsNull=*/true, /*fallbackAllowed=*/true));
+    }
+};
+
+int runImageFallbackTests(int argc, char** argv)
+{
+    TestImageFallback tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include "test_image_fallback.moc"

--- a/src/anthias_webview/tests/test_videoview.cpp
+++ b/src/anthias_webview/tests/test_videoview.cpp
@@ -228,13 +228,15 @@ private:
     }
 };
 
-// Combined entry point: this binary hosts two independent QtTest
-// classes — TestVideoView (here) and TestRotation (test_rotation.cpp,
-// run via the runRotationTests factory so its class stays private to
-// its own translation unit). QTEST_MAIN can only host one, so we exec
-// each in turn and OR their exit codes. QApplication (not
-// QCoreApplication) because the VideoView tests need the widgets stack.
+// Combined entry point: this binary hosts three independent QtTest
+// classes: TestVideoView (here), TestRotation (test_rotation.cpp)
+// and TestImageFallback (test_image_fallback.cpp), the latter two run
+// via factories so their classes stay private to their own
+// translation unit. QTEST_MAIN can only host one, so we exec each in
+// turn and OR their exit codes. QApplication (not QCoreApplication)
+// because the VideoView tests need the widgets stack.
 extern int runRotationTests(int argc, char** argv);
+extern int runImageFallbackTests(int argc, char** argv);
 
 int main(int argc, char** argv)
 {
@@ -245,6 +247,7 @@ int main(int argc, char** argv)
         status |= QTest::qExec(&tc, argc, argv);
     }
     status |= runRotationTests(argc, argv);
+    status |= runImageFallbackTests(argc, argv);
     return status;
 }
 #include "test_videoview.moc"

--- a/src/anthias_webview/tests/tests.pro
+++ b/src/anthias_webview/tests/tests.pro
@@ -18,16 +18,21 @@ CONFIG += c++17 console testcase
 # TestRotation — QTEST_MAIN only hosts one class). The qrc carries the
 # QML scene (videoview.qml) the production widget loads. rotation.cpp is
 # deliberately QtCore-only (no View / QtWebEngine) so these tests link
-# without the webengine modules.
+# without the webengine modules. image_fallback.cpp is the same shape:
+# the black-flash fallback's paint/no-paint decision, extracted from
+# View::paintEvent() so it's covered here too.
 SOURCES += \
     ../src/videoview.cpp \
     ../src/rotation.cpp \
+    ../src/image_fallback.cpp \
     test_videoview.cpp \
-    test_rotation.cpp
+    test_rotation.cpp \
+    test_image_fallback.cpp
 
 HEADERS += \
     ../src/videoview.h \
-    ../src/rotation.h
+    ../src/rotation.h \
+    ../src/image_fallback.h
 
 RESOURCES += ../src/videoview.qrc
 


### PR DESCRIPTION
### Issues Fixed

Fixes #3262

### Description

Reduces black screen time during the image-fetch portion of a video-to-image transition, by falling back to the last real raster frame while a fresh loadImage() fetch is in flight, instead of painting black for the whole round-trip. Applies to any real image load that starts from a blanked state (also covers webpage-to-image), documented in the view.h comment on lastRasterImage.

Does not address the video-surface teardown time (~460ms on Pi 4, separate from the fetch) or the deliberate blanks in playVideo()/loadPage().

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [x] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [x] I added a documentation for the changes I have made (when necessary).