### PR TITLE
feat(upload): send large assets in chunks so they clear a proxy body limit

### DIFF
--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -154,6 +154,19 @@ if [[ -f /etc/anthias/proxy.env ]]; then
     set +a
 fi
 
+# Operator-set device variables, same mechanism. Unlike proxy.env this
+# file is not managed by the ansible role: it is where an operator puts
+# a setting that has to survive an upgrade. This script regenerates
+# docker-compose.yml from the template on every run and passes -f
+# explicitly, so an edit to the generated file — or a
+# docker-compose.override.yml — does not survive one. Absent by
+# default; every variable it can carry works when unset.
+if [[ -f /etc/anthias/anthias.env ]]; then
+    set -a
+    . /etc/anthias/anthias.env
+    set +a
+fi
+
 cat /home/${USER}/anthias/docker-compose.yml.tmpl \
     | envsubst \
     > /home/${USER}/anthias/docker-compose.yml

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -154,19 +154,6 @@ if [[ -f /etc/anthias/proxy.env ]]; then
     set +a
 fi
 
-# Operator-set device variables, same mechanism. Unlike proxy.env this
-# file is not managed by the ansible role: it is where an operator puts
-# a setting that has to survive an upgrade. This script regenerates
-# docker-compose.yml from the template on every run and passes -f
-# explicitly, so an edit to the generated file — or a
-# docker-compose.override.yml — does not survive one. Absent by
-# default; every variable it can carry works when unset.
-if [[ -f /etc/anthias/anthias.env ]]; then
-    set -a
-    . /etc/anthias/anthias.env
-    set +a
-fi
-
 cat /home/${USER}/anthias/docker-compose.yml.tmpl \
     | envsubst \
     > /home/${USER}/anthias/docker-compose.yml

--- a/conftest.py
+++ b/conftest.py
@@ -250,23 +250,62 @@ if _APP_AVAILABLE:
 
 
 @pytest.fixture(scope='session', autouse=True)
-def _ensure_assetdir() -> None:
-    """
-    Some legacy fixtures (e.g. ``api/tests/test_v1_endpoints.py::
-    cleanup_asset_dir``) iterate ``settings['assetdir']`` during
-    teardown without creating it first. The Docker test image creates
-    ``/data/anthias_assets`` in its build (see
-    ``docker/Dockerfile.test.j2``); local hosts have no such guarantee.
-    Materialise the path once per session so those fixtures don't
-    ``FileNotFoundError`` out before the test even runs.
+def _isolated_assetdir(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[None]:
+    """Point ``settings['assetdir']`` at a temp directory for the run.
+
+    Upload tests write real files. Unpatched, ``assetdir`` resolves to
+    ``~/anthias_assets`` — a developer's actual asset directory on a
+    host run, and a directory the suite has no business writing into.
+    The path also has to exist before a test touches it: the Docker
+    test image creates ``/data/anthias_assets`` in its build (see
+    ``docker/Dockerfile.test.j2``), local hosts guarantee nothing.
+
+    Redirecting the config file is what makes it hold, rather than
+    just setting the key. ``AnthiasSettings.load()`` rebuilds
+    ``assetdir`` from whatever the config file says — and ``save()``
+    ends in a ``load()`` — so setting the key alone is undone by the
+    next settings-saving test in the same worker. Patching ``home``
+    does not help either: the config stores an absolute
+    ``assetdir = /home/<user>/anthias_assets``, and ``path.join`` with
+    an absolute second argument discards the first.
+
+    So the singleton is pointed at a temp config that carries the temp
+    path, written from the values already in memory. Every later
+    ``load()`` then resolves back to the temp directory, including the
+    one in ``_isolated_settings_conf``'s teardown, which restores
+    whatever ``conf_file`` it found — this one.
     """
     if not _APP_AVAILABLE:
+        yield
         return
+    from unittest import mock
+
     from anthias_server.settings import settings as _anthias_settings
 
-    asset_dir = _anthias_settings.get('assetdir')
-    if asset_dir:
-        os.makedirs(asset_dir, exist_ok=True)
+    home = tmp_path_factory.mktemp('home')
+    asset_dir = home / 'anthias_assets'
+    asset_dir.mkdir()
+    conf_file = str(home / 'anthias.conf')
+    original_conf_file = _anthias_settings.conf_file
+    try:
+        with mock.patch.dict(_anthias_settings, {'assetdir': str(asset_dir)}):
+            _anthias_settings.conf_file = conf_file
+            # Writes the values already in memory — the developer's
+            # real settings — with `assetdir` redirected. `database`
+            # is redirected too: `_get` rebuilds both from the config
+            # the same way, so leaving one behind would point the
+            # suite at the real SQLite file. The secret key is blanked
+            # rather than copied into a world-readable-by-default
+            # temp tree.
+            _anthias_settings['database'] = str(home / 'anthias.db')
+            _anthias_settings['django_secret_key'] = ''
+            _anthias_settings.save()
+            yield
+    finally:
+        _anthias_settings.conf_file = original_conf_file
+        _anthias_settings.load()
 
 
 def pytest_collection_modifyitems(

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,6 +17,10 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - ENVIRONMENT=development
+      # So the chunked-upload path can be exercised in dev — set it in
+      # your shell before `docker compose up`. Empty means the 16 MB
+      # default, same as production.
+      - ANTHIAS_UPLOAD_CHUNK_SIZE_MB=${ANTHIAS_UPLOAD_CHUNK_SIZE_MB:-}
     depends_on:
       redis:
         condition: service_healthy
@@ -24,11 +28,6 @@ services:
     volumes:
       - anthias-data:/data
       - ./:/usr/src/app/
-    environment:
-      # So the chunked-upload path can actually be exercised in dev —
-      # set it in your shell before `docker compose up`. Empty means
-      # the 16 MB default, same as production.
-      - ANTHIAS_UPLOAD_CHUNK_SIZE_MB=${ANTHIAS_UPLOAD_CHUNK_SIZE_MB:-}
 
   anthias-celery:
     # Reuses anthias-server:dev via the explicit image tag above.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,6 +24,11 @@ services:
     volumes:
       - anthias-data:/data
       - ./:/usr/src/app/
+    environment:
+      # So the chunked-upload path can actually be exercised in dev —
+      # set it in your shell before `docker compose up`. Empty means
+      # the 16 MB default, same as production.
+      - ANTHIAS_UPLOAD_CHUNK_SIZE_MB=${ANTHIAS_UPLOAD_CHUNK_SIZE_MB:-}
 
   anthias-celery:
     # Reuses anthias-server:dev via the explicit image tag above.

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -29,10 +29,12 @@ services:
       - no_proxy=${no_proxy}
       # Chunk size for large browser uploads, for an operator behind a
       # proxy that caps request bodies. Empty when unset, which the
-      # server reads as "use the default". Set it durably in
-      # /etc/anthias/anthias.env, which upgrade_containers.sh sources
-      # before envsubst; balena devices use a dashboard variable
-      # instead, which the supervisor injects into every service.
+      # server reads as "use the default". The durable place to set it
+      # is `upload_chunk_size_mb` in ~/.anthias/anthias.conf, which
+      # wins over this and survives an upgrade; balena devices use a
+      # dashboard variable, which the supervisor injects into every
+      # service. This entry only carries a value exported into the
+      # environment of the run that renders the template.
       - ANTHIAS_UPLOAD_CHUNK_SIZE_MB=${ANTHIAS_UPLOAD_CHUNK_SIZE_MB}
     # Gate startup on redis actually answering PING (see the
     # healthcheck on the redis service below) — plain service_started

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -27,6 +27,13 @@ services:
       - http_proxy=${http_proxy}
       - https_proxy=${https_proxy}
       - no_proxy=${no_proxy}
+      # Chunk size for large browser uploads, for an operator behind a
+      # proxy that caps request bodies. Empty when unset, which the
+      # server reads as "use the default". Set it durably in
+      # /etc/anthias/anthias.env, which upgrade_containers.sh sources
+      # before envsubst; balena devices use a dashboard variable
+      # instead, which the supervisor injects into every service.
+      - ANTHIAS_UPLOAD_CHUNK_SIZE_MB=${ANTHIAS_UPLOAD_CHUNK_SIZE_MB}
     # Gate startup on redis actually answering PING (see the
     # healthcheck on the redis service below) — plain service_started
     # only orders container creation, so uvicorn's first Channels /

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -65,7 +65,8 @@ def clamp_screen_rotation(value: Any) -> int:
 # bind-mounts .anthias and anthias_assets separately, and rename(2)
 # across two mounts is EXDEV even on one filesystem — the commit would
 # become a full copy of a multi-GB file onto an SD card, needing twice
-# the free space. views_files closes the fetchability that costs us.
+# the free space. views_files closes the fetchability that costs us,
+# for this and for the API and import staging files already here.
 STAGED_UPLOAD_DIR = '.uploads'
 
 # How long a partial survives without being written to. An abandoned

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -57,24 +57,22 @@ def clamp_screen_rotation(value: Any) -> int:
 
 
 # Where chunked browser uploads stage their partial file, under the
-# asset dir. Shared with the cleanup sweep and the backup filter so
-# the name cannot drift from the code that writes into it.
+# asset dir. Shared with the cleanup sweep and the backup filter so the
+# name cannot drift from the code writing into it.
 #
-# It has to live inside the asset dir, tempting as ~/.anthias looks
-# for something never meant to be served: docker-compose.yml.tmpl
+# It has to be the asset dir, tempting as ~/.anthias looks for
+# something never meant to be served: docker-compose.yml.tmpl
 # bind-mounts .anthias and anthias_assets separately, and rename(2)
-# across two mounts is EXDEV even when they share a filesystem. The
-# commit would become a full copy of a multi-GB file onto an SD card,
-# needing twice the free space. anthias_assets serves this tree, so
-# the fetchability that costs us is closed in views_files instead.
+# across two mounts is EXDEV even on one filesystem — the commit would
+# become a full copy of a multi-GB file onto an SD card, needing twice
+# the free space. views_files closes the fetchability that costs us.
 STAGED_UPLOAD_DIR = '.uploads'
 
-# How long a partial upload survives without being written to. An
-# upload cannot be resumed once abandoned, so holding one longer only
-# occupies the card; the same hour every other stray file in the asset
-# dir gets is enough to cover a slow upload still in progress. A
-# partial swept mid-upload is caught by the offset guard in
-# _stage_upload_chunk and fails loudly rather than corrupting.
+# How long a partial survives without being written to. An abandoned
+# upload cannot be resumed, so holding it longer only occupies the
+# card, and the hour every other stray file in the asset dir gets
+# covers a slow upload still in progress. One swept mid-upload trips
+# the offset guard in _stage_upload_chunk: loud, not corrupt.
 STAGED_UPLOAD_MAX_AGE_MIN = 60
 
 

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -61,19 +61,14 @@ def clamp_screen_rotation(value: Any) -> int:
 # the name cannot drift from the code that writes into it.
 STAGED_UPLOAD_DIR = '.uploads'
 
-# How long a partial upload survives without being written to. A full
-# day rather than the hour every other stray file in the asset dir
-# gets: an operator who pauses a large upload should find their bytes
-# still there, and a partial swept mid-upload is recreated by the next
-# chunk's seek as a sparse file, so the finished asset would be
-# silently corrupt instead of failing.
-STAGED_UPLOAD_MAX_AGE_MIN = 60 * 24
+# How long a partial upload survives without being written to. An
+# upload cannot be resumed once abandoned, so holding one longer only
+# occupies the card; the same hour every other stray file in the asset
+# dir gets is enough to cover a slow upload still in progress. A
+# partial swept mid-upload is caught by the offset guard in
+# _stage_upload_chunk and fails loudly rather than corrupting.
+STAGED_UPLOAD_MAX_AGE_MIN = 60
 
-# Headroom an upload must leave free on the device. A player that
-# fills its card stops being a player: the viewer cannot write, and
-# SQLite cannot either. 512 MB is roughly a normalisation pass plus
-# room for the database to breathe.
-STAGED_UPLOAD_FREE_MARGIN = 512 * 1024 * 1024
 
 # Operator-facing message for ENOSPC during an upload — shared by the
 # HTML upload toast and the API's 507 response so the wording can't

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -56,6 +56,25 @@ def clamp_screen_rotation(value: Any) -> int:
     return rotation if rotation in SCREEN_ROTATION_CHOICES else 0
 
 
+# Where chunked browser uploads stage their partial file, under the
+# asset dir. Shared with the cleanup sweep and the backup filter so
+# the name cannot drift from the code that writes into it.
+STAGED_UPLOAD_DIR = '.uploads'
+
+# How long a partial upload survives without being written to. A full
+# day rather than the hour every other stray file in the asset dir
+# gets: an operator who pauses a large upload should find their bytes
+# still there, and a partial swept mid-upload is recreated by the next
+# chunk's seek as a sparse file, so the finished asset would be
+# silently corrupt instead of failing.
+STAGED_UPLOAD_MAX_AGE_MIN = 60 * 24
+
+# Headroom an upload must leave free on the device. A player that
+# fills its card stops being a player: the viewer cannot write, and
+# SQLite cannot either. 512 MB is roughly a normalisation pass plus
+# room for the database to breathe.
+STAGED_UPLOAD_FREE_MARGIN = 512 * 1024 * 1024
+
 # Operator-facing message for ENOSPC during an upload — shared by the
 # HTML upload toast and the API's 507 response so the wording can't
 # drift between surfaces (Sentry ANTHIAS-3K).

--- a/src/anthias_common/utils.py
+++ b/src/anthias_common/utils.py
@@ -59,6 +59,14 @@ def clamp_screen_rotation(value: Any) -> int:
 # Where chunked browser uploads stage their partial file, under the
 # asset dir. Shared with the cleanup sweep and the backup filter so
 # the name cannot drift from the code that writes into it.
+#
+# It has to live inside the asset dir, tempting as ~/.anthias looks
+# for something never meant to be served: docker-compose.yml.tmpl
+# bind-mounts .anthias and anthias_assets separately, and rename(2)
+# across two mounts is EXDEV even when they share a filesystem. The
+# commit would become a full copy of a multi-GB file onto an SD card,
+# needing twice the free space. anthias_assets serves this tree, so
+# the fetchability that costs us is closed in views_files instead.
 STAGED_UPLOAD_DIR = '.uploads'
 
 # How long a partial upload survives without being written to. An

--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -3,6 +3,7 @@ Tests for V1 API endpoints.
 """
 
 import os
+import shutil
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -30,8 +31,14 @@ def cleanup_asset_dir() -> Iterator[None]:
         yield
     finally:
         asset_directory_path = Path(anthias_settings['assetdir'])
-        for file in asset_directory_path.iterdir():
-            file.unlink()
+        for entry in asset_directory_path.iterdir():
+            # The asset dir is no longer flat: chunked uploads stage
+            # their partials in a subdirectory of it, so unlink() alone
+            # raises IsADirectoryError once one exists.
+            if entry.is_dir():
+                shutil.rmtree(entry, ignore_errors=True)
+            else:
+                entry.unlink()
 
 
 def _get_asset_content_url(asset_id: str) -> str:

--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -3,7 +3,6 @@ Tests for V1 API endpoints.
 """
 
 import os
-import shutil
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -26,19 +25,21 @@ def api_client() -> APIClient:
 
 
 @pytest.fixture
-def cleanup_asset_dir() -> Iterator[None]:
-    try:
+def cleanup_asset_dir(tmp_path: Path) -> Iterator[None]:
+    """Give the test its own asset dir.
+
+    This used to empty ``settings['assetdir']`` on teardown, which is
+    one real directory — ~/anthias_assets on a developer's machine —
+    shared by every xdist worker. Under ``pytest -n auto`` one worker's
+    teardown deleted files another worker was still using, which
+    surfaced as rare failures in whichever upload test happened to be
+    mid-request. It also emptied a developer's actual asset directory,
+    the hazard the backup tests' own fixture calls out.
+    """
+    asset_dir = tmp_path / 'anthias_assets'
+    asset_dir.mkdir()
+    with mock.patch.dict(anthias_settings, {'assetdir': str(asset_dir)}):
         yield
-    finally:
-        asset_directory_path = Path(anthias_settings['assetdir'])
-        for entry in asset_directory_path.iterdir():
-            # The asset dir is no longer flat: chunked uploads stage
-            # their partials in a subdirectory of it, so unlink() alone
-            # raises IsADirectoryError once one exists.
-            if entry.is_dir():
-                shutil.rmtree(entry, ignore_errors=True)
-            else:
-                entry.unlink()
 
 
 def _get_asset_content_url(asset_id: str) -> str:

--- a/src/anthias_server/api/tests/test_v1_endpoints.py
+++ b/src/anthias_server/api/tests/test_v1_endpoints.py
@@ -25,8 +25,12 @@ def api_client() -> APIClient:
 
 
 @pytest.fixture
-def cleanup_asset_dir(tmp_path: Path) -> Iterator[None]:
+def isolated_asset_dir(tmp_path: Path) -> Iterator[None]:
     """Give the test its own asset dir.
+
+    Named for what it does: it isolates, it does not clean up. Most of
+    its users never write into the asset dir at all — the dependency is
+    vestigial there, so don't read coverage into it.
 
     This used to empty ``settings['assetdir']`` on teardown, which is
     one real directory — ~/anthias_assets on a developer's machine —
@@ -47,7 +51,9 @@ def _get_asset_content_url(asset_id: str) -> str:
 
 
 @pytest.mark.django_db
-def test_asset_content(api_client: APIClient, cleanup_asset_dir: None) -> None:
+def test_asset_content(
+    api_client: APIClient, isolated_asset_dir: None
+) -> None:
     asset = Asset.objects.create(**ASSET_CREATION_DATA)
     asset_id = asset.asset_id
 
@@ -60,7 +66,7 @@ def test_asset_content(api_client: APIClient, cleanup_asset_dir: None) -> None:
 
 
 @pytest.mark.django_db
