### PR TITLE
fix(auth): answer htmx callers with HX-Redirect, not a 302

### DIFF
--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -11,7 +11,9 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import './home'
 
 type Toast = { kind: string; message: string; ttlMs?: number }
-type Outcome = { status: number } | { transport: true }
+type Outcome =
+  | { status: number; hxRedirect?: string }
+  | { transport: true }
 
 const realXhr = globalThis.XMLHttpRequest
 
@@ -31,7 +33,10 @@ function stubXhr(outcomes: Outcome[]): void {
         upload: { addEventListener: () => {} },
         open: () => {},
         setRequestHeader: () => {},
-        getResponseHeader: () => null,
+        getResponseHeader: (name: string) =>
+          name === 'HX-Redirect' && 'hxRedirect' in outcome
+            ? (outcome.hxRedirect ?? null)
+            : null,
         addEventListener(type: string, fn: () => void) {
           ;(handlers[type] ??= []).push(fn)
         },
@@ -102,6 +107,18 @@ describe('uploadFiles error reporting', () => {
       'Upload failed mid-transfer — check your connection, or try a ' +
         'smaller file',
     )
+  })
+
+  // The expired-session case: a 2xx carrying HX-Redirect must abort
+  // the batch and navigate, not count as a stored file.
+  test('an HX-Redirect aborts the batch instead of reporting success', async () => {
+    stubXhr([{ status: 204, hxRedirect: '/login/' }])
+    const app = window.homeApp()
+    app.mode = 'add'
+    await app.uploadFiles(fileInput('doomed.mp4'))
+
+    expect(refreshes).toEqual([])
+    expect(app.mode).toBe('add')
   })
 
   test('an unremarkable 400 keeps the original wording', async () => {

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -487,6 +487,18 @@ function homeApp(): HomeAppData {
           if (ev.loaded >= ev.total) this.uploadState = 'processing'
         })
         xhr.addEventListener('load', () => {
+          // An expired session answers with HX-Redirect rather than a
+          // 302 (see lib/auth._login_redirect): a redirect would be
+          // followed transparently and hand us the login page under a
+          // 200, which reads as a successful upload for a file that
+          // was never stored. Nothing here is htmx-managed, so act on
+          // the header ourselves and send the operator to sign in.
+          const redirect = xhr.getResponseHeader('HX-Redirect')
+          if (redirect) {
+            window.location.href = redirect
+            resolve({ status: 'error', failure: { kind: 'auth' } })
+            return
+          }
           const kind = fireToastFromHeader(xhr.getResponseHeader('HX-Trigger'))
           if (xhr.status < 200 || xhr.status >= 300) {
             // Pass the status up so the batch can name the cause. A

--- a/src/anthias_server/app/static/src/home/upload-error.test.ts
+++ b/src/anthias_server/app/static/src/home/upload-error.test.ts
@@ -57,6 +57,14 @@ describe('uploadErrorMessage', () => {
     )
   })
 
+  // Rarely rendered, since the caller navigates to the login page on
+  // this, but a slow navigation should still explain itself.
+  test('an expired session names the session, not the file', () => {
+    expect(uploadErrorMessage({ kind: 'auth' })).toBe(
+      'Your session expired — sign in again to upload',
+    )
+  })
+
   // A stray status 0 should never reach here (the caller maps it to
   // `network`), but pin the fallback so a leak can't render an empty
   // or nonsensical toast.

--- a/src/anthias_server/app/static/src/home/upload-error.ts
+++ b/src/anthias_server/app/static/src/home/upload-error.ts
@@ -18,8 +18,19 @@
 export type UploadFailure =
   | { kind: 'http'; status: number }
   | { kind: 'network' }
+  // The session expired: the server answered with HX-Redirect and the
+  // caller is navigating to the login page. Carries no status because
+  // the response was a perfectly ordinary 2xx.
+  | { kind: 'auth' }
 
 export function uploadErrorMessage(failure: UploadFailure): string {
+  // Usually unseen, since the caller navigates away on this. Worth
+  // having anyway: if the navigation is slow the operator gets an
+  // explanation rather than a blank moment.
+  if (failure.kind === 'auth') {
+    return 'Your session expired — sign in again to upload'
+  }
+
   // Both causes, neither asserted. A proxy enforcing a body limit
   // answers and closes while the browser is still writing, and the
   // browser does not always salvage that response — so a size

--- a/src/anthias_server/lib/auth.py
+++ b/src/anthias_server/lib/auth.py
@@ -345,13 +345,35 @@ def _is_safe_login_next_source(request: HttpRequest) -> bool:
 
 def _login_redirect(request: HttpRequest) -> HttpResponse:
     """Send an unauthenticated request to the login page, preserving
-    the original destination via ``?next=`` when it's safe to do so."""
+    the original destination via ``?next=`` when it's safe to do so.
+
+    An htmx request gets ``HX-Redirect`` instead of a 302. A redirect
+    is meant for a browser navigating, and neither caller that reaches
+    this from JavaScript can act on one: XMLHttpRequest and fetch both
+    follow it transparently and hand the caller the *login page* under
+    a 200. htmx then swaps that whole page into whatever fragment it
+    asked for, and the raw-XHR uploader in home.ts reads the 200 as a
+    successful upload and reports a file as stored that never left the
+    browser. Naming the destination in a header the client can see
+    lets both do the right thing: htmx navigates to the login page,
+    and the uploader can tell an expired session from a stored file.
+
+    ``next`` is already dropped for htmx by _is_safe_login_next_source,
+    so the bare login URL is the whole answer here.
+    """
     from urllib.parse import urlencode
 
+    from django.http import HttpResponse as _HttpResponse
     from django.shortcuts import redirect
     from django.urls import reverse
 
     login_url = reverse('anthias_app:login')
+    if request.headers.get('HX-Request') is not None:
+        # 204: there is no body worth swapping, and htmx honours
+        # HX-Redirect regardless of status.
+        response = _HttpResponse(status=204)
+        response['HX-Redirect'] = login_url
+        return response
     if not _is_safe_login_next_source(request):
         return redirect(login_url)
     # request.get_full_path() preserves any query string. The login

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -177,10 +177,61 @@ def test_authorized_drops_next_for_unsafe_methods(monkeypatch: Any) -> None:
         assert 'next=' not in response['Location']
 
 
-def test_authorized_drops_next_for_htmx_partial(monkeypatch: Any) -> None:
+def test_authorized_answers_htmx_with_hx_redirect(monkeypatch: Any) -> None:
+    """An htmx caller cannot act on a 302: XMLHttpRequest and fetch
+    follow it themselves and hand the caller the login page under a
+    200. htmx would swap that whole page into the fragment it asked
+    for, and the raw-XHR uploader in home.ts reads the 200 as a
+    successful upload. Answer with HX-Redirect, which the client can
+    actually see."""
+    fake_settings = {'auth_backend': 'auth_basic'}
+    monkeypatch.setattr('anthias_server.settings.settings', fake_settings)
+
+    @authorized
+    def view(request: Any) -> str:
+        return 'ok'
+
+    factory = RequestFactory()
+    request = factory.post('/assets/upload/', HTTP_HX_REQUEST='true')
+    request.user = MagicMock(is_authenticated=False)
+    response = view(request)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == 204
+    assert response['HX-Redirect'].endswith('/login/')
+    # Must not also be a redirect: a Location header would be followed
+    # transparently and defeat the whole point.
+    assert not response.has_header('Location')
+
+
+def test_authorized_still_redirects_a_plain_navigation(
+    monkeypatch: Any,
+) -> None:
+    """Only htmx callers get the header treatment. A browser typing a
+    URL still wants a real 302 to the login page."""
+    fake_settings = {'auth_backend': 'auth_basic'}
+    monkeypatch.setattr('anthias_server.settings.settings', fake_settings)
+
+    @authorized
+    def view(request: Any) -> str:
+        return 'ok'
+
+    factory = RequestFactory()
+    request = factory.get('/settings/')
+    request.user = MagicMock(is_authenticated=False)
+    response = view(request)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == 302
+    assert not response.has_header('HX-Redirect')
+
+
+def test_authorized_sends_htmx_partial_to_bare_login(
+    monkeypatch: Any,
+) -> None:
     """Dashboard polls htmx fragments every 5s; if the session expires
-    mid-poll we'd otherwise serialize the partial URL into next,
-    dumping the operator on a bare table fragment after sign-in."""
+    mid-poll we must not serialize the partial URL into next, which
+    would dump the operator on a bare table fragment after sign-in.
+    The destination now rides on HX-Redirect rather than a 302 (see
+    _login_redirect), so the same guarantee is asserted there."""
     fake_settings = {'auth_backend': 'auth_basic'}
     monkeypatch.setattr('anthias_server.settings.settings', fake_settings)
 
@@ -193,9 +244,9 @@ def test_authorized_drops_next_for_htmx_partial(monkeypatch: Any) -> None:
     request.user = MagicMock(is_authenticated=False)
     response = view(request)
     assert isinstance(response, HttpResponse)
-    assert response.status_code == 302
-    assert response['Location'].endswith('/login/')
-    assert 'next=' not in response['Location']
+    assert response.status_code == 204
+    assert response['HX-Redirect'].endswith('/login/')
+    assert 'next=' not in response['HX-Redirect']
 
 
 def test_authorized_no_args_raises(monkeypatch: Any) -> None:


### PR DESCRIPTION
### Issues Fixed

No existing issue. I found this while working on the upload error messages in #3302: if your session expires while the Add asset modal is open, the upload reports success and the file is never stored, but nothing on screen says otherwise.

The rest is all Claude 5 Opus.

### Description

`@authorized` answers an unauthenticated request with a 302 to `/login/`. That is the right answer for a browser navigating to a page, and but wrong for anything calling from JavaScript, because XMLHttpRequest and fetch both follow redirects themselves. The 302 is consumed before any client code runs, so what arrives is the login page with a status of 200.

Two callers reach `_login_redirect` from JavaScript, and both handle that badly:

1. **The six htmx endpoints.** htmx swaps the response into whatever fragment it asked for, so an expired session replaces the asset table with a whole login page rendered inside the table. The URL bar still says `/`.
2. **The uploader in `home.ts`.** It is raw XHR and treats any 2xx without an error toast as success, so it counts the file as uploaded, closes the modal, refreshes the table, and reports nothing wrong.

The second one is silent data loss, which is why I went looking for a root fix rather than a client-side check. There is no client-side check available: you cannot see a redirect that the browser already followed for you.

So the server now says what it means. When the request carries `HX-Request`, `_login_redirect` answers `204` with an `HX-Redirect` header instead of a 302. htmx acts on that natively and navigates to the login page. The uploader is not htmx-managed, so it reads the header itself and does the same.

**Requests without the header are untouched.** A browser typing a URL or following a link still gets its 302 with `?next=` filled in, which is what it wants. Only the six htmx endpoints and the uploader change, and all seven were already doing something wrong.

The decorator already treated htmx requests specially: `_is_safe_login_next_source` drops the fragment URL from `?next=` so signing in doesn't land you on a bare table partial. This finishes that thought rather than introducing a new concept.

One existing test changed. `test_authorized_drops_next_for_htmx_partial` asserted the old 302 contract, so it now asserts the same guarantee against `HX-Redirect`, with its docstring updated to say why.

### Testing

I ran a dev stack with auth enabled and deleted the session cookie to simulate expiry.

Same URL, same expired session, with and without the header:

```
GET /_partials/asset-table/  HX-Request: true  ->  204, HX-Redirect: /login/
GET /_partials/asset-table/  (no header)       ->  302, Location: /login/?next=...
```

Uploading a file with an expired session, measured on both sides:

| | master | this branch |
|---|---|---|
| Assets in the database | 7 -> 7 | 7 -> 7 |
| Ends up on | `/`, modal closed | `/login/` |
| Toasts shown | none | navigated away |

Master stores nothing and says nothing: the modal closes exactly as it does on success.

I also left the dashboard idle for 12 seconds with an expired session and touched nothing. On master the 5s table poll leaves you on `/` with a password field where the asset table used to be. On this branch it navigates to the login page.

44 tests in `tests/test_auth.py`, 1992 in the suite overall, and 99 frontend tests pass. `ruff check`, `ruff format --check` and `mypy` are clean on the changed files.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

Tested against a dev stack rather than on hardware. My only Pi is in use at the moment so I can't test it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