-def test_file_asset(api_client: APIClient, cleanup_asset_dir: None) -> None:
+def test_file_asset(api_client: APIClient, isolated_asset_dir: None) -> None:
     image_path = os.path.join(
         django_settings.BASE_DIR,
         'src/anthias_server/app/static/img/standby.png',
@@ -93,7 +99,7 @@ def test_file_asset_rejects_list_body(api_client: APIClient) -> None:
 
 @pytest.mark.django_db
 def test_file_asset_disk_full_returns_507(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """ENOSPC while writing the upload must come back as an actionable
     507 with the shared disk-full message, not an unhandled 500
@@ -124,7 +130,7 @@ def test_file_asset_disk_full_returns_507(
 
 @pytest.mark.django_db
 def test_file_asset_disk_full_during_parse_returns_507(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """The ANTHIAS-3K stack is ENOSPC during the multipart parse
     (Django spooling the body to a temp file), surfaced when the view
@@ -155,7 +161,7 @@ def test_file_asset_disk_full_during_parse_returns_507(
 
 @pytest.mark.django_db
 def test_file_asset_disk_full_during_write_cleans_up_partial(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """When the disk fills mid-write (open() succeeds, f.write() then
     raises ENOSPC), the handler must remove the partial .tmp and still
@@ -190,7 +196,7 @@ def test_file_asset_disk_full_during_write_cleans_up_partial(
 
 @pytest.mark.django_db
 def test_file_asset_chunked_out_of_order_reassembles(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """A resumable (Content-Range) upload must reassemble correctly
     even when chunks arrive out of order. Append mode ignored the
@@ -253,7 +259,7 @@ def test_file_asset_chunked_out_of_order_reassembles(
     ],
 )
 def test_file_asset_malformed_content_range_returns_400(
-    api_client: APIClient, cleanup_asset_dir: None, header: str
+    api_client: APIClient, isolated_asset_dir: None, header: str
 ) -> None:
     """A client-controlled ``Content-Range`` header must be validated:
     a syntactically malformed value or inconsistent numeric bounds
@@ -274,7 +280,7 @@ def test_file_asset_malformed_content_range_returns_400(
 
 @pytest.mark.django_db
 def test_file_asset_content_range_chunk_length_mismatch_returns_400(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """The chunk body length must match the declared range; a mismatch
     (here 4 bytes for a claimed 10-byte range) is a 400, not a silently
@@ -295,7 +301,7 @@ def test_file_asset_content_range_chunk_length_mismatch_returns_400(
 
 @pytest.mark.django_db
 def test_file_asset_same_name_uploads_are_isolated(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """Two uploads of the same filename must stage at different temp
     paths so they can't clobber or bleed into each other (issue #3135).
@@ -331,7 +337,7 @@ def test_file_asset_same_name_uploads_are_isolated(
 
 @pytest.mark.django_db
 def test_file_asset_content_range_truncates_on_shrink(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """Within one upload session (shared ``upload_id``), the final chunk
     truncates to the declared total so a shrunk re-write can't inherit
@@ -369,7 +375,7 @@ def test_file_asset_content_range_truncates_on_shrink(
 
 @pytest.mark.django_db
 def test_file_asset_malformed_upload_id_returns_400(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """``X-Upload-Id`` becomes a filesystem path, so a value that isn't
     the uuid4 hex shape we mint (here a traversal attempt) must 400
@@ -393,7 +399,7 @@ def test_file_asset_malformed_upload_id_returns_400(
 
 @pytest.mark.django_db
 def test_file_asset_upload_id_ignored_without_content_range(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     """A single-shot (no Content-Range) upload takes the ``open('wb')``
     truncating path, so ``X-Upload-Id`` must be ignored there — otherwise
@@ -531,7 +537,7 @@ def test_recover_streams_large_upload_to_disk(
 
 @pytest.mark.django_db
 def test_playlist_order(
-    api_client: APIClient, cleanup_asset_dir: None
+    api_client: APIClient, isolated_asset_dir: None
 ) -> None:
     playlist_order_url = reverse('api:playlist_order_v1')
 
@@ -578,7 +584,7 @@ def test_assets_control(
     send_to_viewer_mock: Any,
     command: str,
     api_client: APIClient,
-    cleanup_asset_dir: None,
+    isolated_asset_dir: None,
 ) -> None:
     assets_control_url = reverse('api:assets_control_v1', args=[command])
     response = api_client.get(assets_control_url)
@@ -597,7 +603,7 @@ def test_assets_control(
 def test_reboot(
     reboot_anthias_mock: Any,
     api_client: APIClient,
-    cleanup_asset_dir: None,
+    isolated_asset_dir: None,
 ) -> None:
     reboot_url = reverse('api:reboot_v1')
     response = api_client.post(reboot_url)
@@ -614,7 +620,7 @@ def test_reboot(
 def test_shutdown(
     shutdown_anthias_mock: Any,
     api_client: APIClient,
-    cleanup_asset_dir: None,
+    isolated_asset_dir: None,
 ) -> None:
     shutdown_url = reverse('api:shutdown_v1')
     response = api_client.post(shutdown_url)
@@ -631,7 +637,7 @@ def test_shutdown(
 def test_viewer_current_asset(
     send_to_viewer_mock: Any,
     api_client: APIClient,
-    cleanup_asset_dir: None,
+    isolated_asset_dir: None,
 ) -> None:
     asset = Asset.objects.create(
         **{

--- a/src/anthias_server/app/helpers.py
+++ b/src/anthias_server/app/helpers.py
@@ -44,6 +44,8 @@ def template(
     # off a <meta> tag). Sourced from Django settings so it stays
     # env-overridable in one place.
     context['app_store_index_url'] = django_settings.APP_STORE_INDEX_URL
+    # Chunk size for large uploads, read client-side off a <meta> tag.
+    context['upload_chunk_size_mb'] = django_settings.UPLOAD_CHUNK_SIZE_MB
     # Navbar needs is_balena / up_to_date / player_name on every page.
     context.update(_navbar_context())
 

--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -22,7 +22,10 @@ type ProgressLike = {
 // the body was still going out, which the server cannot have seen in
 // full.
 type Outcome =
-  | { status: number; body?: string; trigger?: string }
+  | { status: number; body?: string; trigger?: string; hxRedirect?: string }
+  // A response that arrived while the request body was still going
+  // out — what a proxy enforcing a body limit does.
+  | { status: number; body?: string; trigger?: string; bodyUnfinished: true }
   | { transport: true }
   | { transport: 'cut' }
 
@@ -67,10 +70,15 @@ function stubXhr(outcomes: Outcome[]): void {
         setRequestHeader: (name: string, value: string) => {
           headers[name] = value
         },
-        getResponseHeader: (name: string) =>
-          name === 'HX-Trigger' && 'trigger' in outcome
-            ? (outcome.trigger ?? null)
-            : null,
+        getResponseHeader: (name: string) => {
+          if (name === 'HX-Trigger' && 'trigger' in outcome) {
+            return outcome.trigger ?? null
+          }
+          if (name === 'HX-Redirect' && 'hxRedirect' in outcome) {
+            return outcome.hxRedirect ?? null
+          }
+          return null
+        },
         addEventListener(type: string, fn: () => void) {
           ;(handlers[type] ??= []).push(fn)
         },
@@ -90,7 +98,8 @@ function stubXhr(outcomes: Outcome[]): void {
           // have committed anything.
           const bodySize = requests[requests.length - 1].bodySize
           const cutMidBody =
-            'transport' in outcome && outcome.transport === 'cut'
+            ('transport' in outcome && outcome.transport === 'cut') ||
+            ('bodyUnfinished' in outcome && outcome.bodyUnfinished)
           const type = 'status' in outcome ? 'load' : 'error'
           queueMicrotask(() => {
             uploadHandlers['progress']?.forEach((fn) =>
@@ -134,10 +143,25 @@ function fileInputFrom(file: File): HTMLInputElement {
 
 let toasts: Toast[]
 let refreshes: string[]
+// window.location.href is not assignable in happy-dom, and the auth
+// path's whole job is to navigate — so record the assignment instead.
+let navigations: string[]
 
 beforeEach(() => {
   toasts = []
   refreshes = []
+  navigations = []
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      set href(url: string) {
+        navigations.push(url)
+      },
+      get href() {
+        return navigations[navigations.length - 1] ?? ''
+      },
+    },
+  })
   ;(window as unknown as { Alpine: unknown }).Alpine = {
     store: () => ({
       push: (kind: string, message: string, ttlMs?: number) =>
@@ -172,13 +196,46 @@ describe('uploadFiles error reporting', () => {
     )
   })
 
+  // Cut while the body was still going out: the server cannot have
+  // seen the whole file, so nothing was created and the operator can
+  // safely try again.
   test('a dead socket names both causes without asserting one', async () => {
-    stubXhr([{ transport: true }])
+    stubXhr([{ transport: 'cut' }])
     await window.homeApp().uploadFiles(fileInput('big-video.mp4'))
 
     expect(toasts[0]?.message).toBe(
       'Upload failed mid-transfer — check your connection, or try a ' +
         'smaller file',
+    )
+  })
+
+  // The single-shot path commits the same way a final chunk does — the
+  // server writes the file, creates the row, and answers afterwards —
+  // so a reply lost after the body went out is exactly as ambiguous
+  // here, and this is the path most uploads take.
+  test('a single-shot reply lost after the body went out is unconfirmed', async () => {
+    stubXhr([{ transport: true }])
+    const app = window.homeApp()
+    app.mode = 'add'
+    await app.uploadFiles(fileInput('big-video.mp4'))
+
+    expect(toasts[0]?.message).toBe(
+      'Upload may have finished — check the asset list before ' +
+        'uploading it again',
+    )
+    expect(app.mode).toBeNull()
+  })
+
+  // A proxy enforcing a body limit answers and closes while the
+  // browser is still writing, so the response arrives with the body
+  // unfinished. Nothing was committed, and saying "may have finished"
+  // would send the operator hunting for an asset that cannot exist.
+  test('a status answered mid-body is not called ambiguous', async () => {
+    stubXhr([{ status: 502, bodyUnfinished: true }])
+    await window.homeApp().uploadFiles(fileInput('big-video.mp4'))
+
+    expect(toasts[0]?.message).toBe(
+      'The server failed while handling the upload — check the device logs',
     )
   })
 
@@ -332,6 +389,22 @@ describe('chunked uploads', () => {
     await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(2)
+    // Not "File too large": the file was already split, so the remedy
+    // is a smaller chunk, and telling the operator to shrink the file
+    // sends them at the one thing that cannot help.
+    expect(toasts[0]?.message).toBe(
+      'Even split up, each part is too large for a proxy in front of ' +
+        'the device — lower the upload chunk size',
+    )
+  })
+
+  // The single-shot path keeps the original wording: there, the file
+  // really is what exceeded the limit.
+  test('a 413 on an unsplit upload still blames the file', async () => {
+    setChunkSizeMb('16')
+    stubXhr([{ status: 413 }])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
     expect(toasts[0]?.message).toContain('File too large')
   })
 
@@ -339,14 +412,67 @@ describe('chunked uploads', () => {
   // refusing this file and answering with its own toast, which the
   // single-shot path would have replayed. Treat it the same way: one
   // file rejected, batch intact.
-  test('a non-JSON 200 is a rejection, not a transport failure', async () => {
+  // With a toast, the server has explained itself and the file is
+  // simply refused — replay it and carry on, as single-shot does.
+  test('a non-JSON 200 with a toast is a rejection', async () => {
+    setChunkSizeMb('1')
+    stubXhr([
+      {
+        status: 200,
+        trigger: '{"toast":{"kind":"error","message":"Invalid file type."}}',
+      },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
+
+    expect(sends).toBe(1)
+    // The server's own toast stands alone — no client-invented error.
+    expect(toasts.map((t) => t.message)).toEqual(['Invalid file type.'])
+  })
+
+  // Without one, nobody has told the operator anything. A login page, a
+  // captive portal or a proxy's own 200 all look like this, and
+  // dropping the file in silence leaves no asset, no error, and a
+  // progress bar that completed normally.
+  test('a non-JSON 200 with no toast is never silent', async () => {
     setChunkSizeMb('1')
     stubXhr([{ status: 200 }])
     await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(1)
-    // No client-invented error: the server's own toast stands alone.
-    expect(toasts).toEqual([])
+    expect(toasts.length).toBe(1)
+    expect(toasts[0]?.kind).toBe('error')
+  })
+
+  // The expired-session case. An XHR follows a 302 invisibly, so the
+  // server answers 2xx + HX-Redirect; the batch must stop and the
+  // operator must land on the login page, not lose every file over the
+  // chunk size in silence.
+  test('an HX-Redirect on a staging chunk aborts and navigates', async () => {
+    setChunkSizeMb('1')
+    stubXhr([{ status: 200, hxRedirect: '/login/' }])
+    const app = window.homeApp()
+    await app.uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
+
+    expect(sends).toBe(1)
+    expect(navigations).toEqual(['/login/'])
+    expect(toasts[0]?.message).toBe(
+      'Your session expired — sign in again to upload',
+    )
+  })
+
+  test('an HX-Redirect on the commit aborts and navigates', async () => {
+    setChunkSizeMb('1')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, hxRedirect: '/login/' },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
+
+    expect(navigations).toEqual(['/login/'])
+    expect(toasts[0]?.message).toBe(
+      'Your session expired — sign in again to upload',
+    )
   })
 })
 
@@ -443,9 +569,14 @@ describe('chunked upload failures', () => {
         body: '{"error":"This upload could not be resumed. Check whether it already appears in the asset list before uploading it again."}',
       },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
+    const app = window.homeApp()
+    app.mode = 'add'
+    await app.uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(toasts[0]?.message).toContain('already appears in the asset list')
+    // Same instruction as the unconfirmed toast, so the modal has to
+    // get out of the way of the list here too.
+    expect(app.mode).toBeNull()
   })
 
   // A body that never finished going out cannot have committed

--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -318,6 +318,42 @@ describe('chunked upload failures', () => {
     expect(sends).toBe(2)
   })
 
+  // The commit renames the partial into place before it answers, so a
+  // lost reply may mean the asset already exists. Resending would be
+  // met with the server's 409, and telling the operator to try again
+  // is what produces the duplicate.
+  test('a lost response to the final chunk is not resent', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { transport: true },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(sends).toBe(3)
+    expect(toasts[0]?.message).toBe(
+      'Upload may have finished — check the asset list before ' +
+        'uploading it again',
+    )
+  }, 10000)
+
+  // A staging chunk commits nothing, so resending one is safe — the
+  // server seeks and overwrites the same range.
+  test('a lost response to a staging chunk still is resent', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { transport: true },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200 },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(sends).toBe(4)
+    expect(toasts).toEqual([])
+  }, 10000)
+
   // The server mints nothing now: a retry of chunk 0 that lost its
   // response would otherwise strand the staged bytes under an id the
   // client never learned.

--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -11,7 +11,20 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import './home'
 
 type Toast = { kind: string; message: string; ttlMs?: number }
-type Outcome = { status: number; body?: string } | { transport: true }
+type ProgressLike = {
+  lengthComputable: boolean
+  loaded: number
+  total: number
+}
+// `transport: true` is a response that never came back after the
+// request body had gone out — the ambiguous case, since the server may
+// have acted on it. `transport: 'cut'` is the connection dying while
+// the body was still going out, which the server cannot have seen in
+// full.
+type Outcome =
+  | { status: number; body?: string }
+  | { transport: true }
+  | { transport: 'cut' }
 
 // What each request actually carried, so the chunk tests can assert
 // on the wire format the server stages by.
@@ -37,11 +50,19 @@ function stubXhr(outcomes: Outcome[]): void {
     function XMLHttpRequestStub() {
       const outcome = outcomes[Math.min(index++, outcomes.length - 1)]
       const handlers: Record<string, (() => void)[]> = {}
+      const uploadHandlers: Record<
+        string,
+        ((ev: ProgressLike) => void)[]
+      > = {}
       const headers: Record<string, string> = {}
       return {
         status: 'status' in outcome ? outcome.status : 0,
         responseText: ('body' in outcome && outcome.body) || '',
-        upload: { addEventListener: () => {} },
+        upload: {
+          addEventListener(type: string, fn: (ev: ProgressLike) => void) {
+            ;(uploadHandlers[type] ??= []).push(fn)
+          },
+        },
         open: () => {},
         setRequestHeader: (name: string, value: string) => {
           headers[name] = value
@@ -59,8 +80,26 @@ function stubXhr(outcomes: Outcome[]): void {
             bodyType: body instanceof Blob ? body.type : '',
             bodySize: body instanceof Blob ? body.size : 0,
           })
+          // A real XHR streams the body out first: progress events,
+          // then upload.load once it is all gone, and only then the
+          // response (or the error). Modelled here because uploadOne
+          // reads the difference — a body that never finished cannot
+          // have committed anything.
+          const bodySize = requests[requests.length - 1].bodySize
+          const cutMidBody =
+            'transport' in outcome && outcome.transport === 'cut'
           const type = 'status' in outcome ? 'load' : 'error'
-          queueMicrotask(() => handlers[type]?.forEach((fn) => fn()))
+          queueMicrotask(() => {
+            uploadHandlers['progress']?.forEach((fn) =>
+              fn({
+                lengthComputable: true,
+                loaded: cutMidBody ? Math.floor(bodySize / 2) : bodySize,
+                total: bodySize,
+              }),
+            )
+            if (!cutMidBody) uploadHandlers['load']?.forEach((fn) => fn())
+            handlers[type]?.forEach((fn) => fn())
+          })
         },
       }
     }
@@ -336,6 +375,78 @@ describe('chunked upload failures', () => {
       'Upload may have finished — check the asset list before ' +
         'uploading it again',
     )
+  }, 10000)
+
+  // Behind a proxy the lost-commit case usually arrives as a gateway
+  // 502/504, not a socket error. Exempting only `status === 0` from
+  // the retry would leave the common shape of it being resent, into
+  // the server's 409, for an upload that had already worked.
+  test('a 5xx answer to the final chunk is not resent either', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 502 },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(sends).toBe(3)
+    expect(toasts[0]?.message).toBe(
+      'Upload may have finished — check the asset list before ' +
+        'uploading it again',
+    )
+  }, 10000)
+
+  // The 409 exists to say the asset may already be there. It is
+  // reachable almost only on the final chunk, so a commit that reports
+  // only its status code throws away the one message that matters.
+  test("the final chunk shows the server's own explanation", async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      {
+        status: 409,
+        body: '{"error":"This upload could not be resumed. Check whether it already appears in the asset list before uploading it again."}',
+      },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(toasts[0]?.message).toContain('already appears in the asset list')
+  })
+
+  // A body that never finished going out cannot have committed
+  // anything, so this one is safe to resend and must not be reported
+  // as "may have finished".
+  test('a connection cut mid-commit is resent, not called ambiguous', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { transport: 'cut' },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(sends).toBe(5)
+    expect(toasts[0]?.message).toBe(
+      'Upload failed mid-transfer — check your connection, or try a ' +
+        'smaller file',
+    )
+  }, 10000)
+
+  // The toast says to check the asset list; the Add modal covers it.
+  test('an unconfirmed commit closes the modal', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { transport: true },
+    ])
+    const app = window.homeApp()
+    app.mode = 'add'
+    await app.uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(app.mode).toBeNull()
   }, 10000)
 
   // A staging chunk commits nothing, so resending one is safe — the

--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -11,32 +11,54 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import './home'
 
 type Toast = { kind: string; message: string; ttlMs?: number }
-type Outcome = { status: number } | { transport: true }
+type Outcome = { status: number; body?: string } | { transport: true }
+
+// What each request actually carried, so the chunk tests can assert
+// on the wire format the server stages by.
+interface SentRequest {
+  range: string | null
+  uploadId: string | null
+  bodyType: string
+  bodySize: number
+}
 
 const realXhr = globalThis.XMLHttpRequest
 
 let sends: number
+let requests: SentRequest[]
 
 // Each send() consumes the next outcome, so a batch can be given a
 // different fate per file.
 function stubXhr(outcomes: Outcome[]): void {
   let index = 0
   sends = 0
+  requests = []
   ;(globalThis as unknown as { XMLHttpRequest: unknown }).XMLHttpRequest =
     function XMLHttpRequestStub() {
       const outcome = outcomes[Math.min(index++, outcomes.length - 1)]
       const handlers: Record<string, (() => void)[]> = {}
+      const headers: Record<string, string> = {}
       return {
         status: 'status' in outcome ? outcome.status : 0,
+        responseText: ('body' in outcome && outcome.body) || '',
         upload: { addEventListener: () => {} },
         open: () => {},
-        setRequestHeader: () => {},
+        setRequestHeader: (name: string, value: string) => {
+          headers[name] = value
+        },
         getResponseHeader: () => null,
         addEventListener(type: string, fn: () => void) {
           ;(handlers[type] ??= []).push(fn)
         },
-        send() {
+        send(fd: FormData) {
           sends += 1
+          const body = fd.get('file_upload')
+          requests.push({
+            range: headers['Content-Range'] ?? null,
+            uploadId: headers['X-Upload-Id'] ?? null,
+            bodyType: body instanceof Blob ? body.type : '',
+            bodySize: body instanceof Blob ? body.size : 0,
+          })
           const type = 'status' in outcome ? 'load' : 'error'
           queueMicrotask(() => handlers[type]?.forEach((fn) => fn()))
         },
@@ -50,6 +72,17 @@ function fileInput(...names: string[]): HTMLInputElement {
   return {
     value: '',
     files: names.map((n) => new File(['x'], n, { type: 'video/mp4' })),
+    form: {
+      getAttribute: () => '/assets/upload/',
+      querySelector: () => ({ value: 'test-csrf' }),
+    },
+  } as unknown as HTMLInputElement
+}
+
+function fileInputFrom(file: File): HTMLInputElement {
+  return {
+    value: '',
+    files: [file],
     form: {
       getAttribute: () => '/assets/upload/',
       querySelector: () => ({ value: 'test-csrf' }),
@@ -120,6 +153,121 @@ describe('uploadFiles error reporting', () => {
     await window.homeApp().uploadFiles(fileInput('big-video.mp4'))
 
     expect(toasts[0]?.ttlMs).toBe(8000)
+  })
+})
+
+// A tiny chunk size keeps these fast: chunkSizeFromMeta reads MB, so
+// 0.001 gives ~1 KB chunks and a 3 KB file becomes 3 requests.
+function setChunkSizeMb(mb: string): void {
+  document.head.innerHTML =
+    `<meta name="anthias-upload-chunk-mb" content="${mb}">`
+}
+
+function bigFile(bytes: number, name = 'big.mp4', type = 'video/mp4'): File {
+  return new File([new Uint8Array(bytes)], name, { type })
+}
+
+describe('chunked uploads', () => {
+  test('a large file is split into sequential ranges covering it', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200 },
+    ])
+    const file = bigFile(2500)
+    await window.homeApp().uploadFiles(fileInputFrom(file))
+
+    expect(requests.map((r) => r.range)).toEqual([
+      'bytes 0-1047/2500',
+      'bytes 1048-2095/2500',
+      'bytes 2096-2499/2500',
+    ])
+  })
+
+  test('the id from the first response rides on every later chunk', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc123"}' },
+      { status: 200, body: '{"upload_id":"abc123"}' },
+      { status: 200 },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(requests.map((r) => r.uploadId)).toEqual([null, 'abc123', 'abc123'])
+  })
+
+  // The regression this exists for: a raw Blob from File.slice()
+  // reports application/octet-stream, and the server uses the
+  // browser's type to catch a file whose extension lies about it (a
+  // HEIC renamed to .jpg). Losing it means the asset skips
+  // normalisation and renders blank on the player.
+  test('each chunk keeps the file type, not the slice default', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200 },
+    ])
+    const file = bigFile(2500, 'photo.jpg', 'image/heic')
+    await window.homeApp().uploadFiles(fileInputFrom(file))
+
+    expect(requests.map((r) => r.bodyType)).toEqual([
+      'image/heic',
+      'image/heic',
+      'image/heic',
+    ])
+  })
+
+  test('a file that fits in one chunk sends no range at all', async () => {
+    setChunkSizeMb('16')
+    stubXhr([{ status: 200 }])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(sends).toBe(1)
+    expect(requests[0].range).toBeNull()
+  })
+
+  test('a dropped chunk is resent rather than losing the upload', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { transport: true },
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 200 },
+    ])
+    const app = window.homeApp()
+    app.mode = 'add'
+    await app.uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(sends).toBe(4)
+    expect(toasts).toEqual([])
+    expect(app.mode).toBeNull()
+  }, 10000)
+
+  // A 4xx is the server's considered answer: resending wastes the
+  // operator's time and, for a proxy size limit, can never succeed.
+  test('a rejected chunk is not resent', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 413 },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(sends).toBe(2)
+    expect(toasts[0]?.message).toContain('File too large')
+  })
+
+  // Without an id the next chunk would open a second staged file on
+  // the server and the upload could never complete.
+  test('a missing upload id fails instead of starting over', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([{ status: 200, body: 'not json' }])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(sends).toBe(1)
+    expect(toasts).toHaveLength(1)
   })
 })
 

--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -22,7 +22,7 @@ type ProgressLike = {
 // the body was still going out, which the server cannot have seen in
 // full.
 type Outcome =
-  | { status: number; body?: string }
+  | { status: number; body?: string; trigger?: string }
   | { transport: true }
   | { transport: 'cut' }
 
@@ -67,7 +67,10 @@ function stubXhr(outcomes: Outcome[]): void {
         setRequestHeader: (name: string, value: string) => {
           headers[name] = value
         },
-        getResponseHeader: () => null,
+        getResponseHeader: (name: string) =>
+          name === 'HX-Trigger' && 'trigger' in outcome
+            ? (outcome.trigger ?? null)
+            : null,
         addEventListener(type: string, fn: () => void) {
           ;(handlers[type] ??= []).push(fn)
         },
@@ -149,6 +152,9 @@ beforeEach(() => {
 // bun runs every test file in one process, so leaving these replaced
 // would hand the stubs to any later file that touches them.
 afterEach(() => {
+  document
+    .querySelectorAll('meta[name="anthias-upload-chunk-mb"]')
+    .forEach((m) => m.remove())
   globalThis.XMLHttpRequest = realXhr
   delete (window as unknown as { Alpine?: unknown }).Alpine
   delete (window as unknown as { htmx?: unknown }).htmx
@@ -197,9 +203,16 @@ describe('uploadFiles error reporting', () => {
 
 // A tiny chunk size keeps these fast: chunkSizeFromMeta reads MB, so
 // 0.001 gives ~1 KB chunks and a 3 KB file becomes 3 requests.
+// Appended rather than assigned over document.head: replacing it wipes
+// the anthias-date-format / anthias-use-24h metas home.ts reads, and —
+// since bun runs every file in one process — leaks the chunk size into
+// tests that never asked for it, silently rerouting them through the
+// chunked path. Cleared in afterEach.
 function setChunkSizeMb(mb: string): void {
-  document.head.innerHTML =
-    `<meta name="anthias-upload-chunk-mb" content="${mb}">`
+  const meta = document.createElement('meta')
+  meta.setAttribute('name', 'anthias-upload-chunk-mb')
+  meta.setAttribute('content', mb)
+  document.head.appendChild(meta)
 }
 
 function bigFile(bytes: number, name = 'big.mp4', type = 'video/mp4'): File {
@@ -468,6 +481,46 @@ describe('chunked upload failures', () => {
 
     expect(app.mode).toBeNull()
   }, 10000)
+
+  // The server refuses some files with 200 plus an error toast rather
+  // than a status code (invalid type, nothing uploaded). Treating that
+  // as success would close the modal, count it as uploaded and fire a
+  // table refresh for an asset that does not exist. No test supplied
+  // an HX-Trigger at all before, so the whole classification was
+  // unpinned.
+  test('a 200 carrying an error toast is a refusal, not a success', async () => {
+    setChunkSizeMb('16')
+    stubXhr([
+      {
+        status: 200,
+        trigger: '{"toast":{"kind":"error","message":"Invalid file type."}}',
+      },
+    ])
+    const app = window.homeApp()
+    app.mode = 'add'
+    await app.uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(toasts[0]?.message).toBe('Invalid file type.')
+    // Not counted as a success: modal stays open, no table refresh.
+    expect(app.mode).toBe('add')
+    expect(refreshes).toEqual([])
+  })
+
+  test('a 200 carrying a success toast is a success', async () => {
+    setChunkSizeMb('16')
+    stubXhr([
+      {
+        status: 200,
+        trigger: '{"toast":{"kind":"success","message":"Uploaded."}}',
+      },
+    ])
+    const app = window.homeApp()
+    app.mode = 'add'
+    await app.uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(app.mode).toBeNull()
+    expect(refreshes).toEqual(['refresh-assets'])
+  })
 
   // A staging chunk commits nothing, so resending one is safe — the
   // server seeks and overwrites the same range.

--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -185,16 +185,20 @@ describe('chunked uploads', () => {
     ])
   })
 
-  test('the id from the first response rides on every later chunk', async () => {
+  // The client mints the id, so the server's echo cannot move an
+  // upload onto a different staged file part-way through.
+  test('the same id rides every chunk, whatever the server echoes', async () => {
     setChunkSizeMb('0.001')
     stubXhr([
-      { status: 200, body: '{"upload_id":"abc123"}' },
-      { status: 200, body: '{"upload_id":"abc123"}' },
+      { status: 200, body: '{"upload_id":"server-said-this"}' },
+      { status: 200, body: '{"upload_id":"and-then-this"}' },
       { status: 200 },
     ])
     await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
 
-    expect(requests.map((r) => r.uploadId)).toEqual([null, 'abc123', 'abc123'])
+    const ids = requests.map((r) => r.uploadId)
+    expect(new Set(ids).size).toBe(1)
+    expect(ids[0]).not.toBe('server-said-this')
   })
 
   // The regression this exists for: a raw Blob from File.slice()
@@ -259,15 +263,76 @@ describe('chunked uploads', () => {
     expect(toasts[0]?.message).toContain('File too large')
   })
 
-  // Without an id the next chunk would open a second staged file on
-  // the server and the upload could never complete.
-  test('a missing upload id fails instead of starting over', async () => {
+  // A 200 that is not the chunk acknowledgement is the server
+  // refusing this file and answering with its own toast, which the
+  // single-shot path would have replayed. Treat it the same way: one
+  // file rejected, batch intact.
+  test('a non-JSON 200 is a rejection, not a transport failure', async () => {
     setChunkSizeMb('0.001')
-    stubXhr([{ status: 200, body: 'not json' }])
+    stubXhr([{ status: 200 }])
     await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
 
     expect(sends).toBe(1)
-    expect(toasts).toHaveLength(1)
+    // No client-invented error: the server's own toast stands alone.
+    expect(toasts).toEqual([])
+  })
+})
+
+describe('chunked upload failures', () => {
+  // The server words these better than any status code can, and the
+  // free-space refusal in particular is something the operator can
+  // act on directly.
+  test("a chunk error shows the server's own explanation", async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"abc"}' },
+      { status: 507, body: '{"error":"Not enough disk space, free some up"}' },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    expect(toasts[0]?.message).toBe('Not enough disk space, free some up')
+  })
+
+  // Type validation runs before staging, so a refused file answers the
+  // first chunk with the asset table and its own toast. That is one
+  // file being rejected, not a transport failure: the rest of the
+  // selection must still upload, exactly as single-shot behaves.
+  test('a refused file does not kill the rest of the batch', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([{ status: 200 }])
+    const input = {
+      value: '',
+      files: [
+        new File([new Uint8Array(2500)], 'doc.pdf', { type: 'application/pdf' }),
+        new File([new Uint8Array(10)], 'ok.mp4', { type: 'video/mp4' }),
+      ],
+      form: {
+        getAttribute: () => '/assets/upload/',
+        querySelector: () => ({ value: 'test-csrf' }),
+      },
+    } as unknown as HTMLInputElement
+
+    await window.homeApp().uploadFiles(input)
+
+    // Both attempted: the rejection did not abort the batch.
+    expect(sends).toBe(2)
+  })
+
+  // The server mints nothing now: a retry of chunk 0 that lost its
+  // response would otherwise strand the staged bytes under an id the
+  // client never learned.
+  test('the upload id is the client\'s own, sent from the first chunk', async () => {
+    setChunkSizeMb('0.001')
+    stubXhr([
+      { status: 200, body: '{"upload_id":"ignored"}' },
+      { status: 200, body: '{"upload_id":"ignored"}' },
+      { status: 200 },
+    ])
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+
+    const ids = requests.map((r) => r.uploadId)
+    expect(ids[0]).toMatch(/^[0-9a-f]{32}$/)
+    expect(new Set(ids).size).toBe(1)
   })
 })
 

--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -538,9 +538,11 @@ describe('chunked upload failures', () => {
     expect(toasts).toEqual([])
   }, 10000)
 
-  // The server mints nothing now: a retry of chunk 0 that lost its
-  // response would otherwise strand the staged bytes under an id the
-  // client never learned.
+  // The client no longer takes the server's id — the server still
+  // mints one when a chunk arrives without the header, for any other
+  // caller. A retry of chunk 0 that lost its response would otherwise
+  // come back with no id, get a second one, and strand the bytes
+  // already staged under an id the client never learned.
   test('the upload id is the client\'s own, sent from the first chunk', async () => {
     setChunkSizeMb('1')
     stubXhr([

--- a/src/anthias_server/app/static/src/home.test.ts
+++ b/src/anthias_server/app/static/src/home.test.ts
@@ -206,34 +206,54 @@ function bigFile(bytes: number, name = 'big.mp4', type = 'video/mp4'): File {
   return new File([new Uint8Array(bytes)], name, { type })
 }
 
+// 1 MB chunks is the smallest the server will ever hand the browser
+// (resolve_upload_chunk_size_mb clamps to [1, 24]), so drive these at
+// that rather than at a size no device can produce. 2.5 MB gives three
+// chunks with a short tail.
+const CHUNK_MB = 1
+const CHUNKED_FILE_BYTES = 2.5 * 1024 * 1024
+
 describe('chunked uploads', () => {
   test('a large file is split into sequential ranges covering it', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200 },
     ])
-    const file = bigFile(2500)
+    const file = bigFile(CHUNKED_FILE_BYTES)
     await window.homeApp().uploadFiles(fileInputFrom(file))
 
-    expect(requests.map((r) => r.range)).toEqual([
-      'bytes 0-1047/2500',
-      'bytes 1048-2095/2500',
-      'bytes 2096-2499/2500',
-    ])
+    // Asserted as properties rather than three literal ranges: the
+    // exact boundaries follow from the chunk size, and pinning them
+    // would make this fail for a change that is still correct. What
+    // must hold is that the ranges are contiguous, start at 0, end at
+    // the last byte, and all declare the same total — a gap reads back
+    // as zeros and an off-by-one truncates, both silently.
+    const parsed = requests.map((r) => {
+      const m = /^bytes (\d+)-(\d+)\/(\d+)$/.exec(r.range ?? '')
+      if (m === null) throw new Error(`unparseable range: ${r.range}`)
+      return { start: +m[1], end: +m[2], total: +m[3] }
+    })
+    expect(parsed.length).toBeGreaterThan(1)
+    expect(parsed[0].start).toBe(0)
+    expect(parsed[parsed.length - 1].end).toBe(file.size - 1)
+    for (const p of parsed) expect(p.total).toBe(file.size)
+    for (let i = 1; i < parsed.length; i++) {
+      expect(parsed[i].start).toBe(parsed[i - 1].end + 1)
+    }
   })
 
   // The client mints the id, so the server's echo cannot move an
   // upload onto a different staged file part-way through.
   test('the same id rides every chunk, whatever the server echoes', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"server-said-this"}' },
       { status: 200, body: '{"upload_id":"and-then-this"}' },
       { status: 200 },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     const ids = requests.map((r) => r.uploadId)
     expect(new Set(ids).size).toBe(1)
@@ -246,13 +266,13 @@ describe('chunked uploads', () => {
   // HEIC renamed to .jpg). Losing it means the asset skips
   // normalisation and renders blank on the player.
   test('each chunk keeps the file type, not the slice default', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200 },
     ])
-    const file = bigFile(2500, 'photo.jpg', 'image/heic')
+    const file = bigFile(CHUNKED_FILE_BYTES, 'photo.jpg', 'image/heic')
     await window.homeApp().uploadFiles(fileInputFrom(file))
 
     expect(requests.map((r) => r.bodyType)).toEqual([
@@ -265,14 +285,14 @@ describe('chunked uploads', () => {
   test('a file that fits in one chunk sends no range at all', async () => {
     setChunkSizeMb('16')
     stubXhr([{ status: 200 }])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(1)
     expect(requests[0].range).toBeNull()
   })
 
   test('a dropped chunk is resent rather than losing the upload', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { transport: true },
@@ -281,7 +301,7 @@ describe('chunked uploads', () => {
     ])
     const app = window.homeApp()
     app.mode = 'add'
-    await app.uploadFiles(fileInputFrom(bigFile(2500)))
+    await app.uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(4)
     expect(toasts).toEqual([])
@@ -291,12 +311,12 @@ describe('chunked uploads', () => {
   // A 4xx is the server's considered answer: resending wastes the
   // operator's time and, for a proxy size limit, can never succeed.
   test('a rejected chunk is not resent', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 413 },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(2)
     expect(toasts[0]?.message).toContain('File too large')
@@ -307,9 +327,9 @@ describe('chunked uploads', () => {
   // single-shot path would have replayed. Treat it the same way: one
   // file rejected, batch intact.
   test('a non-JSON 200 is a rejection, not a transport failure', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([{ status: 200 }])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(1)
     // No client-invented error: the server's own toast stands alone.
@@ -322,12 +342,12 @@ describe('chunked upload failures', () => {
   // free-space refusal in particular is something the operator can
   // act on directly.
   test("a chunk error shows the server's own explanation", async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 507, body: '{"error":"Not enough disk space, free some up"}' },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(toasts[0]?.message).toBe('Not enough disk space, free some up')
   })
@@ -337,7 +357,7 @@ describe('chunked upload failures', () => {
   // file being rejected, not a transport failure: the rest of the
   // selection must still upload, exactly as single-shot behaves.
   test('a refused file does not kill the rest of the batch', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([{ status: 200 }])
     const input = {
       value: '',
@@ -362,13 +382,13 @@ describe('chunked upload failures', () => {
   // met with the server's 409, and telling the operator to try again
   // is what produces the duplicate.
   test('a lost response to the final chunk is not resent', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200, body: '{"upload_id":"abc"}' },
       { transport: true },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(3)
     expect(toasts[0]?.message).toBe(
@@ -382,13 +402,13 @@ describe('chunked upload failures', () => {
   // the retry would leave the common shape of it being resent, into
   // the server's 409, for an upload that had already worked.
   test('a 5xx answer to the final chunk is not resent either', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 502 },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(3)
     expect(toasts[0]?.message).toBe(
@@ -401,7 +421,7 @@ describe('chunked upload failures', () => {
   // reachable almost only on the final chunk, so a commit that reports
   // only its status code throws away the one message that matters.
   test("the final chunk shows the server's own explanation", async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200, body: '{"upload_id":"abc"}' },
@@ -410,7 +430,7 @@ describe('chunked upload failures', () => {
         body: '{"error":"This upload could not be resumed. Check whether it already appears in the asset list before uploading it again."}',
       },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(toasts[0]?.message).toContain('already appears in the asset list')
   })
@@ -419,13 +439,13 @@ describe('chunked upload failures', () => {
   // anything, so this one is safe to resend and must not be reported
   // as "may have finished".
   test('a connection cut mid-commit is resent, not called ambiguous', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200, body: '{"upload_id":"abc"}' },
       { transport: 'cut' },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(5)
     expect(toasts[0]?.message).toBe(
@@ -436,7 +456,7 @@ describe('chunked upload failures', () => {
 
   // The toast says to check the asset list; the Add modal covers it.
   test('an unconfirmed commit closes the modal', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200, body: '{"upload_id":"abc"}' },
@@ -444,7 +464,7 @@ describe('chunked upload failures', () => {
     ])
     const app = window.homeApp()
     app.mode = 'add'
-    await app.uploadFiles(fileInputFrom(bigFile(2500)))
+    await app.uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(app.mode).toBeNull()
   }, 10000)
@@ -452,14 +472,14 @@ describe('chunked upload failures', () => {
   // A staging chunk commits nothing, so resending one is safe — the
   // server seeks and overwrites the same range.
   test('a lost response to a staging chunk still is resent', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"abc"}' },
       { transport: true },
       { status: 200, body: '{"upload_id":"abc"}' },
       { status: 200 },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     expect(sends).toBe(4)
     expect(toasts).toEqual([])
@@ -469,13 +489,13 @@ describe('chunked upload failures', () => {
   // response would otherwise strand the staged bytes under an id the
   // client never learned.
   test('the upload id is the client\'s own, sent from the first chunk', async () => {
-    setChunkSizeMb('0.001')
+    setChunkSizeMb('1')
     stubXhr([
       { status: 200, body: '{"upload_id":"ignored"}' },
       { status: 200, body: '{"upload_id":"ignored"}' },
       { status: 200 },
     ])
-    await window.homeApp().uploadFiles(fileInputFrom(bigFile(2500)))
+    await window.homeApp().uploadFiles(fileInputFrom(bigFile(CHUNKED_FILE_BYTES)))
 
     const ids = requests.map((r) => r.uploadId)
     expect(ids[0]).toMatch(/^[0-9a-f]{32}$/)

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -13,6 +13,11 @@ import {
   type AppsTabData,
   type EditAsset as AppEditAsset,
 } from './apps'
+import {
+  chunkSizeFromMeta,
+  needsChunking,
+  planChunks,
+} from './home/chunking'
 import { uploadErrorMessage, type UploadFailure } from './home/upload-error'
 
 declare global {
@@ -93,6 +98,16 @@ interface HomeAppData {
   uploadFiles(input: HTMLInputElement): Promise<void>
   dropFiles(event: DragEvent): void
   uploadOne(url: string, csrf: string, file: File): Promise<UploadResult>
+  sendUpload(opts: {
+    url: string
+    csrf: string
+    body: Blob
+    filename: string
+    range?: string
+    uploadId?: string
+    sentBytes: number
+    totalBytes: number
+  }): Promise<RawUploadResponse>
   // Bulk selection helpers
   isSelected(id: string): boolean
   toggleSelect(id: string): void
@@ -117,6 +132,54 @@ type UploadResult =
   | { status: 'ok' }
   | { status: 'rejected' }
   | { status: 'error'; failure: UploadFailure }
+
+// One request's outcome, before it means anything. `status` is 0 when
+// no response arrived at all.
+interface RawUploadResponse {
+  status: number
+  text: string
+  trigger: string | null
+}
+
+// Chunking turns one request into dozens, so a single dropped
+// connection should not lose an upload the operator has been waiting
+// on. Only transport failures and 5xx are resent; a 4xx is the
+// server's considered answer.
+const CHUNK_RETRIES = 2
+const CHUNK_RETRY_DELAY_MS = 500
+
+// Decide what the response to a whole-file upload, or to the chunk
+// that commits one, means. Kept in one place so both paths agree.
+function interpretFinalResponse(res: RawUploadResponse): UploadResult {
+  const kind = fireToastFromHeader(res.trigger)
+  if (res.status === 0) {
+    return { status: 'error', failure: { kind: 'network' } }
+  }
+  if (res.status < 200 || res.status >= 300) {
+    // A proxy-generated 413 never reaches Django, so there is no
+    // HX-Trigger toast to replay and the status is all there is.
+    return { status: 'error', failure: { kind: 'http', status: res.status } }
+  }
+  // The server validates and may refuse a file with a 200 + error
+  // toast (invalid type, missing file). Treat that as a rejected
+  // file, not a silent success.
+  return { status: kind === 'error' ? 'rejected' : 'ok' }
+}
+
+function parseUploadId(text: string): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(text)
+    if (parsed && typeof parsed === 'object' && 'upload_id' in parsed) {
+      const id = (parsed as { upload_id: unknown }).upload_id
+      if (typeof id === 'string' && id.length > 0) return id
+    }
+  } catch {
+    // A non-JSON body means the server answered something other than
+    // the chunk acknowledgement; the caller treats a missing id as
+    // fatal rather than starting a second staged file.
+  }
+  return undefined
+}
 
 const DATE_FMT_MAP: Record<string, string> = {
   'mm/dd/yyyy': 'm/d/Y',
@@ -463,58 +526,145 @@ function homeApp(): HomeAppData {
     // replay them here since this isn't an htmx-managed request.
     // Progress flips to "processing" once the bytes are up (the server
     // still has to write to disk + ffprobe).
-    uploadOne(
+    // POST one request of an upload: the whole file, or one chunk of
+    // it. Resolves the raw response so the caller can decide what a
+    // given status means for a chunk versus a final commit.
+    sendUpload(
+      this: HomeAppData,
+      opts: {
+        url: string
+        csrf: string
+        body: Blob
+        filename: string
+        range?: string
+        uploadId?: string
+        sentBytes: number
+        totalBytes: number
+      },
+    ): Promise<RawUploadResponse> {
+      return new Promise<RawUploadResponse>((resolve) => {
+        const xhr = new XMLHttpRequest()
+        xhr.open('POST', opts.url)
+        xhr.setRequestHeader('X-CSRFToken', opts.csrf)
+        // Mark as an htmx request so assets_upload returns the table
+        // partial (+ HX-Trigger toast) instead of a full-page redirect.
+        xhr.setRequestHeader('HX-Request', 'true')
+        if (opts.range) xhr.setRequestHeader('Content-Range', opts.range)
+        if (opts.uploadId) xhr.setRequestHeader('X-Upload-Id', opts.uploadId)
+        this.uploadState = 'sending'
+        xhr.upload.addEventListener('progress', (ev) => {
+          if (!ev.lengthComputable || opts.totalBytes === 0) return
+          // Against the whole file, not this request: otherwise a
+          // chunked upload would run 0-100% once per chunk.
+          const done = opts.sentBytes + ev.loaded
+          this.uploadProgress = Math.min(
+            99,
+            Math.round((done / opts.totalBytes) * 100),
+          )
+          if (done >= opts.totalBytes) this.uploadState = 'processing'
+        })
+        xhr.addEventListener('load', () => {
+          resolve({
+            status: xhr.status,
+            text: xhr.responseText,
+            trigger: xhr.getResponseHeader('HX-Trigger'),
+          })
+        })
+        // No response at all (dropped connection, DNS, TLS): status is
+        // 0 here, so it is not an HTTP failure.
+        const failed = () => resolve({ status: 0, text: '', trigger: null })
+        xhr.addEventListener('error', failed)
+        xhr.addEventListener('abort', failed)
+        const fd = new FormData()
+        fd.append('csrfmiddlewaretoken', opts.csrf)
+        fd.append('file_upload', opts.body, opts.filename)
+        xhr.send(fd)
+      })
+    },
+
+    async uploadOne(
       this: HomeAppData,
       url: string,
       csrf: string,
       file: File,
     ): Promise<UploadResult> {
-      return new Promise<UploadResult>((resolve) => {
-        const xhr = new XMLHttpRequest()
-        xhr.open('POST', url)
-        xhr.setRequestHeader('X-CSRFToken', csrf)
-        // Mark as an htmx request so assets_upload returns the table
-        // partial (+ HX-Trigger toast) instead of a full-page redirect.
-        xhr.setRequestHeader('HX-Request', 'true')
-        this.uploadState = 'sending'
-        this.uploadProgress = 0
-        xhr.upload.addEventListener('progress', (ev) => {
-          if (!ev.lengthComputable || ev.total === 0) return
-          this.uploadProgress = Math.min(
-            99,
-            Math.round((ev.loaded / ev.total) * 100),
-          )
-          if (ev.loaded >= ev.total) this.uploadState = 'processing'
+      this.uploadProgress = 0
+      const chunkSize = chunkSizeFromMeta(
+        metaContent('anthias-upload-chunk-mb') || null,
+      )
+
+      if (!needsChunking(file.size, chunkSize)) {
+        const res = await this.sendUpload({
+          url,
+          csrf,
+          body: file,
+          filename: file.name,
+          sentBytes: 0,
+          totalBytes: file.size,
         })
-        xhr.addEventListener('load', () => {
-          const kind = fireToastFromHeader(xhr.getResponseHeader('HX-Trigger'))
-          if (xhr.status < 200 || xhr.status >= 300) {
-            // Pass the status up so the batch can name the cause. A
-            // proxy-generated 413 never reaches Django, so there is no
-            // HX-Trigger toast to replay and the status is all the
-            // information there is.
-            resolve({
-              status: 'error',
-              failure: { kind: 'http', status: xhr.status },
-            })
-            return
+        return interpretFinalResponse(res)
+      }
+
+      const chunks = planChunks(file.size, chunkSize)
+      let uploadId: string | undefined
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i]
+        const isFinal = i === chunks.length - 1
+        // Re-wrap the slice with the file's own type. A raw Blob from
+        // File.slice() reports application/octet-stream, and the
+        // server uses the browser's type to catch a file whose
+        // extension lies about it (a HEIC renamed to .jpg). Without
+        // this the chunked path would skip normalisation and the
+        // asset would render blank on the player.
+        const body = new Blob([file.slice(chunk.start, chunk.end + 1)], {
+          type: file.type,
+        })
+
+        let res: RawUploadResponse | null = null
+        for (let attempt = 0; attempt <= CHUNK_RETRIES; attempt++) {
+          res = await this.sendUpload({
+            url,
+            csrf,
+            body,
+            filename: file.name,
+            range: chunk.header,
+            uploadId,
+            sentBytes: chunk.start,
+            totalBytes: file.size,
+          })
+          // Only a dropped connection or a server-side stumble is
+          // worth resending: chunking turns one request into dozens,
+          // so a single blip should not lose the whole upload. A 4xx
+          // is the server's considered answer and will not change.
+          const retryable =
+            res.status === 0 || (res.status >= 500 && res.status !== 507)
+          if (!retryable || attempt === CHUNK_RETRIES) break
+          await new Promise((r) => setTimeout(r, CHUNK_RETRY_DELAY_MS))
+        }
+        if (res === null) break
+
+        if (isFinal) return interpretFinalResponse(res)
+
+        if (res.status < 200 || res.status >= 300) {
+          return {
+            status: 'error',
+            failure:
+              res.status === 0
+                ? { kind: 'network' }
+                : { kind: 'http', status: res.status },
           }
-          // The server validates and may refuse a file with a 200 +
-          // error toast (invalid type, missing file). Treat that as a
-          // rejected file, not a silent success.
-          resolve({ status: kind === 'error' ? 'rejected' : 'ok' })
-        })
-        // No response at all (dropped connection, DNS, TLS): status is
-        // 0 here, so it is not an HTTP failure.
-        const networkFailure = () =>
-          resolve({ status: 'error', failure: { kind: 'network' } })
-        xhr.addEventListener('error', networkFailure)
-        xhr.addEventListener('abort', networkFailure)
-        const fd = new FormData()
-        fd.append('csrfmiddlewaretoken', csrf)
-        fd.append('file_upload', file)
-        xhr.send(fd)
-      })
+        }
+        uploadId = parseUploadId(res.text) ?? uploadId
+        if (!uploadId) {
+          // Without an id the next chunk would start a second staged
+          // file and the upload could never complete.
+          return {
+            status: 'error',
+            failure: { kind: 'http', status: res.status },
+          }
+        }
+      }
+      return { status: 'error', failure: { kind: 'network' } }
     },
   }
 }

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -659,14 +659,26 @@ function homeApp(): HomeAppData {
           // worth resending: chunking turns one request into dozens,
           // so a single blip should not lose the whole upload. A 4xx
           // is the server's considered answer and will not change.
+          // Staging a chunk is idempotent, so resending one is safe —
+          // but the final chunk commits, and a lost response there
+          // may mean the asset already exists.
           const retryable =
-            res.status === 0 || (res.status >= 500 && res.status !== 507)
+            (res.status === 0 && !isFinal) ||
+            (res.status >= 500 && res.status !== 507)
           if (!retryable || attempt === CHUNK_RETRIES) break
           await new Promise((r) => setTimeout(r, CHUNK_RETRY_DELAY_MS))
         }
         if (res === null) break
 
-        if (isFinal) return interpretFinalResponse(res)
+        if (isFinal) {
+          // No response to the commit. os.replace may already have
+          // moved the partial into place, so this is not a failure we
+          // can report as one: say so and let the operator look.
+          if (res.status === 0) {
+            return { status: 'error', failure: { kind: 'unconfirmed' } }
+          }
+          return interpretFinalResponse(res)
+        }
 
         if (res.status < 200 || res.status >= 300) {
           const message = parseServerError(res.text)

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -126,8 +126,8 @@ type UploadResult =
   | { status: 'error'; failure: UploadFailure }
 
 // One POST of an upload: the whole file, or one chunk of it.
-// `sentBytes` is what preceded this request, so progress can be
-// reported against the whole file.
+// `sentBytes` is what preceded it, so progress reads against the
+// whole file.
 interface UploadRequest {
   url: string
   csrf: string
@@ -147,15 +147,13 @@ interface RawUploadResponse {
   trigger: string | null
 }
 
-// Chunking turns one request into dozens, so a single dropped
-// connection should not lose an upload the operator has been waiting
-// on. Only transport failures and 5xx are resent; a 4xx is the
-// server's considered answer.
+// Chunking turns one request into dozens, so one dropped connection
+// should not lose an upload the operator has been waiting on.
 const CHUNK_RETRIES = 2
 const CHUNK_RETRY_DELAY_MS = 500
 
-// Send one request, resending it while the failure is one that might
-// not repeat. Staging a chunk is idempotent, so a dropped connection
+// Resend only what might not fail again — a 4xx is the server's
+// considered answer. Staging is idempotent, so a dropped connection
 // there is safe to resend; the final chunk commits, and a lost
 // response to that may mean the asset already exists.
 async function sendWithRetry(
@@ -204,10 +202,10 @@ function parseServerError(text: string): string | undefined {
   return undefined
 }
 
-// Mint the id here rather than taking the server's. A retry of chunk
-// 0 would otherwise arrive with no id, the server would mint a second
-// one, and the bytes already staged under the first would sit
-// orphaned while the upload silently continued elsewhere.
+// Minted here, not taken from the server: a retry of chunk 0 would
+// otherwise arrive with no id, the server would mint a second one, and
+// the bytes staged under the first would sit orphaned while the upload
+// continued elsewhere.
 function newUploadId(): string {
   const bytes = new Uint8Array(16)
   crypto.getRandomValues(bytes)
@@ -222,9 +220,8 @@ function parseUploadId(text: string): string | undefined {
       if (typeof id === 'string' && id.length > 0) return id
     }
   } catch {
-    // A non-JSON body means the server answered something other than
-    // the chunk acknowledgement; the caller treats a missing id as
-    // fatal rather than starting a second staged file.
+    // A non-JSON body is not the chunk acknowledgement; the caller
+    // treats a missing id as fatal rather than staging a second file.
   }
   return undefined
 }
@@ -656,12 +653,11 @@ function homeApp(): HomeAppData {
           {
             url,
             csrf,
-            // Re-wrap the slice with the file's own type. A raw Blob
-            // from File.slice() reports application/octet-stream, and
-            // the server uses the browser's type to catch a file whose
-            // extension lies about it (a HEIC renamed to .jpg).
-            // Without this the chunked path would skip normalisation
-            // and the asset would render blank on the player.
+            // Re-wrapped with the file's own type: File.slice()
+            // reports application/octet-stream, and the server reads
+            // that type to catch an extension that lies (a HEIC
+            // renamed .jpg) — without it, normalisation is skipped and
+            // the asset renders blank.
             body: new Blob([file.slice(chunk.start, chunk.end + 1)], {
               type: file.type,
             }),
@@ -674,8 +670,8 @@ function homeApp(): HomeAppData {
           isFinal,
         )
 
-      // Every chunk but the last only stages bytes; the server
-      // acknowledges each with the upload id and nothing else.
+      // All but the last only stage bytes; the server acknowledges
+      // each with the upload id and nothing else.
       for (const chunk of chunks.slice(0, -1)) {
         const res = await sendChunk(chunk, false)
         if (res.status < 200 || res.status >= 300) {
@@ -689,25 +685,23 @@ function homeApp(): HomeAppData {
                 : { kind: 'http', status: res.status },
           }
         }
-        // A 200 that is not the chunk acknowledgement means the server
-        // refused this file outright (wrong type, nothing uploaded)
-        // and answered with the asset table plus its own toast. That
-        // is a rejection of one file, not a transport failure: replay
-        // the toast and let the batch carry on, exactly as the
-        // single-shot path does.
+        // A 200 that is not the acknowledgement is the server
+        // refusing the file (wrong type, nothing uploaded) and
+        // answering with the asset table and its own toast: one file
+        // rejected, not a transport failure. Replay and carry on, as
+        // single-shot does.
         if (parseUploadId(res.text) === undefined) {
           fireToastFromHeader(res.trigger)
           return { status: 'rejected' }
         }
       }
 
-      // The last chunk carries the final byte, so it is the one that
-      // creates the asset.
+      // The last carries the final byte, so it creates the asset.
       const res = await sendChunk(chunks[chunks.length - 1], true)
       if (res.status === 0) {
-        // No response to the commit. os.replace may already have moved
-        // the partial into place, so this is not a failure we can
-        // report as one: say so and let the operator look.
+        // No response to the commit: os.replace may already have
+        // moved the partial into place, so say so rather than
+        // reporting a failure we cannot claim.
         return { status: 'error', failure: { kind: 'unconfirmed' } }
       }
       return interpretFinalResponse(res)

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -189,15 +189,20 @@ function interpretFinalResponse(res: RawUploadResponse): UploadResult {
   return { status: kind === 'error' ? 'rejected' : 'ok' }
 }
 
-function parseServerError(text: string): string | undefined {
+// One string field of a JSON response body — undefined if the body is
+// not JSON, lacks the field, or holds a non-string there. The chunk
+// endpoint answers with `{upload_id}` on success and `{error}` on
+// refusal, and anything else is the server not answering as a chunk
+// endpoint at all, which both callers handle the same way.
+function jsonStringField(text: string, key: string): string | undefined {
   try {
     const parsed: unknown = JSON.parse(text)
-    if (parsed && typeof parsed === 'object' && 'error' in parsed) {
-      const msg = (parsed as { error: unknown }).error
-      if (typeof msg === 'string' && msg.length > 0) return msg
+    if (parsed && typeof parsed === 'object' && key in parsed) {
+      const value = (parsed as Record<string, unknown>)[key]
+      if (typeof value === 'string' && value.length > 0) return value
     }
   } catch {
-    // Not a JSON body: the caller falls back to the status code.
+    // Not JSON: the same answer as a body without the field.
   }
   return undefined
 }
@@ -210,20 +215,6 @@ function newUploadId(): string {
   const bytes = new Uint8Array(16)
   crypto.getRandomValues(bytes)
   return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
-}
-
-function parseUploadId(text: string): string | undefined {
-  try {
-    const parsed: unknown = JSON.parse(text)
-    if (parsed && typeof parsed === 'object' && 'upload_id' in parsed) {
-      const id = (parsed as { upload_id: unknown }).upload_id
-      if (typeof id === 'string' && id.length > 0) return id
-    }
-  } catch {
-    // A non-JSON body is not the chunk acknowledgement; the caller
-    // treats a missing id as fatal rather than staging a second file.
-  }
-  return undefined
 }
 
 const DATE_FMT_MAP: Record<string, string> = {
@@ -675,7 +666,9 @@ function homeApp(): HomeAppData {
       for (const chunk of chunks.slice(0, -1)) {
         const res = await sendChunk(chunk, false)
         if (res.status < 200 || res.status >= 300) {
-          const message = parseServerError(res.text)
+          // The server's own wording where it gave one; the status
+          // code is the fallback.
+          const message = jsonStringField(res.text, 'error')
           return {
             status: 'error',
             failure: message
@@ -690,7 +683,7 @@ function homeApp(): HomeAppData {
         // answering with the asset table and its own toast: one file
         // rejected, not a transport failure. Replay and carry on, as
         // single-shot does.
-        if (parseUploadId(res.text) === undefined) {
+        if (jsonStringField(res.text, 'upload_id') === undefined) {
           fireToastFromHeader(res.trigger)
           return { status: 'rejected' }
         }

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -140,11 +140,14 @@ interface UploadRequest {
 }
 
 // One request's outcome, before it means anything. `status` is 0 when
-// no response arrived at all.
+// no response arrived at all. `bodySent` says the browser finished
+// handing over the request body, which is what separates "the server
+// never saw this chunk" from "the server may have acted on it".
 interface RawUploadResponse {
   status: number
   text: string
   trigger: string | null
+  bodySent: boolean
 }
 
 // Chunking turns one request into dozens, so one dropped connection
@@ -153,9 +156,16 @@ const CHUNK_RETRIES = 2
 const CHUNK_RETRY_DELAY_MS = 500
 
 // Resend only what might not fail again — a 4xx is the server's
-// considered answer. Staging is idempotent, so a dropped connection
-// there is safe to resend; the final chunk commits, and a lost
-// response to that may mean the asset already exists.
+// considered answer. Staging a chunk is idempotent, so anything that
+// goes wrong there is safe to resend.
+//
+// The final chunk commits: the server renames the partial into place
+// and only then answers, so once its body has gone out, neither a
+// dropped socket nor a 5xx tells us whether the asset exists. Behind a
+// proxy the lost-commit case usually arrives as a gateway 502 or 504
+// rather than a socket error, so exempting only `status === 0` would
+// leave the common shape of it being resent — into the 409 that says
+// the upload cannot be resumed, for an upload that worked.
 async function sendWithRetry(
   send: (opts: UploadRequest) => Promise<RawUploadResponse>,
   opts: UploadRequest,
@@ -163,9 +173,10 @@ async function sendWithRetry(
 ): Promise<RawUploadResponse> {
   for (let attempt = 0; ; attempt++) {
     const res = await send(opts)
+    const mayHaveCommitted = isFinal && res.bodySent
     const retryable =
-      (res.status === 0 && !isFinal) ||
-      (res.status >= 500 && res.status !== 507)
+      !mayHaveCommitted &&
+      (res.status === 0 || (res.status >= 500 && res.status !== 507))
     if (!retryable || attempt === CHUNK_RETRIES) return res
     await new Promise((r) => setTimeout(r, CHUNK_RETRY_DELAY_MS))
   }
@@ -516,6 +527,9 @@ function homeApp(): HomeAppData {
       this.uploadTotal = 0
 
       if (failure) {
+        // "Check the asset list" is unactionable with the Add modal
+        // sitting on top of it.
+        if (failure.kind === 'unconfirmed') this.mode = null
         const store = window.Alpine.store('toasts') as
           | ToastStoreLike
           | undefined
@@ -579,6 +593,12 @@ function homeApp(): HomeAppData {
         if (opts.range) xhr.setRequestHeader('Content-Range', opts.range)
         if (opts.uploadId) xhr.setRequestHeader('X-Upload-Id', opts.uploadId)
         this.uploadState = 'sending'
+        let bodySent = false
+        // Fires once the whole request body has gone out — before any
+        // response, and regardless of what comes back.
+        xhr.upload.addEventListener('load', () => {
+          bodySent = true
+        })
         xhr.upload.addEventListener('progress', (ev) => {
           if (!ev.lengthComputable || opts.totalBytes === 0) return
           // Against the whole file, not this request: otherwise a
@@ -595,11 +615,13 @@ function homeApp(): HomeAppData {
             status: xhr.status,
             text: xhr.responseText,
             trigger: xhr.getResponseHeader('HX-Trigger'),
+            bodySent: true,
           })
         })
         // No response at all (dropped connection, DNS, TLS): status is
         // 0 here, so it is not an HTTP failure.
-        const failed = () => resolve({ status: 0, text: '', trigger: null })
+        const failed = () =>
+          resolve({ status: 0, text: '', trigger: null, bodySent })
         xhr.addEventListener('error', failed)
         xhr.addEventListener('abort', failed)
         const fd = new FormData()
@@ -691,10 +713,17 @@ function homeApp(): HomeAppData {
 
       // The last carries the final byte, so it creates the asset.
       const res = await sendChunk(chunks[chunks.length - 1], true)
-      if (res.status === 0) {
-        // No response to the commit: os.replace may already have
-        // moved the partial into place, so say so rather than
-        // reporting a failure we cannot claim.
+      // The server's own words where it gave any — the 409 that says
+      // to check the asset list, or the 507 that names the disk — beat
+      // anything derivable from a status code.
+      const message = jsonStringField(res.text, 'error')
+      if (message) return { status: 'error', failure: { kind: 'server', message } }
+      // Otherwise: if the bytes went out and nothing intelligible came
+      // back, os.replace may already have moved the partial into
+      // place. Don't report that as a plain failure. A body that never
+      // finished sending could not have committed, so it falls through
+      // to the ordinary transport message.
+      if (res.bodySent && (res.status === 0 || res.status >= 500)) {
         return { status: 'error', failure: { kind: 'unconfirmed' } }
       }
       return interpretFinalResponse(res)

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -166,6 +166,29 @@ function interpretFinalResponse(res: RawUploadResponse): UploadResult {
   return { status: kind === 'error' ? 'rejected' : 'ok' }
 }
 
+function parseServerError(text: string): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(text)
+    if (parsed && typeof parsed === 'object' && 'error' in parsed) {
+      const msg = (parsed as { error: unknown }).error
+      if (typeof msg === 'string' && msg.length > 0) return msg
+    }
+  } catch {
+    // Not a JSON body: the caller falls back to the status code.
+  }
+  return undefined
+}
+
+// Mint the id here rather than taking the server's. A retry of chunk
+// 0 would otherwise arrive with no id, the server would mint a second
+// one, and the bytes already staged under the first would sit
+// orphaned while the upload silently continued elsewhere.
+function newUploadId(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
 function parseUploadId(text: string): string | undefined {
   try {
     const parsed: unknown = JSON.parse(text)
@@ -606,7 +629,7 @@ function homeApp(): HomeAppData {
       }
 
       const chunks = planChunks(file.size, chunkSize)
-      let uploadId: string | undefined
+      const uploadId = newUploadId()
       for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i]
         const isFinal = i === chunks.length - 1
@@ -646,22 +669,25 @@ function homeApp(): HomeAppData {
         if (isFinal) return interpretFinalResponse(res)
 
         if (res.status < 200 || res.status >= 300) {
+          const message = parseServerError(res.text)
           return {
             status: 'error',
-            failure:
-              res.status === 0
+            failure: message
+              ? { kind: 'server', message }
+              : res.status === 0
                 ? { kind: 'network' }
                 : { kind: 'http', status: res.status },
           }
         }
-        uploadId = parseUploadId(res.text) ?? uploadId
-        if (!uploadId) {
-          // Without an id the next chunk would start a second staged
-          // file and the upload could never complete.
-          return {
-            status: 'error',
-            failure: { kind: 'http', status: res.status },
-          }
+        // A 200 that is not the chunk acknowledgement means the server
+        // refused this file outright (wrong type, nothing uploaded)
+        // and answered with the asset table plus its own toast. That
+        // is a rejection of one file, not a transport failure: replay
+        // the toast and let the batch carry on, exactly as the
+        // single-shot path does.
+        if (parseUploadId(res.text) === undefined) {
+          fireToastFromHeader(res.trigger)
+          return { status: 'rejected' }
         }
       }
       return { status: 'error', failure: { kind: 'network' } }

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -14,6 +14,7 @@ import {
   type EditAsset as AppEditAsset,
 } from './apps'
 import {
+  type Chunk,
   chunkSizeFromMeta,
   needsChunking,
   planChunks,
@@ -98,16 +99,7 @@ interface HomeAppData {
   uploadFiles(input: HTMLInputElement): Promise<void>
   dropFiles(event: DragEvent): void
   uploadOne(url: string, csrf: string, file: File): Promise<UploadResult>
-  sendUpload(opts: {
-    url: string
-    csrf: string
-    body: Blob
-    filename: string
-    range?: string
-    uploadId?: string
-    sentBytes: number
-    totalBytes: number
-  }): Promise<RawUploadResponse>
+  sendUpload(opts: UploadRequest): Promise<RawUploadResponse>
   // Bulk selection helpers
   isSelected(id: string): boolean
   toggleSelect(id: string): void
@@ -133,6 +125,20 @@ type UploadResult =
   | { status: 'rejected' }
   | { status: 'error'; failure: UploadFailure }
 
+// One POST of an upload: the whole file, or one chunk of it.
+// `sentBytes` is what preceded this request, so progress can be
+// reported against the whole file.
+interface UploadRequest {
+  url: string
+  csrf: string
+  body: Blob
+  filename: string
+  range?: string
+  uploadId?: string
+  sentBytes: number
+  totalBytes: number
+}
+
 // One request's outcome, before it means anything. `status` is 0 when
 // no response arrived at all.
 interface RawUploadResponse {
@@ -147,6 +153,25 @@ interface RawUploadResponse {
 // server's considered answer.
 const CHUNK_RETRIES = 2
 const CHUNK_RETRY_DELAY_MS = 500
+
+// Send one request, resending it while the failure is one that might
+// not repeat. Staging a chunk is idempotent, so a dropped connection
+// there is safe to resend; the final chunk commits, and a lost
+// response to that may mean the asset already exists.
+async function sendWithRetry(
+  send: (opts: UploadRequest) => Promise<RawUploadResponse>,
+  opts: UploadRequest,
+  isFinal: boolean,
+): Promise<RawUploadResponse> {
+  for (let attempt = 0; ; attempt++) {
+    const res = await send(opts)
+    const retryable =
+      (res.status === 0 && !isFinal) ||
+      (res.status >= 500 && res.status !== 507)
+    if (!retryable || attempt === CHUNK_RETRIES) return res
+    await new Promise((r) => setTimeout(r, CHUNK_RETRY_DELAY_MS))
+  }
+}
 
 // Decide what the response to a whole-file upload, or to the chunk
 // that commits one, means. Kept in one place so both paths agree.
@@ -554,16 +579,7 @@ function homeApp(): HomeAppData {
     // given status means for a chunk versus a final commit.
     sendUpload(
       this: HomeAppData,
-      opts: {
-        url: string
-        csrf: string
-        body: Blob
-        filename: string
-        range?: string
-        uploadId?: string
-        sentBytes: number
-        totalBytes: number
-      },
+      opts: UploadRequest,
     ): Promise<RawUploadResponse> {
       return new Promise<RawUploadResponse>((resolve) => {
         const xhr = new XMLHttpRequest()
@@ -630,56 +646,38 @@ function homeApp(): HomeAppData {
 
       const chunks = planChunks(file.size, chunkSize)
       const uploadId = newUploadId()
-      for (let i = 0; i < chunks.length; i++) {
-        const chunk = chunks[i]
-        const isFinal = i === chunks.length - 1
-        // Re-wrap the slice with the file's own type. A raw Blob from
-        // File.slice() reports application/octet-stream, and the
-        // server uses the browser's type to catch a file whose
-        // extension lies about it (a HEIC renamed to .jpg). Without
-        // this the chunked path would skip normalisation and the
-        // asset would render blank on the player.
-        const body = new Blob([file.slice(chunk.start, chunk.end + 1)], {
-          type: file.type,
-        })
 
-        let res: RawUploadResponse | null = null
-        for (let attempt = 0; attempt <= CHUNK_RETRIES; attempt++) {
-          res = await this.sendUpload({
+      const sendChunk = (
+        chunk: Chunk,
+        isFinal: boolean,
+      ): Promise<RawUploadResponse> =>
+        sendWithRetry(
+          (opts) => this.sendUpload(opts),
+          {
             url,
             csrf,
-            body,
+            // Re-wrap the slice with the file's own type. A raw Blob
+            // from File.slice() reports application/octet-stream, and
+            // the server uses the browser's type to catch a file whose
+            // extension lies about it (a HEIC renamed to .jpg).
+            // Without this the chunked path would skip normalisation
+            // and the asset would render blank on the player.
+            body: new Blob([file.slice(chunk.start, chunk.end + 1)], {
+              type: file.type,
+            }),
             filename: file.name,
             range: chunk.header,
             uploadId,
             sentBytes: chunk.start,
             totalBytes: file.size,
-          })
-          // Only a dropped connection or a server-side stumble is
-          // worth resending: chunking turns one request into dozens,
-          // so a single blip should not lose the whole upload. A 4xx
-          // is the server's considered answer and will not change.
-          // Staging a chunk is idempotent, so resending one is safe —
-          // but the final chunk commits, and a lost response there
-          // may mean the asset already exists.
-          const retryable =
-            (res.status === 0 && !isFinal) ||
-            (res.status >= 500 && res.status !== 507)
-          if (!retryable || attempt === CHUNK_RETRIES) break
-          await new Promise((r) => setTimeout(r, CHUNK_RETRY_DELAY_MS))
-        }
-        if (res === null) break
+          },
+          isFinal,
+        )
 
-        if (isFinal) {
-          // No response to the commit. os.replace may already have
-          // moved the partial into place, so this is not a failure we
-          // can report as one: say so and let the operator look.
-          if (res.status === 0) {
-            return { status: 'error', failure: { kind: 'unconfirmed' } }
-          }
-          return interpretFinalResponse(res)
-        }
-
+      // Every chunk but the last only stages bytes; the server
+      // acknowledges each with the upload id and nothing else.
+      for (const chunk of chunks.slice(0, -1)) {
+        const res = await sendChunk(chunk, false)
         if (res.status < 200 || res.status >= 300) {
           const message = parseServerError(res.text)
           return {
@@ -702,7 +700,17 @@ function homeApp(): HomeAppData {
           return { status: 'rejected' }
         }
       }
-      return { status: 'error', failure: { kind: 'network' } }
+
+      // The last chunk carries the final byte, so it is the one that
+      // creates the asset.
+      const res = await sendChunk(chunks[chunks.length - 1], true)
+      if (res.status === 0) {
+        // No response to the commit. os.replace may already have moved
+        // the partial into place, so this is not a failure we can
+        // report as one: say so and let the operator look.
+        return { status: 'error', failure: { kind: 'unconfirmed' } }
+      }
+      return interpretFinalResponse(res)
     },
   }
 }

--- a/src/anthias_server/app/static/src/home.ts
+++ b/src/anthias_server/app/static/src/home.ts
@@ -148,12 +148,29 @@ interface RawUploadResponse {
   text: string
   trigger: string | null
   bodySent: boolean
+  // An expired session answers a 2xx carrying HX-Redirect rather than
+  // a 302 an XHR would follow invisibly. Carried here because this
+  // handler no longer classifies the response itself: without it the
+  // chunk loop cannot see the header at all, and every file over the
+  // chunk size would be dropped from the batch with the operator never
+  // sent to sign in.
+  redirect: string | null
 }
 
 // Chunking turns one request into dozens, so one dropped connection
 // should not lose an upload the operator has been waiting on.
 const CHUNK_RETRIES = 2
 const CHUNK_RETRY_DELAY_MS = 500
+
+// An expired session is not a failure of this upload, it is the end of
+// the batch: every remaining file answers the same way. Navigating is
+// what resolves it; the failure kind exists so a slow navigation still
+// explains itself.
+function followRedirect(res: RawUploadResponse): UploadResult | null {
+  if (!res.redirect) return null
+  window.location.href = res.redirect
+  return { status: 'error', failure: { kind: 'auth' } }
+}
 
 // Resend only what might not fail again — a 4xx is the server's
 // considered answer. Staging a chunk is idempotent, so anything that
@@ -182,10 +199,32 @@ async function sendWithRetry(
   }
 }
 
-// Decide what the response to a whole-file upload, or to the chunk
-// that commits one, means. Kept in one place so both paths agree.
+// Decide what the response to a request that COMMITS means — the
+// whole file on the single-shot path, or the last chunk of a split
+// one. Both create the asset and answer afterwards, so both carry the
+// same ambiguity when the answer does not arrive intact, and both go
+// through here so neither can drift from the other.
 function interpretFinalResponse(res: RawUploadResponse): UploadResult {
+  const authFailure = followRedirect(res)
+  if (authFailure) return authFailure
   const kind = fireToastFromHeader(res.trigger)
+  // The server's own words where it gave any — the 409 that says to
+  // check the asset list, the 507 that names the disk — beat anything
+  // derivable from a status code.
+  const message = jsonStringField(res.text, 'error')
+  if (message) {
+    return {
+      status: 'error',
+      failure: { kind: 'server', message, status: res.status },
+    }
+  }
+  // The bytes went out and nothing intelligible came back: the asset
+  // may already exist, so don't report a plain failure and don't send
+  // the operator off to upload a second copy. A body that never
+  // finished sending cannot have committed, so it falls through.
+  if (res.bodySent && (res.status === 0 || res.status >= 500)) {
+    return { status: 'error', failure: { kind: 'unconfirmed' } }
+  }
   if (res.status === 0) {
     return { status: 'error', failure: { kind: 'network' } }
   }
@@ -527,9 +566,13 @@ function homeApp(): HomeAppData {
       this.uploadTotal = 0
 
       if (failure) {
-        // "Check the asset list" is unactionable with the Add modal
-        // sitting on top of it.
-        if (failure.kind === 'unconfirmed') this.mode = null
+        // Every outcome that tells the operator the asset may already
+        // be there — ours, and the server's own 409 — is unactionable
+        // with the Add modal sitting on top of the asset list.
+        const mayAlreadyExist =
+          failure.kind === 'unconfirmed' ||
+          (failure.kind === 'server' && failure.status === 409)
+        if (mayAlreadyExist) this.mode = null
         const store = window.Alpine.store('toasts') as
           | ToastStoreLike
           | undefined
@@ -611,17 +654,28 @@ function homeApp(): HomeAppData {
           if (done >= opts.totalBytes) this.uploadState = 'processing'
         })
         xhr.addEventListener('load', () => {
+          // Not hardcoded true: a proxy enforcing a body limit answers
+          // and closes while the browser is still writing, so a
+          // response can arrive with the body unfinished — the one
+          // case this flag exists to catch.
           resolve({
             status: xhr.status,
             text: xhr.responseText,
             trigger: xhr.getResponseHeader('HX-Trigger'),
-            bodySent: true,
+            bodySent,
+            redirect: xhr.getResponseHeader('HX-Redirect'),
           })
         })
         // No response at all (dropped connection, DNS, TLS): status is
         // 0 here, so it is not an HTTP failure.
         const failed = () =>
-          resolve({ status: 0, text: '', trigger: null, bodySent })
+          resolve({
+            status: 0,
+            text: '',
+            trigger: null,
+            bodySent,
+            redirect: null,
+          })
         xhr.addEventListener('error', failed)
         xhr.addEventListener('abort', failed)
         const fd = new FormData()
@@ -657,6 +711,17 @@ function homeApp(): HomeAppData {
       const chunks = planChunks(file.size, chunkSize)
       const uploadId = newUploadId()
 
+      // A 413 means something in front of the device refused this
+      // request. On the single-shot path that is "your file is too
+      // large"; here the file has already been split, so the honest
+      // answer names the chunk size instead.
+      const named = (result: UploadResult): UploadResult =>
+        result.status === 'error' &&
+        result.failure.kind === 'http' &&
+        result.failure.status === 413
+          ? { status: 'error', failure: { kind: 'chunk-too-large' } }
+          : result
+
       const sendChunk = (
         chunk: Chunk,
         isFinal: boolean,
@@ -689,16 +754,17 @@ function homeApp(): HomeAppData {
         const res = await sendChunk(chunk, false)
         if (res.status < 200 || res.status >= 300) {
           // The server's own wording where it gave one; the status
-          // code is the fallback.
+          // code is the fallback. No ambiguity to weigh here: a
+          // staging chunk commits nothing.
           const message = jsonStringField(res.text, 'error')
-          return {
+          return named({
             status: 'error',
             failure: message
-              ? { kind: 'server', message }
+              ? { kind: 'server', message, status: res.status }
               : res.status === 0
                 ? { kind: 'network' }
                 : { kind: 'http', status: res.status },
-          }
+          })
         }
         // A 200 that is not the acknowledgement is the server
         // refusing the file (wrong type, nothing uploaded) and
@@ -706,27 +772,29 @@ function homeApp(): HomeAppData {
         // rejected, not a transport failure. Replay and carry on, as
         // single-shot does.
         if (jsonStringField(res.text, 'upload_id') === undefined) {
-          fireToastFromHeader(res.trigger)
+          const authFailure = followRedirect(res)
+          if (authFailure) return authFailure
+          // Only a rejection if the server actually said so.
+          // fireToastFromHeader pushes nothing when there is no
+          // HX-Trigger, so treating every unrecognised 2xx as a
+          // rejection drops the file with no asset, no error and a
+          // progress bar that completed — which is what a login page,
+          // a captive portal or a proxy's own 200 looks like here.
+          const kind = fireToastFromHeader(res.trigger)
+          if (kind === null) {
+            return {
+              status: 'error',
+              failure: { kind: 'http', status: res.status },
+            }
+          }
           return { status: 'rejected' }
         }
       }
 
       // The last carries the final byte, so it creates the asset.
-      const res = await sendChunk(chunks[chunks.length - 1], true)
-      // The server's own words where it gave any — the 409 that says
-      // to check the asset list, or the 507 that names the disk — beat
-      // anything derivable from a status code.
-      const message = jsonStringField(res.text, 'error')
-      if (message) return { status: 'error', failure: { kind: 'server', message } }
-      // Otherwise: if the bytes went out and nothing intelligible came
-      // back, os.replace may already have moved the partial into
-      // place. Don't report that as a plain failure. A body that never
-      // finished sending could not have committed, so it falls through
-      // to the ordinary transport message.
-      if (res.bodySent && (res.status === 0 || res.status >= 500)) {
-        return { status: 'error', failure: { kind: 'unconfirmed' } }
-      }
-      return interpretFinalResponse(res)
+      return named(
+        interpretFinalResponse(await sendChunk(chunks[chunks.length - 1], true)),
+      )
     },
   }
 }

--- a/src/anthias_server/app/static/src/home/chunking.test.ts
+++ b/src/anthias_server/app/static/src/home/chunking.test.ts
@@ -68,10 +68,21 @@ describe('chunkSizeFromMeta', () => {
     expect(chunkSizeFromMeta('8')).toBe(8 * 1024 * 1024)
   })
 
-  // Above the server's FILE_UPLOAD_MAX_MEMORY_SIZE, Django spools the
-  // chunk to /tmp, which is RAM on a stock Pi image.
+  // The ceiling keeps a chunk under the server's
+  // FILE_UPLOAD_MAX_MEMORY_SIZE, where Django holds it in RAM instead
+  // of spooling it to the SD card.
   test('caps the size so a chunk stays in memory server-side', () => {
     expect(chunkSizeFromMeta('512')).toBe(24 * 1024 * 1024)
+  })
+
+  // The server clamps to the same floor, so this only bites on a meta
+  // tag that was hand-edited — but a size below 1 MB turns a large
+  // video into thousands of sequential requests, and a small enough
+  // one used to floor to 0 bytes, which made planChunks return no
+  // chunks for a file needsChunking had just said to split.
+  test('floors the size the same way the server does', () => {
+    expect(chunkSizeFromMeta('0.5')).toBe(1024 * 1024)
+    expect(chunkSizeFromMeta('0.0000001')).toBe(1024 * 1024)
   })
 
   test('falls back when the tag is missing or nonsense', () => {

--- a/src/anthias_server/app/static/src/home/chunking.test.ts
+++ b/src/anthias_server/app/static/src/home/chunking.test.ts
@@ -1,0 +1,85 @@
+// Behavioural tests for the upload chunk planner. Run with
+// `bun test src/anthias_server/app/static/src/home/chunking.test.ts`.
+//
+// The ranges these produce are what the server stages by, and a wrong
+// one fails silently: the server truncates to the declared total, so a
+// bad final range or an off-by-one start yields an asset of exactly
+// the right size that will not play.
+
+import { describe, expect, test } from 'bun:test'
+
+import { chunkSizeFromMeta, needsChunking, planChunks } from './chunking'
+
+describe('planChunks', () => {
+  test('covers every byte exactly once, with no gap or overlap', () => {
+    const chunks = planChunks(250, 100)
+    expect(chunks.map((c) => [c.start, c.end])).toEqual([
+      [0, 99],
+      [100, 199],
+      [200, 249],
+    ])
+    // The property that matters: each chunk starts where the last ended.
+    chunks.forEach((c, i) => {
+      if (i > 0) expect(c.start).toBe(chunks[i - 1].end + 1)
+    })
+  })
+
+  test('the last chunk ends on the final byte, not past it', () => {
+    // The server truncates to the declared total, so an end past the
+    // file would silently produce a short asset.
+    expect(planChunks(250, 100).at(-1)?.end).toBe(249)
+    expect(planChunks(300, 100).at(-1)?.end).toBe(299)
+  })
+
+  test('an exact multiple does not emit a trailing empty chunk', () => {
+    const chunks = planChunks(300, 100)
+    expect(chunks).toHaveLength(3)
+    expect(chunks.at(-1)?.end).toBe(299)
+  })
+
+  test('the header is the wire format the server parses', () => {
+    expect(planChunks(250, 100)[0].header).toBe('bytes 0-99/250')
+    expect(planChunks(250, 100).at(-1)?.header).toBe('bytes 200-249/250')
+  })
+
+  test('a file smaller than one chunk is a single full-range chunk', () => {
+    expect(planChunks(40, 100)).toEqual([
+      { start: 0, end: 39, header: 'bytes 0-39/40' },
+    ])
+  })
+
+  // An empty file has no representable range (0-0/0 would claim one
+  // byte), and the server rejects it outright.
+  test('an empty file yields no chunks', () => {
+    expect(planChunks(0, 100)).toEqual([])
+  })
+})
+
+describe('needsChunking', () => {
+  test('only files larger than one chunk are split', () => {
+    expect(needsChunking(101, 100)).toBe(true)
+    expect(needsChunking(100, 100)).toBe(false)
+    expect(needsChunking(0, 100)).toBe(false)
+  })
+})
+
+describe('chunkSizeFromMeta', () => {
+  test('reads the configured size in MB', () => {
+    expect(chunkSizeFromMeta('8')).toBe(8 * 1024 * 1024)
+  })
+
+  // Above the server's FILE_UPLOAD_MAX_MEMORY_SIZE, Django spools the
+  // chunk to /tmp, which is RAM on a stock Pi image.
+  test('caps the size so a chunk stays in memory server-side', () => {
+    expect(chunkSizeFromMeta('512')).toBe(24 * 1024 * 1024)
+  })
+
+  test('falls back when the tag is missing or nonsense', () => {
+    const fallback = 16 * 1024 * 1024
+    expect(chunkSizeFromMeta(null)).toBe(fallback)
+    expect(chunkSizeFromMeta('')).toBe(fallback)
+    expect(chunkSizeFromMeta('nope')).toBe(fallback)
+    expect(chunkSizeFromMeta('0')).toBe(fallback)
+    expect(chunkSizeFromMeta('-4')).toBe(fallback)
+  })
+})

--- a/src/anthias_server/app/static/src/home/chunking.ts
+++ b/src/anthias_server/app/static/src/home/chunking.ts
@@ -20,9 +20,11 @@ export interface Chunk {
   header: string
 }
 
-// Chunks must not exceed FILE_UPLOAD_MAX_MEMORY_SIZE on the server
-// (25 MB), or Django spools them to /tmp, which is RAM on a stock Pi
-// image. The server's own default is 16.
+// Kept under the server's FILE_UPLOAD_MAX_MEMORY_SIZE (25 MB), which
+// means Django holds each chunk in RAM rather than spooling it to the
+// SD card — so this is what one in-flight upload costs resident on a
+// board that may have 512 MB. The server clamps to the same ceiling;
+// its own default is 16.
 const FALLBACK_CHUNK_MB = 16
 const MAX_CHUNK_MB = 24
 

--- a/src/anthias_server/app/static/src/home/chunking.ts
+++ b/src/anthias_server/app/static/src/home/chunking.ts
@@ -1,30 +1,26 @@
 // Split a large upload into requests small enough to clear a proxy.
+// Anthias accepts a body of any size; a reverse proxy in front of the
+// device usually cannot (Cloudflare caps non-Enterprise plans at
+// 100 MB), so the bytes arrive in several requests, each carrying the
+// Content-Range the server stages by.
 //
-// Anthias itself accepts a body of any size, but an operator who puts
-// a reverse proxy in front of the device usually cannot: Cloudflare
-// caps every non-Enterprise plan at 100 MB. The bytes have to arrive
-// in several requests, each carrying the Content-Range the server
-// stages by.
-//
-// The arithmetic lives here, away from the DOM, because the failure it
-// guards against is silent: a wrong final range makes the server
-// truncate to the wrong length, and an off-by-one start leaves a hole
-// that reads back as zeros. Both produce an asset of exactly the right
-// size that will not play.
+// The arithmetic sits here, away from the DOM, because it fails
+// silently: a wrong final range truncates to the wrong length and an
+// off-by-one start leaves a hole reading back as zeros — both an asset
+// of exactly the right size that will not play.
 
 export interface Chunk {
   start: number
-  // Inclusive, matching the Content-Range wire format rather than the
-  // exclusive end that File.slice() takes.
+  // Inclusive, as Content-Range is on the wire — not the exclusive end
+  // File.slice() takes.
   end: number
   header: string
 }
 
-// Kept under the server's FILE_UPLOAD_MAX_MEMORY_SIZE (25 MB), which
-// means Django holds each chunk in RAM rather than spooling it to the
-// SD card — so this is what one in-flight upload costs resident on a
-// board that may have 512 MB. The server clamps to the same ceiling;
-// its own default is 16.
+// Under the server's FILE_UPLOAD_MAX_MEMORY_SIZE (25 MB), so Django
+// holds each chunk in RAM rather than spooling it to the SD card —
+// what one in-flight upload costs resident on a 512 MB board. The
+// server clamps to the same ceiling; its default is 16.
 const FALLBACK_CHUNK_MB = 16
 const MAX_CHUNK_MB = 24
 
@@ -37,11 +33,9 @@ export function chunkSizeFromMeta(raw: string | null): number {
   return Math.floor(mb * 1024 * 1024)
 }
 
-// Every chunk of a file, in the order they must be sent. The server
-// tracks a byte count rather than a set of received ranges, so a chunk
-// arriving out of order is indistinguishable from a resumed upload
-// whose partial has gone, and the whole upload is discarded. Send
-// these strictly in sequence, one in flight.
+// Every chunk of a file, in the order they must be sent: strictly in
+// sequence, one in flight (see _stage_upload_chunk in views.py for
+// why out-of-order discards the upload).
 export function planChunks(fileSize: number, chunkSize: number): Chunk[] {
   if (fileSize <= 0 || chunkSize <= 0) return []
   const chunks: Chunk[] = []
@@ -56,10 +50,9 @@ export function planChunks(fileSize: number, chunkSize: number): Chunk[] {
   return chunks
 }
 
-// Whether a file should be sent in pieces at all. A file that fits in
-// one chunk takes the original single-request path, which keeps the
-// common case on well-trodden code and leaves empty files (which have
-// no representable range) alone.
+// One that fits in a single chunk takes the original single-request
+// path: the common case stays on well-trodden code, and empty files —
+// which have no representable range — are left alone.
 export function needsChunking(fileSize: number, chunkSize: number): boolean {
   return fileSize > chunkSize
 }

--- a/src/anthias_server/app/static/src/home/chunking.ts
+++ b/src/anthias_server/app/static/src/home/chunking.ts
@@ -1,0 +1,63 @@
+// Split a large upload into requests small enough to clear a proxy.
+//
+// Anthias itself accepts a body of any size, but an operator who puts
+// a reverse proxy in front of the device usually cannot: Cloudflare
+// caps every non-Enterprise plan at 100 MB. The bytes have to arrive
+// in several requests, each carrying the Content-Range the server
+// stages by.
+//
+// The arithmetic lives here, away from the DOM, because the failure it
+// guards against is silent: a wrong final range makes the server
+// truncate to the wrong length, and an off-by-one start leaves a hole
+// that reads back as zeros. Both produce an asset of exactly the right
+// size that will not play.
+
+export interface Chunk {
+  start: number
+  // Inclusive, matching the Content-Range wire format rather than the
+  // exclusive end that File.slice() takes.
+  end: number
+  header: string
+}
+
+// Chunks must not exceed FILE_UPLOAD_MAX_MEMORY_SIZE on the server
+// (25 MB), or Django spools them to /tmp, which is RAM on a stock Pi
+// image. The server's own default is 16.
+const FALLBACK_CHUNK_MB = 16
+const MAX_CHUNK_MB = 24
+
+export function chunkSizeFromMeta(raw: string | null): number {
+  const parsed = Number(raw)
+  const mb =
+    Number.isFinite(parsed) && parsed > 0
+      ? Math.min(parsed, MAX_CHUNK_MB)
+      : FALLBACK_CHUNK_MB
+  return Math.floor(mb * 1024 * 1024)
+}
+
+// Every chunk of a file, in the order they must be sent. The server
+// tracks a byte count rather than a set of received ranges, so a chunk
+// arriving out of order is indistinguishable from a resumed upload
+// whose partial has gone, and the whole upload is discarded. Send
+// these strictly in sequence, one in flight.
+export function planChunks(fileSize: number, chunkSize: number): Chunk[] {
+  if (fileSize <= 0 || chunkSize <= 0) return []
+  const chunks: Chunk[] = []
+  for (let start = 0; start < fileSize; start += chunkSize) {
+    const end = Math.min(start + chunkSize, fileSize) - 1
+    chunks.push({
+      start,
+      end,
+      header: `bytes ${start}-${end}/${fileSize}`,
+    })
+  }
+  return chunks
+}
+
+// Whether a file should be sent in pieces at all. A file that fits in
+// one chunk takes the original single-request path, which keeps the
+// common case on well-trodden code and leaves empty files (which have
+// no representable range) alone.
+export function needsChunking(fileSize: number, chunkSize: number): boolean {
+  return fileSize > chunkSize
+}

--- a/src/anthias_server/app/static/src/home/chunking.ts
+++ b/src/anthias_server/app/static/src/home/chunking.ts
@@ -17,18 +17,25 @@ export interface Chunk {
   header: string
 }
 
-// Under the server's FILE_UPLOAD_MAX_MEMORY_SIZE (25 MB), so Django
-// holds each chunk in RAM rather than spooling it to the SD card —
-// what one in-flight upload costs resident on a 512 MB board. The
-// server clamps to the same ceiling; its default is 16.
+// The same three numbers resolve_upload_chunk_size_mb clamps to
+// server-side, mirrored here so a meta tag that is absent, empty or
+// hand-edited cannot produce a chunk size the server would refuse.
+// The ceiling keeps a chunk under FILE_UPLOAD_MAX_MEMORY_SIZE (25 MB),
+// where Django holds it in RAM rather than spooling it to the SD card
+// — what one in-flight upload costs resident on a 512 MB board. The
+// floor exists because below it a large file becomes thousands of
+// sequential requests; it also keeps this from ever returning 0,
+// which would make planChunks yield nothing for a file it had just
+// said needed chunking.
 const FALLBACK_CHUNK_MB = 16
 const MAX_CHUNK_MB = 24
+const MIN_CHUNK_MB = 1
 
 export function chunkSizeFromMeta(raw: string | null): number {
   const parsed = Number(raw)
   const mb =
     Number.isFinite(parsed) && parsed > 0
-      ? Math.min(parsed, MAX_CHUNK_MB)
+      ? Math.min(Math.max(parsed, MIN_CHUNK_MB), MAX_CHUNK_MB)
       : FALLBACK_CHUNK_MB
   return Math.floor(mb * 1024 * 1024)
 }

--- a/src/anthias_server/app/static/src/home/upload-error.test.ts
+++ b/src/anthias_server/app/static/src/home/upload-error.test.ts
@@ -40,6 +40,15 @@ describe('uploadErrorMessage', () => {
     )
   })
 
+  // Never "try again": the asset may already be there, and a second
+  // upload is exactly the duplicate this wording exists to avoid.
+  test('an unconfirmed commit sends the operator to the list', () => {
+    expect(uploadErrorMessage({ kind: 'unconfirmed' })).toBe(
+      'Upload may have finished — check the asset list before ' +
+        'uploading it again',
+    )
+  })
+
   // The server's own wording beats anything derived from a status.
   test('a server-supplied message is passed through verbatim', () => {
     expect(

--- a/src/anthias_server/app/static/src/home/upload-error.test.ts
+++ b/src/anthias_server/app/static/src/home/upload-error.test.ts
@@ -31,13 +31,20 @@ describe('uploadErrorMessage', () => {
     expect(uploadErrorMessage({ kind: 'http', status: 502 })).toBe(expected)
   })
 
-  // 507 is intentionally not special-cased: the browser upload path
-  // answers a full disk with 200 + an HX-Trigger toast, so this only
-  // arrives from an API caller and the generic 5xx line is right.
-  test('507 falls through to the generic server message', () => {
+  // A chunked upload answers a full disk with 507, so this is now
+  // reachable from the browser and must not send the operator to the
+  // logs for something they can fix themselves.
+  test('507 names the disk, not the logs', () => {
     expect(uploadErrorMessage({ kind: 'http', status: 507 })).toBe(
-      'The server failed while handling the upload — check the device logs',
+      'Not enough space on the device — free some up and try again',
     )
+  })
+
+  // The server's own wording beats anything derived from a status.
+  test('a server-supplied message is passed through verbatim', () => {
+    expect(
+      uploadErrorMessage({ kind: 'server', message: 'Disk is full.' }),
+    ).toBe('Disk is full.')
   })
 
   test('other 4xx keep the original generic wording', () => {

--- a/src/anthias_server/app/static/src/home/upload-error.ts
+++ b/src/anthias_server/app/static/src/home/upload-error.ts
@@ -20,12 +20,25 @@
 export type UploadFailure =
   | { kind: 'http'; status: number }
   | { kind: 'network' }
+  // A chunked upload whose commit got no response. The asset may
+  // exist: the server renames the partial into place before it
+  // answers, so a lost reply is indistinguishable from a lost commit.
+  | { kind: 'unconfirmed' }
   // The server explained itself in the response body. Its wording is
   // better than anything derivable from a status code, so it wins.
   | { kind: 'server'; message: string }
 
 export function uploadErrorMessage(failure: UploadFailure): string {
   if (failure.kind === 'server') return failure.message
+
+  // Never "try again" here. Telling the operator to re-upload
+  // something that may have completed is what produces a duplicate.
+  if (failure.kind === 'unconfirmed') {
+    return (
+      'Upload may have finished — check the asset list before ' +
+      'uploading it again'
+    )
+  }
 
   // Both causes, neither asserted. A proxy enforcing a body limit
   // answers and closes while the browser is still writing, and the

--- a/src/anthias_server/app/static/src/home/upload-error.ts
+++ b/src/anthias_server/app/static/src/home/upload-error.ts
@@ -9,10 +9,9 @@
 // intermediary the operator controls and retrying cannot help.
 //
 // A single-shot upload answers ENOSPC with 200 plus an HX-Trigger
-// toast, which fireToastFromHeader replays. A chunk answers 507 with
-// the same text as JSON, which the caller passes through as a
-// `server` failure; the 507 branch below is the fallback for when
-// that body cannot be read.
+// toast, which fireToastFromHeader replays; a chunk answers 507 with
+// the same text as JSON, passed through as a `server` failure. The
+// 507 branch below is the fallback for when that body cannot be read.
 
 // A transport failure carries no HTTP status: XMLHttpRequest reports
 // `status === 0` and fires `error` or `abort`. Modelling that as its
@@ -21,8 +20,8 @@ export type UploadFailure =
   | { kind: 'http'; status: number }
   | { kind: 'network' }
   // A chunked upload whose commit got no response. The asset may
-  // exist: the server renames the partial into place before it
-  // answers, so a lost reply is indistinguishable from a lost commit.
+  // exist: the server renames the partial into place before answering,
+  // so a lost reply looks exactly like a lost commit.
   | { kind: 'unconfirmed' }
   // The server explained itself in the response body. Its wording is
   // better than anything derivable from a status code, so it wins.
@@ -31,8 +30,8 @@ export type UploadFailure =
 export function uploadErrorMessage(failure: UploadFailure): string {
   if (failure.kind === 'server') return failure.message
 
-  // Never "try again" here. Telling the operator to re-upload
-  // something that may have completed is what produces a duplicate.
+  // Never "try again": re-uploading something that may have completed
+  // is what produces the duplicate.
   if (failure.kind === 'unconfirmed') {
     return (
       'Upload may have finished — check the asset list before ' +
@@ -69,9 +68,9 @@ export function uploadErrorMessage(failure: UploadFailure): string {
     return 'Upload rejected — reload the page and try again'
   }
 
-  // Before the 5xx branch: a chunked upload reports a full disk as
-  // 507, and "check the device logs" would send the operator to the
-  // wrong place for something they can act on directly.
+  // Before the 5xx branch: a chunk reports a full disk as 507, and
+  // "check the device logs" is the wrong place for something the
+  // operator can act on directly.
   if (status === 507) {
     return 'Not enough space on the device — free some up and try again'
   }

--- a/src/anthias_server/app/static/src/home/upload-error.ts
+++ b/src/anthias_server/app/static/src/home/upload-error.ts
@@ -8,9 +8,11 @@
 // sets `request_body { max_size 0 }`), so it always comes from an
 // intermediary the operator controls and retrying cannot help.
 //
-// No 507 case on purpose — assets_upload answers ENOSPC with 200 plus
-// an HX-Trigger toast carrying DISK_FULL_ERROR, which
-// fireToastFromHeader already replays. Only the REST API returns 507.
+// A single-shot upload answers ENOSPC with 200 plus an HX-Trigger
+// toast, which fireToastFromHeader replays. A chunk answers 507 with
+// the same text as JSON, which the caller passes through as a
+// `server` failure; the 507 branch below is the fallback for when
+// that body cannot be read.
 
 // A transport failure carries no HTTP status: XMLHttpRequest reports
 // `status === 0` and fires `error` or `abort`. Modelling that as its
@@ -18,8 +20,13 @@
 export type UploadFailure =
   | { kind: 'http'; status: number }
   | { kind: 'network' }
+  // The server explained itself in the response body. Its wording is
+  // better than anything derivable from a status code, so it wins.
+  | { kind: 'server'; message: string }
 
 export function uploadErrorMessage(failure: UploadFailure): string {
+  if (failure.kind === 'server') return failure.message
+
   // Both causes, neither asserted. A proxy enforcing a body limit
   // answers and closes while the browser is still writing, and the
   // browser does not always salvage that response — so a size
@@ -47,6 +54,13 @@ export function uploadErrorMessage(failure: UploadFailure): string {
   // answers 302 to /login/, which XHR follows transparently.
   if (status === 403) {
     return 'Upload rejected — reload the page and try again'
+  }
+
+  // Before the 5xx branch: a chunked upload reports a full disk as
+  // 507, and "check the device logs" would send the operator to the
+  // wrong place for something they can act on directly.
+  if (status === 507) {
+    return 'Not enough space on the device — free some up and try again'
   }
 
   if (status >= 500) {

--- a/src/anthias_server/app/static/src/home/upload-error.ts
+++ b/src/anthias_server/app/static/src/home/upload-error.ts
@@ -23,12 +23,39 @@ export type UploadFailure =
   // exist: the server renames the partial into place before answering,
   // so a lost reply looks exactly like a lost commit.
   | { kind: 'unconfirmed' }
+  // The session expired: the server answered with HX-Redirect and the
+  // caller is navigating to the login page. Carries no status because
+  // the response was a perfectly ordinary 2xx. Deliberately the same
+  // shape as the fix in the htmx-auth-redirect PR, so whichever of the
+  // two rebases second resolves to the same thing twice rather than
+  // silently losing it.
+  | { kind: 'auth' }
+  // A proxy refused one CHUNK as too large. The file is not the
+  // problem — splitting it was supposed to be the fix — so the remedy
+  // is a smaller chunk, not a smaller file.
+  | { kind: 'chunk-too-large' }
   // The server explained itself in the response body. Its wording is
-  // better than anything derivable from a status code, so it wins.
-  | { kind: 'server'; message: string }
+  // better than anything derivable from a status code, so it wins —
+  // the status rides along because the caller still has to know a 409
+  // ("it may already be there") from a 507 ("the disk is full").
+  | { kind: 'server'; message: string; status: number }
 
 export function uploadErrorMessage(failure: UploadFailure): string {
+  // Usually unseen, since the caller navigates away on this. Worth
+  // having anyway: if the navigation is slow the operator gets an
+  // explanation rather than a blank moment.
+  if (failure.kind === 'auth') {
+    return 'Your session expired — sign in again to upload'
+  }
+
   if (failure.kind === 'server') return failure.message
+
+  if (failure.kind === 'chunk-too-large') {
+    return (
+      'Even split up, each part is too large for a proxy in front of ' +
+      'the device — lower the upload chunk size'
+    )
+  }
 
   // Never "try again": re-uploading something that may have completed
   // is what produces the duplicate.

--- a/src/anthias_server/app/templates/base.html
+++ b/src/anthias_server/app/templates/base.html
@@ -17,6 +17,7 @@
   {% comment %} Store-catalog index the Add → Apps tab fetches (client-side)
      to list installable signage apps. Env-overridable server setting. {% endcomment %}
   <meta name="anthias-app-store-index" content="{{ app_store_index_url }}">
+  <meta name="anthias-upload-chunk-mb" content="{{ upload_chunk_size_mb }}">
   <link href="/static/favicons/apple-touch-icon-57x57.png" rel="apple-touch-icon-precomposed" sizes="57x57"/>
   <link href="/static/favicons/apple-touch-icon-114x114.png" rel="apple-touch-icon-precomposed" sizes="114x114"/>
   <link href="/static/favicons/apple-touch-icon-72x72.png" rel="apple-touch-icon-precomposed" sizes="72x72"/>

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -74,19 +74,14 @@ _ANTHIAS_REPO_URL = 'https://github.com/Screenly/Anthias'
 # py/path-injection on ``open(final_path, ...)``).
 _SAFE_EXT_RE = re.compile(r'\.[A-Za-z0-9]{1,16}')
 
-# ``<staged>/<upload_id>.part``. The id is echoed by the client on
-# every chunk and lands in a filesystem path, so require the exact
-# 32-lowercase-hex shape we mint (``uuid4().hex``) and reject anything
-# else. This is a path-traversal guard: 32 hex characters cannot
-# contain a ``/`` or ``..``.
+# ``<staged>/<upload_id>.part``. The client echoes the id on every
+# chunk and it lands in a path, so require the exact shape we mint
+# (``uuid4().hex``): 32 hex characters cannot hold ``/`` or ``..``.
 _UPLOAD_ID_RE = re.compile(r'[0-9a-f]{32}')
 
-# ``bytes <start>-<end>/<total>``. A known numeric total is required
-# (``*`` is rejected): the last-chunk handoff below relies on it to
-# decide when the upload is complete.
-# Digit runs are bounded: ``int()`` raises above 4300 digits, and a
-# client-controlled header must not be able to turn that into a 500.
-# 19 digits covers any conceivable file size.
+# ``bytes <start>-<end>/<total>``. ``*`` is rejected: the last-chunk
+# handoff needs the total. 19 digits covers any file and keeps a
+# client header off ``int()``'s 4300-digit ValueError (a 500).
 _CONTENT_RANGE_RE = re.compile(r'bytes (\d{1,19})-(\d{1,19})/(\d{1,19})')
 
 
@@ -99,10 +94,9 @@ def _staged_upload_path(upload_id: str) -> str:
 class _ChunkedUploadError(Exception):
     """A ranged upload the server will not continue.
 
-    Every case means the client must start the upload over rather than
-    send more chunks, so this answers with a real status code: the
-    uploader is JavaScript reading a response, not a browser following
-    a form post.
+    Every case means starting over, and the uploader is JavaScript
+    reading a response rather than a browser following a form post, so
+    these answer with a real status code.
     """
 
     def __init__(self, message: str, status_code: int = 400) -> None:
@@ -115,17 +109,16 @@ def _stage_upload_chunk(
 ) -> tuple[str, str, bool]:
     """Write one ``Content-Range`` chunk of an upload to its partial file.
 
-    Returns ``(upload_id, staged_path, is_final)``. The caller renames
-    the staged file into the asset dir once ``is_final`` is true.
+    Returns ``(upload_id, staged_path, is_final)``; the caller renames
+    the staged file into the asset dir once ``is_final``.
 
-    Chunks for one upload id must arrive **strictly sequentially, one
-    in flight at a time**. What is tracked per upload is a byte count,
-    not a set of received ranges, so a chunk starting beyond the end of
-    what is already stored cannot be distinguished from a resumed
-    upload whose partial has gone, and is treated as the latter: the
-    partial is dropped and the operator asked to start over. Parallel
-    or out-of-order chunks would therefore throw the upload away rather
-    than degrade. Real resumability needs a received-ranges record.
+    Chunks for one id must arrive **strictly in sequence, one in
+    flight**: what is tracked is a byte count, not a set of received
+    ranges, so a chunk starting past the end cannot be told apart from
+    a resumed upload whose partial has gone. Both are treated as the
+    latter — partial dropped, operator asked to start over — so
+    parallel or out-of-order chunks discard the upload rather than
+    degrade it. Real resumability needs a received-ranges record.
     """
     match = _CONTENT_RANGE_RE.fullmatch(
         request.headers['Content-Range'].strip()
@@ -135,8 +128,8 @@ def _stage_upload_chunk(
 
     start_bytes, end_bytes, total_bytes = (int(g) for g in match.groups())
     if total_bytes == 0:
-        # No range can describe an empty file (0-0/0 would claim one
-        # byte). Nothing needs chunking at that size anyway.
+        # No range describes an empty file (0-0/0 claims one byte),
+        # and nothing that size needs chunking anyway.
         raise _ChunkedUploadError(
             'Cannot upload an empty file in chunks. Please try again.'
         )
@@ -147,9 +140,9 @@ def _stage_upload_chunk(
             'Upload chunk did not match its range. Please try again.'
         )
 
-    # The id is only honoured alongside a range: a single-shot upload
-    # never reaches here, so an echoed id cannot truncate an unrelated
-    # in-progress upload.
+    # Only honoured alongside a range — a single-shot upload never
+    # reaches here — so an echoed id cannot truncate an unrelated
+    # upload in progress.
     upload_id = request.headers.get('X-Upload-Id')
     if upload_id is None:
         upload_id = uuid.uuid4().hex
@@ -162,9 +155,9 @@ def _stage_upload_chunk(
     staged_path = _staged_upload_path(upload_id)
     is_final = end_bytes + 1 == total_bytes
 
-    # Refuse an upload that cannot fit before writing any of it: the
-    # alternative is an hour of sending followed by failure, with the
-    # partial then held for a day.
+    # Refuse one that cannot fit before writing any of it: otherwise
+    # an hour of sending, then failure, then the partial held until
+    # the sweep.
     if start_bytes == 0:
         try:
             free = shutil.disk_usage(settings['assetdir']).free
@@ -175,26 +168,23 @@ def _stage_upload_chunk(
 
     try:
         os.makedirs(staged_dir, exist_ok=True)
-        # Open first, then measure the file descriptor. Checking the
-        # size by path and then opening by path leaves a window in
-        # which the cleanup sweep (or a concurrent request's error
-        # path) can unlink the partial: the open would recreate it
-        # empty, the seek would leave a hole, and the finished asset
-        # would be silently corrupt at exactly the right size.
-        # O_NOFOLLOW because the name is derived from a client header.
+        # Measure the descriptor, not the path: between a stat and an
+        # open, the sweep (or a concurrent error path) can unlink the
+        # partial, and the open would recreate it empty, the seek would
+        # leave a hole, and the asset would be silently corrupt at
+        # exactly the right size. O_NOFOLLOW: the name comes from a
+        # client header.
         fd = os.open(
             staged_path,
             os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW,
             0o666,
         )
         with os.fdopen(fd, 'r+b') as f:
-            # Refuse to seek past the end of what we actually hold; see
-            # the sequential-only contract above.
+            # Never seek past what we hold; see the docstring.
             if start_bytes > os.fstat(f.fileno()).st_size:
-                # Don't tell the operator to upload it again: one way
-                # to land here is a commit whose response was lost,
-                # where os.replace has already moved the partial away
-                # and the asset exists. Point at the list first.
+                # Not "try again": one way here is a commit whose
+                # response was lost, where os.replace has already moved
+                # the partial away and the asset exists.
                 raise _ChunkedUploadError(
                     'This upload could not be resumed. Check whether it '
                     'already appears in the asset list before uploading '
@@ -208,18 +198,17 @@ def _stage_upload_chunk(
                 # Drop anything a longer earlier attempt left past the end.
                 f.truncate(total_bytes)
     except _ChunkedUploadError:
-        # The partial is unusable to this client now, and holding it
-        # for a day would only keep the operator stuck on the same
-        # error. Drop it so the retry starts clean.
+        # Unusable to this client now, and holding it would only keep
+        # the operator stuck on the same error.
         with suppress(OSError):
             remove(staged_path)
         raise
     except OSError as exc:
         if not is_disk_full(exc):
             raise
-        # Don't leave a partial squatting on the last free bytes of an
-        # already-full disk. Matches the single-shot path and the REST
-        # API, which both surface ENOSPC rather than raising.
+        # Don't squat on the last free bytes of an already-full disk.
+        # Matches the single-shot path and the REST API, which both
+        # surface ENOSPC rather than raising.
         with suppress(OSError):
             remove(staged_path)
         raise _ChunkedUploadError(DISK_FULL_ERROR, status_code=507) from exc
@@ -816,19 +805,18 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
     final_name = uuid.uuid4().hex
     final_path = path.join(settings['assetdir'], f'{final_name}{src_ext}')
 
-    # A ranged upload arrives as several requests. Each one stages its
-    # bytes into a per-upload partial file and returns early; only the
-    # request carrying the final byte falls through to create the
-    # asset. Everything above this point (type detection, the display
-    # name, the extension) runs per chunk on the same filename, so a
-    # file Anthias will refuse is refused on the first chunk rather
-    # than after the operator has waited out the whole upload.
+    # A ranged upload arrives as several requests: each stages its
+    # bytes and returns early, and only the one carrying the final byte
+    # falls through to create the asset. Everything above (type,
+    # display name, extension) runs per chunk on the same filename, so
+    # a file Anthias will refuse is refused on the first chunk, not
+    # after the whole upload.
     staged_path = None
     if 'Content-Range' in request.headers:
-        # Answer a chunk with JSON and a real status rather than the
-        # asset table: the caller is our own uploader reading a
-        # response, and re-rendering the table per chunk would also fan
-        # out a websocket refresh for an asset that does not exist yet.
+        # JSON and a real status, not the asset table: our own
+        # uploader is reading this, and re-rendering per chunk would
+        # fan out a websocket refresh for an asset that does not exist
+        # yet.
         try:
             upload_id, staged_path, is_final = _stage_upload_chunk(
                 request, file_upload
@@ -840,8 +828,8 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
 
     try:
         if staged_path is not None:
-            # The bytes are already on disk in the asset dir, so this
-            # is a rename within one filesystem rather than a copy.
+            # Already on disk in the asset dir: a rename within one
+            # filesystem, not a copy.
             os.replace(staged_path, final_path)
         else:
             with open(final_path, 'wb') as f:

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -74,6 +74,10 @@ _ANTHIAS_REPO_URL = 'https://github.com/Screenly/Anthias'
 # py/path-injection on ``open(final_path, ...)``).
 _SAFE_EXT_RE = re.compile(r'\.[A-Za-z0-9]{1,16}')
 
+# Extensions that mark a file as transient somewhere else in the
+# system, so an asset must never be stored under one. See _safe_ext.
+_RESERVED_EXTS = frozenset({'.tmp', '.part'})
+
 # ``<staged>/<upload_id>.part``. The id arrives on every chunk and
 # lands in a filesystem path — our own uploader mints it, anything
 # else may send what it likes — so require the exact shape minted
@@ -124,8 +128,10 @@ def _stage_upload_chunk(
     """
     # Resolved first: every rejection below abandons the upload, and
     # dropping the partial it abandons needs the id. Only honoured
-    # alongside a range — a single-shot upload never reaches here — so
-    # an echoed id cannot truncate an unrelated upload in progress.
+    # alongside a range, so a single-shot upload never reaches here at
+    # all. What keeps one caller off another's partial is the id
+    # itself — 32 unguessable hex, minted per upload — not the range
+    # checks, which now run after this point.
     upload_id = request.headers.get('X-Upload-Id')
     if upload_id is None:
         upload_id = uuid.uuid4().hex
@@ -163,19 +169,7 @@ def _stage_upload_chunk(
             raise _ChunkedUploadError(
                 'Upload chunk did not match its range. Please try again.'
             )
-
         is_final = end_bytes + 1 == total_bytes
-
-        # Refuse one that cannot fit before writing any of it:
-        # otherwise an hour of sending, then failure, then the partial
-        # held until the sweep.
-        if start_bytes == 0:
-            try:
-                free = shutil.disk_usage(settings['assetdir']).free
-            except OSError:
-                free = None
-            if free is not None and total_bytes > free:
-                raise _ChunkedUploadError(DISK_FULL_ERROR, status_code=507)
 
         os.makedirs(staged_dir, exist_ok=True)
         # Measure the descriptor, not the path: between a stat and an
@@ -190,8 +184,22 @@ def _stage_upload_chunk(
             0o666,
         )
         with os.fdopen(fd, 'r+b') as f:
+            held = os.fstat(f.fileno()).st_size
+            # Checked on every chunk, not just the first. `total_bytes`
+            # is re-read from each request and never pinned, so a
+            # client whose declared total grows after chunk 0 would
+            # otherwise never be measured against the disk at all —
+            # the refusal reads like a property of the upload and was
+            # a property of its first request. Costs one statvfs per
+            # chunk and needs no state.
+            try:
+                free = shutil.disk_usage(settings['assetdir']).free
+            except OSError:
+                free = None
+            if free is not None and total_bytes - held > free:
+                raise _ChunkedUploadError(DISK_FULL_ERROR, status_code=507)
             # Never seek past what we hold; see the docstring.
-            if start_bytes > os.fstat(f.fileno()).st_size:
+            if start_bytes > held:
                 # Not "try again": one way here is the sweep taking
                 # a partial that went an hour without a chunk. Another
                 # is a client resending a commit — ours does not,
@@ -798,7 +806,21 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
     #      a clean Pi base image could slip past normalisation
     #      and fail to render.
     def _safe_ext(candidate: str) -> str:
-        return candidate if _SAFE_EXT_RE.fullmatch(candidate) else ''
+        if not _SAFE_EXT_RE.fullmatch(candidate):
+            return ''
+        # Suffixes the platform treats as transient. An asset stored
+        # under one is not merely odd, it is unstable: the celery
+        # sweep deletes `*.tmp` from this directory on sight, and the
+        # backup filter drops `*.part`, so the row would outlive its
+        # file or vanish from every backup. A crafted multipart part
+        # (filename `clip.tmp`, Content-Type `video/tmp`) reaches here
+        # — a browser cannot, it sends application/octet-stream, which
+        # the type gate above rejects. Falls through to the next
+        # candidate in the chain rather than erroring: the operator's
+        # file is fine, only the name we would store it under is not.
+        if candidate.lower() in _RESERVED_EXTS:
+            return ''
+        return candidate
 
     src_ext = _safe_ext(guess_extension(file_type) or '')
     if not src_ext:

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1,4 +1,3 @@
-import hashlib
 import logging
 import os
 import re
@@ -37,7 +36,6 @@ from django.views.decorators.http import require_http_methods
 from anthias_common.utils import (
     DISK_FULL_ERROR,
     STAGED_UPLOAD_DIR,
-    STAGED_UPLOAD_FREE_MARGIN,
     clamp_screen_rotation,
     connect_to_redis,
     is_disk_full,
@@ -92,36 +90,10 @@ _UPLOAD_ID_RE = re.compile(r'[0-9a-f]{32}')
 _CONTENT_RANGE_RE = re.compile(r'bytes (\d{1,19})-(\d{1,19})/(\d{1,19})')
 
 
-def _staged_upload_name(request: HttpRequest, upload_id: str) -> str:
-    """On-disk stem for ``upload_id``, scoped to the calling session.
-
-    Knowing a stranger's id would otherwise be enough to finish their
-    staged bytes as your own asset, or to delete their partial. With
-    auth off (the default) there is no session, and the stem degrades
-    to an unguessable function of the id.
-    """
-    session_key = getattr(request, 'session', None)
-    salt = getattr(session_key, 'session_key', None) or ''
-    digest = hashlib.sha256(f'{upload_id}:{salt}'.encode()).hexdigest()
-    return digest[:32]
-
-
-def _staged_upload_path(request: HttpRequest, upload_id: str) -> str:
+def _staged_upload_path(upload_id: str) -> str:
     """Absolute path of the partial file for ``upload_id``."""
-    stem = _staged_upload_name(request, upload_id)
-    return path.join(settings['assetdir'], STAGED_UPLOAD_DIR, f'{stem}.part')
-
-
-def _committed_upload_path(request: HttpRequest, upload_id: str) -> str:
-    """Marker left behind when an upload has already become an asset.
-
-    Retrying a chunk whose request timed out after it succeeded would
-    otherwise build a second asset: the staged file is renamed away on
-    commit, so nothing distinguishes the replay from a fresh upload.
-    Swept on the same deadline as the partials.
-    """
-    stem = _staged_upload_name(request, upload_id)
-    return path.join(settings['assetdir'], STAGED_UPLOAD_DIR, f'{stem}.done')
+    staged = path.join(settings['assetdir'], STAGED_UPLOAD_DIR)
+    return path.join(staged, f'{upload_id}.part')
 
 
 class _ChunkedUploadError(Exception):
@@ -187,13 +159,8 @@ def _stage_upload_chunk(
             raise _ChunkedUploadError('Malformed upload id. Please try again.')
 
     staged_dir = path.join(settings['assetdir'], STAGED_UPLOAD_DIR)
-    staged_path = _staged_upload_path(request, upload_id)
+    staged_path = _staged_upload_path(upload_id)
     is_final = end_bytes + 1 == total_bytes
-
-    if path.exists(_committed_upload_path(request, upload_id)):
-        raise _ChunkedUploadError(
-            'This upload has already finished.', status_code=409
-        )
 
     # Refuse an upload that cannot fit before writing any of it: the
     # alternative is an hour of sending followed by failure, with the
@@ -203,7 +170,7 @@ def _stage_upload_chunk(
             free = shutil.disk_usage(settings['assetdir']).free
         except OSError:
             free = None
-        if free is not None and total_bytes + STAGED_UPLOAD_FREE_MARGIN > free:
+        if free is not None and total_bytes > free:
             raise _ChunkedUploadError(DISK_FULL_ERROR, status_code=507)
 
     try:
@@ -870,10 +837,6 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
             # The bytes are already on disk in the asset dir, so this
             # is a rename within one filesystem rather than a copy.
             os.replace(staged_path, final_path)
-            # Before the row exists, so a retry arriving mid-request
-            # is turned away rather than building a second asset.
-            with suppress(OSError):
-                open(_committed_upload_path(request, upload_id), 'wb').close()
         else:
             with open(final_path, 'wb') as f:
                 f.writelines(file_upload.chunks())

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -120,53 +120,61 @@ def _stage_upload_chunk(
     parallel or out-of-order chunks discard the upload rather than
     degrade it. Real resumability needs a received-ranges record.
     """
-    match = _CONTENT_RANGE_RE.fullmatch(
-        request.headers['Content-Range'].strip()
-    )
-    if match is None:
-        raise _ChunkedUploadError('Malformed upload range. Please try again.')
-
-    start_bytes, end_bytes, total_bytes = (int(g) for g in match.groups())
-    if total_bytes == 0:
-        # No range describes an empty file (0-0/0 claims one byte),
-        # and nothing that size needs chunking anyway.
-        raise _ChunkedUploadError(
-            'Cannot upload an empty file in chunks. Please try again.'
-        )
-    if end_bytes < start_bytes or end_bytes >= total_bytes:
-        raise _ChunkedUploadError('Invalid upload range. Please try again.')
-    if file_upload.size != end_bytes - start_bytes + 1:
-        raise _ChunkedUploadError(
-            'Upload chunk did not match its range. Please try again.'
-        )
-
-    # Only honoured alongside a range — a single-shot upload never
-    # reaches here — so an echoed id cannot truncate an unrelated
-    # upload in progress.
+    # Resolved first: every rejection below abandons the upload, and
+    # dropping the partial it abandons needs the id. Only honoured
+    # alongside a range — a single-shot upload never reaches here — so
+    # an echoed id cannot truncate an unrelated upload in progress.
     upload_id = request.headers.get('X-Upload-Id')
     if upload_id is None:
         upload_id = uuid.uuid4().hex
     else:
         upload_id = upload_id.strip().lower()
         if not _UPLOAD_ID_RE.fullmatch(upload_id):
+            # Nothing to drop: without a well-formed id there is no
+            # partial whose name we could derive.
             raise _ChunkedUploadError('Malformed upload id. Please try again.')
 
     staged_dir = path.join(settings['assetdir'], STAGED_UPLOAD_DIR)
     staged_path = _staged_upload_path(upload_id)
-    is_final = end_bytes + 1 == total_bytes
-
-    # Refuse one that cannot fit before writing any of it: otherwise
-    # an hour of sending, then failure, then the partial held until
-    # the sweep.
-    if start_bytes == 0:
-        try:
-            free = shutil.disk_usage(settings['assetdir']).free
-        except OSError:
-            free = None
-        if free is not None and total_bytes > free:
-            raise _ChunkedUploadError(DISK_FULL_ERROR, status_code=507)
 
     try:
+        match = _CONTENT_RANGE_RE.fullmatch(
+            request.headers['Content-Range'].strip()
+        )
+        if match is None:
+            raise _ChunkedUploadError(
+                'Malformed upload range. Please try again.'
+            )
+
+        start_bytes, end_bytes, total_bytes = (int(g) for g in match.groups())
+        if total_bytes == 0:
+            # No range describes an empty file (0-0/0 claims one byte),
+            # and nothing that size needs chunking anyway.
+            raise _ChunkedUploadError(
+                'Cannot upload an empty file in chunks. Please try again.'
+            )
+        if end_bytes < start_bytes or end_bytes >= total_bytes:
+            raise _ChunkedUploadError(
+                'Invalid upload range. Please try again.'
+            )
+        if file_upload.size != end_bytes - start_bytes + 1:
+            raise _ChunkedUploadError(
+                'Upload chunk did not match its range. Please try again.'
+            )
+
+        is_final = end_bytes + 1 == total_bytes
+
+        # Refuse one that cannot fit before writing any of it:
+        # otherwise an hour of sending, then failure, then the partial
+        # held until the sweep.
+        if start_bytes == 0:
+            try:
+                free = shutil.disk_usage(settings['assetdir']).free
+            except OSError:
+                free = None
+            if free is not None and total_bytes > free:
+                raise _ChunkedUploadError(DISK_FULL_ERROR, status_code=507)
+
         os.makedirs(staged_dir, exist_ok=True)
         # Measure the descriptor, not the path: between a stat and an
         # open, the sweep (or a concurrent error path) can unlink the
@@ -182,9 +190,11 @@ def _stage_upload_chunk(
         with os.fdopen(fd, 'r+b') as f:
             # Never seek past what we hold; see the docstring.
             if start_bytes > os.fstat(f.fileno()).st_size:
-                # Not "try again": one way here is a commit whose
-                # response was lost, where os.replace has already moved
-                # the partial away and the asset exists.
+                # Not "try again": one way here is the sweep taking
+                # a partial that went an hour without a chunk. Another
+                # is a client resending a commit — ours does not,
+                # precisely because os.replace may already have moved
+                # the partial away and created the asset.
                 raise _ChunkedUploadError(
                     'This upload could not be resumed. Check whether it '
                     'already appears in the asset list before uploading '
@@ -198,8 +208,9 @@ def _stage_upload_chunk(
                 # Drop anything a longer earlier attempt left past the end.
                 f.truncate(total_bytes)
     except _ChunkedUploadError:
-        # Unusable to this client now, and holding it would only keep
-        # the operator stuck on the same error.
+        # Every rejection above abandons the upload — the client starts
+        # over under a fresh id — so whatever is staged is dead weight
+        # on the card until the sweep. Drop it now.
         with suppress(OSError):
             remove(staged_path)
         raise

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -1,5 +1,8 @@
+import hashlib
 import logging
+import os
 import re
+import shutil
 import tarfile
 import uuid
 from contextlib import suppress
@@ -12,11 +15,13 @@ from urllib.parse import urlparse, urlunparse
 from django.contrib import messages
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as django_login
+from django.core.files.uploadedfile import UploadedFile
 from django.http import (
     FileResponse,
     Http404,
     HttpRequest,
     HttpResponse,
+    JsonResponse,
     StreamingHttpResponse,
 )
 from django.http.response import HttpResponseBase
@@ -31,6 +36,8 @@ from django.views.decorators.http import require_http_methods
 
 from anthias_common.utils import (
     DISK_FULL_ERROR,
+    STAGED_UPLOAD_DIR,
+    STAGED_UPLOAD_FREE_MARGIN,
     clamp_screen_rotation,
     connect_to_redis,
     is_disk_full,
@@ -68,6 +75,183 @@ _ANTHIAS_REPO_URL = 'https://github.com/Screenly/Anthias'
 # can't smuggle ``/`` or ``..`` into the on-disk path (CodeQL
 # py/path-injection on ``open(final_path, ...)``).
 _SAFE_EXT_RE = re.compile(r'\.[A-Za-z0-9]{1,16}')
+
+# ``<staged>/<upload_id>.part``. The id is echoed by the client on
+# every chunk and lands in a filesystem path, so require the exact
+# 32-lowercase-hex shape we mint (``uuid4().hex``) and reject anything
+# else. This is a path-traversal guard: 32 hex characters cannot
+# contain a ``/`` or ``..``.
+_UPLOAD_ID_RE = re.compile(r'[0-9a-f]{32}')
+
+# ``bytes <start>-<end>/<total>``. A known numeric total is required
+# (``*`` is rejected): the last-chunk handoff below relies on it to
+# decide when the upload is complete.
+# Digit runs are bounded: ``int()`` raises above 4300 digits, and a
+# client-controlled header must not be able to turn that into a 500.
+# 19 digits covers any conceivable file size.
+_CONTENT_RANGE_RE = re.compile(r'bytes (\d{1,19})-(\d{1,19})/(\d{1,19})')
+
+
+def _staged_upload_name(request: HttpRequest, upload_id: str) -> str:
+    """On-disk stem for ``upload_id``, scoped to the calling session.
+
+    Knowing a stranger's id would otherwise be enough to finish their
+    staged bytes as your own asset, or to delete their partial. With
+    auth off (the default) there is no session, and the stem degrades
+    to an unguessable function of the id.
+    """
+    session_key = getattr(request, 'session', None)
+    salt = getattr(session_key, 'session_key', None) or ''
+    digest = hashlib.sha256(f'{upload_id}:{salt}'.encode()).hexdigest()
+    return digest[:32]
+
+
+def _staged_upload_path(request: HttpRequest, upload_id: str) -> str:
+    """Absolute path of the partial file for ``upload_id``."""
+    stem = _staged_upload_name(request, upload_id)
+    return path.join(settings['assetdir'], STAGED_UPLOAD_DIR, f'{stem}.part')
+
+
+def _committed_upload_path(request: HttpRequest, upload_id: str) -> str:
+    """Marker left behind when an upload has already become an asset.
+
+    Retrying a chunk whose request timed out after it succeeded would
+    otherwise build a second asset: the staged file is renamed away on
+    commit, so nothing distinguishes the replay from a fresh upload.
+    Swept on the same deadline as the partials.
+    """
+    stem = _staged_upload_name(request, upload_id)
+    return path.join(settings['assetdir'], STAGED_UPLOAD_DIR, f'{stem}.done')
+
+
+class _ChunkedUploadError(Exception):
+    """A ranged upload the server will not continue.
+
+    Every case means the client must start the upload over rather than
+    send more chunks, so this answers with a real status code: the
+    uploader is JavaScript reading a response, not a browser following
+    a form post.
+    """
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _stage_upload_chunk(
+    request: HttpRequest, file_upload: UploadedFile[bytes]
+) -> tuple[str, str, bool]:
+    """Write one ``Content-Range`` chunk of an upload to its partial file.
+
+    Returns ``(upload_id, staged_path, is_final)``. The caller renames
+    the staged file into the asset dir once ``is_final`` is true.
+
+    Chunks for one upload id must arrive **strictly sequentially, one
+    in flight at a time**. What is tracked per upload is a byte count,
+    not a set of received ranges, so a chunk starting beyond the end of
+    what is already stored cannot be distinguished from a resumed
+    upload whose partial has gone, and is treated as the latter: the
+    partial is dropped and the operator asked to start over. Parallel
+    or out-of-order chunks would therefore throw the upload away rather
+    than degrade. Real resumability needs a received-ranges record.
+    """
+    match = _CONTENT_RANGE_RE.fullmatch(
+        request.headers['Content-Range'].strip()
+    )
+    if match is None:
+        raise _ChunkedUploadError('Malformed upload range. Please try again.')
+
+    start_bytes, end_bytes, total_bytes = (int(g) for g in match.groups())
+    if total_bytes == 0:
+        # No range can describe an empty file (0-0/0 would claim one
+        # byte). Nothing needs chunking at that size anyway.
+        raise _ChunkedUploadError(
+            'Cannot upload an empty file in chunks. Please try again.'
+        )
+    if end_bytes < start_bytes or end_bytes >= total_bytes:
+        raise _ChunkedUploadError('Invalid upload range. Please try again.')
+    if file_upload.size != end_bytes - start_bytes + 1:
+        raise _ChunkedUploadError(
+            'Upload chunk did not match its range. Please try again.'
+        )
+
+    # The id is only honoured alongside a range: a single-shot upload
+    # never reaches here, so an echoed id cannot truncate an unrelated
+    # in-progress upload.
+    upload_id = request.headers.get('X-Upload-Id')
+    if upload_id is None:
+        upload_id = uuid.uuid4().hex
+    else:
+        upload_id = upload_id.strip().lower()
+        if not _UPLOAD_ID_RE.fullmatch(upload_id):
+            raise _ChunkedUploadError('Malformed upload id. Please try again.')
+
+    staged_dir = path.join(settings['assetdir'], STAGED_UPLOAD_DIR)
+    staged_path = _staged_upload_path(request, upload_id)
+    is_final = end_bytes + 1 == total_bytes
+
+    if path.exists(_committed_upload_path(request, upload_id)):
+        raise _ChunkedUploadError(
+            'This upload has already finished.', status_code=409
+        )
+
+    # Refuse an upload that cannot fit before writing any of it: the
+    # alternative is an hour of sending followed by failure, with the
+    # partial then held for a day.
+    if start_bytes == 0:
+        try:
+            free = shutil.disk_usage(settings['assetdir']).free
+        except OSError:
+            free = None
+        if free is not None and total_bytes + STAGED_UPLOAD_FREE_MARGIN > free:
+            raise _ChunkedUploadError(DISK_FULL_ERROR, status_code=507)
+
+    try:
+        os.makedirs(staged_dir, exist_ok=True)
+        # Open first, then measure the file descriptor. Checking the
+        # size by path and then opening by path leaves a window in
+        # which the cleanup sweep (or a concurrent request's error
+        # path) can unlink the partial: the open would recreate it
+        # empty, the seek would leave a hole, and the finished asset
+        # would be silently corrupt at exactly the right size.
+        # O_NOFOLLOW because the name is derived from a client header.
+        fd = os.open(
+            staged_path,
+            os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o666,
+        )
+        with os.fdopen(fd, 'r+b') as f:
+            # Refuse to seek past the end of what we actually hold; see
+            # the sequential-only contract above.
+            if start_bytes > os.fstat(f.fileno()).st_size:
+                raise _ChunkedUploadError(
+                    'This upload expired. Please try uploading it again.',
+                    status_code=409,
+                )
+            f.seek(start_bytes)
+            for piece in file_upload.chunks():
+                f.write(piece)
+            if is_final:
+                # Drop anything a longer earlier attempt left past the end.
+                f.truncate(total_bytes)
+    except _ChunkedUploadError:
+        # The partial is unusable to this client now, and holding it
+        # for a day would only keep the operator stuck on the same
+        # error. Drop it so the retry starts clean.
+        with suppress(OSError):
+            remove(staged_path)
+        raise
+    except OSError as exc:
+        if not is_disk_full(exc):
+            raise
+        # Don't leave a partial squatting on the last free bytes of an
+        # already-full disk. Matches the single-shot path and the REST
+        # API, which both surface ENOSPC rather than raising.
+        with suppress(OSError):
+            remove(staged_path)
+        raise _ChunkedUploadError(DISK_FULL_ERROR, status_code=507) from exc
+
+    return upload_id, staged_path, is_final
 
 
 def _parse_local_datetime(value: str) -> datetime:
@@ -658,9 +842,41 @@ def assets_upload(request: HttpRequest) -> HttpResponse:
     # overwriting the older one.
     final_name = uuid.uuid4().hex
     final_path = path.join(settings['assetdir'], f'{final_name}{src_ext}')
+
+    # A ranged upload arrives as several requests. Each one stages its
+    # bytes into a per-upload partial file and returns early; only the
+    # request carrying the final byte falls through to create the
+    # asset. Everything above this point (type detection, the display
+    # name, the extension) runs per chunk on the same filename, so a
+    # file Anthias will refuse is refused on the first chunk rather
+    # than after the operator has waited out the whole upload.
+    staged_path = None
+    if 'Content-Range' in request.headers:
+        # Answer a chunk with JSON and a real status rather than the
+        # asset table: the caller is our own uploader reading a
+        # response, and re-rendering the table per chunk would also fan
+        # out a websocket refresh for an asset that does not exist yet.
+        try:
+            upload_id, staged_path, is_final = _stage_upload_chunk(
+                request, file_upload
+            )
+        except _ChunkedUploadError as exc:
+            return JsonResponse({'error': str(exc)}, status=exc.status_code)
+        if not is_final:
+            return JsonResponse({'upload_id': upload_id})
+
     try:
-        with open(final_path, 'wb') as f:
-            f.writelines(file_upload.chunks())
+        if staged_path is not None:
+            # The bytes are already on disk in the asset dir, so this
+            # is a rename within one filesystem rather than a copy.
+            os.replace(staged_path, final_path)
+            # Before the row exists, so a retry arriving mid-request
+            # is turned away rather than building a second asset.
+            with suppress(OSError):
+                open(_committed_upload_path(request, upload_id), 'wb').close()
+        else:
+            with open(final_path, 'wb') as f:
+                f.writelines(file_upload.chunks())
     except OSError as exc:
         if not is_disk_full(exc):
             raise

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -191,8 +191,14 @@ def _stage_upload_chunk(
             # Refuse to seek past the end of what we actually hold; see
             # the sequential-only contract above.
             if start_bytes > os.fstat(f.fileno()).st_size:
+                # Don't tell the operator to upload it again: one way
+                # to land here is a commit whose response was lost,
+                # where os.replace has already moved the partial away
+                # and the asset exists. Point at the list first.
                 raise _ChunkedUploadError(
-                    'This upload expired. Please try uploading it again.',
+                    'This upload could not be resumed. Check whether it '
+                    'already appears in the asset list before uploading '
+                    'it again.',
                     status_code=409,
                 )
             f.seek(start_bytes)

--- a/src/anthias_server/app/views.py
+++ b/src/anthias_server/app/views.py
@@ -74,9 +74,11 @@ _ANTHIAS_REPO_URL = 'https://github.com/Screenly/Anthias'
 # py/path-injection on ``open(final_path, ...)``).
 _SAFE_EXT_RE = re.compile(r'\.[A-Za-z0-9]{1,16}')
 
-# ``<staged>/<upload_id>.part``. The client echoes the id on every
-# chunk and it lands in a path, so require the exact shape we mint
-# (``uuid4().hex``): 32 hex characters cannot hold ``/`` or ``..``.
+# ``<staged>/<upload_id>.part``. The id arrives on every chunk and
+# lands in a filesystem path — our own uploader mints it, anything
+# else may send what it likes — so require the exact shape minted
+# here (``uuid4().hex``): 32 hex characters cannot hold ``/`` or
+# ``..``.
 _UPLOAD_ID_RE = re.compile(r'[0-9a-f]{32}')
 
 # ``bytes <start>-<end>/<total>``. ``*`` is rejected: the last-chunk

--- a/src/anthias_server/app/views_files.py
+++ b/src/anthias_server/app/views_files.py
@@ -96,17 +96,23 @@ def anthias_assets(request: HttpRequest, filename: str) -> HttpResponseBase:
     target = os.path.realpath(os.path.join(base, filename))
     if not target.startswith(base):
         raise Http404
-    # Not everything in the asset dir is an asset: chunked uploads
-    # stage a partial at `.uploads/<id>.part` (see STAGED_UPLOAD_DIR),
-    # the one thing here never meant to be fetchable — and the CIDR
-    # gate above does not exclude LAN clients in the default no-SSL
-    # install. Assets are always `<uuid>.<ext>`, so nothing legitimate
-    # has a dot-leading component, and refusing the lot covers whatever
-    # lands here next without keeping a list in sync.
-    if any(
-        part.startswith('.')
-        for part in os.path.relpath(target, base).split(os.sep)
-    ):
+    # Not everything in the asset dir is an asset, and the rest of it
+    # was never meant to be fetchable — while the CIDR gate above does
+    # not exclude LAN clients in the default no-SSL install. Three
+    # kinds of transient file live here:
+    #
+    #   * `.uploads/<id>.part`   — a chunked browser upload
+    #   * `.import-<hex><ext>`   — a content import, and its `.part`
+    #   * `<upload_id>.tmp`      — a resumable REST API upload
+    #
+    # Assets are always `<uuid>.<ext>`, and never `.tmp`: the celery
+    # sweep deletes stale `*.tmp` from this directory outright, which
+    # only holds because nothing durable is named that way. So both
+    # rules refuse transient files and nothing else.
+    relative = os.path.relpath(target, base)
+    if any(part.startswith('.') for part in relative.split(os.sep)):
+        raise Http404
+    if relative.endswith('.tmp'):
         raise Http404
     try:
         return FileResponse(open(target, 'rb'))

--- a/src/anthias_server/app/views_files.py
+++ b/src/anthias_server/app/views_files.py
@@ -96,6 +96,19 @@ def anthias_assets(request: HttpRequest, filename: str) -> HttpResponseBase:
     target = os.path.realpath(os.path.join(base, filename))
     if not target.startswith(base):
         raise Http404
+    # Not everything in the asset dir is an asset. Chunked uploads
+    # stage a partial at `.uploads/<id>.part` (see STAGED_UPLOAD_DIR),
+    # which is the one thing in this tree that was never meant to be
+    # fetchable — and the CIDR gate above does not exclude LAN clients
+    # in the default no-SSL install. Uploaded assets are always
+    # `<uuid>.<ext>`, so no legitimate request has a dot-leading path
+    # component; refusing the lot covers whatever else lands here
+    # later without needing this list kept in sync.
+    if any(
+        part.startswith('.')
+        for part in os.path.relpath(target, base).split(os.sep)
+    ):
+        raise Http404
     try:
         return FileResponse(open(target, 'rb'))
     except (FileNotFoundError, IsADirectoryError):

--- a/src/anthias_server/app/views_files.py
+++ b/src/anthias_server/app/views_files.py
@@ -96,14 +96,13 @@ def anthias_assets(request: HttpRequest, filename: str) -> HttpResponseBase:
     target = os.path.realpath(os.path.join(base, filename))
     if not target.startswith(base):
         raise Http404
-    # Not everything in the asset dir is an asset. Chunked uploads
+    # Not everything in the asset dir is an asset: chunked uploads
     # stage a partial at `.uploads/<id>.part` (see STAGED_UPLOAD_DIR),
-    # which is the one thing in this tree that was never meant to be
-    # fetchable — and the CIDR gate above does not exclude LAN clients
-    # in the default no-SSL install. Uploaded assets are always
-    # `<uuid>.<ext>`, so no legitimate request has a dot-leading path
-    # component; refusing the lot covers whatever else lands here
-    # later without needing this list kept in sync.
+    # the one thing here never meant to be fetchable — and the CIDR
+    # gate above does not exclude LAN clients in the default no-SSL
+    # install. Assets are always `<uuid>.<ext>`, so nothing legitimate
+    # has a dot-leading component, and refusing the lot covers whatever
+    # lands here next without keeping a list in sync.
     if any(
         part.startswith('.')
         for part in os.path.relpath(target, base).split(os.sep)

--- a/src/anthias_server/app/views_files.py
+++ b/src/anthias_server/app/views_files.py
@@ -101,18 +101,21 @@ def anthias_assets(request: HttpRequest, filename: str) -> HttpResponseBase:
     # not exclude LAN clients in the default no-SSL install. Three
     # kinds of transient file live here:
     #
-    #   * `.uploads/<id>.part`   — a chunked browser upload
-    #   * `.import-<hex><ext>`   — a content import, and its `.part`
-    #   * `<upload_id>.tmp`      — a resumable REST API upload
+    #   * `.uploads/<id>.part`      — a chunked browser upload
+    #   * `.import-<hex><ext>`      — a content import, and its `.part`
+    #   * `<upload_id>.tmp`         — a resumable REST API upload
+    #   * `<uuid>.<ext>.part`       — a yt-dlp or remote-video download
+    #                                 in progress (celery_tasks)
     #
-    # Assets are always `<uuid>.<ext>`, and never `.tmp`: the celery
-    # sweep deletes stale `*.tmp` from this directory outright, which
-    # only holds because nothing durable is named that way. So both
-    # rules refuse transient files and nothing else.
+    # Assets are always `<uuid>.<ext>`, and never `.tmp` or `.part`:
+    # _safe_ext refuses those as source extensions precisely so the
+    # celery sweep (which deletes `*.tmp` on sight) and the backup
+    # filter cannot swallow a real asset. So both rules below refuse
+    # transient files and nothing else.
     relative = os.path.relpath(target, base)
     if any(part.startswith('.') for part in relative.split(os.sep)):
         raise Http404
-    if relative.endswith('.tmp'):
+    if relative.endswith(('.tmp', '.part')):
         raise Http404
     try:
         return FileResponse(open(target, 'rb'))

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -40,6 +40,8 @@ if not _django_apps.apps_ready:
 # Place imports that uses Django in this block.
 
 from anthias_common.utils import (
+    STAGED_UPLOAD_DIR,
+    STAGED_UPLOAD_MAX_AGE_MIN,
     connect_to_redis,
     get_video_duration,
     is_balena_app,
@@ -598,6 +600,22 @@ def cleanup() -> None:
         '+60',
         '-delete',
     )
+
+    # Partial chunked uploads, renamed out on the final chunk. They
+    # outlive the hour above; see STAGED_UPLOAD_MAX_AGE_MIN for why.
+    staged_dir = path.join(asset_dir, STAGED_UPLOAD_DIR)
+    if path.isdir(staged_dir):
+        for pattern in ('*.part', '*.done'):
+            sh.find(
+                staged_dir,
+                '-name',
+                pattern,
+                '-type',
+                'f',
+                '-mmin',
+                f'+{STAGED_UPLOAD_MAX_AGE_MIN}',
+                '-delete',
+            )
 
     # Orphaned asset files: forum 6636 / GH #2657. Asset rows can be
     # deleted while their file lingers (e.g. URI didn't match assetdir

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -601,8 +601,8 @@ def cleanup() -> None:
         '-delete',
     )
 
-    # Partial chunked uploads, renamed out on the final chunk. They
-    # outlive the hour above; see STAGED_UPLOAD_MAX_AGE_MIN for why.
+    # Partial chunked uploads, renamed out on the final chunk; see
+    # STAGED_UPLOAD_MAX_AGE_MIN.
     staged_dir = path.join(asset_dir, STAGED_UPLOAD_DIR)
     if path.isdir(staged_dir):
         sh.find(

--- a/src/anthias_server/celery_tasks.py
+++ b/src/anthias_server/celery_tasks.py
@@ -605,17 +605,16 @@ def cleanup() -> None:
     # outlive the hour above; see STAGED_UPLOAD_MAX_AGE_MIN for why.
     staged_dir = path.join(asset_dir, STAGED_UPLOAD_DIR)
     if path.isdir(staged_dir):
-        for pattern in ('*.part', '*.done'):
-            sh.find(
-                staged_dir,
-                '-name',
-                pattern,
-                '-type',
-                'f',
-                '-mmin',
-                f'+{STAGED_UPLOAD_MAX_AGE_MIN}',
-                '-delete',
-            )
+        sh.find(
+            staged_dir,
+            '-name',
+            '*.part',
+            '-type',
+            'f',
+            '-mmin',
+            f'+{STAGED_UPLOAD_MAX_AGE_MIN}',
+            '-delete',
+        )
 
     # Orphaned asset files: forum 6636 / GH #2657. Asset rows can be
     # deleted while their file lingers (e.g. URI didn't match assetdir

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -760,13 +760,15 @@ APP_STORE_INDEX_URL = getenv(
     'https://signage-apps.com/manifest.json',
 )
 
-# Size of each request a large browser upload is split into. Kept
-# under FILE_UPLOAD_MAX_MEMORY_SIZE above so a chunk is buffered in
-# memory rather than spooled to FILE_UPLOAD_TEMP_DIR, which is /tmp
-# and therefore RAM on a stock Pi image: sizing chunks to a proxy's
-# limit instead would cost that much memory per upload on a board
-# that may have 512 MB. Lower it if a proxy in front of the device
-# caps request bodies below this.
+# Size of each request a large browser upload is split into. A chunk
+# under FILE_UPLOAD_MAX_MEMORY_SIZE above (25 MB) is held entirely in
+# RAM by MemoryFileUploadHandler, so this number is what one in-flight
+# upload costs resident — keep it small on a board that may have
+# 512 MB. Above that limit Django spools to FILE_UPLOAD_TEMP_DIR,
+# which is unset, so /tmp: no container here mounts a tmpfs there, so
+# that is the writable overlay, i.e. the SD card. Trading RAM for card
+# writes is the wrong way round on this hardware. Lower it if a proxy
+# in front of the device caps request bodies below this.
 UPLOAD_CHUNK_SIZE_MB_DEFAULT = 16
 # Same ceiling the browser applies in home/chunking.ts. Clamped here
 # too so the client cap is a second line of defence rather than the

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -754,6 +754,15 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Overridable via env so a device can be pointed at the staging index
 # (stage.signage-apps.com) or a self-hosted mirror; defaults to the
 # production store index.
+# Size of each request a large browser upload is split into. Kept
+# under FILE_UPLOAD_MAX_MEMORY_SIZE above so a chunk is buffered in
+# memory rather than spooled to FILE_UPLOAD_TEMP_DIR, which is /tmp
+# and therefore RAM on a stock Pi image: sizing chunks to a proxy's
+# limit instead would cost that much memory per upload on a board
+# that may have 512 MB. Lower it if a proxy in front of the device
+# caps request bodies below this.
+UPLOAD_CHUNK_SIZE_MB = int(getenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '16'))
+
 APP_STORE_INDEX_URL = getenv(
     'APP_STORE_INDEX_URL',
     'https://signage-apps.com/manifest.json',

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import asyncio
 import configparser
 import logging
+import math
 import platform
 import secrets
 import socket
@@ -796,9 +797,18 @@ def resolve_upload_chunk_size_mb() -> int:
     raw = (getenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB') or '').strip()
     if not raw:
         return UPLOAD_CHUNK_SIZE_MB_DEFAULT
+    # Parsed as a float and rounded down rather than read as an int:
+    # MB is a decimal quantity, so ``8.5`` is a plausible thing for an
+    # operator with a 10 MB proxy cap to write, and rejecting it would
+    # hand them 16 — a value that cannot clear the cap they are trying
+    # to fit under. Every fallback in this function goes the other way
+    # for the same reason. float() also swallows nan/inf and the
+    # thousand-digit integer that would overflow int().
     try:
-        parsed = int(raw)
+        parsed_mb = float(raw)
     except ValueError:
+        parsed_mb = math.nan
+    if not math.isfinite(parsed_mb):
         logging.getLogger(__name__).warning(
             'Ignoring unparseable ANTHIAS_UPLOAD_CHUNK_SIZE_MB=%r; '
             'using %d MB.',
@@ -806,6 +816,7 @@ def resolve_upload_chunk_size_mb() -> int:
             UPLOAD_CHUNK_SIZE_MB_DEFAULT,
         )
         return UPLOAD_CHUNK_SIZE_MB_DEFAULT
+    parsed = math.floor(parsed_mb)
     clamped = max(
         UPLOAD_CHUNK_SIZE_MB_MIN, min(parsed, UPLOAD_CHUNK_SIZE_MB_MAX)
     )

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -10,6 +10,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 import asyncio
 import configparser
+import logging
 import platform
 import secrets
 import socket
@@ -754,6 +755,11 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Overridable via env so a device can be pointed at the staging index
 # (stage.signage-apps.com) or a self-hosted mirror; defaults to the
 # production store index.
+APP_STORE_INDEX_URL = getenv(
+    'APP_STORE_INDEX_URL',
+    'https://signage-apps.com/manifest.json',
+)
+
 # Size of each request a large browser upload is split into. Kept
 # under FILE_UPLOAD_MAX_MEMORY_SIZE above so a chunk is buffered in
 # memory rather than spooled to FILE_UPLOAD_TEMP_DIR, which is /tmp
@@ -761,12 +767,59 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # limit instead would cost that much memory per upload on a board
 # that may have 512 MB. Lower it if a proxy in front of the device
 # caps request bodies below this.
-UPLOAD_CHUNK_SIZE_MB = int(getenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '16'))
+UPLOAD_CHUNK_SIZE_MB_DEFAULT = 16
+# Same ceiling the browser applies in home/chunking.ts. Clamped here
+# too so the client cap is a second line of defence rather than the
+# only one: an operator who reads the docstring and sets 32 to match
+# their proxy would otherwise get 24 with nothing to say why.
+UPLOAD_CHUNK_SIZE_MB_MAX = 24
+# A floor as well, because there is no useful setting below it: 0.5
+# turns a 2 GB video into ~4000 sequential requests, each with its
+# own round trip and multipart parse.
+UPLOAD_CHUNK_SIZE_MB_MIN = 1
 
-APP_STORE_INDEX_URL = getenv(
-    'APP_STORE_INDEX_URL',
-    'https://signage-apps.com/manifest.json',
-)
+
+def resolve_upload_chunk_size_mb() -> int:
+    """Effective upload chunk size, in MB.
+
+    Parsed defensively and clamped to
+    ``[UPLOAD_CHUNK_SIZE_MB_MIN, UPLOAD_CHUNK_SIZE_MB_MAX]``: this is a
+    device variable, typically set once through the balena dashboard
+    and never looked at again. A trailing space or a stray unit
+    (``16m``) would otherwise raise ValueError while this module
+    imports, and the container would never come up — on a headless
+    device, with no shell to work out why. Same posture as
+    ``resolve_time_zone`` above: no value can wedge Django at startup.
+    """
+    raw = (getenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB') or '').strip()
+    if not raw:
+        return UPLOAD_CHUNK_SIZE_MB_DEFAULT
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            'Ignoring unparseable ANTHIAS_UPLOAD_CHUNK_SIZE_MB=%r; '
+            'using %d MB.',
+            raw,
+            UPLOAD_CHUNK_SIZE_MB_DEFAULT,
+        )
+        return UPLOAD_CHUNK_SIZE_MB_DEFAULT
+    clamped = max(
+        UPLOAD_CHUNK_SIZE_MB_MIN, min(parsed, UPLOAD_CHUNK_SIZE_MB_MAX)
+    )
+    if clamped != parsed:
+        logging.getLogger(__name__).warning(
+            'ANTHIAS_UPLOAD_CHUNK_SIZE_MB=%d is outside [%d, %d]; '
+            'using %d MB.',
+            parsed,
+            UPLOAD_CHUNK_SIZE_MB_MIN,
+            UPLOAD_CHUNK_SIZE_MB_MAX,
+            clamped,
+        )
+    return clamped
+
+
+UPLOAD_CHUNK_SIZE_MB = resolve_upload_chunk_size_mb()
 
 # Host suffixes an installed app's launch URL / manifest may live on.
 # The catalog is fetched client-side, so the create endpoint can't

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -679,9 +679,14 @@ def get_configured_time_zone(
         config_file = str(Path(home) / CONFIG_DIR / CONFIG_FILE)
     parser = configparser.ConfigParser()
     try:
+        # See get_configured_upload_chunk_size_mb: this is read on
+        # every request too, so the same refusal of non-plain files
+        # and of undecodable content applies.
+        if not Path(config_file).is_file():
+            return None
         parser.read(config_file)
         time_zone = parser.get('main', 'timezone', fallback='').strip()
-    except (configparser.Error, OSError):
+    except (configparser.Error, OSError, UnicodeDecodeError):
         return None
     if not time_zone:
         return None
@@ -761,70 +766,83 @@ APP_STORE_INDEX_URL = getenv(
     'https://signage-apps.com/manifest.json',
 )
 
-# Size of each request a large browser upload is split into. Under
-# FILE_UPLOAD_MAX_MEMORY_SIZE above (25 MB) MemoryFileUploadHandler
-# holds a chunk entirely in RAM, so this is what one in-flight upload
-# costs resident — keep it small on a board that may have 512 MB.
-# Over it, Django spools to FILE_UPLOAD_TEMP_DIR, which is unset, so
-# /tmp: no container here mounts a tmpfs there, making it the writable
-# overlay, i.e. the SD card. Trading RAM for card writes is the wrong
-# way round on this hardware. Lower it if a proxy in front of the
-# device caps request bodies below this.
+# Size of each request a large browser upload is split into, for an
+# operator behind a proxy that caps request bodies. The ceiling keeps a
+# chunk under FILE_UPLOAD_MAX_MEMORY_SIZE above (25 MB), where Django
+# holds it in RAM rather than spooling it to the SD card; below the
+# floor a large video becomes thousands of sequential requests. Mirrored
+# in home/chunking.ts, which a test pins.
 UPLOAD_CHUNK_SIZE_MB_DEFAULT = 16
-# The ceiling home/chunking.ts applies, enforced here too so the client
-# cap is a second line of defence rather than the only one: an operator
-# setting 32 to match their proxy otherwise got 24 with nothing to say
-# why.
 UPLOAD_CHUNK_SIZE_MB_MAX = 24
-# A floor too — below it there is no useful setting: 0.5 turns a 2 GB
-# video into ~4000 sequential requests, each with its own round trip
-# and multipart parse.
 UPLOAD_CHUNK_SIZE_MB_MIN = 1
 
 
-def resolve_upload_chunk_size_mb() -> int:
-    """Effective upload chunk size, in MB.
+def get_configured_upload_chunk_size_mb(
+    config_file: str | None = None,
+) -> str:
+    """Raw ``[main] upload_chunk_size_mb`` from anthias.conf, or ''.
 
-    Parsed defensively and clamped to
-    ``[UPLOAD_CHUNK_SIZE_MB_MIN, UPLOAD_CHUNK_SIZE_MB_MAX]``. It is a
-    device variable, set once through the balena dashboard and never
-    looked at again: a trailing space or a stray unit (``16m``) would
-    otherwise raise ValueError as this module imports and the container
-    would never come up, on a headless device with no shell to work out
-    why. Same posture as ``resolve_time_zone`` above — no value can
-    wedge Django at startup.
+    Refuses anything that is not a plain file, and undecodable content:
+    a FIFO here blocks the import forever and the container never
+    starts. Same guards as ``get_configured_time_zone`` above.
     """
-    raw = (getenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB') or '').strip()
+    if config_file is None:
+        home = getenv('HOME')
+        if not home:
+            return ''
+        config_file = str(Path(home) / CONFIG_DIR / CONFIG_FILE)
+    try:
+        if not Path(config_file).is_file():
+            return ''
+        parser = configparser.ConfigParser()
+        parser.read(config_file)
+        return parser.get('main', 'upload_chunk_size_mb', fallback='').strip()
+    except (configparser.Error, OSError, UnicodeDecodeError):
+        return ''
+
+
+def resolve_upload_chunk_size_mb() -> int:
+    """Effective upload chunk size in MB, clamped to [MIN, MAX].
+
+    anthias.conf first — the rung that survives an upgrade, since
+    docker-compose.yml is regenerated from its template every run —
+    then ANTHIAS_UPLOAD_CHUNK_SIZE_MB, which is how a balena dashboard
+    variable arrives. Resolved once at import; there is no Settings
+    field for it, so changing it already means a restart.
+
+    Read as a decimal and rounded down, because MB is decimal and an
+    operator writing 8.5 to fit a 10 MB cap must not be handed 16.
+    Nothing here may raise: on a headless device a bad value would mean
+    a container that never starts, with no shell to find out why.
+    """
+    raw = get_configured_upload_chunk_size_mb()
+    if not raw:
+        raw = (getenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB') or '').strip()
     if not raw:
         return UPLOAD_CHUNK_SIZE_MB_DEFAULT
-    # Parsed as a float and rounded down rather than read as an int:
-    # MB is a decimal quantity, so ``8.5`` is a plausible thing for an
-    # operator with a 10 MB proxy cap to write, and rejecting it would
-    # hand them 16 — a value that cannot clear the cap they are trying
-    # to fit under. Every fallback in this function goes the other way
-    # for the same reason. float() also swallows nan/inf and the
-    # thousand-digit integer that would overflow int().
+
+    logger = logging.getLogger(__name__)
     try:
-        parsed_mb = float(raw)
-    except ValueError:
-        parsed_mb = math.nan
-    if not math.isfinite(parsed_mb):
-        logging.getLogger(__name__).warning(
-            'Ignoring unparseable ANTHIAS_UPLOAD_CHUNK_SIZE_MB=%r; '
-            'using %d MB.',
+        # float() then floor: one except covers a stray unit, nan, and
+        # the thousand-digit integer that overflows on the way down.
+        parsed = math.floor(float(raw))
+    except (ValueError, OverflowError):
+        logger.warning(
+            'Ignoring unparseable upload chunk size %r; using %d MB.',
             raw,
             UPLOAD_CHUNK_SIZE_MB_DEFAULT,
         )
         return UPLOAD_CHUNK_SIZE_MB_DEFAULT
-    parsed = math.floor(parsed_mb)
+
     clamped = max(
         UPLOAD_CHUNK_SIZE_MB_MIN, min(parsed, UPLOAD_CHUNK_SIZE_MB_MAX)
     )
     if clamped != parsed:
-        logging.getLogger(__name__).warning(
-            'ANTHIAS_UPLOAD_CHUNK_SIZE_MB=%d is outside [%d, %d]; '
-            'using %d MB.',
-            parsed,
+        # Reported as written, not as parsed: 0.5 logged as "0 is
+        # outside [1, 24]" sends the operator hunting for a zero.
+        logger.warning(
+            'Upload chunk size %r is outside [%d, %d]; using %d MB.',
+            raw,
             UPLOAD_CHUNK_SIZE_MB_MIN,
             UPLOAD_CHUNK_SIZE_MB_MAX,
             clamped,
@@ -833,6 +851,7 @@ def resolve_upload_chunk_size_mb() -> int:
 
 
 UPLOAD_CHUNK_SIZE_MB = resolve_upload_chunk_size_mb()
+
 
 # Host suffixes an installed app's launch URL / manifest may live on.
 # The catalog is fetched client-side, so the create endpoint can't

--- a/src/anthias_server/django_project/settings.py
+++ b/src/anthias_server/django_project/settings.py
@@ -760,24 +760,24 @@ APP_STORE_INDEX_URL = getenv(
     'https://signage-apps.com/manifest.json',
 )
 
-# Size of each request a large browser upload is split into. A chunk
-# under FILE_UPLOAD_MAX_MEMORY_SIZE above (25 MB) is held entirely in
-# RAM by MemoryFileUploadHandler, so this number is what one in-flight
-# upload costs resident — keep it small on a board that may have
-# 512 MB. Above that limit Django spools to FILE_UPLOAD_TEMP_DIR,
-# which is unset, so /tmp: no container here mounts a tmpfs there, so
-# that is the writable overlay, i.e. the SD card. Trading RAM for card
-# writes is the wrong way round on this hardware. Lower it if a proxy
-# in front of the device caps request bodies below this.
+# Size of each request a large browser upload is split into. Under
+# FILE_UPLOAD_MAX_MEMORY_SIZE above (25 MB) MemoryFileUploadHandler
+# holds a chunk entirely in RAM, so this is what one in-flight upload
+# costs resident — keep it small on a board that may have 512 MB.
+# Over it, Django spools to FILE_UPLOAD_TEMP_DIR, which is unset, so
+# /tmp: no container here mounts a tmpfs there, making it the writable
+# overlay, i.e. the SD card. Trading RAM for card writes is the wrong
+# way round on this hardware. Lower it if a proxy in front of the
+# device caps request bodies below this.
 UPLOAD_CHUNK_SIZE_MB_DEFAULT = 16
-# Same ceiling the browser applies in home/chunking.ts. Clamped here
-# too so the client cap is a second line of defence rather than the
-# only one: an operator who reads the docstring and sets 32 to match
-# their proxy would otherwise get 24 with nothing to say why.
+# The ceiling home/chunking.ts applies, enforced here too so the client
+# cap is a second line of defence rather than the only one: an operator
+# setting 32 to match their proxy otherwise got 24 with nothing to say
+# why.
 UPLOAD_CHUNK_SIZE_MB_MAX = 24
-# A floor as well, because there is no useful setting below it: 0.5
-# turns a 2 GB video into ~4000 sequential requests, each with its
-# own round trip and multipart parse.
+# A floor too — below it there is no useful setting: 0.5 turns a 2 GB
+# video into ~4000 sequential requests, each with its own round trip
+# and multipart parse.
 UPLOAD_CHUNK_SIZE_MB_MIN = 1
 
 
@@ -785,13 +785,13 @@ def resolve_upload_chunk_size_mb() -> int:
     """Effective upload chunk size, in MB.
 
     Parsed defensively and clamped to
-    ``[UPLOAD_CHUNK_SIZE_MB_MIN, UPLOAD_CHUNK_SIZE_MB_MAX]``: this is a
-    device variable, typically set once through the balena dashboard
-    and never looked at again. A trailing space or a stray unit
-    (``16m``) would otherwise raise ValueError while this module
-    imports, and the container would never come up — on a headless
-    device, with no shell to work out why. Same posture as
-    ``resolve_time_zone`` above: no value can wedge Django at startup.
+    ``[UPLOAD_CHUNK_SIZE_MB_MIN, UPLOAD_CHUNK_SIZE_MB_MAX]``. It is a
+    device variable, set once through the balena dashboard and never
+    looked at again: a trailing space or a stray unit (``16m``) would
+    otherwise raise ValueError as this module imports and the container
+    would never come up, on a headless device with no shell to work out
+    why. Same posture as ``resolve_time_zone`` above — no value can
+    wedge Django at startup.
     """
     raw = (getenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB') or '').strip()
     if not raw:

--- a/src/anthias_server/lib/backup_helper.py
+++ b/src/anthias_server/lib/backup_helper.py
@@ -21,9 +21,8 @@ def _skip_staged_uploads(member: tarfile.TarInfo) -> tarfile.TarInfo | None:
     """Keep partial chunked uploads out of a backup.
 
     ``tar.add`` recurses, and an in-progress upload can be gigabytes of
-    a file the operator has not finished sending. It is meaningless
-    once restored (the upload session is gone), so backing it up only
-    inflates the archive.
+    a file nobody finished sending — meaningless once restored, since
+    the upload session is gone, so it only inflates the archive.
     """
     parts = member.name.split('/')
     return None if STAGED_UPLOAD_DIR in parts else member

--- a/src/anthias_server/lib/backup_helper.py
+++ b/src/anthias_server/lib/backup_helper.py
@@ -29,6 +29,13 @@ def _skip_staged_uploads(member: tarfile.TarInfo) -> tarfile.TarInfo | None:
     is long gone — so they only inflate the archive.
     """
     parts = member.name.split('/')
+    # Scoped to the asset dir, which is where all four shapes are
+    # written. `.anthias` is in the same archive and holds the config
+    # and the database, where an atomic-write sidecar is a plausible
+    # future name — excluding one of those would mean a backup that
+    # silently restores incomplete.
+    if parts[0] != 'anthias_assets':
+        return member
     if STAGED_UPLOAD_DIR in parts:
         return None
     leaf = parts[-1]

--- a/src/anthias_server/lib/backup_helper.py
+++ b/src/anthias_server/lib/backup_helper.py
@@ -18,14 +18,23 @@ directories = ['.anthias', 'anthias_assets']
 
 
 def _skip_staged_uploads(member: tarfile.TarInfo) -> tarfile.TarInfo | None:
-    """Keep partial chunked uploads out of a backup.
+    """Keep half-finished uploads out of a backup.
 
-    ``tar.add`` recurses, and an in-progress upload can be gigabytes of
-    a file nobody finished sending — meaningless once restored, since
-    the upload session is gone, so it only inflates the archive.
+    ``tar.add`` recurses, and the asset dir holds several kinds of
+    in-progress file, each of which can be gigabytes of something
+    nobody finished sending: ``.uploads/<id>.part`` from the browser,
+    ``<upload_id>.tmp`` from the REST API, and ``.import-<hex>`` (plus
+    its ``.part``) from the content importer, which allows 5 GiB. All
+    are meaningless once restored — the session that was writing them
+    is long gone — so they only inflate the archive.
     """
     parts = member.name.split('/')
-    return None if STAGED_UPLOAD_DIR in parts else member
+    if STAGED_UPLOAD_DIR in parts:
+        return None
+    leaf = parts[-1]
+    if leaf.endswith(('.tmp', '.part')) or leaf.startswith('.import-'):
+        return None
+    return member
 
 
 # Tarballs created by older releases used these top-level entry names.

--- a/src/anthias_server/lib/backup_helper.py
+++ b/src/anthias_server/lib/backup_helper.py
@@ -10,9 +10,25 @@ from datetime import UTC, datetime
 from os import getenv, makedirs, path, remove
 from typing import Any
 
+from anthias_common.utils import STAGED_UPLOAD_DIR
+
 logger = logging.getLogger(__name__)
 
 directories = ['.anthias', 'anthias_assets']
+
+
+def _skip_staged_uploads(member: tarfile.TarInfo) -> tarfile.TarInfo | None:
+    """Keep partial chunked uploads out of a backup.
+
+    ``tar.add`` recurses, and an in-progress upload can be gigabytes of
+    a file the operator has not finished sending. It is meaningless
+    once restored (the upload session is gone), so backing it up only
+    inflates the archive.
+    """
+    parts = member.name.split('/')
+    return None if STAGED_UPLOAD_DIR in parts else member
+
+
 # Tarballs created by older releases used these top-level entry names.
 # Recognise them so users can still restore pre-rename backups.
 legacy_directories = ['.screenly', 'screenly_assets']
@@ -114,7 +130,11 @@ def stream_backup() -> Generator[bytes]:
                 ) as tar,
             ):
                 for directory in directories:
-                    tar.add(path.join(home, directory), arcname=directory)
+                    tar.add(
+                        path.join(home, directory),
+                        arcname=directory,
+                        filter=_skip_staged_uploads,
+                    )
         except BrokenPipeError:
             logger.info('backup download cancelled by the client')
         except Exception as exc:
@@ -212,7 +232,11 @@ def create_backup(name: str = default_archive_name) -> str:
         ) as tar:
             for directory in directories:
                 path_to_dir = path.join(home, directory)
-                tar.add(path_to_dir, arcname=directory)
+                tar.add(
+                    path_to_dir,
+                    arcname=directory,
+                    filter=_skip_staged_uploads,
+                )
     except OSError:
         remove(file_path)
         raise

--- a/src/anthias_server/lib/screenly_migration.py
+++ b/src/anthias_server/lib/screenly_migration.py
@@ -182,9 +182,11 @@ def _resolve_local_path(uri: str) -> Path | None:
     """Return a safe absolute path under ANTHIAS_ASSETS_ROOT, or None.
 
     Returns None for non-local URIs (http://, https://, youtube://, …).
-    Uses the same realpath + startswith guard as ``views_files.anthias_assets``
-    so a tampered DB row can't trick us into opening a file outside the
-    asset directory.
+    Uses the same realpath + startswith traversal guard as
+    ``views_files.anthias_assets`` so a tampered DB row can't trick us
+    into opening a file outside the asset directory. That view also
+    refuses the asset dir's transient staging files, which is about
+    what it hands to HTTP clients and does not apply here.
     """
     if not uri.startswith(str(ANTHIAS_ASSETS_ROOT) + os.sep):
         return None

--- a/src/anthias_server/settings.py
+++ b/src/anthias_server/settings.py
@@ -31,6 +31,16 @@ DEFAULTS = {
         # UTC), so this is the only way to schedule/display in local
         # time there.
         'timezone': '',
+        # Size of each request a large browser upload is split into,
+        # for an operator behind a proxy that caps request bodies.
+        # Empty defers to the resolved default — see
+        # resolve_upload_chunk_size_mb() in django_project/settings.py
+        # for the config -> ANTHIAS_UPLOAD_CHUNK_SIZE_MB env -> 16
+        # precedence. Lives here so a docker-compose install has one
+        # place to set it that survives an upgrade: this file is on the
+        # mounted volume, while docker-compose.yml is regenerated from
+        # its template on every run.
+        'upload_chunk_size_mb': '',
         'use_24_hour_clock': False,
         'use_ssl': False,
         'auth_backend': '',

--- a/tests/test_backup_helper.py
+++ b/tests/test_backup_helper.py
@@ -12,6 +12,7 @@ from unittest import mock
 import pytest
 from django.http import StreamingHttpResponse
 
+from anthias_common.utils import STAGED_UPLOAD_DIR
 from anthias_server.lib.backup_helper import (
     BackupRecoverError,
     astream_backup,
@@ -308,3 +309,34 @@ def test_recover_skips_path_traversal_member(legacy_home: str) -> None:
     assert path.isfile(path.join(legacy_home, '.anthias', 'anthias.conf'))
     parent_of_home = path.dirname(legacy_home)
     assert not path.exists(path.join(parent_of_home, 'evil.txt'))
+
+
+@pytest.mark.parametrize(
+    'relative',
+    [
+        f'anthias_assets/{STAGED_UPLOAD_DIR}/abc.part',
+        'anthias_assets/deadbeef.tmp',
+        'anthias_assets/.import-deadbeef.mp4',
+        'anthias_assets/.import-deadbeef.mp4.part',
+    ],
+)
+def test_backup_excludes_half_finished_uploads(
+    backup_home: str, relative: str
+) -> None:
+    """A backup taken mid-upload would otherwise carry gigabytes of a
+    file nobody finished sending, and that is meaningless once
+    restored — the session writing it is gone."""
+    staged = path.join(backup_home, relative)
+    os.makedirs(path.dirname(staged), exist_ok=True)
+    with open(staged, 'wb') as f:
+        f.write(b'0' * 1024)
+    keep = path.join(backup_home, 'anthias_assets', 'deadbeef.mp4')
+    with open(keep, 'wb') as f:
+        f.write(b'1' * 16)
+
+    archive = create_backup(name='exclusion-test')
+    with tarfile.open(path.join(backup_home, static_dir, archive)) as tar:
+        names = tar.getnames()
+
+    assert not [n for n in names if n.endswith(path.basename(staged))]
+    assert [n for n in names if n.endswith('deadbeef.mp4')]

--- a/tests/test_backup_helper.py
+++ b/tests/test_backup_helper.py
@@ -340,3 +340,21 @@ def test_backup_excludes_half_finished_uploads(
 
     assert not [n for n in names if n.endswith(path.basename(staged))]
     assert [n for n in names if n.endswith('deadbeef.mp4')]
+
+
+def test_backup_keeps_a_matching_name_outside_the_asset_dir(
+    backup_home: str,
+) -> None:
+    """The exclusions describe files the asset dir holds. `.anthias`
+    rides in the same archive and holds the config and the database,
+    where an atomic-write sidecar is a plausible name — dropping one of
+    those would mean a backup that silently restores incomplete."""
+    sidecar = path.join(backup_home, '.anthias', 'anthias.conf.tmp')
+    with open(sidecar, 'wb') as f:
+        f.write(b'[main]')
+
+    archive = create_backup(name='scope-test')
+    with tarfile.open(path.join(backup_home, static_dir, archive)) as tar:
+        names = tar.getnames()
+
+    assert [n for n in names if n.endswith('anthias.conf.tmp')]

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -10,6 +10,7 @@ import pytest
 from celery.exceptions import SoftTimeLimitExceeded
 
 import anthias_server.celery_tasks as celery_tasks_module
+from anthias_common.utils import STAGED_UPLOAD_DIR
 from anthias_server.app.models import Asset
 from anthias_server.celery_tasks import (
     ASSET_REVALIDATION_LOCK_KEY,
@@ -167,6 +168,38 @@ def test_cleanup_returns_when_assetdir_missing() -> None:
         mock_sh.find.assert_not_called()
     finally:
         settings['assetdir'] = original
+
+
+def test_cleanup_sweeps_stale_staged_uploads_only(tmp_path: Any) -> None:
+    """A partial nobody has written to for over an hour is swept; one
+    still being written to is not.
+
+    An upload cannot be resumed once abandoned, so an old partial only
+    occupies the card. Sweeping a live one would be worse: the next
+    chunk's offset guard would reject it and the operator would lose
+    the upload."""
+    staged = tmp_path / STAGED_UPLOAD_DIR
+    staged.mkdir()
+    stale = staged / f'{"a" * 32}.part'
+    fresh = staged / f'{"b" * 32}.part'
+    stale.write_bytes(b'old')
+    fresh.write_bytes(b'new')
+    # find compares mtime, so age the stale one by two hours.
+    two_hours_ago = time.time() - 2 * 60 * 60
+    os.utime(stale, (two_hours_ago, two_hours_ago))
+
+    original = settings['assetdir']
+    settings['assetdir'] = str(tmp_path)
+    try:
+        cleanup.apply()
+    finally:
+        settings['assetdir'] = original
+
+    assert not stale.exists()
+    assert fresh.exists()
+    # The directory itself must survive, or the next upload's first
+    # chunk has nowhere to land.
+    assert staged.is_dir()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_django_timezone.py
+++ b/tests/test_django_timezone.py
@@ -9,6 +9,7 @@ apply the same check and fall back to UTC instead of letting Django
 raise ValueError at startup.
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -298,3 +299,18 @@ class TestTimezoneActivationMiddleware:
         # Falls back to deactivate() rather than 500-ing.
         response = middleware(RequestFactory().get('/'))
         assert response.content == b'ok'
+
+
+class TestConfigReadIsRobust:
+    """TimezoneActivationMiddleware re-reads this on every request, so
+    a blocking or throwing read is an outage rather than one bad page."""
+
+    def test_a_fifo_does_not_hang_the_request(self, tmp_path: Path) -> None:
+        fifo = tmp_path / 'anthias.conf'
+        os.mkfifo(fifo)
+        assert get_configured_time_zone(str(fifo)) is None
+
+    def test_binary_content_does_not_raise(self, tmp_path: Path) -> None:
+        conf = tmp_path / 'anthias.conf'
+        conf.write_bytes(bytes(range(256)) * 4)
+        assert get_configured_time_zone(str(conf)) is None

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -10,6 +10,7 @@ accumulate coverage. These tests do.
 
 from __future__ import annotations
 
+import uuid
 from datetime import time, timedelta
 from typing import Any
 from unittest import mock
@@ -2709,6 +2710,117 @@ def test_assets_upload_chunk_past_the_end_drops_the_partial(
         assert gapped.status_code == 409
         assert Asset.objects.count() == 0
         assert not list((tmp_path / STAGED_UPLOAD_DIR).glob('*.part'))
+
+
+@pytest.mark.django_db
+def test_assets_upload_rejects_a_chunk_that_lies_about_its_length(
+    client: Client, tmp_path: Any
+) -> None:
+    """A body shorter or longer than its declared range would be
+    written at the wrong offset, leaving the asset misaligned at
+    exactly the right size."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+        response = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'0123456789', content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-4/20',
+            },
+        )
+
+    assert response.status_code == 400
+    assert Asset.objects.count() == 0
+    assert not list((tmp_path / STAGED_UPLOAD_DIR).glob('*.part'))
+
+
+@pytest.mark.django_db
+def test_assets_upload_refuses_a_file_larger_than_free_space(
+    client: Client, tmp_path: Any
+) -> None:
+    """Checked before any bytes are written: the alternative is an
+    hour of uploading followed by failure."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    usage = mock.Mock(free=10)
+    with (
+        mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
+        mock.patch(
+            'anthias_server.app.views.shutil.disk_usage', return_value=usage
+        ),
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'01234', content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-4/1000',
+            },
+        )
+
+    assert response.status_code == 507
+    assert Asset.objects.count() == 0
+    assert not list((tmp_path / STAGED_UPLOAD_DIR).glob('*.part'))
+
+
+@pytest.mark.django_db
+def test_assets_upload_final_chunk_truncates_a_longer_earlier_attempt(
+    client: Client, tmp_path: Any
+) -> None:
+    """A retry that declares a shorter total must not leave the tail of
+    a longer attempt on the end of the asset."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    upload_id = uuid.uuid4().hex
+    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+        client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'0' * 20, content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-19/40',
+                'X-Upload-Id': upload_id,
+            },
+        )
+        # Same session, now finishing a shorter file.
+        client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'1' * 5, content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 5-9/10',
+                'X-Upload-Id': upload_id,
+            },
+        )
+
+        asset = Asset.objects.get()
+        assert asset.uri is not None
+        with open(asset.uri, 'rb') as f:
+            assert f.read() == b'0' * 5 + b'1' * 5
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2497,7 +2497,14 @@ def test_assets_upload_chunked_round_trip_is_byte_exact(
     ]
 
     upload_id = None
-    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+    with (
+        mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
+        # The commit creates a video asset, and the view dispatches
+        # normalisation for real — which reaches for the Celery result
+        # backend. Mocked like every other video-upload test here so
+        # the documented no-Redis host run stays green.
+        mock.patch('anthias_server.celery_tasks.normalize_video_asset.delay'),
+    ):
         for start, end in bounds:
             headers = {
                 'HX-Request': 'true',
@@ -2860,7 +2867,12 @@ def test_assets_upload_final_chunk_truncates_a_longer_earlier_attempt(
     from anthias_server.settings import settings as anthias_settings
 
     upload_id = uuid.uuid4().hex
-    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+    with (
+        mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
+        # See the round-trip test: the commit dispatches video
+        # normalisation, which needs the Celery result backend.
+        mock.patch('anthias_server.celery_tasks.normalize_video_asset.delay'),
+    ):
         client.post(
             reverse('anthias_app:assets_upload'),
             data={

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2864,13 +2864,23 @@ def test_assets_upload_refuses_a_file_larger_than_free_space(
 def test_assets_upload_final_chunk_truncates_a_longer_earlier_attempt(
     client: Client, tmp_path: Any
 ) -> None:
-    """A retry that declares a shorter total must not leave the tail of
-    a longer attempt on the end of the asset."""
+    """A partial longer than the file being committed must not leave
+    its tail on the end of the asset.
+
+    The staged file is whatever an earlier attempt under this id left
+    behind — abandoned, swept late, or simply longer. Every request
+    here declares the same total for the file it is actually sending:
+    the server does not compare a chunk's total against what earlier
+    chunks declared, and nothing should come to depend on that."""
     from django.core.files.uploadedfile import SimpleUploadedFile
 
     from anthias_server.settings import settings as anthias_settings
 
     upload_id = uuid.uuid4().hex
+    staged = tmp_path / STAGED_UPLOAD_DIR
+    staged.mkdir()
+    (staged / f'{upload_id}.part').write_bytes(b'0' * 40)
+
     with (
         mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
         # See the round-trip test: the commit dispatches video
@@ -2881,26 +2891,12 @@ def test_assets_upload_final_chunk_truncates_a_longer_earlier_attempt(
             reverse('anthias_app:assets_upload'),
             data={
                 'file_upload': SimpleUploadedFile(
-                    'clip.mp4', b'0' * 20, content_type='video/mp4'
+                    'clip.mp4', b'1' * 10, content_type='video/mp4'
                 ),
             },
             headers={
                 'HX-Request': 'true',
-                'Content-Range': 'bytes 0-19/40',
-                'X-Upload-Id': upload_id,
-            },
-        )
-        # Same session, now finishing a shorter file.
-        client.post(
-            reverse('anthias_app:assets_upload'),
-            data={
-                'file_upload': SimpleUploadedFile(
-                    'clip.mp4', b'1' * 5, content_type='video/mp4'
-                ),
-            },
-            headers={
-                'HX-Request': 'true',
-                'Content-Range': 'bytes 5-9/10',
+                'Content-Range': 'bytes 0-9/10',
                 'X-Upload-Id': upload_id,
             },
         )
@@ -2908,7 +2904,7 @@ def test_assets_upload_final_chunk_truncates_a_longer_earlier_attempt(
         asset = Asset.objects.get()
         assert asset.uri is not None
         with open(asset.uri, 'rb') as f:
-            assert f.read() == b'0' * 5 + b'1' * 5
+            assert f.read() == b'1' * 10
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2724,6 +2724,55 @@ def test_assets_upload_chunk_past_the_end_drops_the_partial(
 
 
 @pytest.mark.django_db
+def test_assets_upload_drops_the_partial_when_a_chunk_is_rejected(
+    client: Client, tmp_path: Any
+) -> None:
+    """A rejection abandons the upload, so the bytes already staged are
+    dead weight on the card until the hourly sweep. The client starts
+    over under a fresh id and never asks for them again."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    upload_id = uuid.uuid4().hex
+    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+        staged = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'0' * 10, content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-9/100',
+                'X-Upload-Id': upload_id,
+            },
+        )
+        assert staged.status_code == 200
+        assert list((tmp_path / STAGED_UPLOAD_DIR).glob('*.part'))
+
+        # Rejected before a single byte of it is written, and before
+        # the range is even parsed.
+        rejected = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'1' * 10, content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes not-a-range/100',
+                'X-Upload-Id': upload_id,
+            },
+        )
+
+        assert rejected.status_code == 400
+        assert not list((tmp_path / STAGED_UPLOAD_DIR).glob('*.part'))
+
+
+@pytest.mark.django_db
 def test_assets_upload_rejects_a_chunk_that_lies_about_its_length(
     client: Client, tmp_path: Any
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import time, timedelta
+from types import SimpleNamespace
 from typing import Any
 from unittest import mock
 
@@ -81,15 +82,15 @@ def test_home_exposes_apps_tab_and_store_index(client: Client) -> None:
 
 @pytest.mark.django_db
 def test_home_exposes_the_upload_chunk_size(client: Client) -> None:
-    """The one link that carries the configured chunk size to the
-    browser: settings -> helpers.template -> base.html -> the <meta>
+    """The one link carrying the configured chunk size to the browser:
+    settings -> helpers.template -> base.html -> the <meta> tag
     chunkSizeFromMeta reads. Without it the tag renders empty and every
-    device silently falls back to the client's own 16 MB default,
-    ignoring whatever the operator set."""
+    device falls back to the browser's own default, ignoring whatever
+    the operator set."""
     from django.conf import settings as dj_settings
 
-    response = client.get(reverse('anthias_app:home'))
-    body = response.content.decode()
+    body = client.get(reverse('anthias_app:home')).content.decode()
+
     assert (
         f'<meta name="anthias-upload-chunk-mb" '
         f'content="{dj_settings.UPLOAD_CHUNK_SIZE_MB}">'
@@ -2787,6 +2788,90 @@ def test_assets_upload_drops_the_partial_when_a_chunk_is_rejected(
 
         assert rejected.status_code == 400
         assert not list((tmp_path / STAGED_UPLOAD_DIR).glob('*.part'))
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('ext', ['.tmp', '.part'])
+def test_assets_upload_never_stores_an_asset_under_a_reserved_ext(
+    client: Client, tmp_path: Any, ext: str
+) -> None:
+    """An asset stored as `<uuid>.tmp` deletes itself: the celery sweep
+    removes `*.tmp` from the asset dir after an hour and the row is
+    left pointing at nothing. `<uuid>.part` survives but is dropped
+    from every backup by _skip_staged_uploads.
+
+    A browser cannot reach this — it sends application/octet-stream for
+    an unknown extension, which the type gate rejects — but a crafted
+    multipart part naming `video/tmp` passes, and did produce exactly
+    that before the extension was refused."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with (
+        mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
+        mock.patch('anthias_server.celery_tasks.normalize_video_asset.delay'),
+    ):
+        client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    f'clip{ext}',
+                    b'\x00fake',
+                    content_type=f'video/{ext.lstrip(".")}',
+                ),
+            },
+            headers={'HX-Request': 'true'},
+        )
+
+    asset = Asset.objects.get()
+    assert asset.uri is not None
+    assert not asset.uri.endswith(ext)
+
+
+@pytest.mark.django_db
+def test_assets_upload_checks_free_space_on_every_chunk(
+    client: Client, tmp_path: Any
+) -> None:
+    """`total_bytes` is re-read from each request and never pinned, so
+    a declared total that grows after the first chunk would never be
+    measured against the disk if the check ran only at byte 0 — the
+    refusal would read as a property of the upload while being a
+    property of its first request."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    upload_id = uuid.uuid4().hex
+
+    def post(body: bytes, content_range: str) -> Any:
+        return client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', body, content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': content_range,
+                'X-Upload-Id': upload_id,
+            },
+        )
+
+    with (
+        mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
+        mock.patch(
+            'anthias_server.app.views.shutil.disk_usage',
+            return_value=SimpleNamespace(total=0, used=0, free=100),
+        ),
+    ):
+        # Declares 50 against 100 free, so it passes.
+        assert post(b'0' * 10, 'bytes 0-9/50').status_code == 200
+        # Then grows its claim to 300. 290 still to come, 100 free.
+        assert post(b'1' * 290, 'bytes 10-299/300').status_code == 507
+
+    assert Asset.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -80,6 +80,23 @@ def test_home_exposes_apps_tab_and_store_index(client: Client) -> None:
 
 
 @pytest.mark.django_db
+def test_home_exposes_the_upload_chunk_size(client: Client) -> None:
+    """The one link that carries the configured chunk size to the
+    browser: settings -> helpers.template -> base.html -> the <meta>
+    chunkSizeFromMeta reads. Without it the tag renders empty and every
+    device silently falls back to the client's own 16 MB default,
+    ignoring whatever the operator set."""
+    from django.conf import settings as dj_settings
+
+    response = client.get(reverse('anthias_app:home'))
+    body = response.content.decode()
+    assert (
+        f'<meta name="anthias-upload-chunk-mb" '
+        f'content="{dj_settings.UPLOAD_CHUNK_SIZE_MB}">'
+    ) in body
+
+
+@pytest.mark.django_db
 def test_system_info_renders(client: Client) -> None:
     response = client.get(reverse('anthias_app:system_info'))
     assert response.status_code == 200

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2715,6 +2715,10 @@ def test_assets_upload_chunk_past_the_end_drops_the_partial(
         )
 
         assert gapped.status_code == 409
+        # One way to land here is a commit whose response was lost and
+        # whose asset therefore exists, so the message must not say
+        # "upload it again" without qualification.
+        assert 'asset list' in gapped.json()['error']
         assert Asset.objects.count() == 0
         assert not list((tmp_path / STAGED_UPLOAD_DIR).glob('*.part'))
 

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -2743,6 +2743,78 @@ def test_assets_upload_rejects_a_chunk_that_lies_about_its_length(
 
 
 @pytest.mark.django_db
+def test_assets_upload_proceeds_when_free_space_is_unknowable(
+    client: Client, tmp_path: Any
+) -> None:
+    """If the filesystem will not say how much room is left, take the
+    upload rather than refuse it: a working upload matters more than a
+    check that cannot run."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with (
+        mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
+        mock.patch(
+            'anthias_server.app.views.shutil.disk_usage',
+            side_effect=OSError('cannot stat'),
+        ),
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'01234', content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-4/10',
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()['upload_id']
+
+
+@pytest.mark.django_db
+def test_assets_upload_does_not_mistake_any_oserror_for_a_full_disk(
+    client: Client, tmp_path: Any
+) -> None:
+    """Only ENOSPC becomes the disk-full answer. Anything else is a
+    real fault and must surface rather than be reported to the
+    operator as something they can fix by freeing space."""
+    import errno
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with (
+        mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
+        mock.patch(
+            'anthias_server.app.views.os.open',
+            side_effect=OSError(errno.EACCES, 'Permission denied'),
+        ),
+        pytest.raises(OSError),
+    ):
+        client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'01234', content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-4/10',
+            },
+        )
+
+    assert Asset.objects.count() == 0
+
+
+@pytest.mark.django_db
 def test_assets_upload_refuses_a_file_larger_than_free_space(
     client: Client, tmp_path: Any
 ) -> None:

--- a/tests/test_template_views.py
+++ b/tests/test_template_views.py
@@ -20,6 +20,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from anthias_common import storage_health
+from anthias_common.utils import STAGED_UPLOAD_DIR
 from anthias_server.app import page_context
 from anthias_server.app.models import DURATION_S_MAX, Asset
 from anthias_server.app.templatetags.asset_filters import to_json
@@ -2471,6 +2472,243 @@ def test_assets_upload_disk_full_during_write_cleans_up_partial(
     assert 'disk is full' in response.headers.get('HX-Trigger', '')
     assert Asset.objects.count() == 0
     mock_remove.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_assets_upload_chunked_round_trip_is_byte_exact(
+    client: Client, tmp_path: Any
+) -> None:
+    """Three chunks must reassemble into exactly the bytes sent.
+
+    A wrong range fails silently rather than loudly: the view
+    truncates to the declared total, so an off-by-one produces an
+    asset of the right length that will not play."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    payload = bytes(range(256)) * 12
+    chunk = len(payload) // 3
+    bounds = [
+        (0, chunk - 1),
+        (chunk, 2 * chunk - 1),
+        (2 * chunk, len(payload) - 1),
+    ]
+
+    upload_id = None
+    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+        for start, end in bounds:
+            headers = {
+                'HX-Request': 'true',
+                'Content-Range': f'bytes {start}-{end}/{len(payload)}',
+            }
+            if upload_id:
+                headers['X-Upload-Id'] = upload_id
+            response = client.post(
+                reverse('anthias_app:assets_upload'),
+                data={
+                    'file_upload': SimpleUploadedFile(
+                        'clip.mp4',
+                        payload[start : end + 1],
+                        content_type='video/mp4',
+                    ),
+                },
+                headers=headers,
+            )
+            assert response.status_code == 200
+            if (start, end) != bounds[-1]:
+                upload_id = response.json()['upload_id']
+
+        assert Asset.objects.count() == 1
+        asset = Asset.objects.get()
+        assert asset.uri is not None
+        with open(asset.uri, 'rb') as f:
+            assert f.read() == payload
+        # The staging directory must not keep the partial around.
+        staged = tmp_path / STAGED_UPLOAD_DIR
+        assert not list(staged.glob('*.part'))
+
+
+@pytest.mark.django_db
+def test_assets_upload_chunk_disk_full_is_reported_not_raised(
+    client: Client, tmp_path: Any
+) -> None:
+    """ENOSPC while staging must surface as 507 with the partial
+    removed, not escape as a 500. Chunked uploads are by definition the
+    large ones, so this is the path most likely to fill a card."""
+    import errno
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with (
+        mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}),
+        mock.patch(
+            'anthias_server.app.views.os.open',
+            side_effect=OSError(errno.ENOSPC, 'No space left on device'),
+        ),
+    ):
+        response = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'01234', content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-4/10',
+            },
+        )
+
+    assert response.status_code == 507
+    assert Asset.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_assets_upload_single_shot_ignores_a_stray_upload_id(
+    client: Client, tmp_path: Any
+) -> None:
+    """Without Content-Range the original path must run untouched, even
+    if a client sends an id: honouring one there would let a plain
+    upload truncate an unrelated staged file."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+        response = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'photo.png', b'\x89PNG\r\n', content_type='image/png'
+                ),
+            },
+            headers={'HX-Request': 'true', 'X-Upload-Id': 'a' * 32},
+        )
+
+    assert response.status_code == 200
+    assert Asset.objects.count() == 1
+    assert not (tmp_path / STAGED_UPLOAD_DIR).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'upload_id',
+    ['../../etc/passwd', 'a' * 31, 'a' * 33, '', 'g' * 32, 'a/b'],
+)
+def test_assets_upload_rejects_a_malformed_upload_id(
+    client: Client, tmp_path: Any, upload_id: str
+) -> None:
+    """The id lands in a filesystem path, so anything but the exact
+    shape we mint is refused."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+        response = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'01234', content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-4/10',
+                'X-Upload-Id': upload_id,
+            },
+        )
+
+    assert response.status_code == 400
+    assert Asset.objects.count() == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'content_range',
+    [
+        'bytes */100',
+        'bytes 5-1/10',
+        'bytes 0-10/10',
+        'bytes 0-9/5',
+        'bytes 0-0/0',
+        'bytes 0-4/' + '9' * 5000,
+        'nonsense',
+    ],
+)
+def test_assets_upload_rejects_a_malformed_range(
+    client: Client, tmp_path: Any, content_range: str
+) -> None:
+    """A client-controlled header must never reach a 500. The long
+    total is the case that used to: int() raises above 4300 digits."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+        response = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'01234', content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': content_range,
+            },
+        )
+
+    assert response.status_code == 400
+    assert Asset.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_assets_upload_chunk_past_the_end_drops_the_partial(
+    client: Client, tmp_path: Any
+) -> None:
+    """A gap cannot be told from a resumed upload whose partial has
+    gone, and writing it would leave a hole reading back as zeros. The
+    upload is abandoned rather than silently corrupted."""
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    from anthias_server.settings import settings as anthias_settings
+
+    with mock.patch.dict(anthias_settings, {'assetdir': str(tmp_path)}):
+        first = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'0' * 10, content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 0-9/100',
+            },
+        )
+        upload_id = first.json()['upload_id']
+
+        gapped = client.post(
+            reverse('anthias_app:assets_upload'),
+            data={
+                'file_upload': SimpleUploadedFile(
+                    'clip.mp4', b'1' * 10, content_type='video/mp4'
+                ),
+            },
+            headers={
+                'HX-Request': 'true',
+                'Content-Range': 'bytes 50-59/100',
+                'X-Upload-Id': upload_id,
+            },
+        )
+
+        assert gapped.status_code == 409
+        assert Asset.objects.count() == 0
+        assert not list((tmp_path / STAGED_UPLOAD_DIR).glob('*.part'))
 
 
 @pytest.mark.django_db

--- a/tests/test_upload_chunk_size_setting.py
+++ b/tests/test_upload_chunk_size_setting.py
@@ -1,192 +1,169 @@
-"""Tests for ANTHIAS_UPLOAD_CHUNK_SIZE_MB parsing in the Django settings.
+"""Tests for how the upload chunk size is configured.
 
-The variable is set once through the balena dashboard and rarely
-looked at again, so a trailing space or a stray unit (``16m``) must
-not raise ValueError while the settings module imports — that would
-stop the container from coming up on a device with no shell to
-diagnose it. The bounds are enforced here as well as in the browser
-so the client cap is a second line of defence, not the only one.
+The value reaches Django from anthias.conf, then the
+ANTHIAS_UPLOAD_CHUNK_SIZE_MB env var, then a default — and reaches the
+browser through a <meta> tag. It is set once and rarely looked at
+again, typically through a balena dashboard field or a hand-edited
+config, so no value it can be given may raise: on a headless device
+the container would simply never come up.
 """
 
-import logging
+import os
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
-import yaml
 
 from anthias_server.django_project.settings import (
     UPLOAD_CHUNK_SIZE_MB_DEFAULT,
     UPLOAD_CHUNK_SIZE_MB_MAX,
     UPLOAD_CHUNK_SIZE_MB_MIN,
+    get_configured_upload_chunk_size_mb,
     resolve_upload_chunk_size_mb,
+)
+from anthias_server.settings import DEFAULTS
+
+CHUNKING_TS = (
+    Path(__file__).resolve().parents[1]
+    / 'src/anthias_server/app/static/src/home/chunking.ts'
 )
 
 
-class TestResolveUploadChunkSizeMb:
-    def test_unset_uses_the_default(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+@pytest.fixture(autouse=True)
+def _empty_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Iterator[None]:
+    """Point HOME at an empty directory.
+
+    The config file is the first rung, so without this every env-var
+    case below fails on the machine of any developer who followed the
+    FAQ and set `upload_chunk_size_mb` in their own anthias.conf. CI
+    never sees it — a container's config has no such key.
+    """
+    monkeypatch.setenv('HOME', str(tmp_path))
+    yield
+
+
+def _resolve(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    conf: str | None,
+    env: str | None,
+) -> int:
+    if conf is not None:
+        (tmp_path / '.anthias').mkdir(exist_ok=True)
+        (tmp_path / '.anthias' / 'anthias.conf').write_text(
+            f'[main]\nupload_chunk_size_mb = {conf}\n'
+        )
+    if env is None:
         monkeypatch.delenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', raising=False)
-        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_DEFAULT
+    else:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', env)
+    return resolve_upload_chunk_size_mb()
 
-    def test_a_plain_value_is_honoured(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '8')
-        assert resolve_upload_chunk_size_mb() == 8
 
-    def test_surrounding_whitespace_is_tolerated(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', ' 8 ')
-        assert resolve_upload_chunk_size_mb() == 8
+D = UPLOAD_CHUNK_SIZE_MB_DEFAULT
 
-    @pytest.mark.parametrize(
-        'value', ['16m', 'sixteen', '0x10', 'nan', 'inf', '9' * 5000]
+
+@pytest.mark.parametrize(
+    ('conf', 'env', 'expected', 'why'),
+    [
+        # Precedence. The config file wins because it is the rung that
+        # survives an upgrade; the env var is how balena sets it.
+        ('4', '20', 4, 'config beats the environment'),
+        ('', '20', 20, 'a blank config defers to the environment'),
+        (None, '20', 20, 'no config at all defers to the environment'),
+        (None, None, D, 'neither set'),
+        # Parsing. Either rung may hold anything a human can type.
+        (None, '8', 8, 'a plain value'),
+        (None, ' 8 ', 8, 'surrounding whitespace'),
+        # MB is decimal, and this knob exists to get UNDER a proxy cap,
+        # so 8.5 must not be rounded up or fall back to 16.
+        (None, '8.5', 8, 'a fractional value rounds down'),
+        ('2.9', None, 2, 'and does so from the config too'),
+        # Unparseable falls back rather than raising.
+        (None, '16m', D, 'a stray unit'),
+        (None, 'sixteen', D, 'not a number'),
+        (None, '0x10', D, 'not decimal'),
+        (None, 'nan', D, 'nan'),
+        (None, 'inf', D, 'inf'),
+        (None, '9' * 5000, D, 'longer than int() will parse'),
+        # docker-compose.yml.tmpl always sets the variable, so an
+        # operator who has chosen nothing sends an empty string.
+        (None, '', D, 'empty, which compose always renders'),
+        (None, '   ', D, 'whitespace only'),
+        # Clamped both ways.
+        (None, '32', UPLOAD_CHUNK_SIZE_MB_MAX, 'above the ceiling'),
+        (None, '0', UPLOAD_CHUNK_SIZE_MB_MIN, 'below the floor'),
+        (None, '-4', UPLOAD_CHUNK_SIZE_MB_MIN, 'negative'),
+        ('512', None, UPLOAD_CHUNK_SIZE_MB_MAX, 'clamped from the config'),
+    ],
+)
+def test_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    conf: str | None,
+    env: str | None,
+    expected: int,
+    why: str,
+) -> None:
+    assert _resolve(monkeypatch, tmp_path, conf, env) == expected, why
+
+
+@pytest.mark.parametrize('value', ['16m', '32'])
+def test_a_value_it_cannot_use_is_logged(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    value: str,
+) -> None:
+    """Reported as written, not as parsed: 0.5 logged as "0 is outside
+    [1, 24]" sends the operator looking for a zero they never typed."""
+    with caplog.at_level('WARNING'):
+        _resolve(monkeypatch, tmp_path, None, value)
+    assert value in caplog.text
+
+
+@pytest.mark.parametrize('kind', ['fifo', 'directory', 'binary'])
+def test_an_unreadable_config_is_not_an_error(
+    tmp_path: Path, kind: str
+) -> None:
+    """Read at startup, so a read that blocks or throws means the
+    container never comes up rather than one bad page."""
+    target = tmp_path / 'anthias.conf'
+    if kind == 'fifo':
+        os.mkfifo(target)
+    elif kind == 'directory':
+        target.mkdir()
+    else:
+        target.write_bytes(bytes(range(256)) * 4)
+
+    assert get_configured_upload_chunk_size_mb(str(target)) == ''
+
+
+def test_the_config_file_carries_it_across_an_upgrade() -> None:
+    """upgrade_containers.sh regenerates docker-compose.yml from its
+    template every run, so an env var set on the host is not
+    persistence. anthias.conf is on the mounted volume."""
+    assert 'upload_chunk_size_mb' in DEFAULTS['main']
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('MAX_CHUNK_MB', UPLOAD_CHUNK_SIZE_MB_MAX),
+        ('MIN_CHUNK_MB', UPLOAD_CHUNK_SIZE_MB_MIN),
+        ('FALLBACK_CHUNK_MB', UPLOAD_CHUNK_SIZE_MB_DEFAULT),
+    ],
+)
+def test_browser_bounds_match_the_server(name: str, expected: int) -> None:
+    """chunking.ts cannot import a Python constant, so the two sets are
+    written out twice. Drift resurrects the problem the server-side
+    clamp was added to prevent: a stale browser ceiling silently
+    overriding the value the server advertised."""
+    match = re.search(
+        rf'^const {name} = (\d+)$', CHUNKING_TS.read_text(), re.MULTILINE
     )
-    def test_an_unparseable_value_falls_back_instead_of_raising(
-        self, monkeypatch: pytest.MonkeyPatch, value: str
-    ) -> None:
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', value)
-        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_DEFAULT
-
-    @pytest.mark.parametrize('value', ['', '   '])
-    def test_an_empty_value_uses_the_default(
-        self, monkeypatch: pytest.MonkeyPatch, value: str
-    ) -> None:
-        """Not a hypothetical: docker-compose.yml.tmpl always sets the
-        variable, and it renders empty for every operator who has not
-        chosen a value."""
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', value)
-        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_DEFAULT
-
-    def test_an_unparseable_value_says_so(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '16m')
-        with caplog.at_level(logging.WARNING):
-            resolve_upload_chunk_size_mb()
-        assert '16m' in caplog.text
-
-    @pytest.mark.parametrize(
-        ('value', 'expected'),
-        [('8.5', 8), ('1.9', 1), ('23.9', 23), ('0.5', 1)],
-    )
-    def test_a_fractional_value_rounds_down_not_up(
-        self, monkeypatch: pytest.MonkeyPatch, value: str, expected: int
-    ) -> None:
-        """MB is a decimal quantity, and this knob only ever exists to
-        get *under* a proxy's cap. An operator who writes 8.5 to fit a
-        10 MB limit must not be handed 16."""
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', value)
-        assert resolve_upload_chunk_size_mb() == expected
-
-    def test_a_value_above_the_ceiling_is_clamped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '32')
-        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_MAX
-
-    def test_a_value_below_the_floor_is_clamped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '0')
-        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_MIN
-
-    def test_a_negative_value_is_clamped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '-4')
-        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_MIN
-
-    def test_a_clamped_value_says_so(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '32')
-        with caplog.at_level(logging.WARNING):
-            resolve_upload_chunk_size_mb()
-        assert str(UPLOAD_CHUNK_SIZE_MB_MAX) in caplog.text
-
-
-class TestUploadChunkSizeIsReachable:
-    """The variable has to survive the trip from the operator to Django.
-
-    A setting only settings.py knows about is unreachable on the plain
-    docker-compose install: the template lists anthias-server's
-    environment explicitly, Compose passes only what it declares, and
-    upgrade_containers.sh regenerates the file from that template on
-    every run. This is the install the chunking exists for — balena
-    devices get dashboard variables injected into every service.
-    """
-
-    def test_compose_template_passes_the_variable_to_the_server(
-        self,
-    ) -> None:
-        template = (
-            Path(__file__).resolve().parents[1] / 'docker-compose.yml.tmpl'
-        )
-        services = yaml.safe_load(template.read_text())['services']
-        assert (
-            'ANTHIAS_UPLOAD_CHUNK_SIZE_MB=${ANTHIAS_UPLOAD_CHUNK_SIZE_MB}'
-            in services['anthias-server']['environment']
-        )
-
-    def test_upgrade_sources_the_operator_env_file(self) -> None:
-        """Without this, a value set on the device is reverted by the
-        next upgrade and the 413s come back unexplained."""
-        script = (
-            Path(__file__).resolve().parents[1]
-            / 'bin'
-            / 'upgrade_containers.sh'
-        ).read_text()
-        sourcing = script.index('. /etc/anthias/anthias.env')
-        rendering = script.index('| envsubst')
-        assert sourcing < rendering
-
-
-class TestUploadChunkSizeBoundsAgree:
-    """The browser mirrors these bounds, and nothing else ties them.
-
-    chunking.ts cannot import a Python constant, so the two sets are
-    written out twice and can drift silently — which resurrects the
-    problem the server-side clamp was added to prevent. An operator
-    sets 32 to match their proxy, the server serves its own ceiling in
-    the meta tag, and a stale ceiling in the browser quietly overrides
-    it with something smaller.
-    """
-
-    @staticmethod
-    def _chunking_ts_const(name: str) -> int:
-        source = (
-            Path(__file__).resolve().parents[1]
-            / 'src'
-            / 'anthias_server'
-            / 'app'
-            / 'static'
-            / 'src'
-            / 'home'
-            / 'chunking.ts'
-        ).read_text()
-        match = re.search(rf'^const {name} = (\d+)$', source, re.MULTILINE)
-        assert match is not None, f'{name} not found in chunking.ts'
-        return int(match.group(1))
-
-    def test_ceiling_matches(self) -> None:
-        assert self._chunking_ts_const('MAX_CHUNK_MB') == (
-            UPLOAD_CHUNK_SIZE_MB_MAX
-        )
-
-    def test_floor_matches(self) -> None:
-        assert self._chunking_ts_const('MIN_CHUNK_MB') == (
-            UPLOAD_CHUNK_SIZE_MB_MIN
-        )
-
-    def test_fallback_matches_the_server_default(self) -> None:
-        assert self._chunking_ts_const('FALLBACK_CHUNK_MB') == (
-            UPLOAD_CHUNK_SIZE_MB_DEFAULT
-        )
+    assert match is not None, f'{name} not found in chunking.ts'
+    assert int(match.group(1)) == expected

--- a/tests/test_upload_chunk_size_setting.py
+++ b/tests/test_upload_chunk_size_setting.py
@@ -41,7 +41,9 @@ class TestResolveUploadChunkSizeMb:
         monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', ' 8 ')
         assert resolve_upload_chunk_size_mb() == 8
 
-    @pytest.mark.parametrize('value', ['16m', 'sixteen', '0x10', '1_6'])
+    @pytest.mark.parametrize(
+        'value', ['16m', 'sixteen', '0x10', 'nan', 'inf', '9' * 5000]
+    )
     def test_an_unparseable_value_falls_back_instead_of_raising(
         self, monkeypatch: pytest.MonkeyPatch, value: str
     ) -> None:
@@ -67,6 +69,19 @@ class TestResolveUploadChunkSizeMb:
         with caplog.at_level(logging.WARNING):
             resolve_upload_chunk_size_mb()
         assert '16m' in caplog.text
+
+    @pytest.mark.parametrize(
+        ('value', 'expected'),
+        [('8.5', 8), ('1.9', 1), ('23.9', 23), ('0.5', 1)],
+    )
+    def test_a_fractional_value_rounds_down_not_up(
+        self, monkeypatch: pytest.MonkeyPatch, value: str, expected: int
+    ) -> None:
+        """MB is a decimal quantity, and this knob only ever exists to
+        get *under* a proxy's cap. An operator who writes 8.5 to fit a
+        10 MB limit must not be handed 16."""
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', value)
+        assert resolve_upload_chunk_size_mb() == expected
 
     def test_a_value_above_the_ceiling_is_clamped(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_upload_chunk_size_setting.py
+++ b/tests/test_upload_chunk_size_setting.py
@@ -9,6 +9,7 @@ so the client cap is a second line of defence, not the only one.
 """
 
 import logging
+import re
 from pathlib import Path
 
 import pytest
@@ -146,3 +147,46 @@ class TestUploadChunkSizeIsReachable:
         sourcing = script.index('. /etc/anthias/anthias.env')
         rendering = script.index('| envsubst')
         assert sourcing < rendering
+
+
+class TestUploadChunkSizeBoundsAgree:
+    """The browser mirrors these bounds, and nothing else ties them.
+
+    chunking.ts cannot import a Python constant, so the two sets are
+    written out twice and can drift silently — which resurrects the
+    problem the server-side clamp was added to prevent. An operator
+    sets 32 to match their proxy, the server serves its own ceiling in
+    the meta tag, and a stale ceiling in the browser quietly overrides
+    it with something smaller.
+    """
+
+    @staticmethod
+    def _chunking_ts_const(name: str) -> int:
+        source = (
+            Path(__file__).resolve().parents[1]
+            / 'src'
+            / 'anthias_server'
+            / 'app'
+            / 'static'
+            / 'src'
+            / 'home'
+            / 'chunking.ts'
+        ).read_text()
+        match = re.search(rf'^const {name} = (\d+)$', source, re.MULTILINE)
+        assert match is not None, f'{name} not found in chunking.ts'
+        return int(match.group(1))
+
+    def test_ceiling_matches(self) -> None:
+        assert self._chunking_ts_const('MAX_CHUNK_MB') == (
+            UPLOAD_CHUNK_SIZE_MB_MAX
+        )
+
+    def test_floor_matches(self) -> None:
+        assert self._chunking_ts_const('MIN_CHUNK_MB') == (
+            UPLOAD_CHUNK_SIZE_MB_MIN
+        )
+
+    def test_fallback_matches_the_server_default(self) -> None:
+        assert self._chunking_ts_const('FALLBACK_CHUNK_MB') == (
+            UPLOAD_CHUNK_SIZE_MB_DEFAULT
+        )

--- a/tests/test_upload_chunk_size_setting.py
+++ b/tests/test_upload_chunk_size_setting.py
@@ -1,0 +1,85 @@
+"""Tests for ANTHIAS_UPLOAD_CHUNK_SIZE_MB parsing in the Django settings.
+
+The variable is set once through the balena dashboard and rarely
+looked at again, so a trailing space or a stray unit (``16m``) must
+not raise ValueError while the settings module imports — that would
+stop the container from coming up on a device with no shell to
+diagnose it. The bounds are enforced here as well as in the browser
+so the client cap is a second line of defence, not the only one.
+"""
+
+import logging
+
+import pytest
+
+from anthias_server.django_project.settings import (
+    UPLOAD_CHUNK_SIZE_MB_DEFAULT,
+    UPLOAD_CHUNK_SIZE_MB_MAX,
+    UPLOAD_CHUNK_SIZE_MB_MIN,
+    resolve_upload_chunk_size_mb,
+)
+
+
+class TestResolveUploadChunkSizeMb:
+    def test_unset_uses_the_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', raising=False)
+        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_DEFAULT
+
+    def test_a_plain_value_is_honoured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '8')
+        assert resolve_upload_chunk_size_mb() == 8
+
+    def test_surrounding_whitespace_is_tolerated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', ' 8 ')
+        assert resolve_upload_chunk_size_mb() == 8
+
+    @pytest.mark.parametrize('value', ['16m', '', 'sixteen', '8.5', '0x10'])
+    def test_an_unparseable_value_falls_back_instead_of_raising(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', value)
+        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_DEFAULT
+
+    def test_an_unparseable_value_says_so(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '16m')
+        with caplog.at_level(logging.WARNING):
+            resolve_upload_chunk_size_mb()
+        assert '16m' in caplog.text
+
+    def test_a_value_above_the_ceiling_is_clamped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '32')
+        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_MAX
+
+    def test_a_value_below_the_floor_is_clamped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '0')
+        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_MIN
+
+    def test_a_negative_value_is_clamped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '-4')
+        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_MIN
+
+    def test_a_clamped_value_says_so(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', '32')
+        with caplog.at_level(logging.WARNING):
+            resolve_upload_chunk_size_mb()
+        assert str(UPLOAD_CHUNK_SIZE_MB_MAX) in caplog.text

--- a/tests/test_upload_chunk_size_setting.py
+++ b/tests/test_upload_chunk_size_setting.py
@@ -9,8 +9,10 @@ so the client cap is a second line of defence, not the only one.
 """
 
 import logging
+from pathlib import Path
 
 import pytest
+import yaml
 
 from anthias_server.django_project.settings import (
     UPLOAD_CHUNK_SIZE_MB_DEFAULT,
@@ -39,10 +41,20 @@ class TestResolveUploadChunkSizeMb:
         monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', ' 8 ')
         assert resolve_upload_chunk_size_mb() == 8
 
-    @pytest.mark.parametrize('value', ['16m', '', 'sixteen', '8.5', '0x10'])
+    @pytest.mark.parametrize('value', ['16m', 'sixteen', '0x10', '1_6'])
     def test_an_unparseable_value_falls_back_instead_of_raising(
         self, monkeypatch: pytest.MonkeyPatch, value: str
     ) -> None:
+        monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', value)
+        assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_DEFAULT
+
+    @pytest.mark.parametrize('value', ['', '   '])
+    def test_an_empty_value_uses_the_default(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        """Not a hypothetical: docker-compose.yml.tmpl always sets the
+        variable, and it renders empty for every operator who has not
+        chosen a value."""
         monkeypatch.setenv('ANTHIAS_UPLOAD_CHUNK_SIZE_MB', value)
         assert resolve_upload_chunk_size_mb() == UPLOAD_CHUNK_SIZE_MB_DEFAULT
 
@@ -83,3 +95,39 @@ class TestResolveUploadChunkSizeMb:
         with caplog.at_level(logging.WARNING):
             resolve_upload_chunk_size_mb()
         assert str(UPLOAD_CHUNK_SIZE_MB_MAX) in caplog.text
+
+
+class TestUploadChunkSizeIsReachable:
+    """The variable has to survive the trip from the operator to Django.
+
+    A setting only settings.py knows about is unreachable on the plain
+    docker-compose install: the template lists anthias-server's
+    environment explicitly, Compose passes only what it declares, and
+    upgrade_containers.sh regenerates the file from that template on
+    every run. This is the install the chunking exists for — balena
+    devices get dashboard variables injected into every service.
+    """
+
+    def test_compose_template_passes_the_variable_to_the_server(
+        self,
+    ) -> None:
+        template = (
+            Path(__file__).resolve().parents[1] / 'docker-compose.yml.tmpl'
+        )
+        services = yaml.safe_load(template.read_text())['services']
+        assert (
+            'ANTHIAS_UPLOAD_CHUNK_SIZE_MB=${ANTHIAS_UPLOAD_CHUNK_SIZE_MB}'
+            in services['anthias-server']['environment']
+        )
+
+    def test_upgrade_sources_the_operator_env_file(self) -> None:
+        """Without this, a value set on the device is reverted by the
+        next upgrade and the 413s come back unexplained."""
+        script = (
+            Path(__file__).resolve().parents[1]
+            / 'bin'
+            / 'upgrade_containers.sh'
+        ).read_text()
+        sourcing = script.index('. /etc/anthias/anthias.env')
+        rendering = script.index('| envsubst')
+        assert sourcing < rendering

--- a/tests/test_views_files.py
+++ b/tests/test_views_files.py
@@ -194,6 +194,34 @@ def test_anthias_assets_symlink_escape_blocked(
             views_files.anthias_assets(request, filename='link.txt')
 
 
+# Staged chunked uploads live at `.uploads/<id>.part` inside the asset
+# dir so the commit stays a rename within one filesystem. They must
+# not be reachable over HTTP: the id is unguessable, but this view is
+# effectively open on the LAN in the default no-SSL install.
+def test_anthias_assets_staged_upload_not_served(
+    factory: RequestFactory, assets_root: Path
+) -> None:
+    staged = assets_root / '.uploads'
+    staged.mkdir()
+    (staged / 'abc.part').write_text('partial')
+    request = factory.get(
+        '/anthias_assets/.uploads/abc.part', REMOTE_ADDR=DOCKER_BRIDGE_IP
+    )
+    with pytest.raises(Http404):
+        views_files.anthias_assets(request, filename='.uploads/abc.part')
+
+
+def test_anthias_assets_dotfile_not_served(
+    factory: RequestFactory, assets_root: Path
+) -> None:
+    (assets_root / '.secret').write_text('nope')
+    request = factory.get(
+        '/anthias_assets/.secret', REMOTE_ADDR=DOCKER_BRIDGE_IP
+    )
+    with pytest.raises(Http404):
+        views_files.anthias_assets(request, filename='.secret')
+
+
 def test_anthias_assets_directory_request_404(
     factory: RequestFactory, assets_root: Path
 ) -> None:

--- a/tests/test_views_files.py
+++ b/tests/test_views_files.py
@@ -231,6 +231,21 @@ def test_anthias_assets_api_staging_file_not_served(
         views_files.anthias_assets(request, filename='deadbeef.tmp')
 
 
+def test_anthias_assets_download_in_progress_not_served(
+    factory: RequestFactory, assets_root: Path
+) -> None:
+    """celery_tasks stages a yt-dlp or remote-video download at
+    `<uuid>.<ext>.part` at the top level of the asset dir — not
+    dot-leading, not `.tmp`. Handing out a half-downloaded video is the
+    same mistake as handing out a half-uploaded one."""
+    (assets_root / 'deadbeef.mp4.part').write_text('half a video')
+    request = factory.get(
+        '/anthias_assets/deadbeef.mp4.part', REMOTE_ADDR=DOCKER_BRIDGE_IP
+    )
+    with pytest.raises(Http404):
+        views_files.anthias_assets(request, filename='deadbeef.mp4.part')
+
+
 def test_anthias_assets_dotfile_not_served(
     factory: RequestFactory, assets_root: Path
 ) -> None:

--- a/tests/test_views_files.py
+++ b/tests/test_views_files.py
@@ -9,6 +9,7 @@ import pytest
 from django.http import Http404, HttpRequest, HttpResponseBase
 from django.test import RequestFactory
 
+from anthias_common.utils import STAGED_UPLOAD_DIR
 from anthias_server.app import views_files
 from anthias_server.app.views_files import (
     DOCKER_BRIDGE_CIDR,
@@ -201,14 +202,33 @@ def test_anthias_assets_symlink_escape_blocked(
 def test_anthias_assets_staged_upload_not_served(
     factory: RequestFactory, assets_root: Path
 ) -> None:
-    staged = assets_root / '.uploads'
+    staged = assets_root / STAGED_UPLOAD_DIR
     staged.mkdir()
     (staged / 'abc.part').write_text('partial')
+    # Built from the constant, not spelled out: a test that hardcodes
+    # the directory keeps passing after a rename, against a path
+    # nothing writes to any more, while real partials go back to being
+    # served.
+    name = f'{STAGED_UPLOAD_DIR}/abc.part'
     request = factory.get(
-        '/anthias_assets/.uploads/abc.part', REMOTE_ADDR=DOCKER_BRIDGE_IP
+        f'/anthias_assets/{name}', REMOTE_ADDR=DOCKER_BRIDGE_IP
     )
     with pytest.raises(Http404):
-        views_files.anthias_assets(request, filename='.uploads/abc.part')
+        views_files.anthias_assets(request, filename=name)
+
+
+def test_anthias_assets_api_staging_file_not_served(
+    factory: RequestFactory, assets_root: Path
+) -> None:
+    """The REST API stages a resumable upload at `<id>.tmp` in this
+    same directory. Not dot-leading, and the same thing it would be
+    wrong to hand out."""
+    (assets_root / 'deadbeef.tmp').write_text('partial')
+    request = factory.get(
+        '/anthias_assets/deadbeef.tmp', REMOTE_ADDR=DOCKER_BRIDGE_IP
+    )
+    with pytest.raises(Http404):
+        views_files.anthias_assets(request, filename='deadbeef.tmp')
 
 
 def test_anthias_assets_dotfile_not_served(

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -255,13 +255,16 @@
         | Caddy      | `request_body { max_size 0 }`                               |
         | Cloudflare | your plan sets the ceiling; you can lower it, not raise it   |
 
-        If your proxy's ceiling is one you can't raise — Cloudflare's, for instance — Anthias splits a large upload into several smaller requests instead, so it clears the cap without you changing anything. Each request defaults to 16 MB. Lower it to fit a tighter cap by creating `/etc/anthias/anthias.env` on the device:
+        If your proxy's ceiling is one you can't raise — Cloudflare's, for instance — Anthias splits a large upload into several smaller requests instead, so it clears the cap without you changing anything. Each request defaults to 16 MB. To fit a tighter cap, lower it in `~/.anthias/anthias.conf` on the device:
 
         ```
-        ANTHIAS_UPLOAD_CHUNK_SIZE_MB=8
+        [main]
+        upload_chunk_size_mb = 8
         ```
 
-        Then re-run `./bin/upgrade_containers.sh`. That file is read on every upgrade, so the setting survives one; editing `docker-compose.yml` directly does not, since it's regenerated each time. On balena, set the same variable as a device or service variable in the dashboard instead. Values are clamped to 1–24 MB: the ceiling keeps each chunk inside the server's in-memory upload buffer, which matters on a 512 MB board.
+        The change applies on the next page load. That file holds the device's own settings and isn't touched by upgrades, so the value stays put. On balena, where you have a dashboard instead of a shell, set `ANTHIAS_UPLOAD_CHUNK_SIZE_MB` as a device or service variable — the config file wins if both are set.
+
+        Values are clamped to 1–24 MB. The ceiling keeps each chunk inside the server's in-memory upload buffer, which matters on a 512 MB board; below 1 MB a large video turns into thousands of requests.
 
         The bundled `./bin/enable_ssl.sh` Caddy sidecar handles all of this for you. The above is only relevant if you're terminating TLS or proxying with something else.
 

--- a/website/data/faq.yaml
+++ b/website/data/faq.yaml
@@ -255,6 +255,14 @@
         | Caddy      | `request_body { max_size 0 }`                               |
         | Cloudflare | your plan sets the ceiling; you can lower it, not raise it   |
 
+        If your proxy's ceiling is one you can't raise — Cloudflare's, for instance — Anthias splits a large upload into several smaller requests instead, so it clears the cap without you changing anything. Each request defaults to 16 MB. Lower it to fit a tighter cap by creating `/etc/anthias/anthias.env` on the device:
+
+        ```
+        ANTHIAS_UPLOAD_CHUNK_SIZE_MB=8
+        ```
+
+        Then re-run `./bin/upgrade_containers.sh`. That file is read on every upgrade, so the setting survives one; editing `docker-compose.yml` directly does not, since it's regenerated each time. On balena, set the same variable as a device or service variable in the dashboard instead. Values are clamped to 1–24 MB: the ceiling keeps each chunk inside the server's in-memory upload buffer, which matters on a 512 MB board.
+
         The bundled `./bin/enable_ssl.sh` Caddy sidecar handles all of this for you. The above is only relevant if you're terminating TLS or proxying with something else.
 
     - question: Where is the API reference?


### PR DESCRIPTION
### Issues Fixed

No existing issue. This is the fix for the problem behind #3302: I run Anthias behind Cloudflare, and uploading a large video fails. #3302 made the failure legible ("File too large - it exceeds the upload size limit of the server or a proxy in front of it"); this makes the upload work.

### Description

The Add asset upload posts the whole file in one request, so a large video fails wherever a reverse proxy caps the request body. Cloudflare caps every non-Enterprise plan at 100 MB, a video of a few minutes clears that easily, and the operator cannot raise it. The bytes have to arrive in several requests instead.

**Server.** A ranged upload carries `Content-Range`. Each request stages its bytes into `<assetdir>/.uploads/<id>.part` and answers with JSON; only the request carrying the final byte falls through to create the asset, which is then a rename within one filesystem rather than a copy. Type detection, the display name and the extension all run before staging, so a file Anthias will refuse is refused on the first chunk rather than after the operator has waited out the whole upload. **A request without `Content-Range` takes the original path untouched.**

**Browser.** A file larger than the chunk size is sliced and sent sequentially, each slice re-wrapped as a Blob carrying the file's own type. That last part matters: a raw Blob from `File.slice()` reports `application/octet-stream`, and the server reads the browser's type to catch a file whose extension lies about it, such as a HEIC renamed to `.jpg`. Without the re-wrap the chunked path would skip normalisation and the asset would render blank on the player.

Progress is measured against the whole file rather than each request. A dropped connection or a 5xx resends the same chunk twice before giving up; a 4xx is the server's considered answer and is not resent. The chunk that *commits* is never resent once its body has gone out — see known limitation 2.

**Chunk size.** `upload_chunk_size_mb` in `~/.anthias/anthias.conf`, then the `ANTHIAS_UPLOAD_CHUNK_SIZE_MB` environment variable, then 16. The config file comes first because it is the rung that survives an upgrade: `upgrade_containers.sh` regenerates `docker-compose.yml` from its template on every run, so a value set anywhere on the host is not persistence. The environment variable is how a balena device sets it, through a dashboard variable the supervisor injects. Clamped to [1, 24]: the ceiling keeps a chunk under `FILE_UPLOAD_MAX_MEMORY_SIZE`, where Django holds it in RAM rather than spooling it to the SD card, and below the floor a large video becomes thousands of sequential requests.

Parsed defensively, because this is set once and rarely looked at again. `16m` previously raised `ValueError` while settings imported and the container never came up — on a headless device, with no shell to work out why. Read as a decimal and rounded down, since MB is decimal and an operator writing `8.5` to fit a 10 MB cap must not be handed 16, a value that cannot clear the cap they are trying to get under.

**Guards that exist because the failure they prevent is silent.** A chunk is refused if it would seek past what is actually held: the alternative is a hole that reads back as zeros and an asset that is corrupt at exactly the right size. The check runs against the open file descriptor rather than the path, so the cleanup sweep cannot delete the file in between. The final chunk truncates to the declared total, so a retry that shrank cannot leave the tail of a longer earlier attempt behind. Range digits are bounded, because `int()` raises above 4300 digits and a client-controlled header must not reach a 500. Free space is checked on every chunk against `total_bytes - held`, not only on the first: `total_bytes` is re-read from each request and never pinned, so a declared total that grows would otherwise never be measured against the disk.

Partials live under the same one-hour deadline as every other stray file in the asset dir, and are excluded from backups, which tar that directory recursively and would otherwise carry gigabytes of a file nobody finished sending.

### Known limitations

Worth stating plainly rather than leaving to be discovered:

1. **Chunks must arrive strictly sequentially, one in flight.** What is tracked per upload is a byte count, not a set of received ranges, so a chunk starting past the end cannot be told apart from a resumed upload whose partial has gone. Both are treated as the latter: the partial is dropped and the operator asked to start over. Real resumability needs a received-ranges record and is not this change.
2. **A commit whose response is lost leaves the operator unable to tell whether the asset was created.** The server renames the partial into place and *then* answers, so a lost reply is indistinguishable from a lost commit. The commit is no longer resent once its body has gone out — on a dropped socket or a 5xx, since behind a proxy the lost-commit case usually arrives as a gateway 502 rather than a socket error. A body that never finished sending cannot have committed, so that case is still retried and reported as the ordinary transport failure it is. Both the client's message and the server's 409 point at the asset list before anything else, and the modal closes so the list is visible. Removing the ambiguity itself needs a commit marker I built, could not demonstrate, and removed rather than ship protection nobody can rely on. The single-shot path has the same ambiguity and now reports it the same way.
3. **No `fsync` before the final rename**, so power loss immediately after commit could leave the row pointing at unwritten data. Also true of the single-shot path today.

### Testing

Verified through the real Add asset modal in Chromium, against a dev stack with the chunk size at 1 MB:

| | |
|---|---|
| Source | 4,195,538 bytes, sha256 `10c63f2c9113aff7…` |
| Stored asset | 4,195,538 bytes, sha256 `10c63f2c9113aff7…` |
| Requests the server saw | 5 |
| Staging directory afterwards | empty |
| Server tracebacks | none |

Byte-identical, through the browser, running the current bundle.

Unit tests cover the byte-exact multi-chunk round trip, ENOSPC while staging, the single-shot path staying unchanged when a stray upload id is present, rejection matrices for malformed ids and ranges (including the over-4300-digit total that used to 500), a chunk that lies about its length, a gap past the end of the partial, the final truncate, the free-space refusal on a growing total, and on the browser side the range arithmetic, the type re-wrap, the retry policy, the commit-is-never-resent rule and the error mapping.

2058 Python tests and 134 frontend tests pass, serially and under `-n auto`, with Redis unreachable — the no-Docker host recipe CLAUDE.md documents. `ruff check`, `ruff format --check`, `mypy` and `tsc --noEmit` are clean.

**Not tested on hardware.** My only Pi is in use, so the Raspberry Pi and x86 boxes on the checklist are genuinely unticked and nobody else has run this on a device either.

### Since the last review

Six commits, in response to the review at `1cb0e31` and to problems found while re-auditing it.

The three findings from that review:

- **`HX-Redirect` was dropped across the refactor.** #3306 adds a check on that header, for the expired-session case, in the exact handler this branch rewrote — so whichever of the two rebased second would silently lose it, and every file over the chunk size would be dropped from the batch with the operator never sent to sign in. Now carried and acted on in both places a response is classified, in the same shape and wording as #3306, so the rebase resolves to the same thing twice rather than to silence.
- **A rejection was assumed to come with a toast.** `fireToastFromHeader` pushes nothing when there is no `HX-Trigger`, so an unrecognised 2xx dropped the file with no asset, no error and a completed progress bar. The test that pinned that behaviour asserted the toast list was empty, which is what it was describing: a toast that was not there.
- **Free space was checked only at byte 0**, so a declared total that grew was never measured. Now per chunk.

And four found by re-auditing:

- **`.tmp` and `.part` files were served over HTTP.** Three of the four transient shapes in the asset dir predate this branch — the REST API's `<id>.tmp`, the importer's `.import-<hex>`, and yt-dlp's `<uuid>.<ext>.part` — and all were fetchable on a LAN where the CIDR gate does not exclude clients.
- **An asset could be stored under a name we delete.** A crafted multipart part named `clip.tmp` with `Content-Type: video/tmp` was stored as `<uuid>.tmp`, which the hourly sweep removes, leaving a row pointing at nothing.
- **The test suite wrote into the developer's real `~/anthias_assets`** and deleted its contents. Verified with a sentinel file, which did not survive one run.
- **The chunk size could not be set on the docker-compose install at all**, which is the install this feature exists for.

Two corrections to what this PR previously claimed. `int()` tolerates surrounding whitespace, so the trailing-space example I gave for the defensive parsing never crashed anything — `16m` did, and that alone carries the argument. And "the server clamps to [1, 24]" oversold it: the clamp bounds what the server *advertises*, not what arrives.

### Note on overlap

This touches the same upload code as #3306, so the two conflict. The `HX-Redirect` handling above is deliberately identical in shape and wording to #3306's, so whichever merges second resolves to the same thing twice. Happy to rebase at any point.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally and on CI with my changes.
- [ ] I have done an end-to-end test for Raspberry Pi devices.
- [ ] I have tested my changes for x86 devices.
- [ ] I added a documentation for the changes I have made (when necessary).

Tested end to end through a real browser against a dev stack, but not on hardware. The reverse-proxy FAQ entry that #3302 extended now documents the chunk size and where to set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
